### PR TITLE
Treat warnings as error

### DIFF
--- a/dev/AnimatedVisualPlayer/TestUI/LottieLogo.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/LottieLogo.cs
@@ -5145,6 +5145,7 @@ namespace AnimatedVisuals
             Vector2 IAnimatedVisual.Size => new Vector2(375, 667);
             void IDisposable.Dispose() => _root?.Dispose();
 
+#pragma warning disable 0649
             ref struct D2D1_RECT_F
             {
                 internal float left;
@@ -5159,6 +5160,8 @@ namespace AnimatedVisuals
                 internal float radiusX;
                 internal float radiusY;
             }
+
+#pragma warning restore 0649
 
             ref struct D2D1_BEZIER_SEGMENT
             {

--- a/dev/Materials/Reveal/TestUI/RevealScenarioGrid.xaml
+++ b/dev/Materials/Reveal/TestUI/RevealScenarioGrid.xaml
@@ -12,14 +12,14 @@
         <ResourceDictionary>
             <DataTemplate x:Key="ImageTextItem" x:DataType="local:RevealGridItem">
                 <StackPanel>
-                    <Image Source="{x:Bind Image}" Width="138" Height="138" Stretch="UniformToFill" Margin="0,0,0,5"/>
+                    <Image Source="{x:Bind ImageSource}" Width="138" Height="138" Stretch="UniformToFill" Margin="0,0,0,5"/>
                     <TextBlock Text="{x:Bind Header}" FontSize="15" Margin="4,0,4,2"/>
                     <TextBlock Text="{x:Bind SubHeader}" FontSize="12" Margin="4,0,4,8"/>
                 </StackPanel>
             </DataTemplate>
 
             <DataTemplate x:Key="ImageItem" x:DataType="local:RevealGridItem">
-                <Image Source="{x:Bind Image}" Width="250" Stretch="UniformToFill"/>
+                <Image Source="{x:Bind ImageSource}" Width="250" Stretch="UniformToFill"/>
             </DataTemplate>
 
             <DataTemplate x:Key="SemiTransparentItem" x:DataType="local:RevealGridItem">

--- a/dev/Materials/Reveal/TestUI/RevealScenarioGrid.xaml.cs
+++ b/dev/Materials/Reveal/TestUI/RevealScenarioGrid.xaml.cs
@@ -65,28 +65,28 @@ namespace MUXControlsTestApp
 
         public string Header;
         public string SubHeader = "This is a sub-header";
-        public BitmapImage Image;
+        public BitmapImage ImageSource;
 
         public static ObservableCollection<RevealGridItem> GetItems()
         {
             if(items == null)
             {
                 items = new ObservableCollection<RevealGridItem>();
-                items.Add(new RevealGridItem { Header = "Smile", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage12.jpg")) });
-                items.Add(new RevealGridItem { Header = "Business", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage23.jpg")) });
-                items.Add(new RevealGridItem { Header = "Kid", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage20.jpg")) });
-                items.Add(new RevealGridItem { Header = "Metal", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage22.jpg")) });
-                items.Add(new RevealGridItem { Header = "Super Metal", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage7.jpg")) });
-                items.Add(new RevealGridItem { Header = "Smile", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage12.jpg")) });
-                items.Add(new RevealGridItem { Header = "Business", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage23.jpg")) });
-                items.Add(new RevealGridItem { Header = "Kid", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage20.jpg")) });
-                items.Add(new RevealGridItem { Header = "Metal", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage22.jpg")) });
-                items.Add(new RevealGridItem { Header = "Super Metal", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage7.jpg")) });
-                items.Add(new RevealGridItem { Header = "Smile", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage12.jpg")) });
-                items.Add(new RevealGridItem { Header = "Business", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage23.jpg")) });
-                items.Add(new RevealGridItem { Header = "Kid", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage20.jpg")) });
-                items.Add(new RevealGridItem { Header = "Metal", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage22.jpg")) });
-                items.Add(new RevealGridItem { Header = "Super Metal", Image = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage7.jpg")) });
+                items.Add(new RevealGridItem { Header = "Smile", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage12.jpg")) });
+                items.Add(new RevealGridItem { Header = "Business", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage23.jpg")) });
+                items.Add(new RevealGridItem { Header = "Kid", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage20.jpg")) });
+                items.Add(new RevealGridItem { Header = "Metal", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage22.jpg")) });
+                items.Add(new RevealGridItem { Header = "Super Metal", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage7.jpg")) });
+                items.Add(new RevealGridItem { Header = "Smile", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage12.jpg")) });
+                items.Add(new RevealGridItem { Header = "Business", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage23.jpg")) });
+                items.Add(new RevealGridItem { Header = "Kid", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage20.jpg")) });
+                items.Add(new RevealGridItem { Header = "Metal", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage22.jpg")) });
+                items.Add(new RevealGridItem { Header = "Super Metal", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage7.jpg")) });
+                items.Add(new RevealGridItem { Header = "Smile", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage12.jpg")) });
+                items.Add(new RevealGridItem { Header = "Business", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage23.jpg")) });
+                items.Add(new RevealGridItem { Header = "Kid", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage20.jpg")) });
+                items.Add(new RevealGridItem { Header = "Metal", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage22.jpg")) });
+                items.Add(new RevealGridItem { Header = "Super Metal", ImageSource = new BitmapImage(new Uri("https://raw.githubusercontent.com/Microsoft/Windows-universal-samples/master/SharedContent/media/Samples/LandscapeImage7.jpg")) });
             }
 
             return items;

--- a/dev/Materials/Reveal/TestUI/RevealScenarioList.xaml
+++ b/dev/Materials/Reveal/TestUI/RevealScenarioList.xaml
@@ -17,13 +17,13 @@
                         <ColumnDefinition Width="auto"/>
                     </Grid.ColumnDefinitions>
 
-                    <Image Source="{x:Bind Image}" Stretch="UniformToFill"/>
+                    <Image Source="{x:Bind ImageSource}" Stretch="UniformToFill"/>
                     <TextBlock Text="{x:Bind Header}" Grid.Row="1" VerticalAlignment="Center" Margin="12"/>
                 </Grid>
             </DataTemplate>
 
             <DataTemplate x:Key="ImageItem" x:DataType="local:RevealGridItem">
-                <Image Source="{x:Bind Image}" Width="250" Stretch="UniformToFill"/>
+                <Image Source="{x:Bind ImageSource}" Width="250" Stretch="UniformToFill"/>
             </DataTemplate>
 
             <DataTemplate x:Key="SemiTransparentItem" x:DataType="local:RevealGridItem">

--- a/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
+++ b/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
@@ -3,6 +3,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <!-- We need to define NuGet references using this newer style for running tests locally in VS to work.
        However, for some reason, specifially in lab builds, using the below to resolve NuGet references

--- a/test/IXMPTestApp/TAEF/IXMPTestApp.TAEF.csproj
+++ b/test/IXMPTestApp/TAEF/IXMPTestApp.TAEF.csproj
@@ -5,6 +5,7 @@
     <DefineConstants>$(DefineConstants);USING_TAEF</DefineConstants>
     <ProjectGuid>{02800516-6BE8-42A9-9665-5446896BB5C5}</ProjectGuid>
     <IsTaefTestProject Condition="'$(IsTDPConfiguration)' == 'true'">true</IsTaefTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <ProjectGuid>{74F24BC4-794D-4CB2-8420-80FF7FDACFE9}</ProjectGuid>

--- a/test/MUXControls.Test/MSTest/MUXControls.Test.csproj
+++ b/test/MUXControls.Test/MSTest/MUXControls.Test.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v2.1</TargetFrameworkVersion>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm;win-arm64</RuntimeIdentifiers>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
     <None Include="BuildAppX.cmd">

--- a/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
+++ b/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <ProjectGuid>{4D8C5D1B-F982-44A1-B744-DD0E51651BF2}</ProjectGuid>
     <DefineConstants>$(DefineConstants);USING_TAEF</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition="$(BuildingWithBuildExe) != 'true'">
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/test/MUXControlsAdhocApp/MUXControlsAdhocApp.csproj
+++ b/test/MUXControlsAdhocApp/MUXControlsAdhocApp.csproj
@@ -22,6 +22,7 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <PackageCertificateKeyFile>..\..\build\MSTest.pfx</PackageCertificateKeyFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -3,6 +3,7 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <!-- We need to define NuGet references using this newer style for running tests locally in VS to work.
        However, for some reason, specifially in lab builds, using the below to resolve NuGet references

--- a/test/MUXControlsTestApp/TAEF/MUXControlsTestApp.TAEF.csproj
+++ b/test/MUXControlsTestApp/TAEF/MUXControlsTestApp.TAEF.csproj
@@ -5,6 +5,7 @@
     <DefineConstants>$(DefineConstants);USING_TAEF</DefineConstants>
     <ProjectGuid>{DEDC1E4F-CFA5-4443-83EB-E79D425DF7E7}</ProjectGuid>
     <IsTaefTestProject Condition="'$(IsTDPConfiguration)' == 'true'">true</IsTaefTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <AppxManifest Include="Package.VS.appxmanifest" Condition="$(BuildingWithBuildExe) != 'true'">

--- a/test/MUXControlsTestAppForIslands/MUXControlsTestAppForIslands.csproj
+++ b/test/MUXControlsTestAppForIslands/MUXControlsTestAppForIslands.csproj
@@ -26,6 +26,7 @@
     <EnableXBindDiagnostics>false</EnableXBindDiagnostics>
     <!-- Supress xaml warnings of type 'foo' is for evaluation purposes only and is subject to change or removal in future updates -->
     <NoWarn>$(NoWarn);8305</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86' Or '$(Configuration)|$(Platform)' == 'Debug_test|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/test/MUXControlsTestAppWPF/MUXControlsTestAppWPF.csproj
+++ b/test/MUXControlsTestAppWPF/MUXControlsTestAppWPF.csproj
@@ -19,6 +19,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/test/MUXTestUtilities/MUXTestUtilities.vcxproj
+++ b/test/MUXTestUtilities/MUXTestUtilities.vcxproj
@@ -109,6 +109,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)..\..\dev\Common</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -136,48 +136,56 @@
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
     <ClCompile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
For internal issue:
[Bug 17853194: DepControls: Warnings should be treated as errors when we build.](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/17853194)