### PR TITLE
Fix NavigationViewPane shadow

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -365,23 +365,23 @@ void NavigationView::OnApplyTemplate()
     if (SharedHelpers::IsThemeShadowAvailable())
     {
 #ifdef USE_INSIDER_SDK
-        if (auto splitView = m_rootSplitView.get())
+        // Shadow will get clipped if casting on the splitView.Content directly
+        // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
+        winrt::Canvas shadowReceiver;
+        winrt::Thickness shadowReceiverMargin = { -OpenPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
+        shadowReceiver.Margin(shadowReceiverMargin);
+
+        if (auto contentGrid = GetTemplateChildT<winrt::Grid>(c_contentGridName, controlProtected))
         {
-            if (auto paneRoot = splitView.Pane())
+            contentGrid.SetRowSpan(shadowReceiver, contentGrid.RowDefinitions().Size());
+            contentGrid.Children().Append(shadowReceiver);
+
+            winrt::ThemeShadow shadow;
+            shadow.Receivers().Append(shadowReceiver);
+            if (auto splitView = m_rootSplitView.get())
             {
-                // Shadow will get clipped if casting on the splitView.Content directly
-                // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
-                winrt::Canvas shadowReceiver;
-                winrt::Thickness shadowReceiverMargin = { -OpenPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
-                shadowReceiver.Margin(shadowReceiverMargin);
-
-                if (auto contentGrid = GetTemplateChildT<winrt::Grid>(c_contentGridName, controlProtected))
+                if (auto paneRoot = splitView.Pane())
                 {
-                    contentGrid.SetRowSpan(shadowReceiver, contentGrid.RowDefinitions().Size());
-                    contentGrid.Children().Append(shadowReceiver);
-
-                    winrt::ThemeShadow shadow;
-                    shadow.Receivers().Append(shadowReceiver);
                     if (winrt::IUIElement10 paneRoot_uiElement10 = paneRoot)
                     {
                         paneRoot_uiElement10.Shadow(shadow);

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -367,12 +367,21 @@ void NavigationView::OnApplyTemplate()
 #ifdef USE_INSIDER_SDK
         if (auto splitView = m_rootSplitView.get())
         {
-            if (auto contentRoot = splitView.Content())
+            if (auto paneRoot = splitView.Pane())
             {
-                if (auto paneRoot = splitView.Pane())
+                // Shadow will get clipped if casting on the splitView.Content directly
+                // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
+                winrt::Canvas shadowReceiver;
+                winrt::Thickness shadowReceiverMargin = { -OpenPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
+                shadowReceiver.Margin(shadowReceiverMargin);
+
+                if (auto contentGrid = GetTemplateChildT<winrt::Grid>(c_contentGridName, controlProtected))
                 {
+                    contentGrid.SetRowSpan(shadowReceiver, contentGrid.RowDefinitions().Size());
+                    contentGrid.Children().Append(shadowReceiver);
+
                     winrt::ThemeShadow shadow;
-                    shadow.Receivers().Append(contentRoot);
+                    shadow.Receivers().Append(shadowReceiver);
                     if (winrt::IUIElement10 paneRoot_uiElement10 = paneRoot)
                     {
                         paneRoot_uiElement10.Shadow(shadow);

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3344,8 +3344,6 @@ void NavigationView::UpdatePaneShadow()
     if (SharedHelpers::IsThemeShadowAvailable())
     {
 #ifdef USE_INSIDER_SDK
-        // Shadow will get clipped if casting on the splitView.Content directly
-        // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
         winrt::Canvas shadowReceiver = GetTemplateChildT<winrt::Canvas>(c_paneShadowReceiverCanvas, *this);
         if (!shadowReceiver)
         {
@@ -3372,6 +3370,8 @@ void NavigationView::UpdatePaneShadow()
             }
         }
 
+        // Shadow will get clipped if casting on the splitView.Content directly
+        // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
         winrt::Thickness shadowReceiverMargin = { -OpenPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
         shadowReceiver.Margin(shadowReceiverMargin);
 #endif

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -2741,10 +2741,12 @@ void NavigationView::OnIsPaneOpenChanged()
 #ifdef USE_INSIDER_SDK
         if (auto splitView = m_rootSplitView.get())
         {
+            auto displayMode = splitView.DisplayMode();
+            auto isOverlay = displayMode == winrt::SplitViewDisplayMode::Overlay || displayMode == winrt::SplitViewDisplayMode::CompactOverlay;
             if (auto paneRoot = splitView.Pane())
             {
                 auto currentTranslation = paneRoot.Translation();
-                auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, IsPaneOpen() ? c_paneElevationTranslationZ : 0.0f };
+                auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, IsPaneOpen() && isOverlay ? c_paneElevationTranslationZ : 0.0f };
                 paneRoot.Translation(translation);
             }
         }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -2664,9 +2664,9 @@ void NavigationView::OnPropertyChanged(const winrt::DependencyPropertyChangedEve
     {
         UpdateVisualState();
     }
-    else if (property == s_OpenPaneLengthProperty)
+    else if (property == s_CompactPaneLengthProperty)
     {
-        // Need to update receiver margins when OpenPaneLength changes
+        // Need to update receiver margins when CompactPaneLength changes
         UpdatePaneShadow();
     }
 }
@@ -3372,7 +3372,7 @@ void NavigationView::UpdatePaneShadow()
 
         // Shadow will get clipped if casting on the splitView.Content directly
         // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
-        winrt::Thickness shadowReceiverMargin = { -OpenPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
+        winrt::Thickness shadowReceiverMargin = { -CompactPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
         shadowReceiver.Margin(shadowReceiverMargin);
 #endif
     }

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -105,6 +105,7 @@ private:
     void PropagateNavigationViewAsParent();
     void PropagateChangeToNavigationViewLists(NavigationViewPropagateTarget target, std::function<void(NavigationViewList*)> const& function);
     void PropagateChangeToNavigationViewList(winrt::ListView const& listView, std::function<void(NavigationViewList*)> const& function);
+    void UpdatePaneShadow();
 
     void InvalidateTopNavPrimaryLayout();
     // Measure functions for top navigation   

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -8,7 +8,7 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Dark">
-            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
+            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemChromeMediumColor" />
             <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
 
@@ -68,7 +68,7 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
+            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemChromeMediumColor" />
             <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
 
@@ -128,7 +128,7 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
+            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemChromeMediumColor" />
             <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="SystemChromeMediumHighColor" />
 

--- a/dev/NavigationView/NavigationView_rs2_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs2_themeresources.xaml
@@ -8,7 +8,7 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicElementMediumBrush" />
+            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemControlAcrylicElementBrush" />
             <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicWindowMediumBrush" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicElementMediumBrush" />
 
@@ -40,7 +40,7 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicElementMediumBrush" />
+            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemControlAcrylicElementBrush" />
             <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicWindowMediumBrush" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicElementMediumBrush" />
 
@@ -72,7 +72,7 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicElementMediumBrush" />
+            <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SystemControlAcrylicElementBrush" />
             <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicWindowMediumBrush" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="SystemControlChromeMediumLowAcrylicElementMediumBrush" />
 


### PR DESCRIPTION
[Internal Issue](https://microsoft.visualstudio.com/OS/_workitems/edit/20386041)

NavigationView was casting shadow on SplitView.Content, which makes the shadow gets clipped by the content grid.

Inserted a canvas with negative margin in content grid to let shadow be drawn out of the grid.

Also, I just learned that we only want pane shadow in overlay mode, fixed that as well.