### PR TITLE
Selecting custom color on non-100% DPI crashes settings

### DIFF
--- a/dev/ColorPicker/ColorSpectrum.cpp
+++ b/dev/ColorPicker/ColorSpectrum.cpp
@@ -886,20 +886,20 @@ void ColorSpectrum::CreateBitmapsAndColorMap()
     shared_ptr<vector<::byte>> bgraMaxPixelData = make_shared<vector<::byte>>();
     shared_ptr<vector<Hsv>> newHsvValues = make_shared<vector<Hsv>>();
 
-    bgraMinPixelData->reserve(static_cast<size_t>(minDimension * minDimension * 4));
+    bgraMinPixelData->reserve(static_cast<size_t>(round(minDimension * minDimension * 4)));
 
     // We'll only save pixel data for the middle bitmaps if our third dimension is hue.
     if (components == winrt::ColorSpectrumComponents::ValueSaturation ||
         components == winrt::ColorSpectrumComponents::SaturationValue)
     {
-        bgraMiddle1PixelData->reserve(static_cast<size_t>(minDimension * minDimension * 4));
-        bgraMiddle2PixelData->reserve(static_cast<size_t>(minDimension * minDimension * 4));
-        bgraMiddle3PixelData->reserve(static_cast<size_t>(minDimension * minDimension * 4));
-        bgraMiddle4PixelData->reserve(static_cast<size_t>(minDimension * minDimension * 4));
+        bgraMiddle1PixelData->reserve(static_cast<size_t>(round(minDimension * minDimension * 4)));
+        bgraMiddle2PixelData->reserve(static_cast<size_t>(round(minDimension * minDimension * 4)));
+        bgraMiddle3PixelData->reserve(static_cast<size_t>(round(minDimension * minDimension * 4)));
+        bgraMiddle4PixelData->reserve(static_cast<size_t>(round(minDimension * minDimension * 4)));
     }
 
-    bgraMaxPixelData->reserve(static_cast<size_t>(minDimension * minDimension * 4));
-    newHsvValues->reserve(static_cast<size_t>(minDimension * minDimension));
+    bgraMaxPixelData->reserve(static_cast<size_t>(round(minDimension * minDimension * 4)));
+    newHsvValues->reserve(static_cast<size_t>(round(minDimension * minDimension)));
 
     winrt::WorkItemHandler workItemHandler(
         [minDimension, hsv, minHue, maxHue, minSaturation, maxSaturation, minValue, maxValue, shape, components,

--- a/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
+++ b/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
@@ -32,6 +33,82 @@ namespace MUXControlsTestApp.Utilities
             }
 
             return null;
+        }
+
+        public static DependencyObject SearchVisualTree(DependencyObject root, string name)
+        {
+            int size = VisualTreeHelper.GetChildrenCount(root);
+            DependencyObject child = null;
+
+            for (int i = 0; i < size && child == null; i++)
+            {
+                DependencyObject depObj = VisualTreeHelper.GetChild(root, i);
+                FrameworkElement fe = depObj as FrameworkElement;
+
+                if (fe.Name.Equals(name))
+                {
+                    child = fe;
+                }
+                else
+                {
+                    child = SearchVisualTree(fe, name);
+                }
+            }
+
+            return child;
+        }
+
+        public static DependencyObject FindVisualChildByName(FrameworkElement parent, string name)
+        {
+            if (parent.Name == name)
+            {
+                return parent;
+            }
+
+            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+
+            for (int i = 0; i < childrenCount; i++)
+            {
+                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
+
+                if (childAsFE != null)
+                {
+                    DependencyObject result = FindVisualChildByName(childAsFE, name);
+
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public static List<T> FindVisualChildrenByType<T>(FrameworkElement parent) where T : class
+        {
+            List<T> children = new List<T>();
+            T parentAsT = parent as T;
+
+            if (parentAsT != null)
+            {
+                children.Add(parentAsT);
+            }
+
+            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+
+            for (int i = 0; i < childrenCount; i++)
+            {
+                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
+
+                if (childAsFE != null)
+                {
+                    List<T> result = FindVisualChildrenByType<T>(childAsFE);
+                    children.AddRange(result);
+                }
+            }
+
+            return children;
         }
     }
 }

--- a/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
+++ b/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
@@ -35,29 +35,6 @@ namespace MUXControlsTestApp.Utilities
             return null;
         }
 
-        public static DependencyObject SearchVisualTree(DependencyObject root, string name)
-        {
-            int size = VisualTreeHelper.GetChildrenCount(root);
-            DependencyObject child = null;
-
-            for (int i = 0; i < size && child == null; i++)
-            {
-                DependencyObject depObj = VisualTreeHelper.GetChild(root, i);
-                FrameworkElement fe = depObj as FrameworkElement;
-
-                if (fe.Name.Equals(name))
-                {
-                    child = fe;
-                }
-                else
-                {
-                    child = SearchVisualTree(fe, name);
-                }
-            }
-
-            return child;
-        }
-
         public static DependencyObject FindVisualChildByName(FrameworkElement parent, string name)
         {
             if (parent.Name == name)
@@ -83,32 +60,6 @@ namespace MUXControlsTestApp.Utilities
             }
 
             return null;
-        }
-
-        public static List<T> FindVisualChildrenByType<T>(FrameworkElement parent) where T : class
-        {
-            List<T> children = new List<T>();
-            T parentAsT = parent as T;
-
-            if (parentAsT != null)
-            {
-                children.Add(parentAsT);
-            }
-
-            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
-
-            for (int i = 0; i < childrenCount; i++)
-            {
-                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
-
-                if (childAsFE != null)
-                {
-                    List<T> result = FindVisualChildrenByType<T>(childAsFE);
-                    children.AddRange(result);
-                }
-            }
-
-            return children;
         }
     }
 }

--- a/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
+++ b/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 


### PR DESCRIPTION
Within the context of `ColorSpectrum::CreateBitmapsAndColorMap()`, minDimension is a non-integer value.  We call round() on the value for `pixelWidth` and `pixelHeight` which we pass into `CreateSurfaceFromPixelData()`, but we just cast the value to an integer type without rounding when we call `bgraMinPixelData->reserve()`.  As a result, the explicit pixel width and height that we use there can be out of sync with the implicit pixel width and height that we use to size the vectors into which we put color information.  Since we round down when sizing the vector and up when filling the vector, we can run into a buffer overflow in this case.