### PR TITLE
Helix test fix

### DIFF
--- a/build/Helix/global.json
+++ b/build/Helix/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.DotNet.Helix.Sdk": "1.0.0-beta.18610.4"
+    "Microsoft.DotNet.Helix.Sdk": "1.0.0-beta.18619.3"
   }
 }

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -1,6 +1,4 @@
-set
 robocopy %HELIX_CORRELATION_PAYLOAD% . /s
-dir /b /s
 te MUXControls.Test.dll MUXControlsTestApp.appx /enablewttlogging /unicodeOutput:false /testtimeout:0:05 %*
 type te.wtl
 cd scripts

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -112,4 +112,4 @@ jobs:
       command: custom
       projects: build\Helix\RunTestsInHelix.proj
       custom: msbuild
-      arguments: '/p:HelixAccessToken=$(BotAccount-dotnet-github-anon-kaonashi-bot-helix-token) /p:HelixBuild=$(Build.BuildId)'
+      arguments: '/p:HelixBuild=$(Build.BuildId) /p:Creator:WinUI /p:IsExternal=true'

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -112,4 +112,4 @@ jobs:
       command: custom
       projects: build\Helix\RunTestsInHelix.proj
       custom: msbuild
-      arguments: '/p:HelixBuild=$(Build.BuildId) /p:Creator:WinUI /p:IsExternal=true'
+      arguments: '/p:HelixBuild=$(Build.BuildId) /p:Creator=WinUI /p:IsExternal=true'


### PR DESCRIPTION
Helix started enforcing a rule that jobs sent to an Open queue should not send an access token. Updating the yml to obey this.

When not sending an access token you must explicitly set Creator to something, since it is no longer inferred from the access token. Also, the IsExternal flag must be set.