### PR TITLE
Use NuGet.org v3 feed. Update NuGet tool to 4.9.3

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-InstallNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallNuget-Steps.yml
@@ -1,5 +1,5 @@
 parameters:
-  nugetVersion: 4.9.1   
+  nugetVersion: 4.9.3
 
 steps:
   - task: NuGetToolInstaller@0

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -46,7 +46,7 @@ jobs:
         <configuration>
           <packageSources>
             <clear />
-            <add key='NuGet official package source' value='https://nuget.org/api/v2/' />
+            <add key='NuGet official package source' value='https://api.nuget.org/v3/index.json' />
             <add key='dotnetfeed' value='https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json' />
             <add key='local' value='$env:artifactDownloadPath\drop'/>
           </packageSources>

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -34,9 +34,9 @@ jobs:
       arguments: 17763
 
   - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.9.1'
+    displayName: 'Use NuGet 4.9.3'
     inputs:
-      versionSpec: 4.9.1
+      versionSpec: 4.9.3
         
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore MUXControls.sln'
@@ -93,9 +93,9 @@ jobs:
   steps:
 
   - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.9.1'
+    displayName: 'Use NuGet 4.9.3'
     inputs:
-      versionSpec: 4.9.1
+      versionSpec: 4.9.3
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore build/Helix/packages.config'

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet official package source" value="https://nuget.org/api/v2/" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/test/MUXControlsReleaseTest/nuget.config
+++ b/test/MUXControlsReleaseTest/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NuGet official package source" value="https://nuget.org/api/v2/" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/tools/PublishPackageToArcade/nuget.config
+++ b/tools/PublishPackageToArcade/nuget.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NuGet official package source" value="https://nuget.org/api/v2/" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="MUXControls" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/DEPControls/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
We are hitting intermittent issues in our Azure Pipelines builds where nuget restore fails.

Updating the feed url and the nuget tool to the latest versions should help mitigate the issue.