### PR TITLE
Update NugetWrapper.cmd to download nuget.exe 

### DIFF
--- a/tools/NugetWrapper.cmd
+++ b/tools/NugetWrapper.cmd
@@ -3,6 +3,11 @@ setlocal
 
 set VisualStudioVersion=15.0
 
-\\edge-svcs\nuget\v4.6.2\NuGet.exe %*
+if not exist %TEMP%\nuget.4.9.2.exe (
+    echo Nuget.exe not found in the temp dir, downloading.
+    powershell -Command "& { Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/v4.9.2/nuget.exe -outfile $env:TEMP\nuget.4.9.2.exe }"
+)
+
+%TEMP%\nuget.4.9.2.exe %*
 
 exit /B %ERRORLEVEL%


### PR DESCRIPTION
The share we were using internally just disappeared. I don't want to rely on everyone having a specific version of nuget.exe on their path so I think this script still has value, but it should grab nuget from a more stable location.

I'm just downloading from nuget.org for now -- I assume this is a pretty stable url?