### PR TITLE
Removing Scroller/ScrollViewer's IsAnchoredAtHorizontalExtent and IsAnchoredAtVerticalExtent boolean properties

### DIFF
--- a/dev/Generated/MetadataSummary.cs
+++ b/dev/Generated/MetadataSummary.cs
@@ -447,8 +447,6 @@ namespace CustomTasks
             NeedsPropChangedCallbackMetadata["Scroller.HorizontalScrollMode"] = true;
             NeedsPropChangedCallbackMetadata["Scroller.HorizontalScrollRailingMode"] = true;
             NeedsPropChangedCallbackMetadata["Scroller.InputKind"] = true;
-            NeedsPropChangedCallbackMetadata["Scroller.IsAnchoredAtHorizontalExtent"] = true;
-            NeedsPropChangedCallbackMetadata["Scroller.IsAnchoredAtVerticalExtent"] = true;
             NeedsPropChangedCallbackMetadata["Scroller.MaxZoomFactor"] = true;
             PropValidationCallbackMetadata["Scroller.MaxZoomFactor"] = "ValidateZoomFactoryBoundary";
             NeedsPropChangedCallbackMetadata["Scroller.MinZoomFactor"] = true;
@@ -467,8 +465,6 @@ namespace CustomTasks
             DefaultValueMetadata["Scroller.HorizontalScrollMode"] = @"Scroller::s_defaultHorizontalScrollMode";
             DefaultValueMetadata["Scroller.HorizontalScrollRailingMode"] = @"Scroller::s_defaultHorizontalScrollRailingMode";
             DefaultValueMetadata["Scroller.InputKind"] = @"Scroller::s_defaultInputKind";
-            DefaultValueMetadata["Scroller.IsAnchoredAtHorizontalExtent"] = @"Scroller::s_defaultAnchorAtExtent";
-            DefaultValueMetadata["Scroller.IsAnchoredAtVerticalExtent"] = @"Scroller::s_defaultAnchorAtExtent";
             DefaultValueMetadata["Scroller.MaxZoomFactor"] = @"Scroller::s_defaultMaxZoomFactor";
             DefaultValueMetadata["Scroller.MinZoomFactor"] = @"Scroller::s_defaultMinZoomFactor";
             DefaultValueMetadata["Scroller.VerticalAnchorRatio"] = @"Scroller::s_defaultAnchorRatio";
@@ -496,8 +492,6 @@ namespace CustomTasks
             NeedsPropChangedCallbackMetadata["ScrollViewer.HorizontalScrollMode"] = true;
             NeedsPropChangedCallbackMetadata["ScrollViewer.HorizontalScrollRailingMode"] = true;
             NeedsPropChangedCallbackMetadata["ScrollViewer.InputKind"] = true;
-            NeedsPropChangedCallbackMetadata["ScrollViewer.IsAnchoredAtHorizontalExtent"] = true;
-            NeedsPropChangedCallbackMetadata["ScrollViewer.IsAnchoredAtVerticalExtent"] = true;
             NeedsPropChangedCallbackMetadata["ScrollViewer.MaxZoomFactor"] = true;
             PropValidationCallbackMetadata["ScrollViewer.MaxZoomFactor"] = "ValidateZoomFactoryBoundary";
             NeedsPropChangedCallbackMetadata["ScrollViewer.MinZoomFactor"] = true;
@@ -523,8 +517,6 @@ namespace CustomTasks
             DefaultValueMetadata["ScrollViewer.HorizontalScrollMode"] = @"ScrollViewer::s_defaultHorizontalScrollMode";
             DefaultValueMetadata["ScrollViewer.HorizontalScrollRailingMode"] = @"ScrollViewer::s_defaultHorizontalScrollRailingMode";
             DefaultValueMetadata["ScrollViewer.InputKind"] = @"ScrollViewer::s_defaultInputKind";
-            DefaultValueMetadata["ScrollViewer.IsAnchoredAtHorizontalExtent"] = @"ScrollViewer::s_defaultAnchorAtExtent";
-            DefaultValueMetadata["ScrollViewer.IsAnchoredAtVerticalExtent"] = @"ScrollViewer::s_defaultAnchorAtExtent";
             DefaultValueMetadata["ScrollViewer.MaxZoomFactor"] = @"ScrollViewer::s_defaultMaxZoomFactor";
             DefaultValueMetadata["ScrollViewer.MinZoomFactor"] = @"ScrollViewer::s_defaultMinZoomFactor";
             DefaultValueMetadata["ScrollViewer.VerticalAnchorRatio"] = @"ScrollViewer::s_defaultAnchorRatio";

--- a/dev/Generated/ScrollViewer.properties.cpp
+++ b/dev/Generated/ScrollViewer.properties.cpp
@@ -19,8 +19,6 @@ GlobalDependencyProperty ScrollViewerProperties::s_HorizontalScrollControllerPro
 GlobalDependencyProperty ScrollViewerProperties::s_HorizontalScrollModeProperty{ nullptr };
 GlobalDependencyProperty ScrollViewerProperties::s_HorizontalScrollRailingModeProperty{ nullptr };
 GlobalDependencyProperty ScrollViewerProperties::s_InputKindProperty{ nullptr };
-GlobalDependencyProperty ScrollViewerProperties::s_IsAnchoredAtHorizontalExtentProperty{ nullptr };
-GlobalDependencyProperty ScrollViewerProperties::s_IsAnchoredAtVerticalExtentProperty{ nullptr };
 GlobalDependencyProperty ScrollViewerProperties::s_MaxZoomFactorProperty{ nullptr };
 GlobalDependencyProperty ScrollViewerProperties::s_MinZoomFactorProperty{ nullptr };
 GlobalDependencyProperty ScrollViewerProperties::s_ScrollerProperty{ nullptr };
@@ -169,28 +167,6 @@ void ScrollViewerProperties::EnsureProperties()
                 ValueHelper<winrt::InputKind>::BoxValueIfNecessary(ScrollViewer::s_defaultInputKind),
                 winrt::PropertyChangedCallback(&OnPropertyChanged));
     }
