### PR TITLE
Fix OS ports

### DIFF
--- a/tools/UpdateBuildMachineGitInstalls.ps1
+++ b/tools/UpdateBuildMachineGitInstalls.ps1
@@ -9,9 +9,9 @@ $adalPath = Get-AdalPath
 Write-Verbose "ADALPath: $adalPath"
 Add-Type -Path "$adalPath\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
 
-$result = Queue-BuildOnMachine -MachineName "PKGESWINUI24" -ClientAlias "winui2" -BuildId "17093" # Install GVFS
+$result = Queue-BuildOnMachine -MachineName "PKGESWINUI24" -BuildId "17093" # Install GVFS
 Write-Host "PKGESWINUI24: $($result._links.web.href)"
-$result = Queue-BuildOnMachine -MachineName "PKGESWINUI25" -ClientAlias "winui2" -BuildId "17093" # Install GVFS
+$result = Queue-BuildOnMachine -MachineName "PKGESWINUI25" -BuildId "17093" # Install GVFS
 Write-Host "PKGESWINUI25: $($result._links.web.href)"
-$result = Queue-BuildOnMachine -MachineName "PKGESWINUI44" -ClientAlias "winui" -BuildId "17093" # Install GVFS
+$result = Queue-BuildOnMachine -MachineName "PKGESWINUI44" -BuildId "17093" # Install GVFS
 Write-Host "PKGESWINUI44: $($result._links.web.href)"

--- a/tools/UpdateBuildMachineGitInstalls.ps1
+++ b/tools/UpdateBuildMachineGitInstalls.ps1
@@ -1,0 +1,17 @@
+[CmdLetBinding()]
+Param(
+    )
+
+Import-Module -Name $PSScriptRoot\BuildMachineUtils.psm1 -DisableNameChecking
+
+$adalPath = Get-AdalPath
+
+Write-Verbose "ADALPath: $adalPath"
+Add-Type -Path "$adalPath\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
+
+$result = Queue-BuildOnMachine -MachineName "PKGESWINUI24" -ClientAlias "winui2" -BuildId "17093" # Install GVFS
+Write-Host "PKGESWINUI24: $($result._links.web.href)"
+$result = Queue-BuildOnMachine -MachineName "PKGESWINUI25" -ClientAlias "winui2" -BuildId "17093" # Install GVFS
+Write-Host "PKGESWINUI25: $($result._links.web.href)"
+$result = Queue-BuildOnMachine -MachineName "PKGESWINUI44" -ClientAlias "winui" -BuildId "17093" # Install GVFS
+Write-Host "PKGESWINUI44: $($result._links.web.href)"

--- a/tools/WindowsPorting/PerformDEPControlsPort.cmd
+++ b/tools/WindowsPorting/PerformDEPControlsPort.cmd
@@ -521,7 +521,8 @@ echo.
 echo Pulling latest from %1...
 echo.
 
-call git pull --force
+call git fetch
+call git merge FETCH_HEAD
 call :CheckErrorLevel "Pull" || goto Cleanup
 goto:eof
 


### PR DESCRIPTION
For reasons that are still unclear to me, the build machine hits the following error when trying to "git pull" after checking out an official branch:

```
2019-01-15T22:35:32.6038892Z Your configuration specifies to merge with the ref 'refs/heads/official/rs_onecore_dep_uxp'
2019-01-15T22:35:32.6039124Z from the remote, but no such ref was fetched.
2019-01-15T22:35:32.8300900Z ##[error] Pull FAILED.  Skipping to cleanup.
2019-01-15T22:35:32.9743307Z ##[error]Process completed with exit code 1.
```

Every resource I could find online indicates that this means that the target branch no longer exists, but it clearly does, and this command succeeds locally on the same machine - it only fails when the build account is running the script.

After a bunch of testing, it looks as though replacing `git pull` with the equivalent commands `git fetch` and `git merge FETCH_HEAD` makes the build machine no longer hit this issue and get past the syncing step.  I don't understand why this works where the other doesn't, but at the moment I really want to get the OS porting script back up and running as my first priority.

While I was at it, I also included a helper script that I wrote that I needed to fix another thing on the build machines.