### PR TITLE
Update NuGet tool version from 4.4.1 to 4.9.1

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -41,9 +41,9 @@ jobs:
       arguments: 17763
 
   - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.4.1'
+    displayName: 'Use NuGet 4.9.1'
     inputs:
-      versionSpec: 4.4.1
+      versionSpec: 4.9.1
         
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore MUXControls.sln'
@@ -88,9 +88,9 @@ jobs:
       downloadPath: '$(buildOutputDir)'
 
   - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.4.1'
+    displayName: 'Use NuGet 4.9.1'
     inputs:
-      versionSpec: 4.4.1
+      versionSpec: 4.9.1
 
     # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg
   - powershell: |

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -23,9 +23,9 @@ jobs:
     displayName: 'Install RS5 SDK (17763)'
 
   - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.4.1'
+    displayName: 'Use NuGet 4.9.1'
     inputs:
-      versionSpec: 4.4.1
+      versionSpec: 4.9.1
         
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore MUXControls.sln'


### PR DESCRIPTION
The latest version of NuGet has a number of performance fixes. This reduces the time for a NuGet Restore in the CI builds from 10 mins to 5 mins.