### PR TITLE
Fxing Scroller and ItemsRepeater tests

### DIFF
--- a/dev/Scroller/InteractionTests/ScrollerTestsWithInputHelper.cs
+++ b/dev/Scroller/InteractionTests/ScrollerTestsWithInputHelper.cs
@@ -603,7 +603,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 PrepareForScrollerManipulationStart("scroller12");
 
                 KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
-                InputHelper.RotateWheel(scroller12UIObject, -mouseWheelDeltaForVelocityUnit);
+                // Starting with 19H1, the InteractionTracker changes the scale by a factor of 1.1 for each 60 mouse wheel delta.
+                // For earlier versions, a mouse wheel delta of 120 is required for the same 1.1 scale change.
+                InputHelper.RotateWheel(scroller12UIObject,
+                    PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone5) ? (int) (-mouseWheelDeltaForVelocityUnit / 2) : -mouseWheelDeltaForVelocityUnit);
                 KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
 
                 Log.Comment("Waiting for scroller12 pinch completion");
@@ -691,7 +694,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 PrepareForScrollerManipulationStart("scroller52");
 
                 KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
-                InputHelper.RotateWheel(scroller52UIObject, mouseWheelDeltaForVelocityUnit);
+                // Starting with 19H1, the InteractionTracker changes the scale by a factor of 1.1 for each 60 mouse wheel delta.
+                // For earlier versions, a mouse wheel delta of 120 is required for the same 1.1 scale change.
+                InputHelper.RotateWheel(scroller52UIObject,
+                    PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone5) ? mouseWheelDeltaForVelocityUnit / 2 : mouseWheelDeltaForVelocityUnit);
                 KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
 
                 Log.Comment("Waiting for scroller52 stretch completion");


### PR DESCRIPTION
Fixing these Scroller tests:
- PinchRectangleWithMouseWheel
- StretchImageWithMouseWheel
Starting in 19H1, the mouse wheel delta required to achieve a 10% scale change is 60 instead of the previous 120.

Fixing these ItemsRepeater tests:
- ValidateNoScrollingSurfaceScenario: Only run on OS platform. Adjustment required changed from 32 to 33px.
- ValidateBasicScrollViewerScenario: Adding viewChangeCompletedEvent to wait for end of ChangeView operations.
