### PR TITLE
Fix crash when scrolling nested ItemsRepeaters

### DIFF
--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -298,6 +298,8 @@ void ViewManager::UpdatePin(const winrt::UIElement& element, bool addPin)
                     repeater.InvalidateMeasure();
                 }
             }
+
+            break;
         }
 
         child = parent;


### PR DESCRIPTION
Fixing a bug where UpdatePin used to crash because AddPin cannot be done on an element that is not realized. This is possible when elements are getting recycled. we only need to care about the repeater in question - not every repeater in the tree. Each of those other repeaters will get the focus changed event as well to handle it for themselves. I don't have a test for this since I do not have a consistent repro.

Internal Issue: https://microsoft.visualstudio.com/OS/_queries/query/54592ba2-0892-4050-9ed9-19bdef3b13b4/