### PR TITLE
Make SDK install script handle bad inputs better

### DIFF
--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -14,6 +14,13 @@ $WindowsSDKInstalledRegPath = "$WindowsSDKRegPath\$WindowsSDKVersion\Installed O
 $StrongNameRegPath = "HKLM:\SOFTWARE\Microsoft\StrongName\Verification"
 $PublicKeyTokens = @("31bf3856ad364e35")
 
+if ($buildNumber -notmatch "^\d{5,}$")
+{
+    Write-Host "ERROR: '$buildNumber' doesn't look like a windows build number"
+    Write-Host
+    Exit 1
+}
+
 function Download-File
 {
     param ([string] $outDir,
@@ -264,7 +271,9 @@ if ($InstallWindowsSDK)
     # Check to make sure the file is at least 10 MB.
     if ($downloadFileItem.Length -lt 10*1024*1024)
     {
-        Write-Error "Downloaded file ($downloadFile) doesn't look large enough to be an ISO..."
+        Write-Host
+        Write-Host "ERROR: Downloaded file doesn't look large enough to be an ISO. The requested version may not be on microsoft.com yet."
+        Write-Host
         Exit 1
     }
 

--- a/build/Install-WindowsSdkISO.ps1
+++ b/build/Install-WindowsSdkISO.ps1
@@ -1,5 +1,5 @@
 [CmdletBinding()]
-param([Parameter(Mandatory=$true)]
+param([Parameter(Mandatory=$true, Position=0)]
       [string]$buildNumber)
 
 # Ensure the error action preference is set to the default for PowerShell3, 'Stop'
@@ -258,6 +258,15 @@ if ($InstallWindowsSDK)
 
     Write-Verbose "Getting WinSDK from $uri"
     $downloadFile = Download-File $winsdkTempDir $uri $file
+    Write-Verbose "File is at $downloadFile"
+    $downloadFileItem = Get-Item $downloadFile
+    
+    # Check to make sure the file is at least 10 MB.
+    if ($downloadFileItem.Length -lt 10*1024*1024)
+    {
+        Write-Error "Downloaded file ($downloadFile) doesn't look large enough to be an ISO..."
+        Exit 1
+    }
 
     # TODO Check if zip, exe, iso, etc.
     try


### PR DESCRIPTION
And also make the first argument positional so you don't have to use the -buildNumber when invoking it locally.