### PR TITLE
Enable ThemeShadow and XamlRoot codepaths in MUX

### DIFF
--- a/DevCmd.cmd
+++ b/DevCmd.cmd
@@ -6,8 +6,11 @@ set PATH=%PATH%;%~dp0\tools
 
 call %~dp0\tools\addaliases.cmd
 
-IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise" (
-    call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+powershell -Command "&{ 'set _VSINSTALLDIR15=' + (Get-ItemProperty 'HKLM:\software\wow6432node\Microsoft\VisualStudio\SxS\vs7' -Name '15.0').'15.0' }" > %TEMP%\vsinstalldir.bat
+call %TEMP%\vsinstalldir.bat
+
+IF EXIST "%_VSINSTALLDIR15%" (
+    call "%_VSINSTALLDIR15%\Common7\Tools\VsDevCmd.bat"
 ) ELSE (
     call "%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Enterprise\Common7\Tools\VsDevCmd.bat"
 )

--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -6,7 +6,7 @@
 	<SDKVersionRS3>10.0.16299.0</SDKVersionRS3>
 	<SDKVersionRS4>10.0.17134.0</SDKVersionRS4>
 	<SDKVersionRS5>10.0.17763.0</SDKVersionRS5>
-	<SDKVersion19H1Insider>10.0.18312.0</SDKVersion19H1Insider>
+	<SDKVersion19H1Insider>10.0.18323.0</SDKVersion19H1Insider>
   </PropertyGroup>
   <PropertyGroup>
     <UseInsiderSDK>true</UseInsiderSDK>

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -21,8 +21,8 @@ steps:
     inputs:
       targetType: filePath
       filePath: build\Install-WindowsSdkISO.ps1
-      arguments: 18312
-    displayName: 'Install Insider SDK (18312)'
+      arguments: 18323
+    displayName: 'Install Insider SDK (18323)'
 
   - template: MUX-InstallNuget-Steps.yml
 

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -27,11 +27,11 @@ jobs:
       filename: 'set'
 
   - task: powershell@2
-    displayName: 'Install Insider SDK (18312)'
+    displayName: 'Install Insider SDK (18323)'
     inputs:
       targetType: filePath
       filePath: build\Install-WindowsSdkISO.ps1
-      arguments: 18312
+      arguments: 18323
 
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 4.9.3'

--- a/dev/CommandBarFlyout/CommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyout.cpp
@@ -256,11 +256,14 @@ winrt::Control CommandBarFlyout::CreatePresenter()
     presenter.Padding(winrt::ThicknessHelper::FromUniformLength(0));
     presenter.Content(*commandBar);
 
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
     // We will provide our own shadow, not the one that FlyoutPresenter has by default.
     // We need to specifically target the CommandBar for the shadow, not the default node far
     // above that.
-    presenter.IsDefaultShadowEnabled(false);
+    if (winrt::IFlyoutPresenter2 presenter2 = presenter)
+    {
+        presenter2.IsDefaultShadowEnabled(false);
+    }
 #endif
 
     commandBar->SetOwningFlyout(*this);

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -366,7 +366,7 @@ void NavigationView::OnApplyTemplate()
 
     if (SharedHelpers::IsThemeShadowAvailable())
     {
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
         if (auto splitView = m_rootSplitView.get())
         {
             if (auto contentRoot = splitView.Content())
@@ -375,7 +375,10 @@ void NavigationView::OnApplyTemplate()
                 {
                     winrt::ThemeShadow shadow;
                     shadow.Receivers().Append(contentRoot);
-                    paneRoot.Shadow(shadow);
+                    if (winrt::IUIElement10 paneRoot_uiElement10 = paneRoot)
+                    {
+                        paneRoot_uiElement10.Shadow(shadow);
+                    }
                 }
             }
         }
