### PR TITLE
Adding Background property to ItemsRepeater

### DIFF
--- a/dev/Generated/ItemsRepeater.properties.cpp
+++ b/dev/Generated/ItemsRepeater.properties.cpp
@@ -9,6 +9,7 @@
 CppWinRTActivatableClassWithDPFactory(ItemsRepeater)
 
 GlobalDependencyProperty ItemsRepeaterProperties::s_AnimatorProperty{ nullptr };
+GlobalDependencyProperty ItemsRepeaterProperties::s_BackgroundProperty{ nullptr };
 GlobalDependencyProperty ItemsRepeaterProperties::s_HorizontalCacheLengthProperty{ nullptr };
 GlobalDependencyProperty ItemsRepeaterProperties::s_ItemsSourceProperty{ nullptr };
 GlobalDependencyProperty ItemsRepeaterProperties::s_ItemTemplateProperty{ nullptr };
@@ -34,6 +35,17 @@ void ItemsRepeaterProperties::EnsureProperties()
                 winrt::name_of<winrt::ItemsRepeater>(),
                 false /* isAttached */,
                 ValueHelper<winrt::ElementAnimator>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_BackgroundProperty)
+    {
+        s_BackgroundProperty =
+            InitializeDependencyProperty(
+                L"Background",
+                winrt::name_of<winrt::Brush>(),
+                winrt::name_of<winrt::ItemsRepeater>(),
+                false /* isAttached */,
+                ValueHelper<winrt::Brush>::BoxedDefaultValue(),
                 nullptr);
     }
     if (!s_HorizontalCacheLengthProperty)
@@ -96,6 +108,7 @@ void ItemsRepeaterProperties::EnsureProperties()
 void ItemsRepeaterProperties::ClearProperties()
 {
     s_AnimatorProperty = nullptr;
+    s_BackgroundProperty = nullptr;
     s_HorizontalCacheLengthProperty = nullptr;
     s_ItemsSourceProperty = nullptr;
     s_ItemTemplateProperty = nullptr;
@@ -111,6 +124,16 @@ void ItemsRepeaterProperties::Animator(winrt::ElementAnimator const& value)
 winrt::ElementAnimator ItemsRepeaterProperties::Animator()
 {
     return ValueHelper<winrt::ElementAnimator>::CastOrUnbox(static_cast<ItemsRepeater*>(this)->GetValue(s_AnimatorProperty));
+}
+
+void ItemsRepeaterProperties::Background(winrt::Brush const& value)
+{
+    static_cast<ItemsRepeater*>(this)->SetValue(s_BackgroundProperty, ValueHelper<winrt::Brush>::BoxValueIfNecessary(value));
+}
+
+winrt::Brush ItemsRepeaterProperties::Background()
+{
+    return ValueHelper<winrt::Brush>::CastOrUnbox(static_cast<ItemsRepeater*>(this)->GetValue(s_BackgroundProperty));
 }
 
 void ItemsRepeaterProperties::HorizontalCacheLength(double value)

--- a/dev/Generated/ItemsRepeater.properties.h
+++ b/dev/Generated/ItemsRepeater.properties.h
@@ -12,6 +12,9 @@ public:
     void Animator(winrt::ElementAnimator const& value);
     winrt::ElementAnimator Animator();
 
+    void Background(winrt::Brush const& value);
+    winrt::Brush Background();
+
     void HorizontalCacheLength(double value);
     double HorizontalCacheLength();
 
@@ -28,6 +31,7 @@ public:
     double VerticalCacheLength();
 
     static winrt::DependencyProperty AnimatorProperty() { return s_AnimatorProperty; }
+    static winrt::DependencyProperty BackgroundProperty() { return s_BackgroundProperty; }
     static winrt::DependencyProperty HorizontalCacheLengthProperty() { return s_HorizontalCacheLengthProperty; }
     static winrt::DependencyProperty ItemsSourceProperty() { return s_ItemsSourceProperty; }
     static winrt::DependencyProperty ItemTemplateProperty() { return s_ItemTemplateProperty; }
@@ -35,6 +39,7 @@ public:
     static winrt::DependencyProperty VerticalCacheLengthProperty() { return s_VerticalCacheLengthProperty; }
 
     static GlobalDependencyProperty s_AnimatorProperty;
+    static GlobalDependencyProperty s_BackgroundProperty;
     static GlobalDependencyProperty s_HorizontalCacheLengthProperty;
     static GlobalDependencyProperty s_ItemsSourceProperty;
     static GlobalDependencyProperty s_ItemTemplateProperty;

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -8,6 +8,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 using Common;
+using Windows.UI.Xaml.Media;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -116,6 +117,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.SetValue(ItemsRepeater.ItemsSourceProperty, dataSource);
                 Verify.AreSame(dataSource, repeater.GetValue(ItemsRepeater.ItemsSourceProperty) as ItemsSourceView);
                 Verify.AreSame(dataSource, repeater.ItemsSourceView);
+            });
+        }
+
+        [TestMethod]
+        public void ValidateGetSetBackground()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                ItemsRepeater repeater = new ItemsRepeater();
+                var redBrush = new SolidColorBrush(Colors.Red);
+                repeater.SetValue(ItemsRepeater.BackgroundProperty, redBrush);
+                Verify.AreSame(redBrush, repeater.GetValue(ItemsRepeater.BackgroundProperty) as Brush);
+                Verify.AreSame(redBrush, repeater.Background);
+
+                var blueBrush = new SolidColorBrush(Colors.Blue);
+                repeater.Background = blueBrush;
+                Verify.AreSame(blueBrush, repeater.Background);
             });
         }
     }

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -255,7 +255,7 @@ double ItemsRepeater::HorizontalCacheLength()
 
 void ItemsRepeater::HorizontalCacheLength(double value)
 {
-    SetValue(s_HorizontalCacheLengthProperty, box_value(value));
+    SetValue(s_horizontalCacheLengthProperty, box_value(value));
 }
 
 double ItemsRepeater::VerticalCacheLength()
