### PR TITLE
Updating FireEvent to be callable from process detach

### DIFF
--- a/dev/dll/dllmain.cpp
+++ b/dev/dll/dllmain.cpp
@@ -19,6 +19,8 @@ HINSTANCE g_hInstance = NULL;
 void InitCheckedMemoryChainLock();
 #endif
 
+STDAPI_(void) SendTelemetryOnSuspend();
+
 STDAPI_(BOOL) DllMain(_In_ HINSTANCE hInstance, _In_ DWORD reason, _In_opt_ void *)
 {
     if (DLL_PROCESS_ATTACH == reason)
@@ -34,6 +36,7 @@ STDAPI_(BOOL) DllMain(_In_ HINSTANCE hInstance, _In_ DWORD reason, _In_opt_ void
     }
     else if (DLL_PROCESS_DETACH == reason)
     {
+        SendTelemetryOnSuspend();
         UnRegisterTraceLogging();
     }
 


### PR DESCRIPTION
In order to report accurate control counts on Win32 apps, we will now fire control count telemetry on process detach.  We need to eliminate the use of API calls to other libraries in order to avoid hanging or crashing due to holding the loader lock upon process detach.

Changes entail:
- Restructure FireEvent() to compose and fire the event and minimize dependencies on other binaries.  This implementation relies only on InterlockedExchange() and TraceLoggingWrite(); both which are callable during process detach.
- Added utility functions for string composition for FireEvent().
- Added call to SendTelemetryOnSuspend() upon hitting process detach, which will occur on normal process shutdown on Win32 apps.