### PR TITLE
Add step to publish nupkg to artifact feed during CI build

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -57,8 +57,6 @@ jobs:
       artifactName: 'drop'
 
   - ${{if parameters.publishVstsFeed }}:
-    - template: MUX-InstallNuget-Steps.yml
-
     - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
       displayName: 'NuGet push to ${{ parameters.publishVstsFeed }}'
       inputs:

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -7,6 +7,7 @@ parameters:
 # The "primary" build arch is the one that the nuspec gets its winmd, pri, and other neutral files from
   primaryBuildArch: x86
   buildFlavor: Release
+  publishVstsFeed: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -54,3 +55,14 @@ jobs:
     inputs:
       PathtoPublish: '${{ parameters.nupkgdir }}'
       artifactName: 'drop'
+
+  - ${{if parameters.publishVstsFeed }}:
+    - template: MUX-InstallNuget-Steps.yml
+
+    - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+      displayName: 'NuGet push to ${{ parameters.publishVstsFeed }}'
+      inputs:
+        command: push
+        publishVstsFeed: ${{ parameters.publishVstsFeed }}
+
+

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -58,6 +58,7 @@ jobs:
   parameters:
     jobName: CreateNugetPackage
     dependsOn: Build
+    # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
     publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
  
 # Build solution that depends on nuget package

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -58,7 +58,8 @@ jobs:
   parameters:
     jobName: CreateNugetPackage
     dependsOn: Build
-  
+    publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
+ 
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:


### PR DESCRIPTION
It's handy to have the CI build nuget package readily available for internal testing. Publishing it to the artifact feed in the same project as the pipeline for now since that's easy to set up.