### PR TITLE
Enable RS2 and RS3 testing in Helix

### DIFF
--- a/build/Helix/InstallTestAppDependencies.ps1
+++ b/build/Helix/InstallTestAppDependencies.ps1
@@ -1,0 +1,7 @@
+foreach($line in Get-Content ..\MUXControlsTestApp.dependencies.txt) {
+    Add-AppxPackage ..\$line
+}
+
+foreach($line in Get-Content ..\IXMPTestApp.dependencies.txt) {
+    Add-AppxPackage ..\$line
+}

--- a/build/Helix/PrepareHelixPayload.ps1
+++ b/build/Helix/PrepareHelixPayload.ps1
@@ -40,3 +40,4 @@ Copy-Item "build\helix\runtests.cmd" $payloadDir
 New-Item -ItemType Directory -Force -Path "$payloadDir\scripts"
 Copy-Item "build\helix\ConvertWttLogToXUnit.ps1" "$payloadDir\scripts"
 Copy-Item "build\helix\ConvertWttLogToXUnit.cs" "$payloadDir\scripts"
+Copy-Item "build\helix\InstallTestAppDependencies.ps1" "$payloadDir\scripts"

--- a/build/Helix/RunTestsInHelix.proj
+++ b/build/Helix/RunTestsInHelix.proj
@@ -5,7 +5,7 @@
     <EnableXUnitReporter>true</EnableXUnitReporter>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>
-    <HelixPreCommands>$(HelixPreCommands);set testnameprefix=$(Configuration).$(Platform)</HelixPreCommands>
+    <HelixPreCommands>$(HelixPreCommands);set testnameprefix=$(Configuration).$(Platform);set testbuildplatform=$(Platform)</HelixPreCommands>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Helix/RunTestsInHelix.proj
+++ b/build/Helix/RunTestsInHelix.proj
@@ -99,7 +99,7 @@
       <Timeout>00:20:00</Timeout>
       <Command>call %HELIX_CORRELATION_PAYLOAD%\runtests.cmd /name:Windows.UI.Xaml.Tests.MUXControls.InteractionTests.SliderInteractionTests.*</Command>
     </HelixWorkItem>
-    <!-- <HelixWorkItem Include="ApiTests.ThemeResourcesTests">
+    <HelixWorkItem Include="ApiTests.ThemeResourcesTests">
       <Timeout>00:20:00</Timeout>
       <Command>call %HELIX_CORRELATION_PAYLOAD%\runtests.cmd /name:Windows.UI.Xaml.Tests.MUXControls.ApiTests.ThemeResourcesTests.*</Command>
     </HelixWorkItem>
@@ -246,7 +246,7 @@
     <HelixWorkItem Include="ApiTests.RepeaterTests.ViewportTests">
       <Timeout>00:20:00</Timeout>
       <Command>call %HELIX_CORRELATION_PAYLOAD%\runtests.cmd /name:Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.ViewportTests.*</Command>
-    </HelixWorkItem> -->
+    </HelixWorkItem>
 
     <HelixWorkItem Include="IXMPTestApp.Tests">
       <Timeout>00:20:00</Timeout>

--- a/build/Helix/RunTestsInHelix.proj
+++ b/build/Helix/RunTestsInHelix.proj
@@ -99,7 +99,7 @@
       <Timeout>00:20:00</Timeout>
       <Command>call %HELIX_CORRELATION_PAYLOAD%\runtests.cmd /name:Windows.UI.Xaml.Tests.MUXControls.InteractionTests.SliderInteractionTests.*</Command>
     </HelixWorkItem>
-    <HelixWorkItem Include="ApiTests.ThemeResourcesTests">
+    <!-- <HelixWorkItem Include="ApiTests.ThemeResourcesTests">
       <Timeout>00:20:00</Timeout>
       <Command>call %HELIX_CORRELATION_PAYLOAD%\runtests.cmd /name:Windows.UI.Xaml.Tests.MUXControls.ApiTests.ThemeResourcesTests.*</Command>
     </HelixWorkItem>
