### PR TITLE
Try to fix the stability issue of LightDismissTest and VerifyLightDismissDoesntSendDuplicateEvents

### DIFF
--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3102,7 +3102,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                             WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
                             Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState);
                             Verify.AreEqual(expectedString, closingCounts.GetText());
-                            return;
                         });
                 }
             }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -2857,6 +2857,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 string expectString = status == PaneOpenStatus.Opened ? "Opened" : "Closed";
                 var eventTextBlock = new TextBlock(FindElement.ByName("PaneOpenedOrClosedEvent"));
 
+                Log.Comment("PaneOpenedOrClosedEvent before wait: " + eventTextBlock.GetText());
                 TestEnvironment.VerifyAreEqualWithRetry(100, // wait max to 5s
                     () => expectString,
                     () => eventTextBlock.GetText());
@@ -2884,45 +2885,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         return;
                     }
 
-                    // Bug 19409503
-                    if (PlatformConfiguration.IsOsVersion(OSVersion.Redstone3))
-                    {
-                        Log.Warning("Test is disabled on RS3 because it's not stable");
-                        return;
-                    }
-
-                    SetNavViewWidth(ControlWidth.Medium);
-
                     CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
 
-                    // On phone, the pane will initially be in the closed compact state, so open it before
-                    // proceeding with the test.
-                    if (isPaneOpenCheckBox.ToggleState == ToggleState.Off)
+                    Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState, "Pane should be open by default since test is disabled on mobile");
+
+                    SetNavViewWidth(ControlWidth.Medium);
+                    WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+
+                    using (var waiter = isPaneOpenCheckBox.GetToggledWaiter())
                     {
-                        using (var waiter = isPaneOpenCheckBox.GetToggledWaiter())
-                        {
-                            isPaneOpenCheckBox.Toggle();
-                            waiter.Wait();
-                        }
-                        WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
+                        isPaneOpenCheckBox.Toggle();
+                        waiter.Wait();
                     }
+                    WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
 
                     Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState);
 
-                    KeyboardHelper.PressKey(Key.Backspace, ModifierKey.Windows);
-                    Wait.ForIdle();
-                    WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
-                    Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "Verify Windows+Back light dismisses the pane");
+                    PaneOpenCloseTestCaseRetry(3, () =>
+                    {
+                        KeyboardHelper.PressKey(Key.Backspace, ModifierKey.Windows);
+                        Wait.ForIdle();
+                        WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+                        Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "Verify Windows+Back light dismisses the pane");
+                    });
 
                     isPaneOpenCheckBox.Toggle();
                     Wait.ForIdle();
                     WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
                     Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState);
 
-                    KeyboardHelper.PressKey(Key.Left, ModifierKey.Alt);
-                    Wait.ForIdle();
-                    WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
-                    Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "Verify Alt+Left light dismisses the pane");
+                    PaneOpenCloseTestCaseRetry(3, () =>
+                    {
+                        KeyboardHelper.PressKey(Key.Left, ModifierKey.Alt);
+                        Wait.ForIdle();
+                        WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+                        Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "Verify Alt+Left light dismisses the pane");
+                    });
 
                     isPaneOpenCheckBox.Toggle();
                     Wait.ForIdle();
@@ -3006,7 +3004,38 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 }
             }
         }
-      
+
+        private void PaneOpenCloseTestCaseRetry(int retryNumber, Action action)
+        {
+            for (int i = 0; i < retryNumber; i++)
+            {
+                try
+                {
+                    if (i > 0)
+                    {
+                        Log.Comment("Retry on " + i);
+                    }
+                    action();
+                    return;
+                }
+                catch (Exception e)
+                {
+                    CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
+                    Log.Comment("IsPaneOpenCheckBox toggle status: " + isPaneOpenCheckBox.ToggleState);
+
+                    Edit closingCounts = new Edit(FindElement.ByName("ClosingEventCountTextBlock"));
+                    Log.Comment("ClosingEventCountTextBlock text: " + closingCounts.GetText());
+
+                    TextBlock eventTextBlock = new TextBlock(FindElement.ByName("PaneOpenedOrClosedEvent"));
+                    Log.Comment("PaneOpenedOrClosedEvent text: " + eventTextBlock.GetText());
+
+                    Log.Comment(e.Message);
+                }
+            }
+
+            throw new Exception("Reach max number of retry " + retryNumber);
+        }
+
         [TestMethod]
         public void VerifyLightDismissDoesntSendDuplicateEvents()
         {
@@ -3028,43 +3057,53 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         return;
                     }
                     