@@ -2750,7 +2753,7 @@ void NavigationView::OnIsPaneOpenChanged()
 
     if (SharedHelpers::IsThemeShadowAvailable())
     {
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
         if (auto splitView = m_rootSplitView.get())
         {
             if (auto paneRoot = splitView.Pane())

--- a/dev/Scroller/Scroller.cpp
+++ b/dev/Scroller/Scroller.cpp
@@ -6153,11 +6153,10 @@ void Scroller::SetKeyEvents()
 
     if (!m_isListeningToKeystrokes)
     {
-#ifdef USE_INTERNAL_SDK
-        if (SharedHelpers::IsXamlRootAvailable())
-
+#ifdef USE_INSIDER_SDK
+        if (winrt::IUIElement10 uiElement10 = *this)
         {
-            if (auto xamlRoot = XamlRoot())
+            if (auto xamlRoot = uiElement10.XamlRoot())
             {
                 auto xamlRootContent = xamlRoot.Content();
 
@@ -6193,10 +6192,10 @@ void Scroller::ResetKeyEvents()
 
     if (m_isListeningToKeystrokes)
     {
-#ifdef USE_INTERNAL_SDK
-        if (SharedHelpers::IsXamlRootAvailable())
+#ifdef USE_INSIDER_SDK
+        if (winrt::IUIElement10 uiElement10 = *this)
         {
-            if (auto xamlRoot = XamlRoot())
+            if (auto xamlRoot = uiElement10.XamlRoot())
             {
                 auto xamlRootContent = xamlRoot.Content();
 

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -673,10 +673,10 @@ void SwipeControl::AttachDismissingHandlers()
 
     DetachDismissingHandlers();
 
-#ifdef USE_INTERNAL_SDK
-    if (SharedHelpers::IsXamlRootAvailable())
+#ifdef USE_INSIDER_SDK
+    if (winrt::IUIElement10 uiElement10 = *this)
     {
-        if (auto xamlRoot = XamlRoot())
+        if (auto xamlRoot = uiElement10.XamlRoot())
         {
             auto xamlRootContent = xamlRoot.Content();
 
@@ -717,10 +717,10 @@ void SwipeControl::DetachDismissingHandlers()
 {
     SWIPECONTROL_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
 
-#ifdef USE_INTERNAL_SDK
-    if (SharedHelpers::IsXamlRootAvailable())
+#ifdef USE_INSIDER_SDK
+    if (winrt::IUIElement10 uiElement10 = *this)
     {
-        if (auto xamlRoot = this->XamlRoot())
+        if (auto xamlRoot = uiElement10.XamlRoot())
         {
             auto xamlRootContent = xamlRoot.Content();
 
@@ -752,7 +752,7 @@ void SwipeControl::DismissSwipeOnAcceleratorKeyActivator(const winrt::Windows::U
     CloseIfNotRemainOpenExecuteItem();
 }
 
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
 
 void SwipeControl::DismissSwipeOnXamlRootKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args)
 {

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -84,7 +84,7 @@ private:
     void DetachDismissingHandlers();
     void DismissSwipeOnAcceleratorKeyActivator(const winrt::Windows::UI::Core::CoreDispatcher & sender, const winrt::AcceleratorKeyEventArgs & args);
 
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
     // Used on platforms where we have XamlRoot.
     void DismissSwipeOnXamlRootKeyDown(const winrt::IInspectable & sender, const winrt::KeyRoutedEventArgs & args);
     void CurrentXamlRootChanged(const winrt::XamlRoot & sender, const winrt::XamlRootChangedEventArgs & args);
@@ -180,7 +180,7 @@ private:
     winrt::event_token m_inputEaterTappedToken{};
     tracker_ref<winrt::IInspectable> m_onPointerPressedEventHandler{ this };
 
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
     // Used on platforms where we have XamlRoot.
     tracker_ref<winrt::IInspectable> m_onXamlRootPointerPressedEventHandler{ this };
     tracker_ref<winrt::IInspectable> m_onXamlRootKeyDownEventHandler{ this };

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -203,15 +203,6 @@ bool SharedHelpers::IsDispatcherQueueAvailable()
     return s_isAvailable;
 }
 
-bool SharedHelpers::IsXamlRootAvailable()
-{
-    static bool s_IsXamlRootAvailable =
-        IsSystemDll() ||
-        IsVanadiumOrHigher() ||
-        winrt::ApiInformation::IsTypePresent(L"Windows.UI.Xaml.XamlRoot");
-    return s_IsXamlRootAvailable;
-}
-
 bool SharedHelpers::IsThemeShadowAvailable()
 {
     static bool s_isThemeShadowAvailable =

--- a/dev/inc/CppWinRTIncludes.h
+++ b/dev/inc/CppWinRTIncludes.h
@@ -30,7 +30,7 @@
 #include <winrt\Windows.UI.Input.h>
 #include <winrt\Windows.UI.Text.h>
 #include <winrt\Windows.UI.ViewManagement.h>
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
 #include <winrt\Windows.UI.WindowManagement.h>
 #endif
 #include <winrt\Windows.UI.Xaml.h>
@@ -89,7 +89,7 @@ namespace winrt
     using namespace ::winrt::Windows::UI::Input;
     using namespace ::winrt::Windows::UI::Text;
     using namespace ::winrt::Windows::UI::ViewManagement;
-#ifdef USE_INTERNAL_SDK
+#ifdef USE_INSIDER_SDK
     using namespace ::winrt::Windows::UI::WindowManagement;
 #endif
     using namespace ::winrt::Windows::UI::Xaml;
@@ -206,6 +206,7 @@ namespace winrt
     using DragItemsStartingEventArgs = winrt::Windows::UI::Xaml::Controls::DragItemsStartingEventArgs;
     using DragItemsStartingEventHandler = winrt::Windows::UI::Xaml::Controls::DragItemsStartingEventHandler;
     using FlyoutPresenter = winrt::Windows::UI::Xaml::Controls::FlyoutPresenter;
+    using IFlyoutPresenter2 = winrt::Windows::UI::Xaml::Controls::IFlyoutPresenter2;
     using FocusDisengagedEventArgs = winrt::Windows::UI::Xaml::Controls::FocusDisengagedEventArgs;
     using FocusEngagedEventArgs = winrt::Windows::UI::Xaml::Controls::FocusEngagedEventArgs;
     using FontIcon = winrt::Windows::UI::Xaml::Controls::FontIcon;
@@ -303,6 +304,7 @@ namespace winrt
     using RectangleGeometry = winrt::Windows::UI::Xaml::Media::RectangleGeometry;
     using SolidColorBrush = ::winrt::Windows::UI::Xaml::Media::SolidColorBrush;
     using Stretch = winrt::Windows::UI::Xaml::Media::Stretch;
+    using ThemeShadow = winrt::Windows::UI::Xaml::Media::ThemeShadow;
     using TranslateTransform = winrt::Windows::UI::Xaml::Media::TranslateTransform;
     using VisualTreeHelper = winrt::Windows::UI::Xaml::Media::VisualTreeHelper;
     using XamlCompositionBrushBase = ::winrt::Windows::UI::Xaml::Media::XamlCompositionBrushBase;

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -53,8 +53,6 @@ public:
 
     static bool IsDispatcherQueueAvailable();
 
-    static bool IsXamlRootAvailable();
-
     static bool IsThemeShadowAvailable();
 
     // Actual OS version checks

--- a/test/TestAppUtils/TestFrame.cs
+++ b/test/TestAppUtils/TestFrame.cs
@@ -169,20 +169,24 @@ namespace MUXControlsTestApp
 
         private void SetRootGridSizeFromWindowSize()
         {
-#if USE_INTERNAL_SDK
+            var size = new Size(Window.Current.Bounds.Width, Window.Current.Bounds.Height);
+
+#if USE_INSIDER_SDK
             if (Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.UI.Xaml.XamlRoot"))
             {
-                var xamlRoot = _rootGrid.XamlRoot;
-                var size = xamlRoot.Size;
-                _rootGrid.Width = size.Width;
-                _rootGrid.Height = size.Height;
+                try
+                {
+                    var xamlRoot = _rootGrid.XamlRoot;
+                    size = xamlRoot.Size;
+                }
+                catch (InvalidCastException)
+                {
+                    // If running on mismatched OS build, just fall back to window bounds.
+                }
             }
-            else
 #endif
-            {
-                _rootGrid.Width = Window.Current.Bounds.Width;
-                _rootGrid.Height = Window.Current.Bounds.Height;
-            }
+            _rootGrid.Width = size.Width;
+            _rootGrid.Height = size.Height;
         }
 
         private void GoBackInvokerButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
ThemeShadow and XamlRoot are now in insider SDK, so switch their #ifdefs to use USE_INSIDER_SDK.

I changed the XamlRoot/ThemeShadow stuff to use try_as instead of checking IsTypePresent. IsTypePresent gives false positives on inside builds because the type is present with the same name but the interfaces may have changed since the SDK we compiled against and if you're running on the wrong build it will crash. The try_as defends more robustly against interface changes and is more performant.

Also retargeted to 18323 because that's the latest available and the interfaces changed between 18312 and 18323 so it wasn't working on latest insider. (which conveniently helped me catch the previous issue 😀).

Fixes #258.