### PR TITLE
Instrument ItemsRepeater

### DIFF
--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -12,6 +12,7 @@
 #include "RepeaterAutomationPeer.h"
 #include "ViewportManagerWithPlatformFeatures.h"
 #include "ViewportManagerDownlevel.h"
+#include "RuntimeProfiler.h"
 
 #ifndef BUILD_WINDOWS
 #include "ItemTemplateWrapper.h"
@@ -22,6 +23,8 @@ winrt::Rect ItemsRepeater::InvalidRect = { -1.f, -1.f, -1.f, -1.f };
 
 ItemsRepeater::ItemsRepeater()
 {
+    __RP_Marker_ClassById(RuntimeProfiler::ProfId_ItemsRepeater);
+
     if (SharedHelpers::IsRS5OrHigher())
     {
         m_viewportManager = std::make_shared<ViewportManagerWithPlatformFeatures>(this);

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -33,6 +33,7 @@ namespace RuntimeProfiler
         ProfId_TextCommandBarFlyout,
         ProfId_RadioButtons,
         ProfId_RadioMenuFlyoutItem,
+        ProfId_ItemsRepeater,
         ProfId_Size
     } ProfilerClassId;
 


### PR DESCRIPTION
As per offline discussion, instrumenting instance counting telemetry on ItemsRepeater type.  This entails:

- Defining a new Profile id in instrumentation header.
- Putting a instance counting marker on the ItemsRepeater constructor.