### PR TITLE
Add F4 behavior and remove unneeded items from accessible tree.

### DIFF
--- a/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -56,24 +56,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper("SplitButton Tests"))
             {
                 SplitButton splitButton = FindElement.ByName<SplitButton>("TestSplitButton");
-                Button primaryButton = GetPrimaryButton(splitButton);
-                Button secondaryButton = GetSecondaryButton(splitButton);
 
                 TextBlock clickCountTextBlock = FindElement.ByName<TextBlock>("ClickCountTextBlock");
                 TextBlock flyoutOpenedCountTextBlock = FindElement.ByName<TextBlock>("FlyoutOpenedCountTextBlock");
                 TextBlock flyoutClosedCountTextBlock = FindElement.ByName<TextBlock>("FlyoutClosedCountTextBlock");
                 
                 Verify.AreEqual("0", clickCountTextBlock.DocumentText);
-                Log.Comment("Click primary button");
-                primaryButton.Click();
-                Wait.ForIdle();
+                ClickPrimaryButton(splitButton);
                 Verify.AreEqual("1", clickCountTextBlock.DocumentText);
                 VerifyElement.NotFound("TestFlyout", FindBy.Name);
 
                 Verify.AreEqual("0", flyoutOpenedCountTextBlock.DocumentText);
-                Log.Comment("Click secondary button");
-                secondaryButton.Click();
-                Wait.ForIdle();
+                ClickSecondaryButton(splitButton);
                 Verify.AreEqual("1", flyoutOpenedCountTextBlock.DocumentText);
                 VerifyElement.Found("TestFlyout", FindBy.Name);
 
@@ -91,30 +85,24 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper("SplitButton Tests"))
             {
                 SplitButton splitButton = FindElement.ByName<SplitButton>("CommandSplitButton");
-                Button primaryButton = GetPrimaryButton(splitButton);
-                Button secondaryButton = GetSecondaryButton(splitButton);
 
                 CheckBox canExecuteCheckBox = FindElement.ByName<CheckBox>("CanExecuteCheckBox");
                 TextBlock executeCountTextBlock = FindElement.ByName<TextBlock>("ExecuteCountTextBlock");
 
                 Log.Comment("Verify that the control starts out enabled");
                 Verify.AreEqual(ToggleState.On, canExecuteCheckBox.ToggleState);
-                Verify.AreEqual(true, primaryButton.IsEnabled);
-                Verify.AreEqual(true, secondaryButton.IsEnabled);
+                Verify.AreEqual(true, splitButton.IsEnabled);
                 Verify.AreEqual("0", executeCountTextBlock.DocumentText);
 
                 Log.Comment("Click primary button to execute command");
-                InputHelper.MoveMouse(primaryButton, 0, 0);
-                Wait.ForIdle();
-                primaryButton.Click();
-                Wait.ForIdle();
+                ClickPrimaryButton(splitButton);
                 Verify.AreEqual("1", executeCountTextBlock.DocumentText);
                 
                 Log.Comment("Verify that setting CanExecute to false disables the primary button");
                 canExecuteCheckBox.Uncheck();
                 Wait.ForIdle();
-                Verify.AreEqual(false, primaryButton.IsEnabled);
-                Verify.AreEqual(true, secondaryButton.IsEnabled);
+                ClickPrimaryButton(splitButton);
+                Verify.AreEqual("1", executeCountTextBlock.DocumentText);
             }
         }
 
