### PR TITLE
Repoint OS ports to the public GitHub repository

### DIFF
--- a/tools/WindowsPorting/ScriptsToCopy/CommitSync.cmd
+++ b/tools/WindowsPorting/ScriptsToCopy/CommitSync.cmd
@@ -4,14 +4,6 @@ setlocal enableDelayedExpansion
 if "%1"=="" goto :Usage
 if "%2"=="" goto :Usage
 
-if not "%3"=="" (
-    set SyncCommand=!SyncCommand! -DEPControlsBranch %3
-)
-
-if not "%4"=="" (
-    set SyncCommand=!SyncCommand! -PortingBranch %4
-)
-
 set CommitCommand=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -File %~dp0\CommitSync.ps1 -SyncedToCommitId %1 -PersonalAccessToken %2
 
 echo Running "%CommitCommand%"
@@ -22,7 +14,7 @@ goto :End
 :Usage
 
 echo.
-echo Usage: CommitSync.cmd ^<commit to sync to^> ^<access token^> [^<source branch^>] [^<porting branch^>]
+echo Usage: CommitSync.cmd ^<commit to sync to^> ^<access token^>
 echo.
 
 :End

--- a/tools/WindowsPorting/ScriptsToCopy/CommitSync.ps1
+++ b/tools/WindowsPorting/ScriptsToCopy/CommitSync.ps1
@@ -294,7 +294,7 @@ if ($commitList.Count -eq 0)
 }
 elseif ($commitList.Count -gt 2)
 {
-    # If we have more than one MUXControls commit that we're porting over
+    # If we have more than one Microsoft.UI.Xaml commit that we're porting over
     # (we check count > 2 since we're ignore the last-synced to commit),
     # then we don't want to attach a name to the accompanying OS repo commit.
     # We'll use the generic name in that case.

--- a/tools/WindowsPorting/ScriptsToCopy/CommitSync.ps1
+++ b/tools/WindowsPorting/ScriptsToCopy/CommitSync.ps1
@@ -320,7 +320,7 @@ $commitList | ForEach-Object {
         $commitComment = (Get-Commit $_.sha).commit.message
         $commitMessage += $commitComment
         $commitMessage += [Environment]::NewLine + [Environment]::NewLine
-        $commitMessage += "Microsoft.UI.Xaml commit $($_.sha) by $($_.commit.committer.name) ($($_.commit.committer.email)) on $((Get-Date $_.commit.committer.date -Format F))"
+        $commitMessage += "Microsoft.UI.Xaml commit $($_.sha) by $($_.commit.author.name) ($($_.commit.author.email)) on $((Get-Date $_.commit.committer.date -Format F))"
 
         # There appears to be no API to extract work items attached to a commit (pull requests yes; commits no),
         # so we'll use a simple regex to pull that information out of the commit message, since it has a consistent form.


### PR DESCRIPTION
We need to change our script that commits ports to retrieve information from the public GitHub repo, which has a slightly different REST API surface, as well.

While I was here, I also removed the last two parameters from CommitSync.ps1.  We literally never use them, and CommitSync.cmd wasn't even passing them in correctly.