### PR TITLE
Make CalendarViewCalendarItemBackground the same as RS3

### DIFF
--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -9,12 +9,15 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -9,15 +9,12 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
-            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
-            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
-            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/dev/Materials/Reveal/RevealBrush_rs1_themeresources.xaml
+++ b/dev/Materials/Reveal/RevealBrush_rs1_themeresources.xaml
@@ -33,6 +33,7 @@
             <!-- Background Brushes -->
             <SolidColorBrush x:Key="SystemControlBackgroundBaseLowRevealBackgroundBrush" Color="{StaticResource SystemBaseLowColor}" />
             <SolidColorBrush x:Key="SystemControlTransparentRevealBackgroundBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlBackgroundAltHighRevealBackgroundBrush" Color="{StaticResource SystemAltHighColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccentRevealBackgroundBrush" Color="{ThemeResource SystemAccentColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent3RevealBackgroundBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.6" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent2RevealBackgroundBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.8" />
@@ -234,6 +235,7 @@
             <!-- Background Brushes -->
             <SolidColorBrush x:Key="SystemControlBackgroundBaseLowRevealBackgroundBrush" Color="{StaticResource SystemBaseLowColor}" />
             <SolidColorBrush x:Key="SystemControlTransparentRevealBackgroundBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlBackgroundAltHighRevealBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccentRevealBackgroundBrush" Color="{ThemeResource SystemAccentColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent3RevealBackgroundBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.6" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent2RevealBackgroundBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.8" />
@@ -435,6 +437,7 @@
             <!-- Background Brushes -->
             <SolidColorBrush x:Key="SystemControlBackgroundBaseLowRevealBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
             <SolidColorBrush x:Key="SystemControlTransparentRevealBackgroundBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlBackgroundAltHighRevealBackgroundBrush" Color="{StaticResource SystemAltHighColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccentRevealBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent3RevealBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent2RevealBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}" />

--- a/dev/Materials/Reveal/RevealBrush_rs1_themeresources.xaml
+++ b/dev/Materials/Reveal/RevealBrush_rs1_themeresources.xaml
@@ -88,7 +88,9 @@
             <Thickness x:Key="ComboBoxItemRevealThemePadding">11,5,11,7</Thickness>
             <Thickness x:Key="ComboBoxItemRevealThemeTouchPadding">11,11,11,13</Thickness>
             <Thickness x:Key="ComboBoxItemRevealThemeGameControllerPadding">11,11,11,13</Thickness>
-            
+
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
+
             <!-- Resources for Windows.UI.Xaml.Controls.Button -->
             <StaticResource x:Key="ButtonRevealBackground" ResourceKey="SystemControlBackgroundBaseLowRevealBackgroundBrush" />
             <StaticResource x:Key="ButtonRevealBackgroundPointerOver" ResourceKey="SystemControlBackgroundBaseLowRevealBackgroundBrush" />
@@ -290,7 +292,9 @@
             <Thickness x:Key="ComboBoxItemRevealThemePadding">11,5,11,7</Thickness>
             <Thickness x:Key="ComboBoxItemRevealThemeTouchPadding">11,11,11,13</Thickness>
             <Thickness x:Key="ComboBoxItemRevealThemeGameControllerPadding">11,11,11,13</Thickness>
-            
+
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
+
             <!-- Resources for Windows.UI.Xaml.Controls.Button -->
             <StaticResource x:Key="ButtonRevealBackground" ResourceKey="SystemControlBackgroundBaseLowRevealBackgroundBrush" />
             <StaticResource x:Key="ButtonRevealBackgroundPointerOver" ResourceKey="SystemControlBackgroundBaseLowRevealBackgroundBrush" />
@@ -492,7 +496,9 @@
             <Thickness x:Key="ComboBoxItemRevealThemePadding">11,5,11,7</Thickness>
             <Thickness x:Key="ComboBoxItemRevealThemeTouchPadding">11,11,11,13</Thickness>
             <Thickness x:Key="ComboBoxItemRevealThemeGameControllerPadding">11,11,11,13</Thickness>
-            
+
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />
+
             <!-- Resources for Windows.UI.Xaml.Controls.Button -->
             <StaticResource x:Key="ButtonRevealBackground" ResourceKey="SystemControlBackgroundBaseLowRevealBackgroundBrush" />
             <StaticResource x:Key="ButtonRevealBackgroundPointerOver" ResourceKey="SystemControlBackgroundBaseLowRevealBackgroundBrush" />

--- a/dev/Materials/Reveal/RevealBrush_rs2_themeresources.xaml
+++ b/dev/Materials/Reveal/RevealBrush_rs2_themeresources.xaml
@@ -57,6 +57,11 @@
                 Color="Transparent"
                 FallbackColor="Transparent"/>
             <local:RevealBackgroundBrush
+                x:Key="SystemControlBackgroundAltHighRevealBackgroundBrush"
+                TargetTheme="Dark" 
+                Color="{StaticResource SystemAltHighColor}" 
+                FallbackColor="{StaticResource SystemAltHighColor}" />
+            <local:RevealBackgroundBrush
                 x:Key="SystemControlHighlightAccentRevealBackgroundBrush"
                 TargetTheme="Dark"
                 Color="{ThemeResource SystemAccentColor}"
@@ -401,6 +406,11 @@
                 Color="Transparent"
                 FallbackColor="Transparent"/>
             <local:RevealBackgroundBrush
+                x:Key="SystemControlBackgroundAltHighRevealBackgroundBrush"
+                TargetTheme="Light" 
+                Color="{StaticResource SystemAltHighColor}" 
+                FallbackColor="{StaticResource SystemAltHighColor}" />
+            <local:RevealBackgroundBrush
                 x:Key="SystemControlHighlightAccentRevealBackgroundBrush"
                 TargetTheme="Light"
                 Color="{ThemeResource SystemAccentColor}"
@@ -736,6 +746,7 @@
             <!-- Background Brushes -->
             <SolidColorBrush x:Key="SystemControlBackgroundBaseLowRevealBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
             <SolidColorBrush x:Key="SystemControlTransparentRevealBackgroundBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlBackgroundAltHighRevealBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccentRevealBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent3RevealBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <SolidColorBrush x:Key="SystemControlHighlightAccent2RevealBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}" />


### PR DESCRIPTION
After reveal is introduced, calendarviewitem has a darker background, and it's not the same as RS3 because reveal background is transparent.
Here is the RS3 background brush:
`<StaticResource x:Key="CalendarViewCalendarItemBackground" ResourceKey="SystemControlBackgroundAltHighBrush" />`

The fix is to define a similar reveal SystemControlBackgroundAltHighRevealBackgroundBrush and make revealbackground use this brush.
 `<StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighRevealBackgroundBrush" />`