### PR TITLE
Developer Guide doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,10 @@ While we strive to accept all community contributions that meet the guidelines o
 
 For details see:
 
-* [Source code structure](docs/developer_guide.md#Source%20code%20structure)
-* [Setup and build environment](docs/developer_guide.md#Building%20the%20repository)
-* [Development process](docs/contribution_workflow.md)
-* [Coding style and conventions](docs/developer_guide.md#Code%20style%20and%20conventions)
+* [Setup and build environment](docs/developer_guide.md#Prerequisites)
+* [Source code structure](docs/source_code_structure.md)
+* [Contribution workflow](docs/contribution_workflow.md)
+* [Coding style and conventions](docs/code_style_and_conventions.md)
 
 ### Contributor License Agreement
 

--- a/docs/code_style_and_conventions.md
+++ b/docs/code_style_and_conventions.md
@@ -1,0 +1,26 @@
+# Code style and conventions
+
+* C++: [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md)
+* C#: Follow the .NET Core team's [C# coding style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)
+
+For all languages respect the [.editorconfig](https://editorconfig.org/) file 
+specified in the source tree. Many IDEs natively support this or can with a 
+plugin.
+
+### File headers
+
+The following file header is the used for WinUI. Please use it for new files.
+
+#### C++/C#
+```
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+```
+
+#### XAML/proj
+
+```
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+```
+
+### C++/WinRT

--- a/docs/contribution_workflow.md
+++ b/docs/contribution_workflow.md
@@ -26,7 +26,7 @@ have one).
     from upstream. They also enable you to create multiple PRs from the same 
     fork.
 4. Make and commit your changes. 
-    * Please follow our [Commit Messages](contribution_workflow.md#Commit%20Messages) 
+    * Please follow our [Commit Messages](contribution_workflow.md#Commit-Messages) 
     guidance.
 5. Add [new tests](developer_guide.md#Testing) corresponding to your change, if applicable.
 6. Build the repository with your changes. 
@@ -46,7 +46,7 @@ have one).
 ## DOs and DON'Ts
 
 Please do:
-* **DO** follow our [coding style](developer_guide.md#Code%20style%20and%20conventions).
+* **DO** follow our [coding style](code_style_and_conventions.md).
 * **DO** give priority to the current style of the project or file you're 
 changing even if it diverges from the general guidelines.
 * **DO** include tests when adding new features. When fixing bugs, start with 

--- a/docs/contribution_workflow.md
+++ b/docs/contribution_workflow.md
@@ -31,7 +31,8 @@ have one).
 5. Add [new tests](developer_guide.md#Testing) corresponding to your change, if applicable.
 6. Build the repository with your changes. 
     * Make sure that the builds are clean.
-    * Make sure that the [tests](developer_guide.md#Testing) are all passing, including your new tests.
+    * Make sure that the [tests](developer_guide.md#Testing) are all passing, including your new 
+    tests.
 7. Create a pull request (PR) against the upstream repository's master branch. 
     * Push your changes to your fork on GitHub (if you haven't already).
     - Note: It is okay for your PR to include a large number of commits. Once 
@@ -70,11 +71,39 @@ discussing it first: see the [New Feature or API Process](feature_proposal_proce
 
 ## Checks
 
-Each pull request must pass the following checks.
+Each pull request to `master` must pass the following checks.
 
-#### WinUI_build_OS
+Pull requests into a fork will not trigger all of these checks, but you can manually request them 
+individually from the pipeline definition page.
 
-This check essentially makes sure that your change actually builds.
+#### [WinUI-Public-Tests](https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=22)
+
+This pipeline builds your change and runs automated tests. These tests should match what you're 
+able to run with local automated testing using Test Explorer.
+
+#### [WinUI-Public-MUX-PR](https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=21)
+
+This check creates a Nuget package to match your change.
+
+#### license/cla
+
+This check confirms that you have completed the [CLA](https://cla.microsoft.com).
+
+### Other Pipelines
+
+Unlike the above checks these are not required for all PRs, but you may see them on some PRs so we 
+define them here:
+
+#### [WinUI-Public-MUX-CI](https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=20)
+
+This pipeline extends [WinUI-Public-MUX-PR](https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=21) 
+to validate more platforms, adding Debug and ARM. It is run after your changes are merged to 
+master.
+
+#### [WinUI_build_OS](https://microsoft.visualstudio.com/WinUI/_build?definitionId=34263)
+
+This check validates that your code can be ported to the core Windows OS to 
+Windows.UI.Xaml.Controls.
 
 One snag you might hit is a failure in `PeformDEPControlsPort.cmd`. This 
 process validates the compatibility of your change with the port to the Windows
@@ -84,18 +113,6 @@ Windows build, so if you run into a problem with this validation step you may
 need the help of a Microsoft employee. You may be able to look at similar code 
 and its use of `BUILD_WINDOWS` to figure out what you need to do, but feel free 
 to @ mention Microsoft team members to ask for help.
-
-#### WinUI-Public-MUX-PR
-
-> Note: Until [this issue](https://github.com/Microsoft/microsoft-ui-xaml/issues/49)
-is resolved the only check made is build validation, not automated tests.
-
-This check runs automated tests on your change. These tests should match what 
-you're able to run with local automated testing using Test Explorer.
-
-#### license/cla
-
-This check confirms that you have completed the [CLA](https://cla.microsoft.com).
 
 ## Commit Messages
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -31,7 +31,7 @@ You will also need to install The Windows 10 Insider SDK 18312. The easiest way
 to install this is to run the Install-WindowsSdkISO.ps1 script from this repo in
 an Administrator Powershell window:
 
-`.\build\Install-WindowsSdkISO.ps1 18312`
+ `.\build\Install-WindowsSdkISO.ps1 18323`
 
 ## Building the repository
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,106 +1,20 @@
-# Developer Guide
+﻿# Developer Guide
 
 This guide provides instructions on how to build the repo and implement 
 improvements.
 
-## Source code structure
+* [Prerequisites](docs/developer_guide.md#Prerequisites)
+* [Building the repository](docs/developer_guide.md#Building-the-repository)
+* [Testing](docs/developer_guide.md#Testing)
+* [Telemetry](docs/developer_guide.md#Telemetry)
 
-#### /build, /tools
+Additional reading:
 
-These folders contain scripts and other support machinery that you shouldn't 
-need to edit for most changes.
+* [Source code structure](docs/source_code_structure.md)
+* [Coding style and conventions](docs/code_style_and_conventions.md)
 
-In particular:
 
-* **/build/NuSpecs** enables .nupkg generation
-* **/build/FrameworkPackage** enables .appx generation
-
-Note that here and in various parts of the codebase you will see references to 
-`BUILD_WINDOWS`. WinUI operates as a standalone package for Xaml apps but is 
-also a way that new controls migrate into [Windows.UI.Xaml.Controls](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls) 
-as part of the Windows build system. The places where the WinUI source needs to 
-differ for this different environment are specified under `BUILD_WINDOWS`. It's 
-expected that it is the responsibility of the Microsoft team members to 
-maintain this part of WinUI, and other community members should be able to 
-ignore it.
-
-#### /dev
-
-Under dev is a separate folder for each of our controls.
-
-Each control is composed of a Shared Item using the Shared Item Template in 
-Visual Studio. It is then included into the respective projects. This gives us 
-flexibility in the future if we need to decompose our other projects into 
-smaller projects, move to a Git submodule model on a per control basis, or 
-create different DLLs of our solution. Currently the project is small enough 
-that the Shared Item Template gives us enough flexibility to add/remove 
-controls to/from the subsequent projects easily.
-
-Also under dev is the actual Microsoft.UI.Xaml project, which is the main DLL 
-that contains all the controls and other solutions which will be packaged and 
-deployed. At this time we believe the Microsoft.UI.Xaml.dll is 
-small enough to include all controls into one DLL. As we increase the number of 
-controls we will revisit this decision and may decompose it into different DLLs 
-in the future. Also we will adjust based on developer feedback if we start to see 
-usage patterns where teams use just a few controls vs. the whole library.
-
-This project also includes the necessary definitions to package the DLL into a 
-NuGet package.
-
-#### /docs
-
-This is where the repo documentation lives, including this document.
-
-Note that developer usage documentation can be found separately on docs.microsoft.com.
-
-#### /test
-
-Our test library and test app (the app that the test library interacts with 
-when executing the tests) are here.
-
-MUXControls.Test is a [MSTest](https://docs.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting) 
-DLL using MITALite that contains all of the test code for the various controls 
-by automating the MUXControlsTestApp.
-
-MUXControlsTestApp is a UWP app that exercises all the controls. This is just a 
-manual testing playground which can be driven by the automated tests for 
-automated verification as well as [TestMethod] control API verification. Note 
-this applications references the MUXControls DLL rather than including the 
-Shared Items.
-
-## Code style and conventions
-
-* C++: [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md)
-* C#: Follow the .NET Core team's [C# coding style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)
-
-For all languages respect the [.editorconfig](https://editorconfig.org/) file 
-specified in the source tree. Many IDEs natively support this or can with a 
-plugin.
-
-### File headers
-
-The following file header is the used for WinUI. Please use it for new files.
-
-#### C++/C#
-```
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See LICENSE in the project root for license information.
-```
-
-#### XAML/proj
-
-```
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-```
-
-### C++/WinRT
-
-## Building the repository
-
-Generally you will want to set your configuration to **Debug**, **x86**, and 
-select **MUXControlsTestApp** as your startup project in Visual Studio.
-
-### Prerequisites
+## Prerequisites
 #### Visual Studio
 
 Install latest VS2017 (15.9 or later) from here: http://visualstudio.com/downloads
@@ -118,6 +32,11 @@ to install this is to run the Install-WindowsSdkISO.ps1 script from this repo in
 an Administrator Powershell window:
 
 `.\build\Install-WindowsSdkISO.ps1 18312`
+
+## Building the repository
+
+Generally you will want to set your configuration to **Debug**, **x86**, and 
+select **MUXControlsTestApp** as your startup project in Visual Studio.
 
 ### Creating a NuGet package
 

--- a/docs/source_code_structure.md
+++ b/docs/source_code_structure.md
@@ -54,8 +54,8 @@ Our test library and test app (the app that the test library interacts with
 when executing the tests) are here.
 
 MUXControls.Test is a [MSTest](https://docs.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting) 
-DLL using MITALite that contains all of the test code for the various controls 
-by automating the MUXControlsTestApp.
+and [TAEF](https://docs.microsoft.com/en-us/windows-hardware/drivers/taef/) DLL that contains all 
+of the test code for the various controls by automating the MUXControlsTestApp.
 
 MUXControlsTestApp is a UWP app that exercises all the controls. This is just a 
 manual testing playground which can be driven by the automated tests for 

--- a/docs/source_code_structure.md
+++ b/docs/source_code_structure.md
@@ -1,0 +1,64 @@
+# Source code structure
+
+#### /build, /tools
+
+These folders contain scripts and other support machinery that you shouldn't 
+need to edit for most changes.
+
+In particular:
+
+* **/build/NuSpecs** enables .nupkg generation
+* **/build/FrameworkPackage** enables .appx generation
+
+Note that here and in various parts of the codebase you will see references to 
+`BUILD_WINDOWS`. WinUI operates as a standalone package for Xaml apps but is 
+also a way that new controls migrate into [Windows.UI.Xaml.Controls](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls) 
+as part of the Windows build system. The places where the WinUI source needs to 
+differ for this different environment are specified under `BUILD_WINDOWS`. It's 
+expected that it is the responsibility of the Microsoft team members to 
+maintain this part of WinUI, and other community members should be able to 
+ignore it.
+
+#### /dev
+
+Under dev is a separate folder for each of our controls.
+
+Each control is composed of a Shared Item using the Shared Item Template in 
+Visual Studio. It is then included into the respective projects. This gives us 
+flexibility in the future if we need to decompose our other projects into 
+smaller projects, move to a Git submodule model on a per control basis, or 
+create different DLLs of our solution. Currently the project is small enough 
+that the Shared Item Template gives us enough flexibility to add/remove 
+controls to/from the subsequent projects easily.
+
+Also under dev is the actual Microsoft.UI.Xaml project, which is the main DLL 
+that contains all the controls and other solutions which will be packaged and 
+deployed. At this time we believe the Microsoft.UI.Xaml.dll is 
+small enough to include all controls into one DLL. As we increase the number of 
+controls we will revisit this decision and may decompose it into different DLLs 
+in the future. Also we will adjust based on developer feedback if we start to see 
+usage patterns where teams use just a few controls vs. the whole library.
+
+This project also includes the necessary definitions to package the DLL into a 
+NuGet package.
+
+#### /docs
+
+This is where the repo documentation lives, including this document.
+
+Note that developer usage documentation can be found separately on docs.microsoft.com.
+
+#### /test
+
+Our test library and test app (the app that the test library interacts with 
+when executing the tests) are here.
+
+MUXControls.Test is a [MSTest](https://docs.microsoft.com/dotnet/api/microsoft.visualstudio.testtools.unittesting) 
+DLL using MITALite that contains all of the test code for the various controls 
+by automating the MUXControlsTestApp.
+
+MUXControlsTestApp is a UWP app that exercises all the controls. This is just a 
+manual testing playground which can be driven by the automated tests for 
+automated verification as well as [TestMethod] control API verification. Note 
+this applications references the MUXControls DLL rather than including the 
+Shared Items.


### PR DESCRIPTION
* Split "Code Style and Conventions" and "Source Code Structure" out of the Developer Guide into separate documents (unchanged). Linked to them from the top of the Developer Guide.
* Updated information on checks and pipelines
* Fix broken links in the documentation (where %20 was being used for deep links instead of hyphen)