### PR TITLE
[MUX] Re-enable AcrylicBrushTests.HideAndShowWindow test to gather more data for investigation

### DIFF
--- a/dev/Materials/Acrylic/InteractionTests/AcrylicBrushTests.cs
+++ b/dev/Materials/Acrylic/InteractionTests/AcrylicBrushTests.cs
@@ -150,11 +150,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-#if !BUILD_WINDOWS
-        // Regression Test for Bug 11144540:Acrylic noise surface is lost after workstation sleep/resume
-        //[TestMethod]
-        //[TestProperty("Platform", "Desktop")]
-        // Disabled due to: Bug 19996114: Unstable test: InteractionTests.AcrylicBrushTests.HideAndShowWindow
+
+        [TestMethod]
+        [TestProperty("Platform", "Desktop")]
         public void HideAndShowWindow()
         {
             if (!OnRS2OrGreater()) { return; }
@@ -250,7 +248,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 HideAndShowWindow_GotWindowVisibleEvent.Set();
             }
         }
-#endif
 
         [TestMethod]
         public void AcrylicAlwaysUseFallback()

--- a/dev/Materials/Acrylic/TestUI/AcrylicBrushPage.xaml.cs
+++ b/dev/Materials/Acrylic/TestUI/AcrylicBrushPage.xaml.cs
@@ -348,9 +348,13 @@ namespace MUXControlsTestApp
 
                 if (_iteration_RunHideAndShowWindow == 1)
                 {
-                    // Validate that Brush has been recreated following Suspend/Resume
+                    // Validate that on MUX Brush is recreated following Suspend/Resume, while in WUXC it is not.
                     CompositionBrush currentComposotionBrush = UpdateCompositionBrush();
+#if BUILD_WINDOWS
+                    result = Object.ReferenceEquals(_previousCompositionBrush, currentComposotionBrush);
+#else
                     result = !Object.ReferenceEquals(_previousCompositionBrush, currentComposotionBrush);
+#endif
                 }
 
                 // Unset all override flags to avoid impacting subsequent tests


### PR DESCRIPTION
[Identical change has already been applied to WUXC]

Test was disabled due to intermittent failures in the MUX / WinUI lab; these don't have dumps or stacks attached and hence are not actionable. Furthermore all test failure data has now been cleaned up so we have no records of failure. 

Re-enable the test to see if reliability issues still persists; also enable it on WUXC  where Pusheen can point us to Watson dumps.

Also fix validation to reflect that in WUXC case we don't recreate the brush on hide/restore.