### PR TITLE
Avoid Narrator pronouncing the MenuFlyoutItem's keyboard accelerator.

### DIFF
--- a/dev/CommonStyles/AppBarButton_rs4_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_rs4_themeresources.xaml
@@ -291,7 +291,8 @@
                                 Foreground="{ThemeResource AppBarButtonKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"
+                                AutomationProperties.AccessibilityView="Raw" />
                         </Grid>
                     
                     </Grid>

--- a/dev/CommonStyles/AppBarToggleButton_rs4_themeresources.xaml
+++ b/dev/CommonStyles/AppBarToggleButton_rs4_themeresources.xaml
@@ -401,7 +401,8 @@
                                 Foreground="{ThemeResource AppBarToggleButtonKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"
+                                AutomationProperties.AccessibilityView="Raw" />
                         </Grid>
                     
                     </Grid>

--- a/dev/MenuFlyout/MenuFlyout_19h1_themeresources.xaml
+++ b/dev/MenuFlyout/MenuFlyout_19h1_themeresources.xaml
@@ -257,7 +257,8 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Visibility="Collapsed" />
+                            Visibility="Collapsed"
+                            AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
                  </ControlTemplate>
             </Setter.Value>

--- a/dev/MenuFlyout/MenuFlyout_rs4_themeresources.xaml
+++ b/dev/MenuFlyout/MenuFlyout_rs4_themeresources.xaml
@@ -173,7 +173,8 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Visibility="Collapsed" />
+                            Visibility="Collapsed"
+                            AutomationProperties.AccessibilityView="Raw" />
                     
                     </Grid>
                 </ControlTemplate>

--- a/dev/MenuFlyout/MenuFlyout_rs5_themeresources.xaml
+++ b/dev/MenuFlyout/MenuFlyout_rs5_themeresources.xaml
@@ -260,7 +260,8 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Visibility="Collapsed" />
+                            Visibility="Collapsed"
+                            AutomationProperties.AccessibilityView="Raw" />
                     
                     </Grid>
                 </ControlTemplate>
@@ -420,7 +421,8 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"
+                                AutomationProperties.AccessibilityView="Raw" />
 
                         </Grid>
                     

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources.xaml
@@ -169,7 +169,8 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"
+                                AutomationProperties.AccessibilityView="Raw" />
                         </Grid>
 
                     </Grid>

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources.xaml
@@ -157,7 +157,8 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Visibility="Collapsed" />
+                                Visibility="Collapsed"
+                                AutomationProperties.AccessibilityView="Raw" />
 
                         </Grid>
 


### PR DESCRIPTION
This replicates a change made on the OS side with PR 2777446 today. It prevents Narrator from pronouncing the MenuFlyoutItem's keyboard accelerator when attempting to navigate inside the menu item with CapsLock + left/right arrow.  That change was made in the OS generic.xaml for 19H1.