@@ -265,7 +265,17 @@ double ItemsRepeater::VerticalCacheLength()
 
 void ItemsRepeater::VerticalCacheLength(double value)
 {
-    SetValue(s_VerticalCacheLengthProperty, box_value(value));
+    SetValue(s_verticalCacheLengthProperty, box_value(value));
+}
+
+winrt::Brush ItemsRepeater::Background()
+{
+    return ValueHelper<winrt::Brush>::CastOrUnbox((this)->GetValue(BackgroundProperty()));
+}
+
+void ItemsRepeater::Background(winrt::Brush const& value)
+{
+    SetValue(BackgroundProperty(), value);
 }
 
 int32_t ItemsRepeater::GetElementIndex(winrt::UIElement const& element)
@@ -458,11 +468,11 @@ void ItemsRepeater::OnPropertyChanged(const winrt::DependencyPropertyChangedEven
     {
         OnAnimatorChanged(safe_cast<winrt::ElementAnimator>(args.OldValue()), safe_cast<winrt::ElementAnimator>(args.NewValue()));
     }
-    else if (property == s_HorizontalCacheLengthProperty)
+    else if (property == s_horizontalCacheLengthProperty)
     {
         m_viewportManager.HorizontalCacheLength(unbox_value<double>(args.NewValue()));
     }
-    else if (property == s_VerticalCacheLengthProperty)
+    else if (property == s_verticalCacheLengthProperty)
     {
         m_viewportManager.VerticalCacheLength(unbox_value<double>(args.NewValue()));
     }

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -88,6 +88,9 @@ public:
     double VerticalCacheLength();
     void VerticalCacheLength(double value);
 
+    winrt::Brush Background();
+    void Background(winrt::Brush const& value);
+
     // Mapping APIs
     int32_t GetElementIndex(winrt::UIElement const& element);
     winrt::UIElement TryGetElement(int index);
@@ -156,15 +159,17 @@ public:
     static winrt::DependencyProperty LayoutProperty() { return s_layoutProperty; }
     static winrt::DependencyProperty AnimatorProperty() { return s_animatorProperty; }
 
-    static winrt::DependencyProperty HorizontalCacheLengthProperty() { return s_HorizontalCacheLengthProperty; }
-    static winrt::DependencyProperty VerticalCacheLengthProperty() { return s_VerticalCacheLengthProperty; }
+    static winrt::DependencyProperty HorizontalCacheLengthProperty() { return s_horizontalCacheLengthProperty; }
+    static winrt::DependencyProperty VerticalCacheLengthProperty() { return s_verticalCacheLengthProperty; }
+
+    static winrt::DependencyProperty BackgroundProperty() { return winrt::Panel::BackgroundProperty(); }
 
     static GlobalDependencyProperty s_itemsSourceProperty;
     static GlobalDependencyProperty s_itemTemplateProperty;
     static GlobalDependencyProperty s_layoutProperty;
     static GlobalDependencyProperty s_animatorProperty;
-    static GlobalDependencyProperty s_HorizontalCacheLengthProperty;
-    static GlobalDependencyProperty s_VerticalCacheLengthProperty;
+    static GlobalDependencyProperty s_horizontalCacheLengthProperty;
+    static GlobalDependencyProperty s_verticalCacheLengthProperty;
 
     static void EnsureProperties();
     static void ClearProperties();

--- a/dev/Repeater/ItemsRepeater.idl
+++ b/dev/Repeater/ItemsRepeater.idl
@@ -1,4 +1,4 @@
-runtimeclass ItemsSourceView;
+﻿runtimeclass ItemsSourceView;
 runtimeclass ItemsRepeater;
 runtimeclass ElementFactory;
 runtimeclass LayoutContext;
@@ -121,6 +121,9 @@ unsealed runtimeclass ItemsRepeater : Windows.UI.Xaml.FrameworkElement
     
     Double HorizontalCacheLength { get; set; };
     Double VerticalCacheLength { get; set; };
+
+    Windows.UI.Xaml.Media.Brush Background{ get; set; };
+
     Int32 GetElementIndex(Windows.UI.Xaml.UIElement element);
     Windows.UI.Xaml.UIElement TryGetElement(Int32 index);
     Windows.UI.Xaml.UIElement GetOrCreateElement(Int32 index);
@@ -134,6 +137,7 @@ unsealed runtimeclass ItemsRepeater : Windows.UI.Xaml.FrameworkElement
     static Windows.UI.Xaml.DependencyProperty AnimatorProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HorizontalCacheLengthProperty { get; };
     static Windows.UI.Xaml.DependencyProperty VerticalCacheLengthProperty { get; };
+    static Windows.UI.Xaml.DependencyProperty BackgroundProperty{ get; };
 }
 
 #ifndef BUILD_WINDOWS