@@ -246,7 +246,7 @@
     <HelixWorkItem Include="ApiTests.RepeaterTests.ViewportTests">
       <Timeout>00:20:00</Timeout>
       <Command>call %HELIX_CORRELATION_PAYLOAD%\runtests.cmd /name:Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.ViewportTests.*</Command>
-    </HelixWorkItem>
+    </HelixWorkItem> -->
 
     <HelixWorkItem Include="IXMPTestApp.Tests">
       <Timeout>00:20:00</Timeout>

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -1,6 +1,6 @@
 robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
 
-te MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx /enablewttlogging /unicodeOutput:false /sessionTimeout:0:15 /testtimeout:0:10 /screenCaptureOnError %* 
+te MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx /enablewttlogging /unicodeOutput:false /sessionTimeout:0:15 /testtimeout:0:10 /screenCaptureOnError /APPX:Unregister=false %* 
 
 %HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\upload_result.py -result te.wtl -result_name te.wtl
 

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -3,7 +3,7 @@ robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
 reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
 
 cd scripts
-powershell -Command Add-AppxPackage ../Microsoft.VCLibs.x86.14.00.appx
+powershell -Command Add-AppxPackage ../Microsoft.VCLibs.%testbuildplatform%.14.00.appx
 powershell -Command Add-AppxPackage ../Microsoft.NET.CoreRuntime.1.1.appx
 cd ..
 

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -6,7 +6,7 @@ cd scripts
 powershell -ExecutionPolicy Bypass .\InstallTestAppDependencies.ps1
 cd ..
 
-te MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx /enablewttlogging /unicodeOutput:false /sessionTimeout:0:15 /testtimeout:0:10 /screenCaptureOnError /APPX:Unregister=false %* 
+te MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx /enablewttlogging /unicodeOutput:false /sessionTimeout:0:15 /testtimeout:0:10 /screenCaptureOnError %* 
 
 %HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\upload_result.py -result te.wtl -result_name te.wtl
 

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -1,5 +1,12 @@
 robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
 
+reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1
+
+cd scripts
+powershell -Command Add-AppxPackage ../Microsoft.VCLibs.x86.14.00.appx
+powershell -Command Add-AppxPackage ../Microsoft.NET.CoreRuntime.1.1.appx
+cd ..
+
 te MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx /enablewttlogging /unicodeOutput:false /sessionTimeout:0:15 /testtimeout:0:10 /screenCaptureOnError /APPX:Unregister=false %* 
 
 %HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\upload_result.py -result te.wtl -result_name te.wtl

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -1,6 +1,6 @@
 robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
 
-reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1
+reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
 
 cd scripts
 powershell -Command Add-AppxPackage ../Microsoft.VCLibs.x86.14.00.appx

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -3,8 +3,7 @@ robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
 reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
 
 cd scripts
-powershell -Command Add-AppxPackage ../Microsoft.VCLibs.%testbuildplatform%.14.00.appx
-powershell -Command Add-AppxPackage ../Microsoft.NET.CoreRuntime.1.1.appx
+powershell -ExecutionPolicy Bypass .\InstallTestAppDependencies.ps1
 cd ..
 
 te MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx /enablewttlogging /unicodeOutput:false /sessionTimeout:0:15 /testtimeout:0:10 /screenCaptureOnError /APPX:Unregister=false %* 

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -87,11 +87,11 @@ jobs:
         buildPlatform: 'x86'
         buildConfiguration: 'release'
         # %3b is the escape code for ';' which is used as the delimiter
-        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open%3bWindows.10.Amd64.ServerRS5.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open%3bWindows.10.Amd64.ClientRS3.ES.Open'
+        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ServerRS5.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open'
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'release'
-        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open%3bWindows.10.Amd64.ClientRS3.ES.Open'
+        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open'
   steps:
 
   - task: NuGetToolInstaller@0

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -114,7 +114,7 @@ jobs:
       buildVersionToDownload: specific
       project: '66f07283-7714-4cbf-be8f-73dfb782cfdc'
       pipeline: 22
