### PR TITLE
make Narrator announces count for Settings item be 1 of 1

### DIFF
--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -64,7 +64,12 @@ winrt::IInspectable NavigationViewItemAutomationPeer::GetPatternCore(winrt::Patt
 int32_t NavigationViewItemAutomationPeer::GetPositionInSetCore()
 {
     int32_t positionInSet = 0;
-    
+
+    if (IsSettingsItem())
+    {
+        return 1;
+    }
+
     if (IsOnTopNavigation())
     {
         if (auto navigationView = GetParentNavigationView())
@@ -85,7 +90,12 @@ int32_t NavigationViewItemAutomationPeer::GetPositionInSetCore()
 int32_t NavigationViewItemAutomationPeer::GetSizeOfSetCore()
 {
     int32_t sizeOfSet = 0;
-    
+
+    if (IsSettingsItem())
+    {
+        return 1;
+    }
+
     if (IsOnTopNavigation())
     {
         if (auto navview = GetParentNavigationView())
@@ -147,6 +157,20 @@ int32_t NavigationViewItemAutomationPeer::GetNavigationViewItemCountInTopNav()
         count = winrt::get_self<NavigationView>(navigationView)->GetNavigationViewItemCountInTopNav();
     }
     return count;
+}
+
+bool NavigationViewItemAutomationPeer::IsSettingsItem()
+{
+    if (auto navView = GetParentNavigationView())
+    {
+        winrt::NavigationViewItem item = Owner().try_as<winrt::NavigationViewItem>();
+        auto settingsItem = navView.SettingsItem();
+        if (item && settingsItem && (item == settingsItem || item.Content() == settingsItem))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool NavigationViewItemAutomationPeer::IsOnTopNavigation()

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.h
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.h
@@ -38,6 +38,7 @@ private:
     winrt::NavigationView GetParentNavigationView();
     bool IsOnTopNavigation();
     bool IsOnTopNavigationOverflow();
+    bool IsSettingsItem();
     NavigationViewListPosition GetNavigationViewListPosition();
     int32_t GetNavigationViewItemCountInPrimaryList();
     int32_t GetNavigationViewItemCountInTopNav();

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -2349,6 +2349,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("NavViewTestSuite", "C")]
+        public void SettingsAccessibilitySetTest()
+        {
+            var testScenarios = RegressionTestScenario.BuildAllRegressionTestScenarios();
+            foreach (var testScenario in testScenarios)
+            {
+                using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),
+                 page2 = new TestSetupHelper(testScenario.TestPageName))
+                {
+                    Log.Comment("Setting focus to Settings");
+                    UIObject settingsItem = testScenario.IsLeftNavTest ? FindElement.ByName("Settings") : FindElement.ByName("SettingsTopNavPaneItem");
+                    settingsItem.SetFocus();
+                    Wait.ForIdle();
+
+                    AutomationElement ae = AutomationElement.FocusedElement;
+                    int positionInSet = (int)ae.GetCurrentPropertyValue(AutomationElement.PositionInSetProperty);
+                    int sizeOfSet = (int)ae.GetCurrentPropertyValue(AutomationElement.SizeOfSetProperty);
+
+                    Verify.AreEqual(1, positionInSet, "Position in set");
+                    Verify.AreEqual(1, sizeOfSet, "Size of set");
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "C")]
         public void ItemsAccessibilitySetTest()
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();


### PR DESCRIPTION
In NavigationView, move Narrator focus to the Settings item.
Actual: Narrator Announces "Settings, 3 of 3" (or "4 of 4", or "5 of 5" depending on NavigationView mode and whether AutoSuggestBox is present.)
Best Fix: Narrator announces "Settings"
Current Fix: Narrator announces "Settings, 1 of 1"

We can't do the best fix because we need os to support it. NavigationViewItem itself is ListViewItem, and narrator would always do 'a of b' for it.
