### PR TITLE
Adding instrumentation for AcrylicBrush.TintLuminosityOpacity propert…

### DIFF
--- a/dev/Materials/Acrylic/AcrylicBrush.cpp
+++ b/dev/Materials/Acrylic/AcrylicBrush.cpp
@@ -318,7 +318,7 @@ void AcrylicBrush::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
         if (property == s_TintLuminosityOpacityProperty)
         {
             //  Logging usage telemetry
-            __RP_Marker_ClassById(RuntimeProfiler::ProfId_Acrylic_TintLuminosityOpacity_Changed);
+            __RP_Marker_ClassMemberById(RuntimeProfiler::ProfId_Acrylic, RuntimeProfiler::ProfMemberId_Acrylic_TintLuminosityOpacity_Changed);
         }
     }
     else if (property == s_AlwaysUseFallbackProperty)

--- a/dev/Materials/Acrylic/AcrylicBrush.cpp
+++ b/dev/Materials/Acrylic/AcrylicBrush.cpp
@@ -288,6 +288,12 @@ void AcrylicBrush::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
                 m_brush.StartAnimation(LuminosityColorColor, MakeColorAnimation(newLuminosityColor, TintTransitionDuration(), m_brush.Compositor()));
             }
         }
+
+        if (property == s_TintLuminosityOpacityProperty)
+        {
+            //  Logging usage telemetry
+            __RP_Marker_ClassById(RuntimeProfiler::ProfId_Acrylic_TintLuminosityOpacity_Changed);
+        }
     }
     else if (property == s_AlwaysUseFallbackProperty)
     {

--- a/dev/Telemetry/RuntimeProfiler.cpp
+++ b/dev/Telemetry/RuntimeProfiler.cpp
@@ -178,7 +178,7 @@ namespace RuntimeProfiler {
 
     //  Yes, we're declaring this as a global, the ctor/dtor are implemented
     //  very carefully and this will not create issues with DllMain().
-    DEFINE_PROFILEGROUP(gGroupClasses, PG_Class, ProfId_Size);
+    DEFINE_PROFILEGROUP(gGroupClasses, PG_Class, ProfId_Size + ProfMemberId_Size);
 
     struct ProfileGroupInfo
     {

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -34,7 +34,6 @@ namespace RuntimeProfiler
         ProfId_RadioButtons,
         ProfId_RadioMenuFlyoutItem,
         ProfId_ItemsRepeater,
-        ProfId_Acrylic_TintLuminosityOpacity_Changed,
         ProfId_Size
     } ProfilerClassId;
 

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -38,6 +38,13 @@ namespace RuntimeProfiler
         ProfId_Size
     } ProfilerClassId;
 
+    //  Ditto above...
+    typedef enum
+    {
+        ProfMemberId_Acrylic_TintLuminosityOpacity_Changed = 0,
+        ProfMemberId_Size
+    } ProfilerMemberId;
+
     void FireEvent(bool Suspend) noexcept;
     void RegisterMethod(ProfileGroup group, UINT16 TypeIndex, UINT16 MethodIndex, volatile LONG *Count) noexcept;
 }
@@ -52,4 +59,14 @@ namespace RuntimeProfiler
         } \
     }
     
+#define __RP_Marker_ClassMemberById(typeindex, memberindex) \
+    { \
+        __pragma (warning ( suppress : 28112)) \
+        static volatile LONG __RuntimeProfiler_Counter = -1; \
+        if (0 == ::InterlockedIncrement(&__RuntimeProfiler_Counter)) \
+        { \
+            RuntimeProfiler::RegisterMethod(RuntimeProfiler::PG_Class, (UINT16)typeindex, (UINT16)memberindex, &__RuntimeProfiler_Counter); \
+        } \
+    }
+
 

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -33,6 +33,7 @@ namespace RuntimeProfiler
         ProfId_TextCommandBarFlyout,
         ProfId_RadioButtons,
         ProfId_RadioMenuFlyoutItem,
+        ProfId_Acrylic_TintLuminosityOpacity_Changed,
         ProfId_Size
     } ProfilerClassId;
 


### PR DESCRIPTION
These are the changes we discussed:

- Defined a new Profile Id in RuntimeProfiler library for Acrylic.TintLuminosityOpacity property set.
- Updated the OnPropertyChanged method to count instances of changes to the TintLuminosityOpacity property.

Note:  We are not special-casing instances of setting this property to null.