### PR TITLE
Fix reflow logic in flow layouts

### DIFF
--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -52,12 +52,11 @@ winrt::Size FlowLayoutAlgorithm::Measure(
     }
 
     m_elementManager.OnBeginMeasure(orientation);
-    bool firstElementNotRealizedBefore = m_elementManager.GetRealizedElementCount() == 0 || m_elementManager.GetDataIndexFromRealizedRangeIndex(0) != 0;
 
     int anchorIndex = GetAnchorIndex(availableSize, isWrapping, minItemSpacing, layoutId);
     Generate(GenerateDirection::Forward, anchorIndex, availableSize, minItemSpacing, lineSpacing, layoutId);
     Generate(GenerateDirection::Backward, anchorIndex, availableSize, minItemSpacing, lineSpacing, layoutId);
-    if (firstElementNotRealizedBefore && IsReflowRequired())
+    if (isWrapping && IsReflowRequired())
     {
         REPEATER_TRACE_INFO(L"%ls: \tReflow Pass \n", layoutId.data());
         auto firstElementBounds = m_elementManager.GetLayoutBoundsForRealizedIndex(0);
@@ -364,8 +363,7 @@ void FlowLayoutAlgorithm::Generate(
 
 bool FlowLayoutAlgorithm::IsReflowRequired() const
 {
-    // Is the MinorStart of element for data index 0 at 0 ?
-    // For stack layout it will always be at 0, so this will always return false
+    // If first element is realized and is not at the very begining we need to reflow.
     return
         m_elementManager.GetRealizedElementCount() > 0 &&
         m_elementManager.GetDataIndexFromRealizedRangeIndex(0) == 0 &&

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -363,7 +363,7 @@ void FlowLayoutAlgorithm::Generate(
 
 bool FlowLayoutAlgorithm::IsReflowRequired() const
 {
-    // If first element is realized and is not at the very begining we need to reflow.
+    // If first element is realized and is not at the very beginning we need to reflow.
     return
         m_elementManager.GetRealizedElementCount() > 0 &&
         m_elementManager.GetDataIndexFromRealizedRangeIndex(0) == 0 &&


### PR DESCRIPTION
Sometimes, after scrolling back, if the anchor is not the very first item, we could end up not doing a reflow which causes us to end up with incorrect layout where the first item is on a single row and there is an empty slot next to it. With this change, if the first item is ever not in its correct place, we force a reflow. I could not get a solid repro, so there is no new test added for this change. We do already have tests that verify the reflow.

Internal Issue: https://microsoft.visualstudio.com/OS/_queries/edit/19618165 
Tests: https://microsoft.visualstudio.com/WinUI/WinUI%20Team/_build/results?buildId=13313753 