### PR TITLE
We should not crash if an ItemTemplate is not set on ItemsRepeater 

### DIFF
--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -82,6 +82,38 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
+        public void ValidateRepeaterDefaults()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var repeater = new ItemsRepeater() 
+                {
+                    ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
+                };
+
+                Content = new ScrollAnchorProvider() {
+                    Width = 400,
+                    Height = 800,
+                    Content = new ScrollViewer {
+                        Content = repeater
+                    }
+                };
+
+                Content.UpdateLayout();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    var element = repeater.TryGetElement(i);
+                    Verify.IsNotNull(element);
+                    Verify.AreEqual(string.Format("Item #{0}", i), ((TextBlock)element).Text);
+                    Verify.AreEqual(i, repeater.GetElementIndex(element));
+                }
+
+                Verify.IsNull(repeater.TryGetElement(20));
+            });
+        }
+
+        [TestMethod]
         [TestProperty("Bug", "12042052")]
         public void CanSetItemsSource()
         {

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -577,11 +577,11 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
     }
 }
 
-void ItemsRepeater::OnItemTemplateChanged(const winrt::IElementFactory& /* oldValue */, const winrt::IElementFactory&  newValue)
+void ItemsRepeater::OnItemTemplateChanged(const winrt::IElementFactory&  oldValue, const winrt::IElementFactory&  newValue)
 {
-    if (m_isLayoutInProgress)
+    if (m_isLayoutInProgress && oldValue)
     {
-        throw winrt::hresult_error(E_FAIL, L"Generator cannot be changed during layout.");
+        throw winrt::hresult_error(E_FAIL, L"ItemTemplate cannot be changed during layout.");
     }
 
     m_itemTemplate = newValue;

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -16,6 +16,7 @@
         </Grid.Resources>
 
         <StackPanel>
+            <Button x:Name="defaultDemo" >Default Demo</Button>
             <Button x:Name="basicDemo" >Basic Demo</Button>
             <Button x:Name="itemTemplateDemo" >ItemTemplate Demo</Button>
             <Button x:Name="collectionChangeDemo" >Collection Changes Demo</Button>

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
@@ -26,6 +26,11 @@ namespace MUXControlsTestApp
         {
             this.InitializeComponent();
 
+            defaultDemo.Click += delegate 
+            {
+                Frame.NavigateWithoutAnimation(typeof(Defaults));
+            };
+
             basicDemo.Click += delegate
             {
                 Frame.NavigateWithoutAnimation(typeof(BasicDemo));

--- a/dev/Repeater/TestUI/Repeater_TestUI.projitems
+++ b/dev/Repeater/TestUI/Repeater_TestUI.projitems
@@ -40,6 +40,10 @@
       <Generator>MSBuild:Compile</Generator>
       <IncludeInWindowsAppx>false</IncludeInWindowsAppx>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Samples\Defaults.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Samples\ItemsViewWithDataPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -100,6 +104,9 @@
       <DependentUpon>BasicDemo.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Samples\CircleLayoutDemo\CircleLayout.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Samples\Defaults.xaml.cs">
+      <DependentUpon>Defaults.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Samples\ItemTemplateSamples\ItemTemplateDemo.xaml.cs">
       <DependentUpon>ItemTemplateDemo.xaml</DependentUpon>
     </Compile>

--- a/dev/Repeater/TestUI/Samples/Defaults.xaml
+++ b/dev/Repeater/TestUI/Samples/Defaults.xaml
@@ -1,0 +1,24 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Page
+    x:Class="MUXControlsTestApp.Samples.Defaults"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel>
+            <Button x:Name="goBackButton">Back</Button>
+        </StackPanel>
+
+        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1">
+            <ScrollViewer>
+                <controls:ItemsRepeater ItemsSource="{x:Bind Data}" />
+            </ScrollViewer>
+        </controls:ScrollAnchorProvider>
+    </Grid>
+</Page>

--- a/dev/Repeater/TestUI/Samples/Defaults.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/Defaults.xaml.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+
+namespace MUXControlsTestApp.Samples
+{
+    public sealed partial class Defaults : Page
+    {
+        public List<string> Data { get; set; }
+
+        public Defaults()
+        {
+            Data = Enumerable.Range(0, 10000).Select(x => x.ToString()).ToList();
+            this.InitializeComponent();
+        }
+    }
+}

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -592,6 +592,16 @@ winrt::UIElement ViewManager::GetElementFromPinnedElements(int index)
 winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
 {
     // The view generator is the provider of last resort.
+
+    auto itemTemplateFactory = m_owner->ItemTemplateShim();
+    if (!itemTemplateFactory)
+    {
+        // If no ItemTemplate was provided, use a default 
+        auto factory = winrt::XamlReader::Load(L"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'><TextBlock Text='{Binding}'/></DataTemplate>").as<winrt::DataTemplate>();
+        m_owner->ItemTemplate(factory);
+        itemTemplateFactory = m_owner->ItemTemplateShim();
+    }
+
     auto data = m_owner->ItemsSourceView().GetAt(index);
 
     if (!m_ElementFactoryGetArgs)
@@ -614,7 +624,7 @@ winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
     args.as<ElementFactoryGetArgs>()->Index(index);
 #endif
 
-    winrt::UIElement element = m_owner->ItemTemplateShim().GetElement(args);
+    winrt::UIElement element = itemTemplateFactory.GetElement(args);
 
     args.Data(nullptr);
     args.Parent(nullptr);


### PR DESCRIPTION
Issue:https://github.com/Microsoft/microsoft-ui-xaml/issues/34

If ItemTemplate property is not set on ItemsRepeater, we currently crash. Instead we should use a default that stamps out TextBlocks.