-      buildId: 1717
+      buildId: 1722
       # project: 'f05f4dbf-3077-427d-91e0-b66d9e4ca374'
       # pipeline: 34322
       # buildId: 13870621

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -1,6 +1,8 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Build
+  condition: 
+    False
   pool:
     vmImage: VS2017-Win2016
   timeoutInMinutes: 120
@@ -70,8 +72,8 @@ jobs:
 
 
 - job: RunTests
-  dependsOn:
-    - Build
+  # dependsOn:
+  #   - Build
   pool:
     vmImage: 'VS2017-Win2016'
   timeoutInMinutes: 120
@@ -105,10 +107,24 @@ jobs:
       nugetConfigPath: nuget.config
       restoreDirectory: packages
 
-  - task: DownloadBuildArtifacts@0 
-    inputs: 
-      artifactName: drop 
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts from other pipeline'
+    inputs:
+      buildType: specific
+      buildVersionToDownload: specific
+      project: '66f07283-7714-4cbf-be8f-73dfb782cfdc'
+      pipeline: 22
+      buildId: 1717
+      # project: 'f05f4dbf-3077-427d-91e0-b66d9e4ca374'
+      # pipeline: 34322
+      # buildId: 13870621
+      artifactName: drop
       downloadPath: '$(artifactsDir)'
+
+  # - task: DownloadBuildArtifacts@0 
+  #   inputs: 
+  #     artifactName: drop 
+  #     downloadPath: '$(artifactsDir)'
 
   - task: powershell@2
     displayName: 'PrepareHelixPayload.ps1'

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -87,11 +87,11 @@ jobs:
         buildPlatform: 'x86'
         buildConfiguration: 'release'
         # %3b is the escape code for ';' which is used as the delimiter
-        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open%3bWindows.10.Amd64.ServerRS5.Open'
+        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open%3bWindows.10.Amd64.ServerRS5.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open%3bWindows.10.Amd64.ClientRS3.ES.Open'
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'release'
-        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open'
+        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open%3bWindows.10.Amd64.ClientRS3.ES.Open'
   steps:
 
   - task: NuGetToolInstaller@0

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -1,8 +1,6 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Build
-  condition: 
-    False
   pool:
     vmImage: VS2017-Win2016
   timeoutInMinutes: 120
@@ -72,8 +70,8 @@ jobs:
 
 
 - job: RunTests
-  # dependsOn:
-  #   - Build
+  dependsOn:
+    - Build
   pool:
     vmImage: 'VS2017-Win2016'
   timeoutInMinutes: 120
@@ -87,11 +85,11 @@ jobs:
         buildPlatform: 'x86'
         buildConfiguration: 'release'
         # %3b is the escape code for ';' which is used as the delimiter
-        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ServerRS5.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open'
+        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open%3bWindows.10.Amd64.ServerRS5.Open'
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'release'
-        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.ClientRS3.DevEx.Open'
+        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open'
   steps:
 
   - task: NuGetToolInstaller@0
@@ -107,24 +105,10 @@ jobs:
       nugetConfigPath: nuget.config
       restoreDirectory: packages
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Build Artifacts from other pipeline'
-    inputs:
-      buildType: specific
-      buildVersionToDownload: specific
-      project: '66f07283-7714-4cbf-be8f-73dfb782cfdc'
-      pipeline: 22
-      buildId: 1722
-      # project: 'f05f4dbf-3077-427d-91e0-b66d9e4ca374'
-      # pipeline: 34322
-      # buildId: 13870621
-      artifactName: drop
+  - task: DownloadBuildArtifacts@0 
+    inputs: 
+      artifactName: drop 
       downloadPath: '$(artifactsDir)'
