### PR TITLE
check for Control.CornerRadius before loading rs5 generic.xaml

### DIFF
--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -169,6 +169,15 @@ bool SharedHelpers::IsApplicationViewGetDisplayRegionsAvailable()
     return s_isApplicationViewGetDisplayRegionsAvailable;
 }
 
+bool SharedHelpers::IsControlCornerRadiusAvailable()
+{
+    static bool s_isControlCornerRadiusAvailable =
+        IsSystemDll() ||
+        Is19H1OrHigher() ||
+        (IsRS5OrHigher() && winrt::ApiInformation::IsPropertyPresent(L"Windows.UI.Xaml.Controls.Control", L"CornerRadius"));
+    return s_isControlCornerRadiusAvailable;
+}
+
 bool SharedHelpers::IsTranslationFacadeAvailable(const winrt::UIElement& element)
 {
     static bool s_areFacadesAvailable = (element.try_as<winrt::Windows::UI::Xaml::IUIElement9>() != nullptr);

--- a/dev/dll/ThemeResources.cpp
+++ b/dev/dll/ThemeResources.cpp
@@ -26,7 +26,7 @@ ThemeResources::ThemeResources()
             // RS3 styles should be used on builds where ListViewItemPresenter's VSM integration works.
             bool isRS3OrHigher = SharedHelpers::DoesListViewItemPresenterVSMWork();
             bool isRS4OrHigher = SharedHelpers::IsRS4OrHigher();
-            bool isRS5OrHigher = SharedHelpers::IsRS5OrHigher();
+            bool isRS5OrHigher = SharedHelpers::IsRS5OrHigher() && SharedHelpers::IsControlCornerRadiusAvailable();
             bool is19H1OrHigher = SharedHelpers::Is19H1OrHigher();
 
             bool isInFrameworkPackage = SharedHelpers::IsInFrameworkPackage();
@@ -132,7 +132,7 @@ void SetDefaultStyleKeyWorker(winrt::IControlProtected const& controlProtected, 
             // RS3 styles should be used on builds where ListViewItemPresenter's VSM integration works.
             bool isRS3OrHigher = SharedHelpers::DoesListViewItemPresenterVSMWork();
             bool isRS4OrHigher = SharedHelpers::IsRS4OrHigher();
-            bool isRS5OrHigher = SharedHelpers::IsRS5OrHigher();
+            bool isRS5OrHigher = SharedHelpers::IsRS5OrHigher() && SharedHelpers::IsControlCornerRadiusAvailable();
             bool is19H1OrHigher = SharedHelpers::Is19H1OrHigher();
 
             bool isInFrameworkPackage = SharedHelpers::IsInFrameworkPackage();

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -45,6 +45,8 @@ public:
 
     static bool IsApplicationViewGetDisplayRegionsAvailable();
 
+    static bool IsControlCornerRadiusAvailable();
+
     static bool IsTranslationFacadeAvailable(const winrt::UIElement& element);
 
     static bool IsIconSourceElementAvailable();


### PR DESCRIPTION
Fix for internal issue: [
Bug 19745067](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/19745067).

Apps that use Microsoft.UI.Xaml are crashing when run on older RS5 prerelease builds. This is because it is loading the RS5 version of our xaml resources, which uses the Control.CornerRadius property in many of its Styles. The Control.CornerRadius property was added in RS5, but old prerelease versions do not have it.

The fix is to check for the api's presence before loading the xaml. We fallback to the RS4 xaml files on older RS5 prerelease machines.