### PR TITLE
Fix WinUI_OS_Port

### DIFF
--- a/tools/WindowsPorting/PerformDEPControlsPort.cmd
+++ b/tools/WindowsPorting/PerformDEPControlsPort.cmd
@@ -123,7 +123,7 @@ if not exist "%OSRepoRoot%\src" (
     echo.
 
     for /f "delims=" %%I in ('dir /B /AD') do ( rd /s /q %%I )
-    rm * -f
+    del /q *
     call :CheckErrorLevel "Deleting current contents" || goto Cleanup
 
     gvfs clone %OSRepoUri% %OSRepoRoot%

--- a/tools/WindowsPorting/PerformDEPControlsPort.cmd
+++ b/tools/WindowsPorting/PerformDEPControlsPort.cmd
@@ -183,8 +183,6 @@ call %OSRepoRoot%\src\tools\razzle.cmd x86fre no_oacr
 call :CheckErrorLevel "Razzle start" || goto Cleanup
 call doublecheck /awd /rc
 
-set WindowsDir=%SDXROOT%\onecoreuap\windows\dxaml\controls
-
 rem If we're planning to check in, then we need to check out a branch that tracks a remote branch.
 rem If we're just planning to build, though, then we can just check out a detached commit.
 if "%BUILDONLY%" neq "--buildonly" (
@@ -249,6 +247,15 @@ echo   STEP 3: SYNC DEPCONTROLS REPO
 echo ---------------------------------
 
 set StartTime=%time%
+
+echo.
+echo Re-starting Razzle...
+echo.
+
+call %OSRepoRoot%\src\tools\razzle.cmd x86fre no_oacr
+call :CheckErrorLevel "Razzle start" || goto Cleanup
+
+set WindowsDir=%SDXROOT%\onecoreuap\windows\dxaml\controls
 
 if "%BUILDONLY%" neq "--buildonly" (
     echo.


### PR DESCRIPTION
There was a change in how the OS provides the build tools such as perl.exe. This caused problems for the OS Porting build machine.

The fix requires us to restart razzle after checking out the porting branch.