-
-  # - task: DownloadBuildArtifacts@0 
-  #   inputs: 
-  #     artifactName: drop 
-  #     downloadPath: '$(artifactsDir)'
 
   - task: powershell@2
     displayName: 'PrepareHelixPayload.ps1'

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -86,12 +86,12 @@ jobs:
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'release'
-        helixTargetQueues: 'Windows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open'
-      # Release_x64:
-      #   buildPlatform: 'x64'
-      #   buildConfiguration: 'release'
-      #   # %3b is the escape code for ';' which is used as the delimiter
-      #   helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ServerRS5.Open'
+        # %3b is the escape code for ';' which is used as the delimiter
+        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open%3bWindows.10.Amd64.ServerRS5.Open'
+      Release_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'release'
+        helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open'
   steps:
 
   - task: NuGetToolInstaller@0

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -84,12 +84,12 @@ jobs:
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'release'
-        helixTargetQueues: 'Windows.10.Amd64.ClientRS4.Open'
-      Release_x64:
-        buildPlatform: 'x64'
-        buildConfiguration: 'release'
-        # %3b is the escape code for ';' which is used as the delimiter
-        helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ServerRS5.Open'
+        helixTargetQueues: 'Windows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS3.VS2017.Open'
+      # Release_x64:
+      #   buildPlatform: 'x64'
+      #   buildConfiguration: 'release'
+      #   # %3b is the escape code for ';' which is used as the delimiter
+      #   helixTargetQueues: 'Windows.10.Amd64.Open%3bWindows.10.Amd64.ServerRS5.Open'
   steps:
 
   - task: NuGetToolInstaller@0

--- a/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
+++ b/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
@@ -37,44 +37,47 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                     DeploymentResult result = null;
 
                     var installedPackages = packageManager.FindPackagesForUser(string.Empty, packageFamilyName);
-                    //foreach (var installedPackage in installedPackages)
-                    //{
-                    //    Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
 
-                    //    AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
-                    //    var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
-                    //    removePackageOperation.Completed = (operation, status) =>
-                    //    {
-                    //        if (status != AsyncStatus.Started)
-                    //        {
-                    //            result = operation.GetResults();
-                    //            removePackageCompleteEvent.Set();
-                    //        }
-                    //    };
-                    //    removePackageCompleteEvent.WaitOne();
-
-                    //    if (!string.IsNullOrEmpty(result.ErrorText))
-                    //    {
-                    //        Log.Error("Removal failed!");
-                    //        Log.Error("Package removal ActivityId = {0}", result.ActivityId);
-                    //        Log.Error("Package removal ErrorText = {0}", result.ErrorText);
-                    //        Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
-                    //    }
-                    //    else
-                    //    {
-                    //        Log.Comment("Removal successful.");
-                    //    }
-                    //}
                     foreach (var installedPackage in installedPackages)
                     {
                         Log.Comment("!!!!Test AppX package already installed. {0}", installedPackage.Id.FullName);
                     }
 
-                    if(installedPackages.Any())
+                    //if (installedPackages.Any())
+                    //{
+                    //    TestAppxInstalled.Add(packageFamilyName);
+                    //    Log.Comment("Test app is already installed. Skipping installation");
+                    //    return;
+                    //}
+
+
+                    foreach (var installedPackage in installedPackages)
                     {
-                        TestAppxInstalled.Add(packageFamilyName);
-                        Log.Comment("Test app is already installed. Skipping installation");
-                        return;
+                        Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
+
+                        AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
+                        var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
+                        removePackageOperation.Completed = (operation, status) =>
+                        {
+                            if (status != AsyncStatus.Started)
+                            {
+                                result = operation.GetResults();
+                                removePackageCompleteEvent.Set();
+                            }
+                        };
+                        removePackageCompleteEvent.WaitOne();
+
+                        if (!string.IsNullOrEmpty(result.ErrorText))
+                        {
+                            Log.Error("Removal failed!");
+                            Log.Error("Package removal ActivityId = {0}", result.ActivityId);
+                            Log.Error("Package removal ErrorText = {0}", result.ErrorText);
+                            Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
+                        }
+                        else
+                        {
+                            Log.Comment("Removal successful.");
+                        }
                     }
 
                     // The test app has not been installed yet. Install it so tests can pass

