### PR TITLE
fix CI build on arm

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -32,7 +32,7 @@ PublishFile $FullBuildOutput\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd $Full
 PublishFile $FullBuildOutput\Microsoft.UI.Xaml\Generic.xaml $FullPublishDir\Microsoft.UI.Xaml\
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml.Design\Microsoft.UI.Xaml.Design.dll $FullPublishDir\Microsoft.UI.Xaml.Design\
 
-PublishFile $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\MUXControls.Test.dll $FullPublishDir\Test\
+PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\MUXControls.Test.dll $FullPublishDir\Test\
 
 # Publish pdbs:
 $symbolsOutputDir = "$($FullPublishDir)\Symbols\"


### PR DESCRIPTION
We don't build MUXControls.Test.dll on arm64. 

Manually run of this commit here: https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=778