-                    // Bug 19409503
-                    if (PlatformConfiguration.IsOsVersion(OSVersion.Redstone3))
-                    {
-                        Log.Warning("Test is disabled on RS3 because it's not stable");
-                        return;
-                    }
+                    CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
+                    Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState, "Pane should be open by default since test is disabled on mobile");
 
                     SetNavViewWidth(ControlWidth.Medium);
-
-                    CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
-
-                    Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState);
-
-                    Log.Comment("Reset the event count");
-                    new Button(FindElement.ById("ClosingEventCountResetButton")).Invoke();
-                    Wait.ForIdle();
-
-                    Log.Comment("Open the pane");
-                    using (var waiter = isPaneOpenCheckBox.GetToggledWaiter())
-                    {
-                        isPaneOpenCheckBox.Toggle();
-                        waiter.Wait();
-                    }
-                    WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
-
-                    Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState);
-
-                    var closingCounts = new Edit(FindElement.ByName("ClosingEventCountTextBlock"));
-                    var expectedString = "1-1";
-
-                    //  trigger a light dismiss
-                    KeyboardHelper.PressKey(Key.Left, ModifierKey.Alt);
-                    Wait.ForIdle();
-
                     WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
-                    Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState);
-                    Verify.AreEqual(expectedString, closingCounts.GetText());
+
+                    PaneOpenCloseTestCaseRetry(3, () =>
+                        {
+                            // recover from the exception if needed
+                            if (isPaneOpenCheckBox.ToggleState != ToggleState.Off)
+                            {
+                                using (var waiter = isPaneOpenCheckBox.GetToggledWaiter())
+                                {
+                                    isPaneOpenCheckBox.Toggle();
+                                    waiter.Wait();
+                                }
+                                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+                            }
+
+                            Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState);
+
+                            Log.Comment("Reset the event count");
+                            new Button(FindElement.ById("ClosingEventCountResetButton")).Invoke();
+                            Wait.ForIdle();
+
+                            Log.Comment("Open the pane");
+                            using (var waiter = isPaneOpenCheckBox.GetToggledWaiter())
+                            {
+                                isPaneOpenCheckBox.Toggle();
+                                waiter.Wait();
+                            }
+                            WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
+
+                            Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState);
+
+                            var closingCounts = new Edit(FindElement.ByName("ClosingEventCountTextBlock"));
+                            var expectedString = "1-1";
+
+                            //  trigger a light dismiss
+                            KeyboardHelper.PressKey(Key.Left, ModifierKey.Alt);
+                            Wait.ForIdle();
+
+                            WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+                            Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState);
+                            Verify.AreEqual(expectedString, closingCounts.GetText());
+                            return;
+                        });
                 }
             }
         }


### PR DESCRIPTION
Two bugs are related to this PR: Bug 19816577 and Bug 19409503.
1. Refactor the two test cases and remove some unreachable checks.
2. Add PaneOpenCloseTestCaseRetry
3. Enable tests on RS3 (Bug 19409503.)
4. add more debug informaiton

This may not actually fix the problem, but will provide more information for troubleshooting

The two tests are not very stable, and errors like below:
LightDismissTest failure:
Send text '{WIN DOWN}{BACKSPACE}{WIN UP}'.
Actual retry times: 100
[Error]: AreEqual(Closed, Opened)

VerifyLightDismissDoesntSendDuplicateEvents failures:
[Error]: AreEqual(1-1, 1-2)

Problem is because of delayed animation.
For LightDismissTest, most likely, we send out the keys too early and the pane is not fully opened yet because of animation.
For VerifyLightDismissDoesntSendDuplicateEvents, best guess is that We clicked ClosingEventCountResetButton, but the Pane is not fully closed yet after SetNavViewWidth. so I add WaitAndAssertPaneStatus after that.


tests passed: https://microsoft.visualstudio.com/WinUI/WinUI%20Team/_build/results?buildId=13377717
