### PR TITLE
Adding telemetry for XLayout types

### DIFF
--- a/dev/Repeater/NonVirtualizingLayout.cpp
+++ b/dev/Repeater/NonVirtualizingLayout.cpp
@@ -6,8 +6,14 @@
 #include "ItemsRepeater.common.h"
 #include "Layout.h"
 #include "NonVirtualizingLayout.h"
+#include "RuntimeProfiler.h"
 
 CppWinRTActivatableClassWithBasicFactory(NonVirtualizingLayout)
+
+NonVirtualizingLayout::NonVirtualizingLayout()
+{
+    __RP_Marker_ClassById(RuntimeProfiler::ProfId_NonVirtualizingLayout);
+}
 
 #pragma region INonVirtualizingLayoutOverrides
 

--- a/dev/Repeater/NonVirtualizingLayout.h
+++ b/dev/Repeater/NonVirtualizingLayout.h
@@ -10,6 +10,8 @@ class NonVirtualizingLayout :
     public winrt::implementation::NonVirtualizingLayoutT<NonVirtualizingLayout, Layout>
 {
 public:
+    NonVirtualizingLayout();
+
 #pragma region INonVirtualizingLayoutOverrides
     virtual void InitializeForContextCore(winrt::LayoutContext const& context);
     virtual void UninitializeForContextCore(winrt::LayoutContext const& context);

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -9,8 +9,14 @@
 #include "StackLayoutState.h"
 #include "StackLayout.h"
 #include "StackLayoutFactory.h"
+#include "RuntimeProfiler.h"
 
 #pragma region IFlowLayout
+
+StackLayout::StackLayout()
+{
+    __RP_Marker_ClassById(RuntimeProfiler::ProfId_StackLayout);
+}
 
 winrt::Orientation StackLayout::Orientation()
 {

--- a/dev/Repeater/StackLayout.h
+++ b/dev/Repeater/StackLayout.h
@@ -15,6 +15,7 @@ class StackLayout :
     public OrientationBasedMeasures
 {
 public:
+    StackLayout();
 
 #pragma region IStackLayout
     winrt::Orientation Orientation();

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -8,8 +8,14 @@
 #include "UniformGridLayoutState.h"
 #include "UniformGridLayout.h"
 #include "UniformGridLayoutFactory.h"
+#include "RuntimeProfiler.h"
 
 #pragma region IGridLayout
+
+UniformGridLayout::UniformGridLayout()
+{
+    __RP_Marker_ClassById(RuntimeProfiler::ProfId_UniformGridLayout);
+}
 
 winrt::Orientation UniformGridLayout::Orientation()
 {

--- a/dev/Repeater/UniformGridLayout.h
+++ b/dev/Repeater/UniformGridLayout.h
@@ -15,6 +15,8 @@ class UniformGridLayout :
     public OrientationBasedMeasures
 {
 public:
+    UniformGridLayout();
+
 #pragma region IGridLayout
     winrt::Orientation Orientation();
     void Orientation(winrt::Orientation const& value);

--- a/dev/Repeater/VirtualizingLayout.cpp
+++ b/dev/Repeater/VirtualizingLayout.cpp
@@ -5,8 +5,14 @@
 #include <common.h>
 #include "ItemsRepeater.common.h"
 #include "VirtualizingLayout.h"
+#include "RuntimeProfiler.h"
 
 CppWinRTActivatableClassWithBasicFactory(VirtualizingLayout)
+
+VirtualizingLayout::VirtualizingLayout()
+{
+    __RP_Marker_ClassById(RuntimeProfiler::ProfId_VirtualizingLayout);
+}
 
 #pragma region IVirtualizingLayoutOverrides
 

--- a/dev/Repeater/VirtualizingLayout.h
+++ b/dev/Repeater/VirtualizingLayout.h
@@ -10,6 +10,7 @@ class VirtualizingLayout :
     public winrt::implementation::VirtualizingLayoutT<VirtualizingLayout, Layout>
 {
 public:
+    VirtualizingLayout();
 
 #pragma region IVirtualizingLayoutOverrides
     virtual void InitializeForContextCore(winrt::VirtualizingLayoutContext const& context);

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -34,6 +34,10 @@ namespace RuntimeProfiler
         ProfId_RadioButtons,
         ProfId_RadioMenuFlyoutItem,
         ProfId_ItemsRepeater,
+        ProfId_NonVirtualizingLayout,
+        ProfId_StackLayout,
+        ProfId_UniformGridLayout,
+        ProfId_VirtualizingLayout,
         ProfId_Size
     } ProfilerClassId;
 


### PR DESCRIPTION
As per discussion, adding instrumentation for types for:
- NonVirtualizingLayout
- StackLayout
- UniformGridLayout
- VirtualizingLayout

The changes entail (for each type):
- Defining ProfId_ value
- Adding a constructor
- Calling telemetry marker on constructor