-    if (!s_IsAnchoredAtHorizontalExtentProperty)
-    {
-        s_IsAnchoredAtHorizontalExtentProperty =
-            InitializeDependencyProperty(
-                L"IsAnchoredAtHorizontalExtent",
-                winrt::name_of<bool>(),
-                winrt::name_of<winrt::ScrollViewer>(),
-                false /* isAttached */,
-                ValueHelper<bool>::BoxValueIfNecessary(ScrollViewer::s_defaultAnchorAtExtent),
-                winrt::PropertyChangedCallback(&OnPropertyChanged));
-    }
-    if (!s_IsAnchoredAtVerticalExtentProperty)
-    {
-        s_IsAnchoredAtVerticalExtentProperty =
-            InitializeDependencyProperty(
-                L"IsAnchoredAtVerticalExtent",
-                winrt::name_of<bool>(),
-                winrt::name_of<winrt::ScrollViewer>(),
-                false /* isAttached */,
-                ValueHelper<bool>::BoxValueIfNecessary(ScrollViewer::s_defaultAnchorAtExtent),
-                winrt::PropertyChangedCallback(&OnPropertyChanged));
-    }
     if (!s_MaxZoomFactorProperty)
     {
         s_MaxZoomFactorProperty =
@@ -327,8 +303,6 @@ void ScrollViewerProperties::ClearProperties()
     s_HorizontalScrollModeProperty = nullptr;
     s_HorizontalScrollRailingModeProperty = nullptr;
     s_InputKindProperty = nullptr;
-    s_IsAnchoredAtHorizontalExtentProperty = nullptr;
-    s_IsAnchoredAtVerticalExtentProperty = nullptr;
     s_MaxZoomFactorProperty = nullptr;
     s_MinZoomFactorProperty = nullptr;
     s_ScrollerProperty = nullptr;
@@ -493,26 +467,6 @@ void ScrollViewerProperties::InputKind(winrt::InputKind const& value)
 winrt::InputKind ScrollViewerProperties::InputKind()
 {
     return ValueHelper<winrt::InputKind>::CastOrUnbox(static_cast<ScrollViewer*>(this)->GetValue(s_InputKindProperty));
-}
-
-void ScrollViewerProperties::IsAnchoredAtHorizontalExtent(bool value)
-{
-    static_cast<ScrollViewer*>(this)->SetValue(s_IsAnchoredAtHorizontalExtentProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
-}
-
-bool ScrollViewerProperties::IsAnchoredAtHorizontalExtent()
-{
-    return ValueHelper<bool>::CastOrUnbox(static_cast<ScrollViewer*>(this)->GetValue(s_IsAnchoredAtHorizontalExtentProperty));
-}
-
-void ScrollViewerProperties::IsAnchoredAtVerticalExtent(bool value)
-{
-    static_cast<ScrollViewer*>(this)->SetValue(s_IsAnchoredAtVerticalExtentProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
-}
-
-bool ScrollViewerProperties::IsAnchoredAtVerticalExtent()
-{
-    return ValueHelper<bool>::CastOrUnbox(static_cast<ScrollViewer*>(this)->GetValue(s_IsAnchoredAtVerticalExtentProperty));
 }
 
 void ScrollViewerProperties::MaxZoomFactor(double value)

--- a/dev/Generated/ScrollViewer.properties.h
+++ b/dev/Generated/ScrollViewer.properties.h
@@ -42,12 +42,6 @@ public:
     void InputKind(winrt::InputKind const& value);
     winrt::InputKind InputKind();
 
-    void IsAnchoredAtHorizontalExtent(bool value);
-    bool IsAnchoredAtHorizontalExtent();
-
-    void IsAnchoredAtVerticalExtent(bool value);
-    bool IsAnchoredAtVerticalExtent();
-
     void MaxZoomFactor(double value);
     double MaxZoomFactor();
 
@@ -89,8 +83,6 @@ public:
     static winrt::DependencyProperty HorizontalScrollModeProperty() { return s_HorizontalScrollModeProperty; }
     static winrt::DependencyProperty HorizontalScrollRailingModeProperty() { return s_HorizontalScrollRailingModeProperty; }
     static winrt::DependencyProperty InputKindProperty() { return s_InputKindProperty; }
-    static winrt::DependencyProperty IsAnchoredAtHorizontalExtentProperty() { return s_IsAnchoredAtHorizontalExtentProperty; }
-    static winrt::DependencyProperty IsAnchoredAtVerticalExtentProperty() { return s_IsAnchoredAtVerticalExtentProperty; }
     static winrt::DependencyProperty MaxZoomFactorProperty() { return s_MaxZoomFactorProperty; }
     static winrt::DependencyProperty MinZoomFactorProperty() { return s_MinZoomFactorProperty; }
     static winrt::DependencyProperty ScrollerProperty() { return s_ScrollerProperty; }
@@ -114,8 +106,6 @@ public:
     static GlobalDependencyProperty s_HorizontalScrollModeProperty;
     static GlobalDependencyProperty s_HorizontalScrollRailingModeProperty;
     static GlobalDependencyProperty s_InputKindProperty;
-    static GlobalDependencyProperty s_IsAnchoredAtHorizontalExtentProperty;
-    static GlobalDependencyProperty s_IsAnchoredAtVerticalExtentProperty;
     static GlobalDependencyProperty s_MaxZoomFactorProperty;
     static GlobalDependencyProperty s_MinZoomFactorProperty;
     static GlobalDependencyProperty s_ScrollerProperty;

--- a/dev/Generated/Scroller.properties.cpp
+++ b/dev/Generated/Scroller.properties.cpp
@@ -16,8 +16,6 @@ GlobalDependencyProperty ScrollerProperties::s_HorizontalScrollChainingModePrope
 GlobalDependencyProperty ScrollerProperties::s_HorizontalScrollModeProperty{ nullptr };
 GlobalDependencyProperty ScrollerProperties::s_HorizontalScrollRailingModeProperty{ nullptr };
 GlobalDependencyProperty ScrollerProperties::s_InputKindProperty{ nullptr };
-GlobalDependencyProperty ScrollerProperties::s_IsAnchoredAtHorizontalExtentProperty{ nullptr };
-GlobalDependencyProperty ScrollerProperties::s_IsAnchoredAtVerticalExtentProperty{ nullptr };
 GlobalDependencyProperty ScrollerProperties::s_MaxZoomFactorProperty{ nullptr };
 GlobalDependencyProperty ScrollerProperties::s_MinZoomFactorProperty{ nullptr };
 GlobalDependencyProperty ScrollerProperties::s_VerticalAnchorRatioProperty{ nullptr };
@@ -130,28 +128,6 @@ void ScrollerProperties::EnsureProperties()
                 ValueHelper<winrt::InputKind>::BoxValueIfNecessary(Scroller::s_defaultInputKind),
                 winrt::PropertyChangedCallback(&OnPropertyChanged));
     }
-    if (!s_IsAnchoredAtHorizontalExtentProperty)
-    {
-        s_IsAnchoredAtHorizontalExtentProperty =
-            InitializeDependencyProperty(
-                L"IsAnchoredAtHorizontalExtent",
-                winrt::name_of<bool>(),
-                winrt::name_of<winrt::Scroller>(),
-                false /* isAttached */,
-                ValueHelper<bool>::BoxValueIfNecessary(Scroller::s_defaultAnchorAtExtent),
-                winrt::PropertyChangedCallback(&OnPropertyChanged));
-    }
-    if (!s_IsAnchoredAtVerticalExtentProperty)
-    {
-        s_IsAnchoredAtVerticalExtentProperty =
-            InitializeDependencyProperty(
-                L"IsAnchoredAtVerticalExtent",
-                winrt::name_of<bool>(),
-                winrt::name_of<winrt::Scroller>(),
-                false /* isAttached */,
-                ValueHelper<bool>::BoxValueIfNecessary(Scroller::s_defaultAnchorAtExtent),
-                winrt::PropertyChangedCallback(&OnPropertyChanged));
-    }
     if (!s_MaxZoomFactorProperty)
     {
         s_MaxZoomFactorProperty =
@@ -252,8 +228,6 @@ void ScrollerProperties::ClearProperties()
     s_HorizontalScrollModeProperty = nullptr;
     s_HorizontalScrollRailingModeProperty = nullptr;
     s_InputKindProperty = nullptr;
-    s_IsAnchoredAtHorizontalExtentProperty = nullptr;
-    s_IsAnchoredAtVerticalExtentProperty = nullptr;
     s_MaxZoomFactorProperty = nullptr;
     s_MinZoomFactorProperty = nullptr;
     s_VerticalAnchorRatioProperty = nullptr;
@@ -385,26 +359,6 @@ void ScrollerProperties::InputKind(winrt::InputKind const& value)
 winrt::InputKind ScrollerProperties::InputKind()
 {
     return ValueHelper<winrt::InputKind>::CastOrUnbox(static_cast<Scroller*>(this)->GetValue(s_InputKindProperty));
-}
-
-void ScrollerProperties::IsAnchoredAtHorizontalExtent(bool value)
-{
-    static_cast<Scroller*>(this)->SetValue(s_IsAnchoredAtHorizontalExtentProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
-}
-
-bool ScrollerProperties::IsAnchoredAtHorizontalExtent()
-{
-    return ValueHelper<bool>::CastOrUnbox(static_cast<Scroller*>(this)->GetValue(s_IsAnchoredAtHorizontalExtentProperty));
-}
-
-void ScrollerProperties::IsAnchoredAtVerticalExtent(bool value)
-{
-    static_cast<Scroller*>(this)->SetValue(s_IsAnchoredAtVerticalExtentProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
-}
-
-bool ScrollerProperties::IsAnchoredAtVerticalExtent()
-{
-    return ValueHelper<bool>::CastOrUnbox(static_cast<Scroller*>(this)->GetValue(s_IsAnchoredAtVerticalExtentProperty));
 }
 
 void ScrollerProperties::MaxZoomFactor(double value)

--- a/dev/Generated/Scroller.properties.h
+++ b/dev/Generated/Scroller.properties.h
@@ -33,12 +33,6 @@ public:
     void InputKind(winrt::InputKind const& value);
     winrt::InputKind InputKind();
 
-    void IsAnchoredAtHorizontalExtent(bool value);
-    bool IsAnchoredAtHorizontalExtent();
-
-    void IsAnchoredAtVerticalExtent(bool value);
-    bool IsAnchoredAtVerticalExtent();
-
     void MaxZoomFactor(double value);
     double MaxZoomFactor();
 
@@ -71,8 +65,6 @@ public:
     static winrt::DependencyProperty HorizontalScrollModeProperty() { return s_HorizontalScrollModeProperty; }
     static winrt::DependencyProperty HorizontalScrollRailingModeProperty() { return s_HorizontalScrollRailingModeProperty; }
     static winrt::DependencyProperty InputKindProperty() { return s_InputKindProperty; }
-    static winrt::DependencyProperty IsAnchoredAtHorizontalExtentProperty() { return s_IsAnchoredAtHorizontalExtentProperty; }
-    static winrt::DependencyProperty IsAnchoredAtVerticalExtentProperty() { return s_IsAnchoredAtVerticalExtentProperty; }
     static winrt::DependencyProperty MaxZoomFactorProperty() { return s_MaxZoomFactorProperty; }
     static winrt::DependencyProperty MinZoomFactorProperty() { return s_MinZoomFactorProperty; }
     static winrt::DependencyProperty VerticalAnchorRatioProperty() { return s_VerticalAnchorRatioProperty; }
@@ -90,8 +82,6 @@ public:
     static GlobalDependencyProperty s_HorizontalScrollModeProperty;
     static GlobalDependencyProperty s_HorizontalScrollRailingModeProperty;
     static GlobalDependencyProperty s_InputKindProperty;
-    static GlobalDependencyProperty s_IsAnchoredAtHorizontalExtentProperty;
-    static GlobalDependencyProperty s_IsAnchoredAtVerticalExtentProperty;
     static GlobalDependencyProperty s_MaxZoomFactorProperty;
     static GlobalDependencyProperty s_MinZoomFactorProperty;
     static GlobalDependencyProperty s_VerticalAnchorRatioProperty;

--- a/dev/ScrollViewer/APITests/ScrollViewerTests.cs
+++ b/dev/ScrollViewer/APITests/ScrollViewerTests.cs
@@ -56,7 +56,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private const ChainingMode c_defaultZoomChainingMode = ChainingMode.Auto;
         private const ZoomMode c_defaultZoomMode = ZoomMode.Disabled;
         private const ContentOrientation c_defaultContentOrientation = ContentOrientation.Vertical;
-        private const bool c_defaultIsAnchoredAtExtent = true;
         private const double c_defaultMinZoomFactor = 0.1;
         private const double c_defaultMaxZoomFactor = 10.0;
         private const double c_defaultAnchorRatio = 0.0;
@@ -112,8 +111,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.IsLessThan(scrollViewer.MaxZoomFactor, c_defaultMaxZoomFactor + c_epsilon);
                 Verify.AreEqual(scrollViewer.HorizontalAnchorRatio, c_defaultAnchorRatio);
                 Verify.AreEqual(scrollViewer.VerticalAnchorRatio, c_defaultAnchorRatio);
-                Verify.AreEqual(scrollViewer.IsAnchoredAtHorizontalExtent, c_defaultIsAnchoredAtExtent);
-                Verify.AreEqual(scrollViewer.IsAnchoredAtVerticalExtent, c_defaultIsAnchoredAtExtent);
                 Verify.AreEqual(scrollViewer.ExtentWidth, 0.0);
                 Verify.AreEqual(scrollViewer.ExtentHeight, 0.0);
                 Verify.AreEqual(scrollViewer.ViewportWidth, 0.0);

--- a/dev/ScrollViewer/ScrollViewer.cpp
+++ b/dev/ScrollViewer/ScrollViewer.cpp
@@ -2012,14 +2012,6 @@ winrt::hstring ScrollViewer::DependencyPropertyToString(const winrt::IDependency
     {
         return L"MaxZoomFactor";
     }
-    else if (dependencyProperty == s_IsAnchoredAtHorizontalExtentProperty)
-    {
-        return L"IsAnchoredAtHorizontalExtent";
-    }
-    else if (dependencyProperty == s_IsAnchoredAtVerticalExtentProperty)
-    {
-        return L"IsAnchoredAtVerticalExtent";
-    }
     else if (dependencyProperty == s_HorizontalAnchorRatioProperty)
     {
         return L"HorizontalAnchorRatio";

--- a/dev/ScrollViewer/ScrollViewer.idl
+++ b/dev/ScrollViewer/ScrollViewer.idl
@@ -69,10 +69,6 @@ unsealed runtimeclass ScrollViewer : Windows.UI.Xaml.Controls.Control
     [MUX_DEFAULT_VALUE("ScrollViewer::s_defaultMaxZoomFactor")]
     [MUX_PROPERTY_VALIDATION_CALLBACK("ValidateZoomFactoryBoundary")]
     Double MaxZoomFactor { get; set; };
-    [MUX_DEFAULT_VALUE("ScrollViewer::s_defaultAnchorAtExtent")]
-    Boolean IsAnchoredAtHorizontalExtent { get; set; };
-    [MUX_DEFAULT_VALUE("ScrollViewer::s_defaultAnchorAtExtent")]
-    Boolean IsAnchoredAtVerticalExtent { get; set; };
     [MUX_DEFAULT_VALUE("ScrollViewer::s_defaultAnchorRatio")]
     [MUX_PROPERTY_VALIDATION_CALLBACK("ValidateAnchorRatio")]
     Double HorizontalAnchorRatio { get; set; };
@@ -117,8 +113,6 @@ unsealed runtimeclass ScrollViewer : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty InputKindProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MinZoomFactorProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MaxZoomFactorProperty { get; };
-    static Windows.UI.Xaml.DependencyProperty IsAnchoredAtHorizontalExtentProperty { get; };
-    static Windows.UI.Xaml.DependencyProperty IsAnchoredAtVerticalExtentProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HorizontalAnchorRatioProperty { get; };
     static Windows.UI.Xaml.DependencyProperty VerticalAnchorRatioProperty { get; };
 }

--- a/dev/ScrollViewer/ScrollViewer.xaml
+++ b/dev/ScrollViewer/ScrollViewer.xaml
@@ -21,8 +21,6 @@
         <Setter Property="InputKind" Value="All"/>
         <Setter Property="MinZoomFactor" Value="0.1"/>
         <Setter Property="MaxZoomFactor" Value="10.0"/>
-        <Setter Property="IsAnchoredAtHorizontalExtent" Value="True"/>
-        <Setter Property="IsAnchoredAtVerticalExtent" Value="True"/>
         <Setter Property="HorizontalAnchorRatio" Value="0.0"/>
         <Setter Property="VerticalAnchorRatio" Value="0.0"/>
         <Setter Property="Template">
@@ -221,8 +219,6 @@
                             InputKind="{TemplateBinding InputKind}"
                             MinZoomFactor="{TemplateBinding MinZoomFactor}"
                             MaxZoomFactor="{TemplateBinding MaxZoomFactor}"
-                            IsAnchoredAtHorizontalExtent="{TemplateBinding IsAnchoredAtHorizontalExtent}"
-                            IsAnchoredAtVerticalExtent="{TemplateBinding IsAnchoredAtVerticalExtent}"
                             HorizontalAnchorRatio="{TemplateBinding HorizontalAnchorRatio}"
                             VerticalAnchorRatio="{TemplateBinding VerticalAnchorRatio}"/>
                         <ScrollBar x:Name="PART_HorizontalScrollBar" 

--- a/dev/ScrollViewer/TestUI/ScrollViewerDynamicPage.xaml
+++ b/dev/ScrollViewer/TestUI/ScrollViewerDynamicPage.xaml
@@ -190,8 +190,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -302,44 +300,28 @@
             <Button x:Name="btnGetMaxZoomFactor" Content="G" Margin="1" Grid.Row="13" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetMaxZoomFactor_Click"/>
             <Button x:Name="btnSetMaxZoomFactor" Content="S" Margin="1" Grid.Row="13" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetMaxZoomFactor_Click"/>
 
-            <TextBlock Text="IsAnchoredAtHorizontalExtent:" Grid.Row="14" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbIsAnchoredAtHorizontalExtent" Width="105" Margin="1" Grid.Row="14" Grid.Column="1" VerticalAlignment="Center">
-                <ComboBoxItem>Yes</ComboBoxItem>
-                <ComboBoxItem>No</ComboBoxItem>
-            </ComboBox>
-            <Button x:Name="btnGetIsAnchoredAtHorizontalExtent" Content="G" Margin="1" Grid.Row="14" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetIsAnchoredAtHorizontalExtent_Click"/>
-            <Button x:Name="btnSetIsAnchoredAtHorizontalExtent" Content="S" Margin="1" Grid.Row="14" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetIsAnchoredAtHorizontalExtent_Click"/>
+            <TextBlock Text="HorizontalAnchorRatio:" Grid.Row="14" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtHorizontalAnchorRatio" Width="105" Grid.Row="14" Margin="1" Grid.Column="1" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetHorizontalAnchorRatio" Content="G" Margin="1" Grid.Row="14" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHorizontalAnchorRatio_Click"/>
+            <Button x:Name="btnSetHorizontalAnchorRatio" Content="S" Margin="1" Grid.Row="14" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHorizontalAnchorRatio_Click"/>
 
-            <TextBlock Text="IsAnchoredAtVerticalExtent:" Grid.Row="15" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbIsAnchoredAtVerticalExtent" Width="105" Margin="1" Grid.Row="15" Grid.Column="1" VerticalAlignment="Center">
-                <ComboBoxItem>Yes</ComboBoxItem>
-                <ComboBoxItem>No</ComboBoxItem>
-            </ComboBox>
-            <Button x:Name="btnGetIsAnchoredAtVerticalExtent" Content="G" Margin="1" Grid.Row="15" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetIsAnchoredAtVerticalExtent_Click"/>
-            <Button x:Name="btnSetIsAnchoredAtVerticalExtent" Content="S" Margin="1" Grid.Row="15" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetIsAnchoredAtVerticalExtent_Click"/>
-
-            <TextBlock Text="HorizontalAnchorRatio:" Grid.Row="16" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtHorizontalAnchorRatio" Width="105" Grid.Row="16" Margin="1" Grid.Column="1" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetHorizontalAnchorRatio" Content="G" Margin="1" Grid.Row="16" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHorizontalAnchorRatio_Click"/>
-            <Button x:Name="btnSetHorizontalAnchorRatio" Content="S" Margin="1" Grid.Row="16" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHorizontalAnchorRatio_Click"/>
-
-            <TextBlock Text="VerticalAnchorRatio:" Grid.Row="17" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtVerticalAnchorRatio" Width="105" Grid.Row="17" Margin="1" Grid.Column="1" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="17" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
-            <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="17" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
+            <TextBlock Text="VerticalAnchorRatio:" Grid.Row="15" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtVerticalAnchorRatio" Width="105" Grid.Row="15" Margin="1" Grid.Column="1" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="15" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
+            <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="15" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
 
             <!-- ifdef USE_SCROLLMODE_AUTO
-            <TextBlock Text="ComputedHorizontalScrollMode:" Grid.Row="18" VerticalAlignment="Center"/>
-            <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="18" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <TextBlock Text="ComputedHorizontalScrollMode:" Grid.Row="16" VerticalAlignment="Center"/>
+            <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="16" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                 <TextBlock x:Name="tblComputedHorizontalScrollMode" Margin="1" VerticalAlignment="Center"/>
             </Border>
-            <Button x:Name="btnGetComputedHorizontalScrollMode" Content="G" Margin="1" Grid.Row="18" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetComputedHorizontalScrollMode_Click"/>
+            <Button x:Name="btnGetComputedHorizontalScrollMode" Content="G" Margin="1" Grid.Row="16" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetComputedHorizontalScrollMode_Click"/>
 
-            <TextBlock Text="ComputedVerticalScrollMode:" Grid.Row="19" VerticalAlignment="Center"/>
-            <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="19" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <TextBlock Text="ComputedVerticalScrollMode:" Grid.Row="17" VerticalAlignment="Center"/>
+            <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="17" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                 <TextBlock x:Name="tblComputedVerticalScrollMode" Margin="1" VerticalAlignment="Center"/>
             </Border>
-            <Button x:Name="btnGetComputedVerticalScrollMode" Content="G" Margin="1" Grid.Row="19" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetComputedVerticalScrollMode_Click"/>
+            <Button x:Name="btnGetComputedVerticalScrollMode" Content="G" Margin="1" Grid.Row="17" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetComputedVerticalScrollMode_Click"/>
             -->
         </Grid>
 

--- a/dev/ScrollViewer/TestUI/ScrollViewerDynamicPage.xaml.cs
+++ b/dev/ScrollViewer/TestUI/ScrollViewerDynamicPage.xaml.cs
@@ -351,42 +351,6 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void BtnGetIsAnchoredAtHorizontalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            UpdateCmbIsAnchoredAtHorizontalExtent();
-        }
-
-        private void BtnSetIsAnchoredAtHorizontalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                scrollViewer.IsAnchoredAtHorizontalExtent = cmbIsAnchoredAtHorizontalExtent.SelectedIndex == 0;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstLogs.Items.Add(ex.ToString());
-            }
-        }
-
-        private void BtnGetIsAnchoredAtVerticalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            UpdateCmbIsAnchoredAtVerticalExtent();
-        }
-
-        private void BtnSetIsAnchoredAtVerticalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                scrollViewer.IsAnchoredAtVerticalExtent = cmbIsAnchoredAtVerticalExtent.SelectedIndex == 0;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstLogs.Items.Add(ex.ToString());
-            }
-        }
-
         private void BtnGetHorizontalAnchorRatio_Click(object sender, RoutedEventArgs e)
         {
             UpdateHorizontalAnchorRatio();
@@ -492,32 +456,6 @@ namespace MUXControlsTestApp
             try
             {
                 cmbXYFocusKeyboardNavigation.SelectedIndex = (int)scrollViewer.XYFocusKeyboardNavigation;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstLogs.Items.Add(ex.ToString());
-            }
-        }
-
-        private void UpdateCmbIsAnchoredAtHorizontalExtent()
-        {
-            try
-            {
-                cmbIsAnchoredAtHorizontalExtent.SelectedIndex = scrollViewer.IsAnchoredAtHorizontalExtent ? 0 : 1;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstLogs.Items.Add(ex.ToString());
-            }
-        }
-
-        private void UpdateCmbIsAnchoredAtVerticalExtent()
-        {
-            try
-            {
-                cmbIsAnchoredAtVerticalExtent.SelectedIndex = scrollViewer.IsAnchoredAtVerticalExtent ? 0 : 1;
             }
             catch (Exception ex)
             {
@@ -1341,8 +1279,6 @@ namespace MUXControlsTestApp
                 UpdateCmbHorizontalScrollBarVisibility();
                 UpdateCmbVerticalScrollBarVisibility();
                 UpdateCmbXYFocusKeyboardNavigation();
-                UpdateCmbIsAnchoredAtHorizontalExtent();
-                UpdateCmbIsAnchoredAtVerticalExtent();
                 UpdateHorizontalAnchorRatio();
                 UpdateVerticalAnchorRatio();
 #if USE_SCROLLMODE_AUTO

--- a/dev/ScrollViewer/TestUI/ScrollViewerWithScrollControllersPage.xaml
+++ b/dev/ScrollViewer/TestUI/ScrollViewerWithScrollControllersPage.xaml
@@ -28,8 +28,6 @@
             <Setter Property="InputKind" Value="All"/>
             <Setter Property="MinZoomFactor" Value="0.1"/>
             <Setter Property="MaxZoomFactor" Value="10.0"/>
-            <Setter Property="IsAnchoredAtHorizontalExtent" Value="True"/>
-            <Setter Property="IsAnchoredAtVerticalExtent" Value="True"/>
             <Setter Property="HorizontalAnchorRatio" Value="0.0"/>
             <Setter Property="VerticalAnchorRatio" Value="0.0"/>
             <Setter Property="Template">
@@ -61,8 +59,6 @@
                                 InputKind="{TemplateBinding InputKind}"
                                 MinZoomFactor="{TemplateBinding MinZoomFactor}"
                                 MaxZoomFactor="{TemplateBinding MaxZoomFactor}"
-                                IsAnchoredAtHorizontalExtent="{TemplateBinding IsAnchoredAtHorizontalExtent}"
-                                IsAnchoredAtVerticalExtent="{TemplateBinding IsAnchoredAtVerticalExtent}"
                                 HorizontalAnchorRatio="{TemplateBinding HorizontalAnchorRatio}"
                                 VerticalAnchorRatio="{TemplateBinding VerticalAnchorRatio}"/>
                             <localUtilities:CompositionScrollController x:Name="PART_HorizontalScrollBar" 

--- a/dev/Scroller/APITests/ScrollerAnchoringTests.cs
+++ b/dev/Scroller/APITests/ScrollerAnchoringTests.cs
@@ -49,14 +49,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private const int c_defaultAnchoringUIRepeaterChildrenCount = 16;
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset remains at 0 when inserting an item at the beginning (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=0).")]
+        [TestProperty("Description", "Verifies HorizontalOffset remains at 0 when inserting an item at the beginning (HorizontalAnchorRatio=0).")]
         public void AnchoringAtLeftEdge()
         {
             AnchoringAtNearEdge(Orientation.Horizontal);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset remains at 0 when inserting an item at the beginning (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=0).")]
+        [TestProperty("Description", "Verifies VerticalOffset remains at 0 when inserting an item at the beginning (VerticalAnchorRatio=0).")]
         public void AnchoringAtTopEdge()
         {
             AnchoringAtNearEdge(Orientation.Vertical);
@@ -102,42 +102,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset growns to max value when inserting an item at the end (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies HorizontalOffset growns to max value when inserting an item at the end (HorizontalAnchorRatio=1).")]
         public void AnchoringAtRightEdgeWhileIncreasingContentWidth()
         {
             AnchoringAtFarEdgeWhileIncreasingContent(Orientation.Horizontal, 0 /*viewportSizeChange*/, 3876 /*expectedFinalOffset*/);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset grows to max value when inserting an item at the end (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies VerticalOffset grows to max value when inserting an item at the end (VerticalAnchorRatio=1).")]
         public void AnchoringAtBottomEdgeWhileIncreasingContentHeight()
         {
             AnchoringAtFarEdgeWhileIncreasingContent(Orientation.Vertical, 0 /*viewportSizeChange*/, 3876 /*expectedFinalOffset*/);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset growns to max value when inserting an item at the end and growing viewport (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies HorizontalOffset growns to max value when inserting an item at the end and growing viewport (HorizontalAnchorRatio=1).")]
         public void AnchoringAtRightEdgeWhileIncreasingContentAndViewportWidth()
         {
             AnchoringAtFarEdgeWhileIncreasingContent(Orientation.Horizontal, 10 /*viewportSizeChange*/, 3866 /*expectedFinalOffset*/);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset grows to max value when inserting an item at the end and growning viewport (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies VerticalOffset grows to max value when inserting an item at the end and growning viewport (VerticalAnchorRatio=1).")]
         public void AnchoringAtBottomEdgeWhileIncreasingContentAndViewportHeight()
         {
             AnchoringAtFarEdgeWhileIncreasingContent(Orientation.Vertical, 10 /*viewportSizeChange*/, 3866 /*expectedFinalOffset*/);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset growns to max value when inserting an item at the end and shrinking viewport (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies HorizontalOffset growns to max value when inserting an item at the end and shrinking viewport (HorizontalAnchorRatio=1).")]
         public void AnchoringAtRightEdgeWhileIncreasingContentAndDecreasingViewportWidth()
         {
             AnchoringAtFarEdgeWhileIncreasingContent(Orientation.Horizontal, -10 /*viewportSizeChange*/, 3886 /*expectedFinalOffset*/);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset grows to max value when inserting an item at the end and shrinking viewport (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies VerticalOffset grows to max value when inserting an item at the end and shrinking viewport (VerticalAnchorRatio=1).")]
         public void AnchoringAtBottomEdgeWhileIncreasingContentAndDecreasingViewportHeight()
         {
             AnchoringAtFarEdgeWhileIncreasingContent(Orientation.Vertical, -10 /*viewportSizeChange*/, 3886 /*expectedFinalOffset*/);
@@ -240,14 +240,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset shrinks to max value when decreasing viewport width (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies HorizontalOffset shrinks to max value when decreasing viewport width (HorizontalAnchorRatio=1).")]
         public void AnchoringAtRightEdgeWhileDecreasingViewportWidth()
         {
             AnchoringAtFarEdgeWhileDecreasingViewport(Orientation.Horizontal);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset shrinks to max value when decreasing viewport height (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies VerticalOffset shrinks to max value when decreasing viewport height (VerticalAnchorRatio=1).")]
         public void AnchoringAtBottomEdgeWhileDecreasingViewportHeight()
         {
             AnchoringAtFarEdgeWhileDecreasingViewport(Orientation.Vertical);
@@ -340,14 +340,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset growns when inserting an item at the beginning (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=0).")]
+        [TestProperty("Description", "Verifies HorizontalOffset growns when inserting an item at the beginning (HorizontalAnchorRatio=0).")]
         public void AnchoringAtAlmostLeftEdge()
         {
             AnchoringAtAlmostNearEdge(Orientation.Horizontal);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset grows when inserting an item at the beginning (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=0).")]
+        [TestProperty("Description", "Verifies VerticalOffset grows when inserting an item at the beginning (VerticalAnchorRatio=0).")]
         public void AnchoringAtAlmostTopEdge()
         {
             AnchoringAtAlmostNearEdge(Orientation.Vertical);
@@ -407,14 +407,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies HorizontalOffset does not change when inserting an item at the end (IsAnchoredAtHorizontalExtent=True, HorizontalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies HorizontalOffset does not change when inserting an item at the end (HorizontalAnchorRatio=1).")]
         public void AnchoringAtAlmostRightEdge()
         {
             AnchoringAtAlmostFarEdge(Orientation.Horizontal);
         }
 
         [TestMethod]
-        [TestProperty("Description", "Verifies VerticalOffset does not change when inserting an item at the end (IsAnchoredAtVerticalExtent=True, VerticalAnchorRatio=1).")]
+        [TestProperty("Description", "Verifies VerticalOffset does not change when inserting an item at the end (VerticalAnchorRatio=1).")]
         public void AnchoringAtAlmostBottomEdge()
         {
             AnchoringAtAlmostFarEdge(Orientation.Vertical);

--- a/dev/Scroller/APITests/ScrollerTests.cs
+++ b/dev/Scroller/APITests/ScrollerTests.cs
@@ -64,7 +64,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private const ZoomMode c_defaultZoomMode = ZoomMode.Disabled;
         private const InputKind c_defaultInputKind = InputKind.All;
         private const ContentOrientation c_defaultContentOrientation = ContentOrientation.None;
-        private const bool c_defaultIsAnchoredAtExtent = true;
         private const double c_defaultMinZoomFactor = 0.1;
         private const double c_defaultZoomFactor = 1.0;
         private const double c_defaultMaxZoomFactor = 10.0;
@@ -124,8 +123,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual(scroller.VerticalOffset, c_defaultVerticalOffset);
                 Verify.AreEqual(scroller.HorizontalAnchorRatio, c_defaultAnchorRatio);
                 Verify.AreEqual(scroller.VerticalAnchorRatio, c_defaultAnchorRatio);
-                Verify.AreEqual(scroller.IsAnchoredAtHorizontalExtent, c_defaultIsAnchoredAtExtent);
-                Verify.AreEqual(scroller.IsAnchoredAtVerticalExtent, c_defaultIsAnchoredAtExtent);
                 Verify.AreEqual(scroller.ExtentWidth, 0.0);
                 Verify.AreEqual(scroller.ExtentHeight, 0.0);
                 Verify.AreEqual(scroller.ViewportWidth, 0.0);
@@ -166,8 +163,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 scroller.MaxZoomFactor = 2.0f;
                 scroller.HorizontalAnchorRatio = 0.25f;
                 scroller.VerticalAnchorRatio = 0.75f;
-                scroller.IsAnchoredAtHorizontalExtent = !c_defaultIsAnchoredAtExtent;
-                scroller.IsAnchoredAtVerticalExtent = !c_defaultIsAnchoredAtExtent;
             });
 
             IdleSynchronizer.Wait();
@@ -191,8 +186,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual(scroller.MaxZoomFactor, 2.0f);
                 Verify.AreEqual(scroller.HorizontalAnchorRatio, 0.25f);
                 Verify.AreEqual(scroller.VerticalAnchorRatio, 0.75f);
-                Verify.AreEqual(scroller.IsAnchoredAtHorizontalExtent, !c_defaultIsAnchoredAtExtent);
-                Verify.AreEqual(scroller.IsAnchoredAtVerticalExtent, !c_defaultIsAnchoredAtExtent);
             });
         }
 

--- a/dev/Scroller/Scroller.cpp
+++ b/dev/Scroller/Scroller.cpp
@@ -3288,11 +3288,6 @@ void Scroller::OnPropertyChanged(
 
         m_isAnchorElementDirty = true;
     }
-    else if (dependencyProperty == s_IsAnchoredAtHorizontalExtentProperty ||
-        dependencyProperty == s_IsAnchoredAtVerticalExtentProperty)
-    {
-        m_isAnchorElementDirty = true;
-    }
     else if (m_scrollerVisualInteractionSource)
     {
         if (dependencyProperty == s_HorizontalScrollChainingModeProperty)
@@ -6587,14 +6582,6 @@ winrt::hstring Scroller::DependencyPropertyToString(const winrt::IDependencyProp
     else if (dependencyProperty == s_MaxZoomFactorProperty)
     {
         return L"MaxZoomFactor";
-    }
-    else if (dependencyProperty == s_IsAnchoredAtHorizontalExtentProperty)
-    {
-        return L"IsAnchoredAtHorizontalExtent";
-    }
-    else if (dependencyProperty == s_IsAnchoredAtVerticalExtentProperty)
-    {
-        return L"IsAnchoredAtVerticalExtent";
     }
     else if (dependencyProperty == s_HorizontalAnchorRatioProperty)
     {

--- a/dev/Scroller/ScrollerAnchoring.cpp
+++ b/dev/Scroller/ScrollerAnchoring.cpp
@@ -8,7 +8,7 @@
 #include "DoubleUtil.h"
 #include "ScrollerTestHooks.h"
 
-// Used when Scroller.IsAnchoredAtHorizontalExtent or Scroller.IsAnchoredAtVerticalExtent is True to determine whether the Content is scrolled to an edge.
+// Used when Scroller.HorizontalAnchorRatio or Scroller.VerticalAnchorRatio is 0.0 or 1.0 to determine whether the Content is scrolled to an edge.
 // It is declared at an edge if it's within 1/10th of a pixel.
 const double c_edgeDetectionTolerance = 0.1;
 
@@ -62,14 +62,13 @@ void Scroller::RaiseAnchorRequested()
 }
 
 // Computes the type of anchoring to perform, if any, based on Scroller.HorizontalAnchorRatio, Scroller.VerticalAnchorRatio, 
-// Scroller.IsAnchoredAtHorizontalExtent, Scroller.IsAnchoredAtVerticalExtent, the current offsets, zoomFactor, viewport size, content size and state.
+// the current offsets, zoomFactor, viewport size, content size and state.
 // When all 4 returned booleans are False, no element anchoring is performed, no far edge anchoring is performed. There may still be anchoring at near edges.
 void Scroller::IsAnchoring(
     _Out_ bool* isAnchoringElementHorizontally,
     _Out_ bool* isAnchoringElementVertically,
     _Out_opt_ bool* isAnchoringFarEdgeHorizontally,
     _Out_opt_ bool* isAnchoringFarEdgeVertically)
-
 {
     *isAnchoringElementHorizontally = false;
     *isAnchoringElementVertically = false;
@@ -97,23 +96,23 @@ void Scroller::IsAnchoring(
     const double horizontalAnchorRatio = HorizontalAnchorRatio();
     const double verticalAnchorRatio = VerticalAnchorRatio();
 
-    // For edge anchoring, the near edge is considered when HorizontalAnchorRatio or VerticalAnchorRatio is less than 0.5. 
-    // When the property is greater than or equal to 0.5, the far edge is considered.
+    // For edge anchoring, the near edge is considered when HorizontalAnchorRatio or VerticalAnchorRatio is 0.0. 
+    // When the property is 1.0, the far edge is considered.
     if (!isnan(horizontalAnchorRatio))
     {
         MUX_ASSERT(horizontalAnchorRatio >= 0.0);
         MUX_ASSERT(horizontalAnchorRatio <= 1.0);
 
-        if (IsAnchoredAtHorizontalExtent())
+        if (horizontalAnchorRatio == 0.0 || horizontalAnchorRatio == 1.0)
         {
-            if (horizontalAnchorRatio >= 0.5 && m_zoomedHorizontalOffset + m_viewportWidth - m_unzoomedExtentWidth * m_zoomFactor > -c_edgeDetectionTolerance)
+            if (horizontalAnchorRatio == 1.0 && m_zoomedHorizontalOffset + m_viewportWidth - m_unzoomedExtentWidth * m_zoomFactor > -c_edgeDetectionTolerance)
             {
                 if (isAnchoringFarEdgeHorizontally)
                 {
                     *isAnchoringFarEdgeHorizontally = true;
                 }
             }
-            else if (!(horizontalAnchorRatio < 0.5 && m_zoomedHorizontalOffset < c_edgeDetectionTolerance))
+            else if (!(horizontalAnchorRatio == 0.0 && m_zoomedHorizontalOffset < c_edgeDetectionTolerance))
             {
                 *isAnchoringElementHorizontally = true;
             }
@@ -129,16 +128,16 @@ void Scroller::IsAnchoring(
         MUX_ASSERT(verticalAnchorRatio >= 0.0);
         MUX_ASSERT(verticalAnchorRatio <= 1.0);
 
-        if (IsAnchoredAtVerticalExtent())
+        if (verticalAnchorRatio == 0.0 || verticalAnchorRatio == 1.0)
         {
-            if (verticalAnchorRatio >= 0.5 && m_zoomedVerticalOffset + m_viewportHeight - m_unzoomedExtentHeight * m_zoomFactor > -c_edgeDetectionTolerance)
+            if (verticalAnchorRatio == 1.0 && m_zoomedVerticalOffset + m_viewportHeight - m_unzoomedExtentHeight * m_zoomFactor > -c_edgeDetectionTolerance)
             {
                 if (isAnchoringFarEdgeVertically)
                 {
                     *isAnchoringFarEdgeVertically = true;
                 }
             }
-            else if (!(verticalAnchorRatio < 0.5 && m_zoomedVerticalOffset < c_edgeDetectionTolerance))
+            else if (!(verticalAnchorRatio == 0.0 && m_zoomedVerticalOffset < c_edgeDetectionTolerance))
             {
                 *isAnchoringElementVertically = true;
             }

--- a/dev/Scroller/ScrollerPrimitives.idl
+++ b/dev/Scroller/ScrollerPrimitives.idl
@@ -163,10 +163,6 @@ unsealed runtimeclass Scroller : Windows.UI.Xaml.FrameworkElement
     MU_XC_NAMESPACE.InteractionState State { get; };
     IScrollController HorizontalScrollController { get; set; };
     IScrollController VerticalScrollController { get; set; };
-    [MUX_DEFAULT_VALUE("Scroller::s_defaultAnchorAtExtent")]
-    Boolean IsAnchoredAtHorizontalExtent { get; set; };
-    [MUX_DEFAULT_VALUE("Scroller::s_defaultAnchorAtExtent")]
-    Boolean IsAnchoredAtVerticalExtent { get; set; };
     [MUX_DEFAULT_VALUE("Scroller::s_defaultAnchorRatio")]
     [MUX_PROPERTY_VALIDATION_CALLBACK("ValidateAnchorRatio")]
     Double HorizontalAnchorRatio { get; set; };
@@ -207,8 +203,6 @@ unsealed runtimeclass Scroller : Windows.UI.Xaml.FrameworkElement
     static Windows.UI.Xaml.DependencyProperty InputKindProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MinZoomFactorProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MaxZoomFactorProperty { get; };
-    static Windows.UI.Xaml.DependencyProperty IsAnchoredAtHorizontalExtentProperty { get; };
-    static Windows.UI.Xaml.DependencyProperty IsAnchoredAtVerticalExtentProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HorizontalAnchorRatioProperty { get; };
     static Windows.UI.Xaml.DependencyProperty VerticalAnchorRatioProperty { get; };
 }

--- a/dev/Scroller/TestUI/ScrollerRepeaterAnchoringPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerRepeaterAnchoringPage.xaml
@@ -62,8 +62,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -74,54 +72,38 @@
 
             <TextBlock Text="Scroller Properties" Grid.ColumnSpan="4" Foreground="Red"/>
 
-            <TextBlock Text="IsAnchoredAtHorizontalExtent:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbIsAnchoredAtHorizontalExtent" Width="75" Margin="1" Grid.Row="1" Grid.Column="1" VerticalAlignment="Center">
-                <ComboBoxItem>Yes</ComboBoxItem>
-                <ComboBoxItem>No</ComboBoxItem>
-            </ComboBox>
-            <Button x:Name="btnGetIsAnchoredAtHorizontalExtent" Content="G" Margin="1" Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetIsAnchoredAtHorizontalExtent_Click"/>
-            <Button x:Name="btnSetIsAnchoredAtHorizontalExtent" Content="S" Margin="1" Grid.Row="1" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetIsAnchoredAtHorizontalExtent_Click"/>
+            <TextBlock Text="HorizontalAnchorRatio:" Grid.Row="1" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtHorizontalAnchorRatio" Grid.Row="1" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetHorizontalAnchorRatio" Content="G" Margin="1" Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHorizontalAnchorRatio_Click"/>
+            <Button x:Name="btnSetHorizontalAnchorRatio" Content="S" Margin="1" Grid.Row="1" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHorizontalAnchorRatio_Click"/>
 
-            <TextBlock Text="IsAnchoredAtVerticalExtent:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbIsAnchoredAtVerticalExtent" Width="75" Margin="1" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">
-                <ComboBoxItem>Yes</ComboBoxItem>
-                <ComboBoxItem>No</ComboBoxItem>
-            </ComboBox>
-            <Button x:Name="btnGetIsAnchoredAtVerticalExtent" Content="G" Margin="1" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetIsAnchoredAtVerticalExtent_Click"/>
-            <Button x:Name="btnSetIsAnchoredAtVerticalExtent" Content="S" Margin="1" Grid.Row="2" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetIsAnchoredAtVerticalExtent_Click"/>
+            <TextBlock Text="VerticalAnchorRatio:" Grid.Row="2" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtVerticalAnchorRatio" Grid.Row="2" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
+            <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="2" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
 
-            <TextBlock Text="HorizontalAnchorRatio:" Grid.Row="3" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtHorizontalAnchorRatio" Grid.Row="3" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetHorizontalAnchorRatio" Content="G" Margin="1" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHorizontalAnchorRatio_Click"/>
-            <Button x:Name="btnSetHorizontalAnchorRatio" Content="S" Margin="1" Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHorizontalAnchorRatio_Click"/>
-
-            <TextBlock Text="VerticalAnchorRatio:" Grid.Row="4" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtVerticalAnchorRatio" Grid.Row="4" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
-            <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
-
-            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="5" Grid.Column="0"/>
-            <TextBlock Text="AnchorElement:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbAnchorElement" Width="75" Margin="1" Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
+            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="3" Grid.Column="0"/>
+            <TextBlock Text="AnchorElement:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbAnchorElement" Width="75" Margin="1" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
                 <ComboBoxItem>Null</ComboBoxItem>
                 <ComboBoxItem>External</ComboBoxItem>
                 <ComboBoxItem>Collapsed</ComboBoxItem>
                 <ComboBoxItem>Border</ComboBoxItem>
                 <ComboBoxItem>Item</ComboBoxItem>
             </ComboBox>
-            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
-            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="5" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
+            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
+            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
 
-            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
-            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
 
-            <TextBlock Text="Scroller Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="7" Margin="0,4,0,0"/>
+            <TextBlock Text="Scroller Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="5" Margin="0,4,0,0"/>
 
-            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="8" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
+            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="6" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
 
-            <TextBlock Text="ItemsRepeater Properties" Grid.Row="9" Grid.ColumnSpan="4" Foreground="Red" Margin="0,4,0,0"/>
+            <TextBlock Text="ItemsRepeater Properties" Grid.Row="7" Grid.ColumnSpan="4" Foreground="Red" Margin="0,4,0,0"/>
 
-            <CheckBox x:Name="chkUseAnimator" Content="Use Animator?" Grid.Row="10" Grid.ColumnSpan="4" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" 
+            <CheckBox x:Name="chkUseAnimator" Content="Use Animator?" Grid.Row="8" Grid.ColumnSpan="4" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" 
                       Checked="ChkUseAnimator_Checked" Unchecked="ChkUseAnimator_Unchecked"/>
         </Grid>
 

--- a/dev/Scroller/TestUI/ScrollerRepeaterAnchoringPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerRepeaterAnchoringPage.xaml.cs
@@ -78,8 +78,6 @@ namespace MUXControlsTestApp
 
                 UpdateRaiseAnchorNotifications(true /*raiseAnchorNotifications*/);
 
-                UpdateCmbIsAnchoredAtHorizontalExtent();
-                UpdateCmbIsAnchoredAtVerticalExtent();
                 UpdateHorizontalAnchorRatio();
                 UpdateVerticalAnchorRatio();
 
@@ -363,42 +361,6 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void BtnGetIsAnchoredAtHorizontalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            UpdateCmbIsAnchoredAtHorizontalExtent();
-        }
-
-        private void BtnSetIsAnchoredAtHorizontalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                scroller.IsAnchoredAtHorizontalExtent = cmbIsAnchoredAtHorizontalExtent.SelectedIndex == 0;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
-        }
-
-        private void BtnGetIsAnchoredAtVerticalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            UpdateCmbIsAnchoredAtVerticalExtent();
-        }
-
-        private void BtnSetIsAnchoredAtVerticalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                scroller.IsAnchoredAtVerticalExtent = cmbIsAnchoredAtVerticalExtent.SelectedIndex == 0;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
-        }
-
         private void BtnGetHorizontalAnchorRatio_Click(object sender, RoutedEventArgs e)
         {
             UpdateHorizontalAnchorRatio();
@@ -509,32 +471,6 @@ namespace MUXControlsTestApp
         {
             if (tblItemIndex != null && txtItemIndex != null && cmbAnchorElement != null)
                 tblItemIndex.Visibility = txtItemIndex.Visibility = cmbAnchorElement.SelectedIndex == 4 ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        private void UpdateCmbIsAnchoredAtHorizontalExtent()
-        {
-            try
-            {
-                cmbIsAnchoredAtHorizontalExtent.SelectedIndex = scroller.IsAnchoredAtHorizontalExtent ? 0 : 1;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
-        }
-
-        private void UpdateCmbIsAnchoredAtVerticalExtent()
-        {
-            try
-            {
-                cmbIsAnchoredAtVerticalExtent.SelectedIndex = scroller.IsAnchoredAtVerticalExtent ? 0 : 1;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
         }
 
         private void UpdateHorizontalAnchorRatio()

--- a/dev/Scroller/TestUI/ScrollerStackPanelAnchoringPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerStackPanelAnchoringPage.xaml
@@ -53,8 +53,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -65,77 +63,61 @@
 
             <TextBlock Text="Scroller Properties" Grid.ColumnSpan="4" Foreground="Red"/>
 
-            <TextBlock Text="IsAnchoredAtHorizontalExtent:" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbIsAnchoredAtHorizontalExtent" Grid.Row="1" Grid.Column="1" Margin="1,0,1,0" HorizontalAlignment="Stretch" VerticalAlignment="Center">
-                <ComboBoxItem>Yes</ComboBoxItem>
-                <ComboBoxItem>No</ComboBoxItem>
-            </ComboBox>
-            <Button x:Name="btnGetIsAnchoredAtHorizontalExtent" Content="G" Margin="1" Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetIsAnchoredAtHorizontalExtent_Click"/>
-            <Button x:Name="btnSetIsAnchoredAtHorizontalExtent" Content="S" Margin="1" Grid.Row="1" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetIsAnchoredAtHorizontalExtent_Click"/>
+            <TextBlock Text="HorizontalAnchorRatio:" Grid.Row="1" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtHorizontalAnchorRatio" Grid.Row="1" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetHorizontalAnchorRatio" Content="G" Margin="1" Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHorizontalAnchorRatio_Click"/>
+            <Button x:Name="btnSetHorizontalAnchorRatio" Content="S" Margin="1" Grid.Row="1" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHorizontalAnchorRatio_Click"/>
 
-            <TextBlock Text="IsAnchoredAtVerticalExtent:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbIsAnchoredAtVerticalExtent" Grid.Row="2" Grid.Column="1" Margin="1,0,1,0" HorizontalAlignment="Stretch" VerticalAlignment="Center">
-                <ComboBoxItem>Yes</ComboBoxItem>
-                <ComboBoxItem>No</ComboBoxItem>
-            </ComboBox>
-            <Button x:Name="btnGetIsAnchoredAtVerticalExtent" Content="G" Margin="1" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetIsAnchoredAtVerticalExtent_Click"/>
-            <Button x:Name="btnSetIsAnchoredAtVerticalExtent" Content="S" Margin="1" Grid.Row="2" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetIsAnchoredAtVerticalExtent_Click"/>
+            <TextBlock Text="VerticalAnchorRatio:" Grid.Row="2" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtVerticalAnchorRatio" Grid.Row="2" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
+            <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="2" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
 
-            <TextBlock Text="HorizontalAnchorRatio:" Grid.Row="3" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtHorizontalAnchorRatio" Grid.Row="3" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetHorizontalAnchorRatio" Content="G" Margin="1" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHorizontalAnchorRatio_Click"/>
-            <Button x:Name="btnSetHorizontalAnchorRatio" Content="S" Margin="1" Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHorizontalAnchorRatio_Click"/>
+            <TextBlock Text="Width:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtWidth" Text="300" Grid.Row="3" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetWidth" Content="G" Margin="1" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetWidth_Click"/>
+            <Button x:Name="btnSetWidth" Content="S" Margin="1" Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetWidth_Click"/>
 
-            <TextBlock Text="VerticalAnchorRatio:" Grid.Row="4" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtVerticalAnchorRatio" Grid.Row="4" Grid.Column="1" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
-            <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
+            <TextBlock Text="Height:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtHeight" Text="600" Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetHeight" Content="G" Margin="1" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHeight_Click"/>
+            <Button x:Name="btnSetHeight" Content="S" Margin="1" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHeight_Click"/>
 
-            <TextBlock Text="Width:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtWidth" Text="300" Grid.Row="5" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetWidth" Content="G" Margin="1" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetWidth_Click"/>
-            <Button x:Name="btnSetWidth" Content="S" Margin="1" Grid.Row="5" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetWidth_Click"/>
-
-            <TextBlock Text="Height:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtHeight" Text="600" Grid.Row="6" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetHeight" Content="G" Margin="1" Grid.Row="6" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHeight_Click"/>
-            <Button x:Name="btnSetHeight" Content="S" Margin="1" Grid.Row="6" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHeight_Click"/>
-
-            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="7" Grid.Column="0"/>
-            <TextBlock Text="AnchorElement:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbAnchorElement" Grid.Row="7" Grid.Column="1" Margin="1,0,1,0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
+            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="5" Grid.Column="0"/>
+            <TextBlock Text="AnchorElement:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbAnchorElement" Grid.Row="5" Grid.Column="1" Margin="1,0,1,0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
                 <ComboBoxItem>Null</ComboBoxItem>
                 <ComboBoxItem>External</ComboBoxItem>
                 <ComboBoxItem>Collapsed</ComboBoxItem>
                 <ComboBoxItem>Border</ComboBoxItem>
                 <ComboBoxItem>Item</ComboBoxItem>
             </ComboBox>
-            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="7" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
-            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="7" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
+            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
+            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="5" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
 
-            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
-            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="8" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
 
-            <TextBlock Text="Scroller Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="9" Margin="0,4,0,0"/>
+            <TextBlock Text="Scroller Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="7" Margin="0,4,0,0"/>
 
-            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="10" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
+            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="8" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
 
-            <TextBlock Text="ScrollerChangeOffsetsOptions" Grid.Row="11" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
-            <TextBlock Text="Offset:" Grid.Column="0" Grid.Row="12" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtCOAO" Text="0" Grid.Column="1" Grid.Row="12" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
-            <TextBlock Text="Duration override (msec):" Grid.Column="0" Grid.Row="13" VerticalAlignment="Center"/>
-            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="13" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+            <TextBlock Text="ScrollerChangeOffsetsOptions" Grid.Row="9" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
+            <TextBlock Text="Offset:" Grid.Column="0" Grid.Row="10" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCOAO" Text="0" Grid.Column="1" Grid.Row="10" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
+            <TextBlock Text="Duration override (msec):" Grid.Column="0" Grid.Row="11" VerticalAlignment="Center"/>
+            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="11" HorizontalAlignment="Stretch" VerticalAlignment="Center">
                 <TextBox x:Name="txtStockOffsetsChangeDuration" IsReadOnly="True" Margin="1"/>
                 <TextBox x:Name="txtOverriddenOffsetsChangeDuration" Margin="1"/>
             </StackPanel>
-            <Button x:Name="btnChangeOffsets" Content="ChangeOffsets" Grid.ColumnSpan="4" Grid.Row="14" Margin="1" HorizontalAlignment="Stretch" Click="BtnChangeOffsets_Click"/>
+            <Button x:Name="btnChangeOffsets" Content="ChangeOffsets" Grid.ColumnSpan="4" Grid.Row="12" Margin="1" HorizontalAlignment="Stretch" Click="BtnChangeOffsets_Click"/>
 
-            <TextBlock Text="ScrollerChangeOffsetsWithAdditionalVelocityOptions" Grid.Row="15" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
-            <TextBlock Text="Velocity:" Grid.Column="0" Grid.Row="16" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtCOWAVAV" Text="0" Grid.Column="1" Grid.Row="16" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
-            <TextBlock Text="InertiaDecayRate:" Grid.Column="0" Grid.Row="17" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtCOWAVAIDR" Text="null" Grid.Column="1" Grid.Row="17" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
-            <Button x:Name="btnChangeOffsetsWithAdditionalVelocity" Content="ChangeOffsets" Grid.ColumnSpan="4" Grid.Row="18" Margin="1" HorizontalAlignment="Stretch" Click="BtnChangeOffsetsWithAdditionalVelocity_Click"/>
+            <TextBlock Text="ScrollerChangeOffsetsWithAdditionalVelocityOptions" Grid.Row="13" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
+            <TextBlock Text="Velocity:" Grid.Column="0" Grid.Row="14" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCOWAVAV" Text="0" Grid.Column="1" Grid.Row="14" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
+            <TextBlock Text="InertiaDecayRate:" Grid.Column="0" Grid.Row="15" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCOWAVAIDR" Text="null" Grid.Column="1" Grid.Row="15" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
+            <Button x:Name="btnChangeOffsetsWithAdditionalVelocity" Content="ChangeOffsets" Grid.ColumnSpan="4" Grid.Row="16" Margin="1" HorizontalAlignment="Stretch" Click="BtnChangeOffsetsWithAdditionalVelocity_Click"/>
         </Grid>
 
         <Grid Grid.Row="1" Grid.Column="2" Margin="1">

--- a/dev/Scroller/TestUI/ScrollerStackPanelAnchoringPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerStackPanelAnchoringPage.xaml.cs
@@ -83,8 +83,6 @@ namespace MUXControlsTestApp
 
                 UpdateRaiseAnchorNotifications(raiseAnchorNotifications: true);
 
-                UpdateCmbIsAnchoredAtHorizontalExtent();
-                UpdateCmbIsAnchoredAtVerticalExtent();
                 UpdateHorizontalAnchorRatio();
                 UpdateVerticalAnchorRatio();
 
@@ -602,42 +600,6 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void BtnGetIsAnchoredAtHorizontalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            UpdateCmbIsAnchoredAtHorizontalExtent();
-        }
-
-        private void BtnSetIsAnchoredAtHorizontalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                scroller.IsAnchoredAtHorizontalExtent = cmbIsAnchoredAtHorizontalExtent.SelectedIndex == 0;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
-        }
-
-        private void BtnGetIsAnchoredAtVerticalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            UpdateCmbIsAnchoredAtVerticalExtent();
-        }
-
-        private void BtnSetIsAnchoredAtVerticalExtent_Click(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                scroller.IsAnchoredAtVerticalExtent = cmbIsAnchoredAtVerticalExtent.SelectedIndex == 0;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
-        }
-
         private void BtnGetHorizontalAnchorRatio_Click(object sender, RoutedEventArgs e)
         {
             UpdateHorizontalAnchorRatio();
@@ -786,32 +748,6 @@ namespace MUXControlsTestApp
         {
             if (tblItemIndex != null && txtItemIndex != null && cmbAnchorElement != null)
                 tblItemIndex.Visibility = txtItemIndex.Visibility = cmbAnchorElement.SelectedIndex == 4 ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        private void UpdateCmbIsAnchoredAtHorizontalExtent()
-        {
-            try
-            {
-                cmbIsAnchoredAtHorizontalExtent.SelectedIndex = scroller.IsAnchoredAtHorizontalExtent ? 0 : 1;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
-        }
-
-        private void UpdateCmbIsAnchoredAtVerticalExtent()
-        {
-            try
-            {
-                cmbIsAnchoredAtVerticalExtent.SelectedIndex = scroller.IsAnchoredAtVerticalExtent ? 0 : 1;
-            }
-            catch (Exception ex)
-            {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollerEvents.Items.Add(ex.ToString());
-            }
         }
 
         private void UpdateHorizontalAnchorRatio()


### PR DESCRIPTION
Issue #264.

In order to align with the old WUX ScrollViewer, we decided to delete the existing Scroller/ScrollViewer IsAnchoredAtHorizontalExtent and IsAnchoredAtVerticalExtent boolean properties. Using HorizontalAnchorRatio=0.0 or HorizontalAnchorRatio=1.0 replaces IsAnchoredAtHorizontalExtent=True. Likewise using VerticalAnchorRatio=0.0 or VerticalAnchorRatio=1.0 replaces IsAnchoredAtVerticalExtent=True.

In other words:
Achieving horizontal anchoring at the left edge:
 - old required settings IsAnchoredAtHorizontalExtent==True and HorizontalAnchorRatio < 0.5
 - new required setting HorizontalAnchorRatio = 0.0 

Achieving horizontal anchoring at the right edge:
 - old required settings IsAnchoredAtHorizontalExtent==True and HorizontalAnchorRatio >= 0.5
 - new required setting HorizontalAnchorRatio = 1.0

Similar changes for the vertical direction.