@@ -125,8 +113,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper("SplitButton Tests"))
             {
                 SplitButton splitButton = FindElement.ByName<SplitButton>("TestSplitButton");
-                Button primaryButton = GetPrimaryButton(splitButton);
-                Button secondaryButton = GetSecondaryButton(splitButton);
 
                 CheckBox simulateTouchCheckBox = FindElement.ByName<CheckBox>("SimulateTouchCheckBox");
 
@@ -141,8 +127,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("0", flyoutOpenedCountTextBlock.DocumentText);
 
                 Log.Comment("Click primary button to open flyout in touch mode");
-                primaryButton.Click();
-                Wait.ForIdle();
+                ClickPrimaryButton(splitButton);
                 
                 Verify.AreEqual("0", clickCountTextBlock.DocumentText);
                 Verify.AreEqual("1", flyoutOpenedCountTextBlock.DocumentText);
@@ -165,6 +150,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 TextBlock flyoutOpenedCountTextBlock = FindElement.ByName<TextBlock>("FlyoutOpenedCountTextBlock");
                 TextBlock flyoutClosedCountTextBlock = FindElement.ByName<TextBlock>("FlyoutClosedCountTextBlock");
 
+                Log.Comment("Verify that SplitButton has no accessible children");
+                Verify.AreEqual(0, splitButton.Children.Count);
+
                 Verify.AreEqual("0", clickCountTextBlock.DocumentText);
                 Log.Comment("Verify that invoking the SplitButton causes a click");
                 splitButton.InvokeAndWait();
@@ -174,11 +162,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Verify that expanding the SplitButton opens the flyout");
                 splitButton.ExpandAndWait();
                 Verify.AreEqual("1", flyoutOpenedCountTextBlock.DocumentText);
+                Verify.AreEqual(ExpandCollapseState.Expanded, splitButton.ExpandCollapseState);
 
                 Verify.AreEqual("0", flyoutClosedCountTextBlock.DocumentText);
                 Log.Comment("Verify that collapsing the SplitButton closes the flyout");
                 splitButton.CollapseAndWait();
                 Verify.AreEqual("1", flyoutClosedCountTextBlock.DocumentText);
+                Verify.AreEqual(ExpandCollapseState.Collapsed, splitButton.ExpandCollapseState);
             }
         }
 
@@ -210,10 +200,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("1", flyoutOpenedCountTextBlock.DocumentText);
 
                 Verify.AreEqual("0", flyoutClosedCountTextBlock.DocumentText);
-                Log.Comment("Verify that press escape closes the flyout");
+                Log.Comment("Verify that pressing escape closes the flyout");
                 KeyboardHelper.PressKey(Key.Escape);
                 Wait.ForIdle();
                 Verify.AreEqual("1", flyoutClosedCountTextBlock.DocumentText);
+
+                Log.Comment("Verify that F4 opens the flyout");
+                splitButton.SetFocus();
+                Wait.ForIdle();
+                TextInput.SendText("{F4}");
+                Wait.ForIdle();
+                Verify.AreEqual("2", flyoutOpenedCountTextBlock.DocumentText);
             }
         }
 
@@ -223,8 +220,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper("SplitButton Tests"))
             {
                 SplitButton splitButton = FindElement.ByName<SplitButton>("ToggleSplitButton");
-                Button primaryButton = GetPrimaryButton(splitButton);
-                Button secondaryButton = GetSecondaryButton(splitButton);
 
                 TextBlock toggleStateTextBlock = FindElement.ByName<TextBlock>("ToggleStateTextBlock");
                 TextBlock toggleStateOnClickTextBlock = FindElement.ByName<TextBlock>("ToggleStateOnClickTextBlock");
@@ -233,22 +228,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("Unchecked", toggleStateOnClickTextBlock.DocumentText);
 
                 Log.Comment("Click primary button to check button");
-                primaryButton.Click();
-                Wait.ForIdle();
+                ClickPrimaryButton(splitButton);
 
                 Verify.AreEqual("Checked", toggleStateTextBlock.DocumentText);
                 Verify.AreEqual("Checked", toggleStateOnClickTextBlock.DocumentText);
 
                 Log.Comment("Click primary button to uncheck button");
-                primaryButton.Click();
-                Wait.ForIdle();
+                ClickPrimaryButton(splitButton);
 
                 Verify.AreEqual("Unchecked", toggleStateTextBlock.DocumentText);
                 Verify.AreEqual("Unchecked", toggleStateOnClickTextBlock.DocumentText);
 
                 Log.Comment("Clicking secondary button should not change toggle state");
-                secondaryButton.Click();
-                Wait.ForIdle();
+                ClickSecondaryButton(splitButton);
 
                 Verify.AreEqual("Unchecked", toggleStateTextBlock.DocumentText);
                 Verify.AreEqual("Unchecked", toggleStateOnClickTextBlock.DocumentText);
@@ -276,30 +268,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        public Button GetPrimaryButton(SplitButton splitButton)
+        public void ClickPrimaryButton(SplitButton splitButton)
         {
-            return new Button(FindDescendant(splitButton, "PrimaryButton"));
+            Log.Comment("Click primary button area");
+            splitButton.Click(PointerButtons.Primary, 5, splitButton.BoundingRectangle.Height / 2);
+            Wait.ForIdle();
         }
 
-        public Button GetSecondaryButton(SplitButton splitButton)
+        public void ClickSecondaryButton(SplitButton splitButton)
         {
-            return new Button(FindDescendant(splitButton, "SecondaryButton"));
-        }
-
-        public UIObject FindDescendant(UIObject parent, string id)
-        {
-            UIObject child = null;
-
-            foreach (UIObject o in parent.Descendants)
-            {
-                if (o.AutomationId == id)
-                {
-                    Log.Comment("Found " + id);
-                    child = o;
-                }
-            }
-
-            return child;
+            Log.Comment("Click secondary button area");
+            splitButton.Click(PointerButtons.Primary, splitButton.BoundingRectangle.Width - 5, splitButton.BoundingRectangle.Height / 2);
+            Wait.ForIdle();
         }
     }
 }

