### PR TITLE
Add yaml for Release build

### DIFF
--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -17,9 +17,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      Debug_x86:
-        buildPlatform: 'x86'
-        buildConfiguration: 'Debug'
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -1,0 +1,110 @@
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+jobs:
+- job: ComponentDetection
+  pool:
+    vmImage: 'VS2017-Win2016'
+
+  steps:
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+
+- job: Build
+  pool:
+    name: Package ES Custom Demands Lab A
+    demands:
+      - ClientAlias -equals depcontrols2
+  timeoutInMinutes: 120
+  strategy:
+    maxParallel: 10
+    matrix:
+      Debug_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Debug'
+      Release_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Release'
+      Release_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
+      Release_Arm:
+        buildPlatform: 'arm'
+        buildConfiguration: 'Release'
+      Release_Arm64:
+        buildPlatform: 'arm64'
+        buildConfiguration: 'Release'
+
+  variables:
+  - name: appxPackageDir
+    value: $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+  - name: buildOutputDir
+    value: $(Build.BinariesDirectory)
+  - name: publishDir
+    value: $(Build.ArtifactStagingDirectory)
+
+  steps:
+  - task: PkgESSetupBuild@10
+    displayName: 'XESSetupBuild'
+    inputs:
+      productName: dep.controls
+      branchVersion: true
+      nugetVer: true
+
+  - template: AzurePipelinesTemplates\MUX-BuildProject-Steps.yml
+    parameters:
+      solutionPath: MUXControls.sln
+      nugetConfigPath: nuget.config
+      appxPackageDir: $(appxPackageDir)
+      buildOutputDir: $(buildOutputDir)
+      publishDir: $(publishDir)
+
+  - task: PkgESCodeSign@10
+    displayName: CodeSign
+    inputs:
+      signConfigXml: '$(Build.SourcesDirectory)\build\SignConfig.xml'
+      inPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)'
+      outPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\signed'
+
+  - task: CmdLine@1
+    displayName: 'Publish Symbol'
+    inputs:
+      filename: '$(Build.SourcesDirectory)\tools\PublishSymbols\PublishSymbols.cmd'      
+
+  - task: powershell@2
+    displayName: 'Copy files to staging dir'
+    inputs:
+      targetType: filePath
+      filePath: build\CopyFilesToStagingDir.ps1
+      arguments: -BuildOutputDir '$(buildOutputDir)' -PublishDir '$(Build.ArtifactStagingDirectory)' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: drop'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'drop'
+
+# Create Nuget Package
+- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+  parameters:
+    jobName: CreateNugetPackage
+    dependsOn: Build
+    # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
+    # publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
+ 
+# Build solution that depends on nuget package
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    dependsOn: CreateNugetPackage
+    useNupkgFromArtifacts: true
+    matrix: 
+      Debug_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Debug'
+      Debug_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Debug'
+      Release_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
+      Release_arm:
+        buildPlatform: 'arm'
+        buildConfiguration: 'Release'

--- a/tools/PublishSymbols/PublishSymbols.ps1
+++ b/tools/PublishSymbols/PublishSymbols.ps1
@@ -10,17 +10,17 @@ if ((!$versionMajor) -or (!$versionMinor))
     Exit 1
 }
 
-$buildVersion = $versionMajor + "." + $versionMinor + "." + $env:TFS_VersionNumber
+$buildVersion = $versionMajor + "." + $versionMinor + "." + $env:BUILD_BUILDNUMBER
 
 Write-Host "Build = $buildVersion"
 
-$buildId=$env:TFS_BuildNumber + "_" + $env:TFS_Platform
-$directory=$env:XES_DFSDROP + "\" + $env:TFS_BuildConfiguration + "\" + $env:TFS_Platform + "\Microsoft.UI.Xaml"
+$buildId=$env:BUILD_BUILDNUMBER + "_" + $env:BUILDCONFIGURATION
+$directory=$env:BUILD_BINARIESDIRECTORY + "\" + $env:BUILDCONFIGURATION + "\" + $env:BUILDPLATFORM + "\Microsoft.UI.Xaml"
 
 Write-Host "buildId = $buildId"
 Write-Host "directory = $directory"
 
-copy pdb_index_template.ini pdb_index.ini
+Copy-Item pdb_index_template.ini pdb_index.ini
 Add-Content pdb_index.ini "Build=$buildVersion"
 
 \\symbols\Tools\createrequest.cmd -i .\pdb_index.ini -d .\requests -c -a -b $buildId -e Release -g $directory


### PR DESCRIPTION
Not much different for now, copy the CI build and add in the code signing and symbol publishing steps.

There's a few other things we may want to do for the Release build so for now I'm not going to try to do more code sharing with the CI yaml file. We can take a look at reconciling these a bit later.

Note that because we're using the PackageES code signing task we need to run the XESSetupBuild task which means we need to be on an internal PackageES machine. For now I'm using our custom machine pool for build too but I think it's worth trying to wean ourselves off of these and just use generic machines for the code signing task only and the Hosted machines for everything else.