### PR TITLE
Fix ambiguous type build warnings in MuxControlsTestAppWPF project

### DIFF
--- a/test/MUXControlsTestAppWPF/MUXControlsTestAppWPF.csproj
+++ b/test/MUXControlsTestAppWPF/MUXControlsTestAppWPF.csproj
@@ -175,10 +175,6 @@
       <Project>{ad0c90b0-4845-4d4b-88f1-86f653f8171b}</Project>
       <Name>Microsoft.UI.Xaml</Name>
     </ProjectReference>
-    <ProjectReference Include="..\MUXControlsTestAppForIslands\MUXControlsTestAppForIslands.csproj">
-      <Project>{43B830B3-6CAA-4C1B-9B09-C324D9E578A0}</Project>
-      <Name>MUXControlsTestAppForIslands</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="MUXControlsTestAppWPF\themes\" />


### PR DESCRIPTION
Fixing a reference that caused ambiguous type warnings. The WPFApp includes files generated from the MuxControlsTestAppForIslands and builds it - it does not need to reference the project also which ended up causing the same types to be defined twice.

Internal Issue: https://microsoft.visualstudio.com/DefaultCollection/OS/_queries/edit/19755236
Test Run: https://microsoft.visualstudio.com/WinUI/WinUI%20Team/_build/results?buildId=13260634 