### PR TITLE
Removed unnecessary Setter in NavigationView default UWP Style

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -108,7 +108,6 @@
                                 <VisualState x:Name="TitleBarVisible" />
                                 <VisualState x:Name="TitleBarCollapsed">
                                     <VisualState.Setters>
-                                        <Setter Target="PaneButtonGrid.Margin" Value="0,32,0,0"/>
                                         <Setter Target="PaneContentGrid.Margin" Value="0,32,0,0"/>
                                     </VisualState.Setters>
                                 </VisualState>


### PR DESCRIPTION
### Removed unnecessary Setter in NavigationView default UWP Style

Removed PaneButtonGrid.Margin in the VisualState Setters for the default UWP NavigationView Style.
PaneButtonGrid does not exist in the NavigationView template and in the code behind of the control.

![image](https://user-images.githubusercontent.com/16295702/49615673-4ee9b480-f97c-11e8-9394-f26b7c2c8e42.png)

![image](https://user-images.githubusercontent.com/16295702/49615708-64f77500-f97c-11e8-88b6-c62d079469a5.png)
