### PR TITLE
Add CODEOWNERS file to add codereviews team to all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Add the code reviews team to all PRs in the repo.
+* @Microsoft/microsoft-ui-xaml-codereviews


### PR DESCRIPTION
I followed the docs [here](https://help.github.com/articles/about-codeowners/), though I don't know how to verify it until it's in master.