### PR TITLE
Ensure that if there is only one item we don't end up reporting zero extent size

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -967,7 +967,28 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             }
         }
 
-#region Private Helpers
+        [TestMethod]
+        public void ValidateFlowLayoutWithOneItemHasNonZeroExtent()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                foreach (ScrollOrientation scrollOrientation in Enum.GetValues(typeof(ScrollOrientation)))
+                {
+                    var repeater = new ItemsRepeater() {
+                        ItemsSource = new List<string>() { "single item" },
+                        Layout = new FlowLayout() { Orientation = scrollOrientation.ToLayoutOrientation() },
+                    };
+
+                    Content = repeater;
+                    Content.UpdateLayout();
+
+                    Verify.IsTrue(repeater.ActualWidth > 10);
+                    Verify.IsTrue(repeater.ActualHeight > 10);
+                }
+            });
+        }
+
+        #region Private Helpers
 
         private enum LayoutChoice
         {

--- a/dev/Repeater/FlowLayout.cpp
+++ b/dev/Repeater/FlowLayout.cpp
@@ -260,7 +260,7 @@ winrt::Rect FlowLayout::GetExtent(
             auto lineSpacing = LineSpacing();
             auto minItemSpacing = MinItemSpacing();
             // We dont have anything realized. make an educated guess.
-            int numLines = (int)(itemsCount / averageItemsPerLine);
+            int numLines = (int)std::ceil(itemsCount / averageItemsPerLine);
             extent =
                 std::isfinite(availableSizeMinor) ? 
                 MinorMajorRect(0, 0, availableSizeMinor, std::max(0.0f, static_cast<float>(numLines * averageLineSize - lineSpacing))) :


### PR DESCRIPTION
If we just had one item in a flow layout we ended up reporting zero size in the virtualizing direction and not showing the item at all. 

Internal Issue: https://microsoft.visualstudio.com/OS/_queries/edit/19619316/?triage=true