--- a/dev/Repeater/RepeaterFactory.cpp
+++ b/dev/Repeater/RepeaterFactory.cpp
@@ -12,8 +12,8 @@ GlobalDependencyProperty ItemsRepeater::s_itemsSourceProperty{ nullptr };
 GlobalDependencyProperty ItemsRepeater::s_itemTemplateProperty{ nullptr };
 GlobalDependencyProperty ItemsRepeater::s_layoutProperty{ nullptr };
 GlobalDependencyProperty ItemsRepeater::s_animatorProperty{ nullptr };
-GlobalDependencyProperty ItemsRepeater::s_HorizontalCacheLengthProperty{ nullptr };
-GlobalDependencyProperty ItemsRepeater::s_VerticalCacheLengthProperty{ nullptr };
+GlobalDependencyProperty ItemsRepeater::s_horizontalCacheLengthProperty{ nullptr };
+GlobalDependencyProperty ItemsRepeater::s_verticalCacheLengthProperty{ nullptr };
 
 /* static */
 void ItemsRepeater::EnsureProperties()
@@ -78,9 +78,9 @@ void ItemsRepeater::EnsureProperties()
                 winrt::PropertyChangedCallback(&ItemsRepeater::OnPropertyChanged));
     }
 
-    if (!s_HorizontalCacheLengthProperty)
+    if (!s_horizontalCacheLengthProperty)
     {
-        s_HorizontalCacheLengthProperty =
+        s_horizontalCacheLengthProperty =
             InitializeDependencyProperty(
                 L"HorizontalCacheLength",
                 winrt::name_of<winrt::IReference<double>>(),
@@ -90,9 +90,9 @@ void ItemsRepeater::EnsureProperties()
                 winrt::PropertyChangedCallback(&ItemsRepeater::OnPropertyChanged));
     }
 
-    if (!s_VerticalCacheLengthProperty)
+    if (!s_verticalCacheLengthProperty)
     {
-        s_VerticalCacheLengthProperty =
+        s_verticalCacheLengthProperty =
             InitializeDependencyProperty(
                 L"VerticalCacheLength",
                 winrt::name_of<winrt::IReference<double>>(),
@@ -110,8 +110,8 @@ void ItemsRepeater::ClearProperties()
     s_itemTemplateProperty = nullptr;
     s_layoutProperty = nullptr;
     s_animatorProperty = nullptr;
-    s_HorizontalCacheLengthProperty = nullptr;
-    s_VerticalCacheLengthProperty = nullptr;
+    s_horizontalCacheLengthProperty = nullptr;
+    s_verticalCacheLengthProperty = nullptr;
 }
 
 void ItemsRepeater::OnPropertyChanged(

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml
@@ -39,7 +39,7 @@
 
         <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1">
             <ScrollViewer x:Name="scrollViewer">
-                <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0" />
+                <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0" Background="LightBlue"/>
             </ScrollViewer>
         </controls:ScrollAnchorProvider>
 


### PR DESCRIPTION
Isssue: https://github.com/Microsoft/microsoft-ui-xaml/issues/29


# Proposal: Need Background property on ItemsRepeater

## Summary
Adding a background property to ItemsRepeater. This allows setting a background. This is especially useful when trying to override an event like say Drag events since these events do not get raised if there is no background. 

## Rationale
This will be similar to how other panels work.

## Usage Examples
<ItemsRepeater Background="Green" />