### PR TITLE
Update Azure Pipelines to decrease build matrix for CI build and increase job timeout.

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -10,15 +10,6 @@ jobs:
       Debug_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Debug'
-      Debug_x64:
-        buildPlatform: 'x64'
-        buildConfiguration: 'Debug'
-      Debug_Arm:
-        buildPlatform: 'arm'
-        buildConfiguration: 'Debug'
-      Debug_Arm64:
-        buildPlatform: 'arm64'
-        buildConfiguration: 'Debug'
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -3,6 +3,7 @@ jobs:
 - job: Build
   pool:
     vmImage: 'VS2017-Win2016'
+  timeoutInMinutes: 120
   strategy:
     maxParallel: 10
     matrix:

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -3,6 +3,7 @@ jobs:
 - job: Build
   pool:
     vmImage: 'VS2017-Win2016'
+  timeoutInMinutes: 120
   strategy:
     maxParallel: 10
     matrix:


### PR DESCRIPTION
The CI build was failing due to the job taking longer than 60 mins. I am increasing the timeout to 120 mins.

I am also decreasing the size of the build matrix for the CI build so it consumes fewer build machines.