### PR TITLE
Fix switching views in ItemsView prototype

### DIFF
--- a/dev/Prototypes/ItemsViewPrototype/FileExplorerScenario.xaml.cs
+++ b/dev/Prototypes/ItemsViewPrototype/FileExplorerScenario.xaml.cs
@@ -36,33 +36,33 @@ namespace DEPControlsTestApp
 
             flatStackButton.Click += (sender, args) =>
             {
+                itemsView.ItemsSource = null;
                 itemsView.ViewDefinition = flatStackDefinition;
-                if (isGrouped)
-                    itemsView.ItemsSource = Items;
+                itemsView.ItemsSource = Items;
                 isGrouped = false;
             };
 
             flatFlowButton.Click += (sender, args) =>
             {
+                itemsView.ItemsSource = null;
                 itemsView.ViewDefinition = flatFlowDefinition;
-                if (isGrouped)
-                    itemsView.ItemsSource = Items;
+                itemsView.ItemsSource = Items;
                 isGrouped = false;
             };
 
             flatTableButton.Click += (sender, args) =>
             {
+                itemsView.ItemsSource = null;
                 itemsView.ViewDefinition = flatTableDefinition;
-                if (isGrouped)
-                    itemsView.ItemsSource = Items;
+                itemsView.ItemsSource = Items;
                 isGrouped = false;
             };
 
             groupedTableButton.Click += (sender, args) =>
             {
+                itemsView.ItemsSource = null;
                 itemsView.ViewDefinition = groupedTableDefinition;
-                if (!isGrouped)
-                    itemsView.ItemsSource = ItemsGroupedByParentMountain;
+                itemsView.ItemsSource = ItemsGroupedByParentMountain;
                 // itemsView.ChildrenRequested += ItemsView_ChildrenRequested;
                 isGrouped = true;
             };
@@ -70,7 +70,7 @@ namespace DEPControlsTestApp
             itemsView.SortFunc = SortItems;
             itemsView.FilterFunc = FilterItems;
         }
-
+        
         private void FileExplorerScenario_Loaded(object sender, RoutedEventArgs e)
         {
             LoadItems();


### PR DESCRIPTION
Repeater does support switching layouts at runtime and getting nice animations, however, when switching view definitions, we are also changing the template. We need a way to morph the same tree across views which we do not currently. In the mean time, just setting the ItemsSource to null and back will cause the elements to go to the recycle pool and back in which case we end up with the views from the new template. With this change, there should not be any weird views that are left over after switching view definitions.