### PR TITLE
MenuBar: Fixes to accessibility and visual issues.

### DIFF
--- a/dev/MenuBar/MenuBar.xaml
+++ b/dev/MenuBar/MenuBar.xaml
@@ -12,7 +12,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:MenuBar">
                     <Grid x:Name="LayoutRoot" Background="{TemplateBinding Background}" HorizontalAlignment="Stretch">
-                        <ItemsControl x:Name="ContentRoot" VerticalAlignment="Stretch" HorizontalAlignment="Left">
+                        <ItemsControl x:Name="ContentRoot" VerticalAlignment="Stretch" HorizontalAlignment="Left" IsTabStop="False">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal"/>

--- a/dev/MenuBar/MenuBarItem.xaml
+++ b/dev/MenuBar/MenuBarItem.xaml
@@ -9,8 +9,9 @@
         <Setter Property="BorderThickness" Value="{ThemeResource MenuBarItemBorderThickness}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource MenuBarItemBorderBrush}"/>
         <Setter Property="Title" Value="Item"/>
-        <Setter Property="IsTabStop" Value="False"/>
+        <Setter Property="IsTabStop" Value="True"/>
         <Setter Property="ExitDisplayModeOnAccessKeyInvoked" Value="False"/>
+        <Setter Property="UseSystemFocusVisuals" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:MenuBarItem">
@@ -69,7 +70,9 @@
                             Background="Transparent"
                             BorderThickness="0"
                             VerticalAlignment="Stretch"
-                            Padding="12,0,12,0"/>
+                            Padding="12,0,12,0"
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw"/>
                     </Grid>
 
                 </ControlTemplate>

--- a/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
+++ b/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
@@ -312,5 +312,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(menuBarItem.BoundingRectangle.Height, 24);
             }
         }
+
+
+        [TestMethod]
+        public void TabTest()
+        {
+            if (PlatformConfiguration.IsDevice(DeviceType.Phone))
+            {
+                Log.Comment("Skipping tests on phone, because menubar is not supported.");
+                return;
+            }
+            using (var setup = new TestSetupHelper("MenuBar Tests"))
+            {
+                var firstButton = FindElement.ByName<Button>("FirstButton");
+                var fileButton = FindElement.ById<Button>("FileItem");
+
+                firstButton.SetFocus();
+                Wait.ForIdle();
+
+                Log.Comment("Verify that pressing tab from previous control goes to the File item");
+                KeyboardHelper.PressKey(Key.Tab);
+                Wait.ForIdle();
+                
+                Verify.AreEqual(true, fileButton.HasKeyboardFocus);
+            }
+        }
     }
 }

--- a/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
+++ b/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
@@ -17,6 +17,8 @@
         </Grid.RowDefinitions>
 
         <StackPanel x:Name="contentRoot" Grid.Row="0">
+            <Button AutomationProperties.Name="FirstButton" Content="First Button"/>
+
             <muxc:MenuBar x:Name="menuBar">
                 <muxc:MenuBarItem x:Name="FileItem" AutomationProperties.Name="FileItem" Title="File">
                     <MenuFlyoutItem x:Name="NewItem" AutomationProperties.Name="NewItem" Text="New" Click="NewItem_Click"/>

--- a/dev/MenuBar/MenuBar_themeresources.xaml
+++ b/dev/MenuBar/MenuBar_themeresources.xaml
@@ -14,7 +14,7 @@
             <StaticResource x:Key="MenuBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="MenuBarItemBackgroundPointerOver" ResourceKey="SystemControlBackgroundListLowBrush" />
             <StaticResource x:Key="MenuBarItemBackgroundPressed" ResourceKey="SystemControlBackgroundListMediumBrush" />
-            <StaticResource x:Key="MenuBarItemBackgroundSelected" ResourceKey="SystemControlBackgroundListLowBrush" />
+            <StaticResource x:Key="MenuBarItemBackgroundSelected" ResourceKey="SystemControlBackgroundListMediumBrush" />
 
             <Thickness x:Key="MenuBarItemBorderThickness">0</Thickness>
 
@@ -30,7 +30,7 @@
             <StaticResource x:Key="MenuBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="MenuBarItemBackgroundPointerOver" ResourceKey="SystemControlBackgroundListLowBrush" />
             <StaticResource x:Key="MenuBarItemBackgroundPressed" ResourceKey="SystemControlBackgroundListMediumBrush" />
-            <StaticResource x:Key="MenuBarItemBackgroundSelected" ResourceKey="SystemControlBackgroundListLowBrush" />
+            <StaticResource x:Key="MenuBarItemBackgroundSelected" ResourceKey="SystemControlBackgroundListMediumBrush" />
 
             <Thickness x:Key="MenuBarItemBorderThickness">0</Thickness>
 
@@ -46,7 +46,7 @@
             <StaticResource x:Key="MenuBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="MenuBarItemBackgroundPointerOver" ResourceKey="SystemControlBackgroundListLowBrush" />
             <StaticResource x:Key="MenuBarItemBackgroundPressed" ResourceKey="SystemControlBackgroundListMediumBrush" />
-            <StaticResource x:Key="MenuBarItemBackgroundSelected" ResourceKey="SystemControlBackgroundListLowBrush" />
+            <StaticResource x:Key="MenuBarItemBackgroundSelected" ResourceKey="SystemControlBackgroundListMediumBrush" />
 
             <Thickness x:Key="MenuBarItemBorderThickness">2</Thickness>
 


### PR DESCRIPTION
This PR fixes a few issues:

1) There was a hidden tabstop in front of the items in the menubar; this was the itemscontrol, which now has IsTabStop-false. I added a test case to verify this.

2) The button inside the MenuBarItem got keyboard focus, instead of the item itself; this was confusing to narrator so I switched it. The test cases didn't have to change because we already had a keyboard test, it's just now appropriately sending those keys to the MenuBarItem instead of its inner button.

3) Visually, when an item is clicked it should appear in the "pressed" state. (I verified this is how menu bar items look in win32.) I fixed the theme resources to account for this.