### PR TITLE
IXamlMetadataProvider generation should be based on the "public" metadata, not the internal metadata

### DIFF
--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -444,7 +444,7 @@
     <None Include="CommonHelpers.tt" />
     <None Include="CppWinRTFilterTypes.tt" />
     <T4ParameterValues Include="MetadataWinmdPaths">
-      <Value>$(OutDir)$(TargetName).winmd;$(OutDir)Microsoft.UI.Private.winmd</Value>
+      <Value>$(OutDir)\sdk\Microsoft.UI.Xaml.winmd</Value>
     </T4ParameterValues>
   </ItemGroup>
   <ItemGroup Condition="$(BuildingWithBuildExe) == 'true'">


### PR DESCRIPTION
Fix #22 

The problem is that our IXMP generated code answers for "private" types, which causes problems where the parser starts asking about types like XamlAmbientLight which it finds squirreled away in the UIElement tree. It asks about these types because "private" DependencyProperties refer to those types and our IXMP implementation returns a XamlType instance corresponding to it. That then causes the .NET runtime to try to turn the TypeName into a real type and it crashes because there's no metadata in the app's WinMDs of that typename. The parser folks recommended that we just return null for "private" types so in this change I switched the XamlMetadataProvider codegen to use the winmd file that's included in the nuget package instead of the "private" one. This way our IXMP is in sync with what's in the nuget package.

Verified that the nuget package with this fix allows XamlControlsGallery to launch again.

Tests passed: https://microsoft.visualstudio.com/WinUI/_build/results?buildId=13332466&_a=summary