### PR TITLE
Change version to 2.1

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -3,26 +3,26 @@
   <Import Project="$(MSBuildThisFileDirectory)\MicrosoftUIXamlVersion.props"/>
   <Import Project="$(MSBuildThisFileDirectory)\Common.targets"/>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Release</Configuration>
       <Architecture>x86</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Debug</Configuration>
       <Architecture>x86</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
     <!-- Some C++/CX projects use Platform=Win32 instead of Platform=x86 -->
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Release</Configuration>
       <Architecture>Win32</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Debug</Configuration>
       <Architecture>Win32</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
@@ -30,13 +30,13 @@
     </AppxPackageRegistration>
   </ItemGroup>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Release</Configuration>
       <Architecture>x64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Debug</Configuration>
       <Architecture>x64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
@@ -44,13 +44,13 @@
     </AppxPackageRegistration>
   </ItemGroup>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Release</Configuration>
       <Architecture>arm</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Debug</Configuration>
       <Architecture>arm</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
@@ -58,13 +58,13 @@
     </AppxPackageRegistration>
   </ItemGroup>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Release</Configuration>
       <Architecture>arm64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.3.0.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.1.appx">
       <Configuration>Debug</Configuration>
       <Architecture>arm64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>

--- a/custom.props
+++ b/custom.props
@@ -7,8 +7,8 @@
   </PropertyGroup>
   
   <PropertyGroup Label="Version">
-    <VersionMajor>3</VersionMajor>
-    <VersionMinor>0</VersionMinor>
+    <VersionMajor>2</VersionMajor>
+    <VersionMinor>1</VersionMinor>
     <XesUseOneStoreVersioning>true</XesUseOneStoreVersioning>
     <XesBaseYearForStoreVersion>2016</XesBaseYearForStoreVersion>
     <VersionInfoProductName>Microsoft.UI.Xaml</VersionInfoProductName>

--- a/dev/inc/BuildMacros.h
+++ b/dev/inc/BuildMacros.h
@@ -22,7 +22,7 @@
 #ifdef _DEBUG
 // NOTE: This could be "Microsoft.UI.Xaml.Debug" if we wanted to have Debug framework packages be distinct and
 // installed side-by-side on a machine.
-#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.3.0"
+#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.2.1"
 #else
-#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.3.0"
+#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.2.1"
 #endif

--- a/tools/MakeAppxHelper.cmd
+++ b/tools/MakeAppxHelper.cmd
@@ -40,7 +40,7 @@ if "%XES_OUTDIR%" == "" (
 )
 
 call ..\build\FrameworkPackage\MakeFrameworkPackage.cmd -Inputs '%WinMDInputs%' ^
--OutputDirectory '%OutputDirectory%' -BasePackageName '%BasePackageName%' -PackageNameSuffix 3.0 ^
+-OutputDirectory '%OutputDirectory%' -BasePackageName '%BasePackageName%' -PackageNameSuffix 2.1 ^
 -Platform %TFS_PLATFORM% -Configuration %TFS_BUILDCONFIGURATION% ^
 -TestAppManifest %TestAppManifest% %3 %4 %5 %6 %7 %8 %9
 


### PR DESCRIPTION
The PMs finally came around on this and agreed to keep the major version the same for most releases and only bump it occasionally. Hence, going back to 2.1 instead of 3.0 for the current release.