### PR TITLE
Update the bug report issue template to not use checkboxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,20 +25,27 @@ Steps to reproduce the behavior:
 NuGet package version: 
 <!-- [e.g. Microsoft.UI.Xaml 2.0.181011001] -->
 
-Windows 10 version:
-- [ ] Insider Build (xxxxx)
-- [ ] October 2018 Update (17763)
-- [ ] April 2018 Update (17134)
-- [ ] Fall Creators Update (16299)
-- [ ] Creators Update (15063)
-- [ ] Anniversary Update (14393)
+Windows 10 version: 
+<!-- Which Windows versions did you see the issue on? Leave blank if you didn't try that version. -->
+| Saw the problem  | Windows 10 version |
+| ---------------- | --------------------- |
+| <!-- Yes/No? --> |Insider Build (xxxxx) |
+| <!-- Yes/No? --> |October 2018 Update (17763) |
+| <!-- Yes/No? --> |April 2018 Update (17134) |
+| <!-- Yes/No? --> |Fall Creators Update (16299) |
+| <!-- Yes/No? --> |Creators Update (15063) |
+| <!-- Yes/No? --> |Anniversary Update (14393) |
 
 Device form factor:
-- [ ] Desktop
-- [ ] Mobile
-- [ ] Xbox
-- [ ] Surface Hub
-- [ ] IoT
+<!-- Which device form factors did you see the issue? Leave blank if you didn't try that version. -->
+| Saw the problem  | Device form factor |
+| ---------------- | --------------------- |
+| <!-- Yes/No? --> |Desktop |
+| <!-- Yes/No? --> |Mobile |
+| <!-- Yes/No? --> |Xbox |
+| <!-- Yes/No? --> |Surface Hub |
+| <!-- Yes/No? --> |IoT |
+
 
 **Additional context**
 <!-- Enter any other applicable info here -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,7 +35,7 @@ NuGet package version:
 | Creators Update (15063)           | <!-- Yes/No? -->   |
 | Anniversary Update (14393)      | <!-- Yes/No? -->   |
 
-<!-- Which device form factors did you see the issue? Leave blank if you didn't try that version. -->
+<!-- Which device form factors did you see the issue on? Leave blank if you didn't try that device. -->
 | Device form factor | Saw the problem? |
 | :-------------------- | :------------------- |
 | Desktop                 | <!-- Yes/No? -->   |

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,26 +25,24 @@ Steps to reproduce the behavior:
 NuGet package version: 
 <!-- [e.g. Microsoft.UI.Xaml 2.0.181011001] -->
 
-Windows 10 version: 
 <!-- Which Windows versions did you see the issue on? Leave blank if you didn't try that version. -->
-| Saw the problem  | Windows 10 version |
-| ---------------- | --------------------- |
-| <!-- Yes/No? --> |Insider Build (xxxxx) |
-| <!-- Yes/No? --> |October 2018 Update (17763) |
-| <!-- Yes/No? --> |April 2018 Update (17134) |
-| <!-- Yes/No? --> |Fall Creators Update (16299) |
-| <!-- Yes/No? --> |Creators Update (15063) |
-| <!-- Yes/No? --> |Anniversary Update (14393) |
+| Windows 10 version                  | Saw the problem? |
+| ---------------------------------- | -------------------- |
+| Insider Build (xxxxx)                   | <!-- Yes/No? -->   |
+| October 2018 Update (17763)   | <!-- Yes/No? -->   |
+| April 2018 Update (17134)        | <!-- Yes/No? -->   |
+| Fall Creators Update (16299)     | <!-- Yes/No? -->   |
+| Creators Update (15063)           | <!-- Yes/No? -->   |
+| Anniversary Update (14393)      | <!-- Yes/No? -->   |
 
-Device form factor:
 <!-- Which device form factors did you see the issue? Leave blank if you didn't try that version. -->
-| Saw the problem  | Device form factor |
-| ---------------- | --------------------- |
-| <!-- Yes/No? --> |Desktop |
-| <!-- Yes/No? --> |Mobile |
-| <!-- Yes/No? --> |Xbox |
-| <!-- Yes/No? --> |Surface Hub |
-| <!-- Yes/No? --> |IoT |
+| Device form factor | Saw the problem? |
+| -------------------- | -------------------- |
+| Desktop                 | <!-- Yes/No? -->   |
+| Mobile                   | <!-- Yes/No? -->   |
+| Xbox                      | <!-- Yes/No? -->   |
+| Surface Hub          | <!-- Yes/No? -->    |
+| IoT                         | <!-- Yes/No? -->    |
 
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ NuGet package version:
 
 <!-- Which Windows versions did you see the issue on? Leave blank if you didn't try that version. -->
 | Windows 10 version                  | Saw the problem? |
-| ---------------------------------- | -------------------- |
+| :--------------------------------- | :-------------------- |
 | Insider Build (xxxxx)                   | <!-- Yes/No? -->   |
 | October 2018 Update (17763)   | <!-- Yes/No? -->   |
 | April 2018 Update (17134)        | <!-- Yes/No? -->   |
@@ -37,7 +37,7 @@ NuGet package version:
 
 <!-- Which device form factors did you see the issue? Leave blank if you didn't try that version. -->
 | Device form factor | Saw the problem? |
-| -------------------- | -------------------- |
+| :-------------------- | :------------------- |
 | Desktop                 | <!-- Yes/No? -->   |
 | Mobile                   | <!-- Yes/No? -->   |
 | Xbox                      | <!-- Yes/No? -->   |


### PR DESCRIPTION
Checkboxes display nicely but have special meaning to GitHub as a "task list", and we want to use the task list to track progress of completion of bigger tasks. So I wanted to remove the checkbox list here to avoid confusion with actual use of task lists.