### PR TITLE
Avoid name conflicts in mux and wux for some keyed styles

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -323,7 +323,7 @@
 
                                     <local:NavigationViewItem
                                             x:Name="SettingsTopNavPaneItem"
-                                            Style="{ThemeResource NavigationViewSettingsItemStyleWhenOnTopPane}"
+                                            Style="{ThemeResource MUX_NavigationViewSettingsItemStyleWhenOnTopPane}"
                                             Grid.Column="8"
                                             Icon="Setting"/>
 
@@ -513,27 +513,27 @@
                             <VisualStateGroup x:Name="ItemOnNavigationViewListPositionStates">
                                 <VisualState x:Name="OnLeftNavigation">
                                     <VisualState.Setters>
-                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource NavigationViewItemPresenterStyleWhenOnLeftPane}" />
+                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource MUX_NavigationViewItemPresenterStyleWhenOnLeftPane}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="OnLeftNavigationReveal">
                                     <VisualState.Setters>
-                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource NavigationViewItemPresenterStyleWhenOnLeftPaneWithRevealFocus}" />
+                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource MUX_NavigationViewItemPresenterStyleWhenOnLeftPaneWithRevealFocus}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="OnTopNavigationPrimary">
                                     <VisualState.Setters>
-                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource NavigationViewItemPresenterStyleWhenOnTopPane}" />
+                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource MUX_NavigationViewItemPresenterStyleWhenOnTopPane}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="OnTopNavigationPrimaryReveal">
                                     <VisualState.Setters>
-                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource NavigationViewItemPresenterStyleWhenOnTopPaneWithRevealFocus}" />
+                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource MUX_NavigationViewItemPresenterStyleWhenOnTopPaneWithRevealFocus}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="OnTopNavigationOverflow">
                                     <VisualState.Setters>
-                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource NavigationViewItemPresenterStyleWhenOnTopPaneOverflow}" />
+                                        <Setter Target="NavigationViewItemPresenter.Style" Value="{StaticResource MUX_NavigationViewItemPresenterStyleWhenOnTopPaneOverflow}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -452,7 +452,7 @@
     </Style>
 
 
-    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="NavigationViewItemPresenterStyleWhenOnLeftPane">
+    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnLeftPane">
         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource NavigationViewItemBorderBrush}" />
@@ -567,7 +567,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="NavigationViewItemPresenterStyleWhenOnLeftPaneWithRevealFocus">
+    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnLeftPaneWithRevealFocus">
         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource NavigationViewItemBorderBrush}" />
@@ -665,7 +665,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="local:NavigationViewItem" x:Key="NavigationViewSettingsItemStyleWhenOnTopPane">
+    <Style TargetType="local:NavigationViewItem" x:Key="MUX_NavigationViewSettingsItemStyleWhenOnTopPane">
         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource NavigationViewItemBorderBrush}" />
@@ -763,7 +763,7 @@
         </Setter>
     </Style>
     
-    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="NavigationViewItemPresenterStyleWhenOnTopPane">
+    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnTopPane">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="primitives:NavigationViewItemPresenter">
@@ -894,7 +894,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="NavigationViewItemPresenterStyleWhenOnTopPaneWithRevealFocus">
+    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnTopPaneWithRevealFocus">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="primitives:NavigationViewItemPresenter">
@@ -991,7 +991,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="NavigationViewItemPresenterStyleWhenOnTopPaneOverflow">
+    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnTopPaneOverflow">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="primitives:NavigationViewItemPresenter">

--- a/dev/NavigationView/NavigationView_rs2_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs2_themeresources.xaml
@@ -106,7 +106,7 @@
 
     <Thickness x:Key="NavigationViewItemBorderThickness">1</Thickness>
 
-    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="NavigationViewItemPresenterStyleWhenOnLeftPane">
+    <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnLeftPane">
         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource NavigationViewItemBorderBrush}" />

--- a/dev/TreeView/TreeView.xaml
+++ b/dev/TreeView/TreeView.xaml
@@ -48,6 +48,6 @@
         </Setter>
     </Style>
     
-    <Style TargetType="local:TreeViewItem" BasedOn="{StaticResource TreeViewItemStyle}"/>
+    <Style TargetType="local:TreeViewItem" BasedOn="{StaticResource MUX_TreeViewItemStyle}"/>
     
 </ResourceDictionary>

--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -8,7 +8,7 @@
     
     <Style TargetType="local:TreeViewItem"
            BasedOn="{StaticResource ListViewItemRevealStyle}"
-           x:Key="TreeViewItemStyle">
+           x:Key="MUX_TreeViewItemStyle">
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Background" Value="{ThemeResource TreeViewItemBackground}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource TreeViewItemBorderBrush}"/>

--- a/dev/TreeView/TreeViewItem_rs1.xaml
+++ b/dev/TreeView/TreeViewItem_rs1.xaml
@@ -6,7 +6,7 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
     <Style TargetType="local:TreeViewItem" 
            BasedOn="{StaticResource ListViewItemRevealStyle}"
-           x:Key="TreeViewItemStyle">
+           x:Key="MUX_TreeViewItemStyle">
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Background" Value="{ThemeResource TreeViewItemBackground}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource TreeViewItemBorderBrush}"/>


### PR DESCRIPTION
wux(Windows.UI.XAML) controls Windows share the same code and xaml resources with mux(Microsoft.UI.XAML).
If the style share the same key name for MUX and WUX, wrong style may apply to the control.

This covers the change to NavigationView and TreeView. This would avoid exceptions like below:

XAML:
<mux:TreeViewItem Content="Haha2"  Style="{ThemeResource TreeViewItemStyle}" />

Exception:
WinRT information: Cannot apply a Style with TargetType 'Windows.UI.Xaml.Controls.TreeViewItem' to an object of type 'Microsoft.UI.Xaml.Controls.TreeViewItem'. [Line: 27 Position: 48]