### PR TITLE
Fix CommandBar overflow popup in "actual bound" mode

### DIFF
--- a/dev/CommonStyles/CommandBar_19h1_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_19h1_themeresources.xaml
@@ -801,17 +801,17 @@
                                 StrokeThickness="1" />
                         </Grid>
                         <Popup x:Name="OverflowPopup">
+                            <Popup.RenderTransform>
+                                <TransformGroup>
+                                    <TranslateTransform x:Name="OverflowContentRootMarginOffsetTransform" />
+                                    <TranslateTransform x:Name="OverflowContentRootTransform" X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentHorizontalOffset}" />
+                                </TransformGroup>
+                            </Popup.RenderTransform>
                             <Grid x:Name="OverflowContentRoot"
                                 Opacity="0"
                                 MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentMinWidth}"
                                 MaxWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentMaxWidth}"
                                 MaxHeight="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentMaxHeight}">
-                                <Grid.RenderTransform>
-                                    <TransformGroup>
-                                        <TranslateTransform x:Name="OverflowContentRootMarginOffsetTransform" />
-                                        <TranslateTransform x:Name="OverflowContentRootTransform" X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentHorizontalOffset}" />
-                                    </TransformGroup>
-                                </Grid.RenderTransform>
                                 <Grid.RowDefinitions>
                                     <RowDefinition />
                                     <RowDefinition Height="Auto" />


### PR DESCRIPTION
[Internal Issue](https://microsoft.visualstudio.com/OS/_workitems/edit/19671707)

We changed the way of calculating and positioning windowed popups. In this new "actual bound" policy, RenderTransforms set on popup's direct child are not respected, which causes some rendering issue on CommandBar overflow menu.

Moving popup child's RenderTransform to popup itself to fix it.