### PR TITLE
CommandBarFlyout Narrator fix

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -37,18 +37,28 @@ CommandBarFlyoutCommandBar::CommandBarFlyoutCommandBar()
 
     RegisterPropertyChangedCallback(
         winrt::AppBar::IsOpenProperty(),
-        [this](auto const&, auto const&) { UpdateUI(); });
-
-    auto vectorChangedHandler = [this](auto const&, auto const&) { UpdateUI(); };
+        [this](auto const&, auto const&)
+        {
+            UpdateFlowsFromAndFlowsTo();
+            UpdateUI();
+        });
 
     // Since we own these vectors, we don't need to cache the event tokens -
     // in fact, if we tried to remove these handlers in our destructor,
     // these properties will have already been cleared, and we'll nullref.
-    PrimaryCommands().VectorChanged({ [this](auto const&, auto const&) { UpdateUI(); } });
+    PrimaryCommands().VectorChanged({
+        [this](auto const&, auto const&)
+        {
+            UpdateFlowsFromAndFlowsTo();
+            UpdateUI();
+        }
+    });
+
     SecondaryCommands().VectorChanged({
         [this](auto const&, auto const&)
         {
             m_secondaryItemsRootSized = false;
+            UpdateFlowsFromAndFlowsTo();
             UpdateUI();
         }
     });
@@ -68,10 +78,12 @@ void CommandBarFlyoutCommandBar::OnApplyTemplate()
 
     m_primaryItemsRoot.set(GetTemplateChildT<winrt::FrameworkElement>(L"PrimaryItemsRoot", thisAsControlProtected));
     m_secondaryItemsRoot.set(GetTemplateChildT<winrt::FrameworkElement>(L"OverflowContentRoot", thisAsControlProtected));
+    m_moreButton.set(GetTemplateChildT<winrt::ButtonBase>(L"MoreButton", thisAsControlProtected));
     m_openingStoryboard.set(GetTemplateChildT<winrt::Storyboard>(L"OpeningStoryboard", thisAsControlProtected));
     m_closingStoryboard.set(GetTemplateChildT<winrt::Storyboard>(L"ClosingStoryboard", thisAsControlProtected));
 
     AttachEventHandlers();
+    UpdateFlowsFromAndFlowsTo();
     UpdateUI(false /* useTransitions */);
 }
 
@@ -183,6 +195,73 @@ void CommandBarFlyoutCommandBar::PlayCloseAnimation(std::function<void()> onComp
     else
     {
         onCompleteFunc();
+    }
+}
+
+void CommandBarFlyoutCommandBar::UpdateFlowsFromAndFlowsTo()
+{
+    if (m_currentPrimaryItemsEndElement)
+    {
+        winrt::AutomationProperties::GetFlowsTo(m_currentPrimaryItemsEndElement.get()).Clear();
+        m_currentPrimaryItemsEndElement.set(nullptr);
+    }
+
+    if (m_currentSecondaryItemsStartElement)
+    {
+        winrt::AutomationProperties::GetFlowsFrom(m_currentSecondaryItemsStartElement.get()).Clear();
+        m_currentSecondaryItemsStartElement.set(nullptr);
+    }
+
+    // If we're not open, then we don't want to do anything special - the only time we do need to do something special
+    // is when the secondary commands are showing, in which case we want to connect the primary and secondary command lists.
+    if (IsOpen())
+    {
+        auto isElementFocusable = [](winrt::ICommandBarElement const& element)
+        {
+            winrt::Control primaryCommandAsControl = element.try_as<winrt::Control>();
+            return
+                primaryCommandAsControl &&
+                primaryCommandAsControl.Visibility() == winrt::Visibility::Visible &&
+                (primaryCommandAsControl.IsEnabled() || primaryCommandAsControl.AllowFocusWhenDisabled()) &&
+                primaryCommandAsControl.IsTabStop();
+        };
+
+        // If we have a more button, then that's the last element in our primary items list.
+        // Otherwise, we'll find the last focusable element in the primary commands.
+        if (m_moreButton)
+        {
+            m_currentPrimaryItemsEndElement.set(m_moreButton.get());
+        }
+        else
+        {
+            auto primaryCommands = PrimaryCommands();
+            for (uint32_t i = primaryCommands.Size() - 1; i >= 0; i--)
+            {
+                auto primaryCommand = primaryCommands.GetAt(i);
+                if (isElementFocusable(primaryCommand))
+                {
+                    m_currentPrimaryItemsEndElement.set(primaryCommand.try_as<winrt::FrameworkElement>());
+                    break;
+                }
+            }
+        }
+
+        auto secondaryCommands = SecondaryCommands();
+        for (uint32_t i = 0; i < secondaryCommands.Size(); i++)
+        {
+            auto secondaryCommand = secondaryCommands.GetAt(i);
+            if (isElementFocusable(secondaryCommand))
+            {
+                m_currentSecondaryItemsStartElement.set(secondaryCommand.try_as<winrt::FrameworkElement>());
+                break;
+            }
+        }
+
+        if (m_currentPrimaryItemsEndElement && m_currentSecondaryItemsStartElement)
+        {
+            winrt::AutomationProperties::GetFlowsTo(m_currentPrimaryItemsEndElement.get()).Append(m_currentSecondaryItemsStartElement.get());
+            winrt::AutomationProperties::GetFlowsFrom(m_currentSecondaryItemsStartElement.get()).Append(m_currentPrimaryItemsEndElement.get());
+        }
     }
 }
 

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -28,16 +28,25 @@ private:
     void AttachEventHandlers();
     void DetachEventHandlers(bool useSafeGet = false);
 
+    void UpdateFlowsFromAndFlowsTo();
     void UpdateUI(bool useTransitions = true);
     void UpdateVisualState(bool useTransitions);
     void UpdateTemplateSettings();
 
     tracker_ref<winrt::FrameworkElement> m_primaryItemsRoot{ this };
     tracker_ref<winrt::FrameworkElement> m_secondaryItemsRoot{ this };
+    tracker_ref<winrt::ButtonBase> m_moreButton{ this };
     weak_ref<winrt::CommandBarFlyout> m_owningFlyout{ nullptr };
     winrt::FrameworkElement::SizeChanged_revoker m_secondaryItemsRootSizeChangedRevoker{};
     winrt::IInspectable m_keyDownHandler{ nullptr };
     winrt::FrameworkElement::Loaded_revoker m_firstSecondaryItemLoadedRevoker{};
+
+    // We need to manually connect the end element of the primary items to the start element of the secondary items
+    // for the purposes of UIA items navigation. To ensure that we only have the current start and end elements registered
+    // (e.g., if the app adds a new start element to the secondary commands, we want to unregister the previous start element),
+    // we'll save references to those elements.
+    tracker_ref<winrt::FrameworkElement> m_currentPrimaryItemsEndElement{ this };
+    tracker_ref<winrt::FrameworkElement> m_currentSecondaryItemsStartElement{ this };
 
     tracker_ref<winrt::Storyboard> m_openingStoryboard{ this };
     tracker_ref<winrt::Storyboard> m_closingStoryboard{ this };


### PR DESCRIPTION
We aren't currently able to use Narrator item navigation to leave the secondary command list in CommandBarFlyout, because it's in its own popup, and by default, popups trap Narrator focus.  To fix this, I've set things up so that we explicitly set FlowsFrom on the first secondary element and FlowsTo on the more button or last primary element, which allows Narrator to know that it should transition between those two elements when doing item navigation.

No tests added because this property is consumed directly by Narrator, and I couldn't find a way to test this external to Narrator.  I did verify using manual testing that Narrator item navigation works with this fix, though.