### PR TITLE
MUX NavigationView should throw if WUXC NavViewItems are added to it

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3143,6 +3143,14 @@ void NavigationView::UpdateListViewItemSource()
                 }
                 });
         }
+        else
+        {
+            m_menuItemsVectorChangedRevoker.revoke();
+        }
+    }
+    else
+    {
+        m_menuItemsVectorChangedRevoker.revoke();
     }
 
     if (!m_appliedTemplate)

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3101,7 +3101,7 @@ void NavigationView::UpdateListViewItemSource()
             auto wuxItem = item.try_as<winrt::Windows::UI::Xaml::Controls::NavigationViewItem>();
             if (wuxItem)
             {
-                throw winrt::hresult_invalid_argument(L"List contains Windows.UI.Xaml.Controls.NavigationViewItem. This control requires that the NavigationViewItems be of type Microsoft.UI.Xaml.Controls.NavigationViewITem");
+                throw winrt::hresult_invalid_argument(L"MenuItems contains a Windows.UI.Xaml.Controls.NavigationViewItem. This control requires that the NavigationViewItems be of type Microsoft.UI.Xaml.Controls.NavigationViewItem.");
             }
         };
 
@@ -3123,7 +3123,7 @@ void NavigationView::UpdateListViewItemSource()
             checkListIsValid(observableVector);
 
             // And any future content changes
-            m_menuItemsVectorChangedToken = observableVector.VectorChanged({
+            m_menuItemsVectorChangedRevoker = observableVector.VectorChanged(winrt::auto_revoke, {
                 [checkItemIsValid, checkListIsValid](winrt::IObservableVector<winrt::IInspectable> const& sender, winrt::IVectorChangedEventArgs const& args)
                 {
                     switch (args.CollectionChange())

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -328,6 +328,7 @@ private:
     winrt::SplitView::PaneOpening_revoker m_splitViewPaneOpeningRevoker{};
     winrt::FrameworkElement::LayoutUpdated_revoker m_layoutUpdatedToken{};
     winrt::UIElement::AccessKeyInvoked_revoker m_accessKeyInvokedRevoker{};
+    winrt::event_token m_menuItemsVectorChangedToken{};
 
     bool m_wasForceClosed{ false };
     bool m_isClosedCompact{ false };

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -328,7 +328,7 @@ private:
     winrt::SplitView::PaneOpening_revoker m_splitViewPaneOpeningRevoker{};
     winrt::FrameworkElement::LayoutUpdated_revoker m_layoutUpdatedToken{};
     winrt::UIElement::AccessKeyInvoked_revoker m_accessKeyInvokedRevoker{};
-    winrt::event_token m_menuItemsVectorChangedToken{};
+    winrt::IObservableVector<IInspectable>::VectorChanged_revoker m_menuItemsVectorChangedRevoker{};
 
     bool m_wasForceClosed{ false };
     bool m_isClosedCompact{ false };

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -3,6 +3,9 @@
 
 using MUXControlsTestApp.Utilities;
 
+using System;
+using System.Collections.Generic;
+
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
@@ -362,5 +365,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 #endif
 
+        [TestMethod]
+        public void VerifyCanNotAddWUXItems()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var navView = new NavigationView();
+
+                // Nothing should go wrong adding a MUX item
+                var muxItem = new Microsoft.UI.Xaml.Controls.NavigationViewItem { Content = "MUX Item" };
+                navView.MenuItems.Add(muxItem);
+
+                navView.MenuItems.Add(new Microsoft.UI.Xaml.Controls.NavigationViewItemSeparator());
+
+                // But adding a MUX item should generate an exception
+                var wuxItem = new Windows.UI.Xaml.Controls.NavigationViewItem { Content = "WUX Item" };
+                Verify.Throws<Exception>(() => { navView.MenuItems.Add(wuxItem); });
+            });
+        }
     }
 }


### PR DESCRIPTION
Because NavView.MenuItems is typed to collection of object, it is easy to accidentally add WUX NavViewItems to a MUX NavView. This is technically a valid thing to do, but it results in bizarre behavior that is confusing to app authors without a easy way of understanding what went wrong.

The MUX NavView should explicitly check for WUXC NavView items and throw with an easily understandable error message so that the app author knows how to fix their app.

[Instance of someone hitting this](https://github.com/Microsoft/microsoft-ui-xaml/issues/1)
[Internal tracking issue](https://microsoft.visualstudio.com/OS/ft_xamlcon/_workitems/edit/19017881)