### PR TITLE
fix build break in debug_test configuration

### DIFF
--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -169,6 +169,7 @@
     <AppxPackageExtension Condition="'$(AppxPackageExtension)'==''">.appx</AppxPackageExtension>
     <AppxPackageTestDir Condition="'$(AppxPackageTestDir)'==''">$(AppxPackageDir)$(AppxPackageName)_Test\</AppxPackageTestDir>
     <AppxPackageOutput Condition="'$(AppxPackageOutput)'==''">$(AppxPackageTestDir)$(AppxPackageName)$(AppxPackageExtension)</AppxPackageOutput>
+    <AppxIntermediateExtension Condition="'$(AppxIntermediateExtension)'==''">.intermediate</AppxIntermediateExtension>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\..\..\build\MSTest.pfx" />


### PR DESCRIPTION
This fixes the build break in muxcontrolstestapp project when building under debug_test configuration. I'm able to now build and run tests and see the incremental build picking up changes in the new run. Still hitting an issue during debug tests but that seems unrelated.

Issue: https://github.com/Microsoft/microsoft-ui-xaml/issues/74
Test Run: https://microsoft.visualstudio.com/WinUI/WinUI%20Team/_build/results?buildId=13383273