### PR TITLE
Fix for errors seen when building locally where CustomTasks was still…

### DIFF
--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -40,7 +40,11 @@ Copy-IntoNewDirectory FrameworkPackageContents\* $fullOutputPath\PackageContents
 
 Copy-IntoNewDirectory PriConfig\* $fullOutputPath
 
-if (!$WindowsSdkBinDir)
+if (!$WindowsSdkBinDir -and $env:WindowsSdkVerBinPath)
+{
+    $WindowsSdkBinDir = "${env:WindowsSdkVerBinPath}\x86"
+}
+else
 {
     $WindowsSdkBinDir = "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x86"
 }

--- a/test/IXMPTestApp/MSTest/project.json
+++ b/test/IXMPTestApp/MSTest/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "CustomTasks": "1.0.32",
+    "MUXCustomBuildTasks": "1.0.37",
     "Microsoft.Net.Native.Compiler": "2.2.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "MSTest.TestAdapter": "1.3.2",

--- a/test/MUXControlsTestApp/MSTest/project.json
+++ b/test/MUXControlsTestApp/MSTest/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "CustomTasks": "1.0.32",
+    "MUXCustomBuildTasks": "1.0.37",
     "Microsoft.Net.Native.Compiler": "2.2.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "MSTest.TestAdapter": "1.3.2",


### PR DESCRIPTION
… being used and makepri.exe wasn't found in the SDK's bin path.