### PR TITLE
Fix issue with CI build sometimes conflicting on nuget version

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -17,7 +17,10 @@ jobs:
   steps:
     # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg
   - powershell: |
+      $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
+      $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
       $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
+      Write-Host "##vso[task.setvariable variable=builddate]$yymm$dd"
       Write-Host "##vso[task.setvariable variable=buildrevision]$revision"
     displayName: 'Get build revision number'
   
@@ -27,6 +30,7 @@ jobs:
       echo parameters.nupkgdir '${{ parameters.nupkgdir }}'
       echo parameters.publishPath '${{ parameters.publishPath }}'
       echo buildrevision=$(buildrevision)
+      echo buildrevision=$(builddate)
     displayName: 'CreateNugetPackage: Display parameters'
 
   - task: DownloadBuildArtifacts@0 
@@ -45,6 +49,7 @@ jobs:
         -BuildOutput '$(Build.SourcesDirectory)\Artifacts\drop' 
         -OutputDir '${{ parameters.nupkgdir }}' 
         -prereleaseversion prerelease 
+        -DateOverride '$(builddate)'
         -Subversion '$(buildrevision)' 
         -SkipFrameworkPackage
         -BuildArch ${{ parameters.primaryBuildArch }}

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -15,7 +15,10 @@ jobs:
     - ${{ parameters.dependsOn }}
 
   steps:
-    # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg
+    # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg.
+    # This relies on the format of the pipeline name being of the format: $(date:yyMM).$(date:dd)$(rev:rrr)
+    # We can't use those variables here (they only work in the *name* of the top level Yaml), so
+    # pull them out here and set the variables for use in the nuget package version.
   - powershell: |
       $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
       $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -4,6 +4,7 @@ Param(
     [string]$OutputDir,
     [string]$VersionOverride,
     [string]$Subversion = "",
+    [string]$DateOverride,
     [string]$prereleaseversion,
     [string]$BuildFlavor = "release",
     [string]$BuildArch = "x86",
@@ -59,9 +60,15 @@ else
 
     $version = "$versionMajor.$versionMinor"
     
-    $pstZone = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time")
-    $pstTime = [System.TimeZoneInfo]::ConvertTimeFromUtc((Get-Date).ToUniversalTime(), $pstZone)
-    $version += "." + ($pstTime).ToString("yyMMdd") + "$subversion"
+    $versiondate = $DateOverride
+    if (-not $versiondate)
+    {
+        $pstZone = [System.TimeZoneInfo]::FindSystemTimeZoneById("Pacific Standard Time")
+        $pstTime = [System.TimeZoneInfo]::ConvertTimeFromUtc((Get-Date).ToUniversalTime(), $pstZone)
+        $versiondate += ($pstTime).ToString("yyMMdd")
+    }
+
+    $version += "." + $versiondate + "$subversion"
 
     Write-Verbose "Version = $version"
 }


### PR DESCRIPTION
We publish the nupkg from the CI build to an artifact feed for test consumption and convenience. We need the versions to be increasing each time the CI build runs, and so the version is Major.Minor.YYMMDDRRR where YYMMDD is the current date and RRR is "revision" which is from AzDO and is a monotonically increasing value on the day for the pipeline.

This seems like it should never conflict but it turns out we were grabbing the Revision from the pipeline but the DateTime from code-behind and they were using different timezones. So there was an 8-hour window each day (because we're in PST, -8 from UTC) wherein two builds that ran could end up with the same nuget version because the revision had gone to 0 but we were using the old date.

The fix is easy, take the datetime and revision both from the pipeline name. Unfortunately we have to do this by string parsing the *name* of the pipeline (yuk) but apparently the $(Date) and $(Rev) variables in AzDO only work in the name of the pipeline. I added a comment in the yml for future maintainers.