--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -297,10 +297,6 @@ void SplitButton::OnSplitButtonKeyDown(const winrt::IInspectable& sender, const 
         m_isKeyDown = true;
         UpdateVisualStates();
     }
-    else if (key == winrt::VirtualKey::Menu)
-    {
-        m_isAltKeyDown = true;
-    }
 }
 
 void SplitButton::OnSplitButtonKeyUp(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args)
@@ -318,18 +314,23 @@ void SplitButton::OnSplitButtonKeyUp(const winrt::IInspectable& sender, const wi
             args.Handled(true);
         }
     }
-    else if (key == winrt::VirtualKey::Menu)
-    {
-        m_isAltKeyDown = false;
-    }
     else if (key == winrt::VirtualKey::Down)
     {
-        if (IsEnabled() && m_isAltKeyDown)
+        winrt::CoreVirtualKeyStates menuState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Menu);
+        bool menuKeyDown = (menuState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+
+        if (IsEnabled() && menuKeyDown)
         {
             // Open the menu on alt-down
             OpenFlyout();
             args.Handled(true);
         }
+    }
+    else if (key == winrt::VirtualKey::F4 && IsEnabled())
+    {
+        // Open the menu on F4
+        OpenFlyout();
+        args.Handled(true);
     }
 }
 

--- a/dev/SplitButton/SplitButton.h
+++ b/dev/SplitButton/SplitButton.h
@@ -65,7 +65,6 @@ private:
     bool m_isFlyoutOpen{ false };
     winrt::PointerDeviceType m_lastPointerDeviceType{ winrt::PointerDeviceType::Mouse };
     bool m_isKeyDown{ false };
-    bool m_isAltKeyDown{ false };
 
     winrt::UIElement::KeyDown_revoker m_keyDownRevoker{};
     winrt::UIElement::KeyUp_revoker m_keyUpRevoker{};

--- a/dev/SplitButton/SplitButton.xaml
+++ b/dev/SplitButton/SplitButton.xaml
@@ -252,7 +252,8 @@
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Padding="{TemplateBinding Padding}"
-                            IsTabStop="False"/>
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw"/>
 
                         <Button x:Name="SecondaryButton"
                             Grid.Column="1"
@@ -265,7 +266,8 @@
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Padding="0,0,8,0"
-                            IsTabStop="False">
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw">
                             <Button.Content>
                                 <TextBlock
                                     FontFamily="Segoe MDL2 Assets"

--- a/dev/SplitButton/SplitButton_rs1.xaml
+++ b/dev/SplitButton/SplitButton_rs1.xaml
@@ -16,7 +16,7 @@
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualMargin" Value="-3" />
-        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="IsTabStop" Value="True"/>
         <Setter Property="Padding" Value="{ThemeResource ButtonPadding}"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -271,7 +271,9 @@
                             CommandParameter="{TemplateBinding CommandParameter}"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
-                            Padding="{TemplateBinding Padding}"/>
+                            Padding="{TemplateBinding Padding}"
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw"/>
 
                         <Button x:Name="SecondaryButton"
                             Grid.Column="1"
@@ -283,7 +285,9 @@
                             VerticalContentAlignment="Stretch"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
-                            Padding="0,0,8,0">
+                            Padding="0,0,8,0"
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw">
                             <Button.Content>
                                 <TextBlock
                                     x:Name="ChevronTextBlock"
@@ -291,7 +295,8 @@
                                     FontSize="12"
                                     Text="&#xE70D;"
                                     VerticalAlignment="Center"
-                                    HorizontalAlignment="Right"/>
+                                    HorizontalAlignment="Right"
+                                    AutomationProperties.AccessibilityView="Raw"/>
                             </Button.Content>
                         </Button>
                     </Grid>


### PR DESCRIPTION
SplitButton has a couple accessibility bugs for the two buttons inside of it. Since accessibility users have no reason to need to access those buttons directly, I removed them from the tree. Curiously, the tab stop situation was different on rs1 vs. everyone else, so I fixed that. Also added F4 as a key that shows the attached flyout.