### PR TITLE
Fix RatingControl scaling

### DIFF
--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -71,7 +71,7 @@ void RatingControl::UpdateCaptionMargins()
     {
         double textScaleFactor = GetUISettings().TextScaleFactor();
         winrt::Thickness margin = captionTextBlock.Margin();
-        margin.Top = c_defaultCaptionTopMargin - ActualRatingFontSize()*c_verticalScaleAnimationCenterPoint;
+        margin.Top = c_defaultCaptionTopMargin - (ActualRatingFontSize() * c_verticalScaleAnimationCenterPoint);
 
         captionTextBlock.Margin(margin);
     }

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -19,6 +19,8 @@ const int c_defaultItemSpacing = 8;
 const float c_mouseOverScale = 0.8f;
 const float c_touchOverScale = 1.0f;
 const float c_noPointerOverMagicNumber = -100;
+
+// 22 = 20(compensate for the -20 margin on StackPanel) + 2(magic number makes the text and star center-aligned)
 const float c_defaultCaptionTopMargin = 22;
 
 const int c_noValueSetSentinel = -1;
@@ -47,18 +49,23 @@ float RatingControl::ActualRatingFontSize()
     return RenderingRatingFontSize() / 2;
 }
 
+// TODO MSFT #10030063: Convert to itemspacing DP
 double RatingControl::ItemSpacing()
 {
-    // Stars are rendered 2x size and we use expression animation to shrink them down to desired size, which will create those spacings (not system margin).
-    // Since text scale factor won't affect system margins, when stars get bigger, the spacing will become smaller.
-    // Therefore we should include TextScaleFactor when calculating item spacing in order to get correct total width and star center positions.
+    // Stars are rendered 2x size and we use expression animation to shrink them down to desired size,
+    // which will create those spacings (not system margin).
+    // Since text scale factor won't affect system margins,
+    // when stars get bigger, the spacing will become smaller.
+    // Therefore we should include TextScaleFactor when calculating item spacing
+    // in order to get correct total width and star center positions.
     double defaultFontSize = c_defaultRatingFontSizeForRendering / 2;
     return c_defaultItemSpacing - (GetUISettings().TextScaleFactor() - 1.0) * defaultFontSize / 2;
 }
 
 void RatingControl::UpdateCaptionMargins()
 {
-    // We manually set margins to caption text to make it center-aligned with the stars because star vertical center is 0.8 instead of the normal 0.5.
+    // We manually set margins to caption text to make it center-aligned with the stars
+    // because star vertical center is 0.8 instead of the normal 0.5.
     // When text scale changes we need to update top margin to make the text follow start center.
     if (auto captionTextBlock = m_captionTextBlock.safe_get())
     {
@@ -857,7 +864,6 @@ double RatingControl::CalculateTotalRatingControlWidth()
 
     if (captionAsWinRT.size() > 0)
     {
-        // TODO MSFT #10030063: Convert to itemspacing DP
         textSpacing = ItemSpacing();
     }
 

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -50,13 +50,16 @@ float RatingControl::ActualRatingFontSize()
 double RatingControl::ItemSpacing()
 {
     // TextScaleFactor will change font size but won't affect spacing/margin.
-    // The scaled-up text will grow out to the margin area, so the "actual" margins become smaller.
+    // The scaled-up glyph will grow out to the margin area, so the "actual" margins become smaller.
     // Therefore we should include TextScaleFactor when calculating item spacing in order to get correct total width and star center positions.
     return c_defaultItemSpacing / GetUISettings().TextScaleFactor();
 }
 
 void RatingControl::UpdateCaptionMargins()
 {
+    // star glyph's vertical center position is set to 0.8 per redline, but caption text's center is 0.5 (default value).
+    // when they scale up the stars and caption text won't be vertically aligned since the vertical center is different.
+    // Update caption text top margin here to fix the alignment.
     if (auto captionTextBlock = m_captionTextBlock.safe_get())
     {
         double textScaleFactor = GetUISettings().TextScaleFactor();

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -19,6 +19,7 @@ const int c_defaultItemSpacing = 8;
 const float c_mouseOverScale = 0.8f;
 const float c_touchOverScale = 1.0f;
 const float c_noPointerOverMagicNumber = -100;
+const float c_defaultCaptionTopMargin = 9;
 
 const int c_noValueSetSentinel = -1;
 
@@ -54,6 +55,23 @@ double RatingControl::ItemSpacing()
     return c_defaultItemSpacing / GetUISettings().TextScaleFactor();
 }
 
+void RatingControl::UpdateCaptionMargins()
+{
+    if (auto captionTextBlock = m_captionTextBlock.safe_get())
+    {
+        double textScaleFactor = GetUISettings().TextScaleFactor();
+        winrt::Thickness margin = captionTextBlock.Margin();
+        margin.Top = c_defaultCaptionTopMargin;
+
+        if (textScaleFactor > 1.01)
+        {
+            margin.Top -= ActualRatingFontSize()*textScaleFactor*(1-c_verticalScaleAnimationCenterPoint);
+        }
+
+        captionTextBlock.Margin(margin);
+    }
+}
+
 void RatingControl::OnApplyTemplate()
 {
     RecycleEvents();
@@ -65,6 +83,7 @@ void RatingControl::OnApplyTemplate()
     {
         m_captionTextBlock.set(captionTextBlock);
         m_captionSizeChangedToken = captionTextBlock.SizeChanged({ this, &RatingControl::OnCaptionSizeChanged });
+        UpdateCaptionMargins();
     }
 
     if (auto backgroundStackPanel = GetTemplateChildT<winrt::StackPanel>(L"RatingBackgroundStackPanel", thisAsControlProtected))
@@ -1149,6 +1168,7 @@ void RatingControl::OnTextScaleFactorChanged(const winrt::UISettings& setting, c
     m_dispatcherHelper.RunAsync([strongThis]()
     {
         strongThis->StampOutRatingItems();
+        strongThis->UpdateCaptionMargins();
     });
     
 }

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -47,9 +47,9 @@ float RatingControl::ActualRatingFontSize()
     return RenderingRatingFontSize() / 2;
 }
 
-inline double RatingControl::ItemSpacing()
+double RatingControl::ItemSpacing()
 {
-    // stars are rendered 2x size and we use expression animation to shrink them down to desired size, which will create those spacings (not system margin).
+    // Stars are rendered 2x size and we use expression animation to shrink them down to desired size, which will create those spacings (not system margin).
     // Since text scale factor won't affect system margins, when stars get bigger, the spacing will become smaller.
     // Therefore we should include TextScaleFactor when calculating item spacing in order to get correct total width and star center positions.
     double defaultFontSize = c_defaultRatingFontSizeForRendering / 2;

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -19,7 +19,7 @@ const int c_defaultItemSpacing = 8;
 const float c_mouseOverScale = 0.8f;
 const float c_touchOverScale = 1.0f;
 const float c_noPointerOverMagicNumber = -100;
-const float c_defaultCaptionTopMargin = 9;
+const float c_defaultCaptionTopMargin = 22;
 
 const int c_noValueSetSentinel = -1;
 
@@ -47,29 +47,24 @@ float RatingControl::ActualRatingFontSize()
     return RenderingRatingFontSize() / 2;
 }
 
-double RatingControl::ItemSpacing()
+inline double RatingControl::ItemSpacing()
 {
-    // TextScaleFactor will change font size but won't affect spacing/margin.
-    // The scaled-up glyph will grow out to the margin area, so the "actual" margins become smaller.
+    // stars are rendered 2x size and we use expression animation to shrink them down to desired size, which will create those spacings (not system margin).
+    // Since text scale factor won't affect system margins, when stars get bigger, the spacing will become smaller.
     // Therefore we should include TextScaleFactor when calculating item spacing in order to get correct total width and star center positions.
-    return c_defaultItemSpacing / GetUISettings().TextScaleFactor();
+    double defaultFontSize = c_defaultRatingFontSizeForRendering / 2;
+    return c_defaultItemSpacing - (GetUISettings().TextScaleFactor() - 1.0) * defaultFontSize / 2;
 }
 
 void RatingControl::UpdateCaptionMargins()
 {
-    // star glyph's vertical center position is set to 0.8 per redline, but caption text's center is 0.5 (default value).
-    // when they scale up the stars and caption text won't be vertically aligned since the vertical center is different.
-    // Update caption text top margin here to fix the alignment.
+    // We manually set margins to caption text to make it center-aligned with the stars because star vertical center is 0.8 instead of the normal 0.5.
+    // When text scale changes we need to update top margin to make the text follow start center.
     if (auto captionTextBlock = m_captionTextBlock.safe_get())
     {
         double textScaleFactor = GetUISettings().TextScaleFactor();
         winrt::Thickness margin = captionTextBlock.Margin();
-        margin.Top = c_defaultCaptionTopMargin;
-
-        if (textScaleFactor > 1.01)
-        {
-            margin.Top -= ActualRatingFontSize()*textScaleFactor*(1-c_verticalScaleAnimationCenterPoint);
-        }
+        margin.Top = c_defaultCaptionTopMargin - ActualRatingFontSize()*c_verticalScaleAnimationCenterPoint;
 
         captionTextBlock.Margin(margin);
     }

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -14,7 +14,7 @@ const float c_horizontalScaleAnimationCenterPoint = 0.5f;
 const float c_verticalScaleAnimationCenterPoint = 0.8f;
 const winrt::Thickness c_focusVisualMargin = { -8, -7, -8, 0 };
 const int c_defaultRatingFontSizeForRendering = 32; // (32 = 2 * [default fontsize] -- because of double size rendering), remove when MSFT #10030063 is done
-const int c_itemSpacing = 8;
+const int c_defaultItemSpacing = 8;
 
 const float c_mouseOverScale = 0.8f;
 const float c_touchOverScale = 1.0f;
@@ -44,6 +44,14 @@ float RatingControl::RenderingRatingFontSize()
 float RatingControl::ActualRatingFontSize()
 {
     return RenderingRatingFontSize() / 2;
+}
+
+double RatingControl::ItemSpacing()
+{
+    // TextScaleFactor will change font size but won't affect spacing/margin.
+    // The scaled-up text will grow out to the margin area, so the "actual" margins become smaller.
+    // Therefore we should include TextScaleFactor when calculating item spacing in order to get correct total width and star center positions.
+    return c_defaultItemSpacing / GetUISettings().TextScaleFactor();
 }
 
 void RatingControl::OnApplyTemplate()
@@ -833,7 +841,7 @@ double RatingControl::CalculateTotalRatingControlWidth()
     if (captionAsWinRT.size() > 0)
     {
         // TODO MSFT #10030063: Convert to itemspacing DP
-        textSpacing = c_itemSpacing;
+        textSpacing = ItemSpacing();
     }
 
     double captionWidth = 0.0;
@@ -851,7 +859,7 @@ double RatingControl::CalculateStarCenter(int starIndex)
     // TODO: sub in real API DP values
     // MSFT #10030063
     // [real Rating Size * (starIndex + 0.5)] + (starIndex * itemSpacing)
-    return (ActualRatingFontSize() * (starIndex + 0.5)) + (starIndex * c_itemSpacing);
+    return (ActualRatingFontSize() * (starIndex + 0.5)) + (starIndex * ItemSpacing());
 }
 
 double RatingControl::CalculateActualRatingWidth()
@@ -859,7 +867,7 @@ double RatingControl::CalculateActualRatingWidth()
     // TODO: replace hardcoding
     // MSFT #10030063
     // (max rating * rating size) + ((max rating - 1) * item spacing)
-    return (MaxRating() * ActualRatingFontSize()) + ((MaxRating() - 1) * c_itemSpacing);
+    return (MaxRating() * ActualRatingFontSize()) + ((MaxRating() - 1) * ItemSpacing());
 }
 
 // IControlOverrides

--- a/dev/RatingControl/RatingControl.h
+++ b/dev/RatingControl/RatingControl.h
@@ -126,6 +126,7 @@ private:
     float RenderingRatingFontSize();
     float ActualRatingFontSize();
     double ItemSpacing();
+    void UpdateCaptionMargins();
 
     // Private members
     tracker_ref<winrt::TextBlock> m_captionTextBlock{ this };

--- a/dev/RatingControl/RatingControl.h
+++ b/dev/RatingControl/RatingControl.h
@@ -125,6 +125,7 @@ private:
 
     float RenderingRatingFontSize();
     float ActualRatingFontSize();
+    double ItemSpacing();
 
     // Private members
     tracker_ref<winrt::TextBlock> m_captionTextBlock{ this };

--- a/dev/RatingControl/RatingControl.xaml
+++ b/dev/RatingControl/RatingControl.xaml
@@ -52,7 +52,7 @@
 
                         <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="-20,-20,-20,-20">
                             <StackPanel x:Name="RatingBackgroundStackPanel" Orientation="Horizontal" Background="Transparent" Margin="20,20,0,20"/>
-                            <TextBlock x:Name="Caption" Height="32" Margin="4,22,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}" VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption" IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
+                            <TextBlock x:Name="Caption" Height="32" Margin="4,9,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}" VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption" IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
                             <!-- 4 = 8 item spacing +4 of magic redline spacing -8 to compensate for scale of the last RatingItem -->
                             <!-- NB: The redlines say 8px, but it's really 12 px because:
                                 Designer note: The value between the last glyph and first text character is 12px.

--- a/dev/RatingControl/RatingControl.xaml
+++ b/dev/RatingControl/RatingControl.xaml
@@ -52,7 +52,7 @@
 
                         <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="-20,-20,-20,-20">
                             <StackPanel x:Name="RatingBackgroundStackPanel" Orientation="Horizontal" Background="Transparent" Margin="20,20,0,20"/>
-                            <TextBlock x:Name="Caption" Height="32" Margin="4,9,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}" VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption" IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
+                            <TextBlock x:Name="Caption" Height="32" Margin="4,22,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}" VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption" IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
                             <!-- 4 = 8 item spacing +4 of magic redline spacing -8 to compensate for scale of the last RatingItem -->
                             <!-- NB: The redlines say 8px, but it's really 12 px because:
                                 Designer note: The value between the last glyph and first text character is 12px.


### PR DESCRIPTION
[Internal issue](https://microsoft.visualstudio.com/OS/_workitems/edit/19747840)

When text scale changes, RatingControl's star scale animation is not following mouse cursor correctly. Also, stars and caption text are not aligned.

This is because item spacing and caption text margin are not scaled correctly together with the star glyphs. Updated the math to account for text scale changes.


