### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ These are early prerelease features and controls that we are still working on.
 
 They will be available in prerelease NuGet packages but not in the stable package versions until they are ready. They are subject to change without notice and may be removed.
 
-* [LayoutPanel](https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.layoutpanel) and related classes
-* [Repeater](https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.repeater) and related classes
-* [Scroller](https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.scroller) and related classes
-* [ScrollerView](https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.scrollerview) and related classes
-* [ScrollBar2](https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.scrollbar2)
+* LayoutPanel and related classes
+* Repeater and related classes
+* Scroller and related classes
+* ScrollerView and related classes
+* ScrollBar2
 
 ### Middleware Support APIs
 


### PR DESCRIPTION
The links to the Preview Features point all to non existing pages in docs.microsoft.com and so leads to 404. So, I'd suggest to remove those  links.