--- a/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
+++ b/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Win32;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
@@ -34,35 +35,45 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 {
                     PackageManager packageManager = new PackageManager();
                     DeploymentResult result = null;
-                    
+
                     var installedPackages = packageManager.FindPackagesForUser(string.Empty, packageFamilyName);
+                    //foreach (var installedPackage in installedPackages)
+                    //{
+                    //    Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
+
+                    //    AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
+                    //    var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
+                    //    removePackageOperation.Completed = (operation, status) =>
+                    //    {
+                    //        if (status != AsyncStatus.Started)
+                    //        {
+                    //            result = operation.GetResults();
+                    //            removePackageCompleteEvent.Set();
+                    //        }
+                    //    };
+                    //    removePackageCompleteEvent.WaitOne();
+
+                    //    if (!string.IsNullOrEmpty(result.ErrorText))
+                    //    {
+                    //        Log.Error("Removal failed!");
+                    //        Log.Error("Package removal ActivityId = {0}", result.ActivityId);
+                    //        Log.Error("Package removal ErrorText = {0}", result.ErrorText);
+                    //        Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
+                    //    }
+                    //    else
+                    //    {
+                    //        Log.Comment("Removal successful.");
+                    //    }
+                    //}
                     foreach (var installedPackage in installedPackages)
                     {
-                        Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
+                        Log.Comment("!!!!Test AppX package already installed. {0}", installedPackage.Id.FullName);
+                    }
 
-                        AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
-                        var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
-                        removePackageOperation.Completed = (operation, status) =>
-                        {
-                            if (status != AsyncStatus.Started)
-                            {
-                                result = operation.GetResults();
-                                removePackageCompleteEvent.Set();
-                            }
-                        };
-                        removePackageCompleteEvent.WaitOne();
-
-                        if (!string.IsNullOrEmpty(result.ErrorText))
-                        {
-                            Log.Error("Removal failed!");
-                            Log.Error("Package removal ActivityId = {0}", result.ActivityId);
-                            Log.Error("Package removal ErrorText = {0}", result.ErrorText);
-                            Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
-                        }
-                        else
-                        {
-                            Log.Comment("Removal successful.");
-                        }
+                    if(installedPackages.Any())
+                    {
+                        TestAppxInstalled.Add(packageFamilyName);
+                        Log.Comment("Test app is already installed. Skipping installation");
                     }
 
                     // The test app has not been installed yet. Install it so tests can pass
@@ -117,7 +128,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 TestAppxInstalled.Add(packageFamilyName);
             }
         }
-        
+
         public static void InstallCert(string certFilePath)
         {
             Log.Comment("Installing cert: {0}", certFilePath);

--- a/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
+++ b/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
@@ -74,6 +74,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                     {
                         TestAppxInstalled.Add(packageFamilyName);
                         Log.Comment("Test app is already installed. Skipping installation");
+                        return;
                     }
 
                     // The test app has not been installed yet. Install it so tests can pass

--- a/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
+++ b/test/MUXControls.Test/TAEF/TestAppInstallHelper.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Win32;
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
@@ -35,22 +34,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 {
                     PackageManager packageManager = new PackageManager();
                     DeploymentResult result = null;
-
+                    
                     var installedPackages = packageManager.FindPackagesForUser(string.Empty, packageFamilyName);
-
-                    foreach (var installedPackage in installedPackages)
-                    {
-                        Log.Comment("!!!!Test AppX package already installed. {0}", installedPackage.Id.FullName);
-                    }
-
-                    //if (installedPackages.Any())
-                    //{
-                    //    TestAppxInstalled.Add(packageFamilyName);
-                    //    Log.Comment("Test app is already installed. Skipping installation");
-                    //    return;
-                    //}
-
-
                     foreach (var installedPackage in installedPackages)
                     {
                         Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
@@ -132,7 +117,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 TestAppxInstalled.Add(packageFamilyName);
             }
         }
-
+        
         public static void InstallCert(string certFilePath)
         {
             Log.Comment("Installing cert: {0}", certFilePath);


### PR DESCRIPTION
We were hitting an issue with test execution in Helix on RS2 and RS3 machines. Sometimes the test appx would fail to install. After debugging, the issue was traced to a problem with the appx package management system. Constantly installing and uninstalling the supporting framework packages (VCLibs and CoreRuntime) makes the issue more likely to be hit.

We work around the issue by manually installing these packages before running the test. This means that when the test app is uninstalled, the supporting packages do not get uninstalled with it, which avoids hitting this appx deployment issue.