### PR TITLE
make navviewitem clickable after navview is freely moved between visualtrees.

### DIFF
--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -54,8 +54,9 @@ public:
     winrt::DependencyObject ContainerFromMenuItem(winrt::IInspectable const& item);
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs&  args);
-    void OnLoaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
+    void OnListViewLoaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnUnloaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
+    void OnLoaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
 
     void OnSettingsInvoked();
 

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -653,6 +653,37 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("NavViewTestSuite", "A")]
+        public void VerifyNavigationViewItemResponseToClickAfterBeingMovedBetweenFrames()
+        {
+            using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),
+                            page2 = new TestSetupHelper("NavigationView Init Test"))
+            {
+                var myLocationButton = FindElement.ByName<Button>("MyLocation");
+                var switchFrameButton = FindElement.ByName<Button>("SwitchFrame");
+                var result = new TextBlock(FindElement.ByName("MyLocationResult"));
+ 
+                Log.Comment("Click on MyLocation Item and verify it's on Frame1");
+                myLocationButton.Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual(result.GetText(), "Frame1");
+
+                Log.Comment("Click on SwitchFrame");
+                switchFrameButton.Invoke();
+                Wait.ForIdle();
+
+                // tree structure changed and rebuild the cache.
+                ElementCache.Clear();
+
+                Log.Comment("Click on MyLocation Item and verify it's on Frame2");
+                myLocationButton = FindElement.ByName<Button>("MyLocation");
+                myLocationButton.Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual(result.GetText(), "Frame2");
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "A")]
         public void ForceIsPaneOpenToFalseOnLeftNavTest()
         {
             using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),

--- a/dev/NavigationView/TestUI/NavigationViewInitPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewInitPage.xaml
@@ -25,6 +25,22 @@
                 <Button x:Name="RemoveItemButton" AutomationProperties.Name="RemoveItemButton" Content="Remove Item" Click="RemoveButton_Click"/>
                 <Button x:Name="ChangeToIEnumerableButton" AutomationProperties.Name="ChangeToIEnumerableButton" Content="Make it IEnumerable" Click="ChangeToIEnumerableButton_Clicks"/>
                 <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Content="Flip Orientation" Click="FlipOrientation_Click"/>
+                
+                <StackPanel>
+                    <Button x:Name="SwitchFrame" AutomationProperties.Name="SwitchFrame" Content="SwitchFrame" Click="SwitchFrame_Click" />
+                    <TextBlock x:Name="MyLocationResult" AutomationProperties.Name="MyLocationResult" Text="Unknown"/>
+
+                    <StackPanel Orientation="Horizontal">
+                        <Frame x:Name="Frame1" Width="200" Height="200">
+                            <controls:NavigationView x:Name="NavView2" IsBackButtonVisible="Collapsed" IsSettingsVisible="False" PaneDisplayMode="Top" ItemInvoked="NavView2_ItemInvoked">
+                                <controls:NavigationView.MenuItems>
+                                    <controls:NavigationViewItem Icon="Accept" Content="MyLocation" AutomationProperties.Name="MyLocation" />
+                                </controls:NavigationView.MenuItems>
+                            </controls:NavigationView>
+                        </Frame>
+                        <Frame x:Name="Frame2" Width="200" Height="200"/>
+                    </StackPanel>
+                </StackPanel>
             </StackPanel>
         </controls:NavigationView>
     </Grid>

--- a/dev/NavigationView/TestUI/NavigationViewInitPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewInitPage.xaml.cs
@@ -13,6 +13,8 @@ using Windows.UI.Xaml.Navigation;
 #if !BUILD_WINDOWS
 using NavigationViewPaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode;
 using MaterialHelperTestApi = Microsoft.UI.Private.Media.MaterialHelperTestApi;
+using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
+using NavigationViewItemInvokedEventArgs = Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs;
 #endif
 
 namespace MUXControlsTestApp
@@ -85,6 +87,34 @@ namespace MUXControlsTestApp
         private void FlipOrientation_Click(object sender, RoutedEventArgs e)
         {
             NavView.PaneDisplayMode = NavView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top ? NavigationViewPaneDisplayMode.Auto : NavigationViewPaneDisplayMode.Top;
+        }
+
+        private void SwitchFrame_Click(object sender, RoutedEventArgs e)
+        {
+            if (Frame2.Content == null)
+            {
+                var content = Frame1.Content;
+                Frame1.Content = null;
+                Frame2.Content = content;
+            }
+            else
+            {
+                var content = Frame2.Content;
+                Frame2.Content = null;
+                Frame1.Content = content;
+            }
+        }
+
+        private void NavView2_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+        {
+            if (Frame2.Content == null)
+            {
+                MyLocationResult.Text = "Frame1";
+            }
+            else
+            {
+                MyLocationResult.Text = "Frame2";
+            }
         }
     }
 }


### PR DESCRIPTION
Fix issue #18 
This resolved two kinds of problem:
1. NavViewItem is not clickable after navview is moved to another place in the visualtree. for example, between two frames. see [issue 18](https://github.com/Microsoft/microsoft-ui-xaml/issues/18)
2. NavViewItem is not clickable if Page.NavigationCacheMode="Enabled" and it's navigating back. see [navigationcachemode breaks](https://wpdev.uservoice.com/forums/110705-universal-windows-platform/suggestions/36649438--bug-page-navigationcachemode-enabled-breaks-na)

The root cause is because that unloaded and loaded event are not paired. When navview is unloaded, we revoked all the event token, but we didn't observe it again when navview is loaded again. After it's moved or page restored from cache, navviewitem doesn't raise click event anymore.

To keep the solution simple, I just hook/unhook titlebar events on unloaded/loaded event. we expect this because titlebar is in global space and it exists even if NavView is inactive or is destroyed.