### PR TITLE
Update build pipelines to generate framework package

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
@@ -1,0 +1,16 @@
+steps:
+  - template: MUX-BuildProject-Steps.yml
+    parameters:
+      solutionPath: MUXControls.sln
+      nugetConfigPath: nuget.config
+      appxPackageDir: $(appxPackageDir)
+      buildOutputDir: $(buildOutputDir)
+      publishDir: $(publishDir)
+
+  - script: |
+      call %Build_SourcesDirectory%\tools\MakeAppxHelper.cmd %BUILDPLATFORM% %BUILDCONFIGURATION% -builddate_yymm %BUILDDATE_YYMM% -builddate_dd $BUILDDATE_DD% -subversion %BUILDREVISION%
+      if %ERRORLEVEL% NEQ 0 (
+          echo ##vso[task.logissue type=error;] Make AppxHelper failed with exit code %ERRORLEVEL%
+          goto END
+      )
+    displayName: 'Make FrameworkPackage'

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -5,6 +5,8 @@ parameters:
   appxPackageDir: '$(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages'
 
 steps:
+  - template: MUX-PopulateBuildDateAndRevision-Steps.yml
+
   - script: |
       echo parameters.solutionPath = '${{ parameters.solutionPath }}'
       echo parameters.nugetConfigPath = '${{ parameters.nugetConfigPath }}'

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -15,17 +15,7 @@ jobs:
     - ${{ parameters.dependsOn }}
 
   steps:
-    # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg.
-    # This relies on the format of the pipeline name being of the format: $(date:yyMM).$(date:dd)$(rev:rrr)
-    # We can't use those variables here (they only work in the *name* of the top level Yaml), so
-    # pull them out here and set the variables for use in the nuget package version.
-  - powershell: |
-      $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
-      $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
-      $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
-      Write-Host "##vso[task.setvariable variable=builddate]$yymm$dd"
-      Write-Host "##vso[task.setvariable variable=buildrevision]$revision"
-    displayName: 'Get build revision number'
+  - template: MUX-PopulateBuildDateAndRevision-Steps.yml
   
   - script: |
       echo parameters.jobName '${{ parameters.jobName }}'
@@ -33,7 +23,7 @@ jobs:
       echo parameters.nupkgdir '${{ parameters.nupkgdir }}'
       echo parameters.publishPath '${{ parameters.publishPath }}'
       echo buildrevision=$(buildrevision)
-      echo buildrevision=$(builddate)
+      echo builddate=$(builddate)
     displayName: 'CreateNugetPackage: Display parameters'
 
   - task: DownloadBuildArtifacts@0 
@@ -56,7 +46,7 @@ jobs:
         -Subversion '$(buildrevision)' 
         -SkipFrameworkPackage
         -BuildArch ${{ parameters.primaryBuildArch }}
-        -BuildFlavor ${{ parameters.buildFlavor }} 
+        -BuildFlavor ${{ parameters.buildFlavor }}
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: nupkg'

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -44,7 +44,6 @@ jobs:
         -prereleaseversion prerelease 
         -DateOverride '$(builddate)'
         -Subversion '$(buildrevision)' 
-        -SkipFrameworkPackage
         -BuildArch ${{ parameters.primaryBuildArch }}
         -BuildFlavor ${{ parameters.buildFlavor }}
 

--- a/build/AzurePipelinesTemplates/MUX-PopulateBuildDateAndRevision-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-PopulateBuildDateAndRevision-Steps.yml
@@ -1,0 +1,19 @@
+steps:
+    # Extract the build revision number from Build.BuildNumber. This is needed to pass to build-nupkg.
+    # This relies on the format of the pipeline name being of the format: $(date:yyMM).$(date:dd)$(rev:rrr)
+    # We can't use those variables here (they only work in the *name* of the top level Yaml), so
+    # pull them out here and set the variables for use in the nuget package version.
+  - powershell: |
+      $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
+      $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
+      $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)
+      Write-Host "##vso[task.setvariable variable=builddate]$yymm$dd"
+      Write-Host "##vso[task.setvariable variable=builddate_yymm]$yymm"
+      Write-Host "##vso[task.setvariable variable=builddate_dd]$dd"
+      Write-Host "##vso[task.setvariable variable=buildrevision]$revision"
+
+      Write-Host builddate=$yymm$dd
+      Write-Host builddate_yymm=$yymm
+      Write-Host builddate_dd=$dd
+      Write-Host buildrevision=$revision
+    displayName: 'Get build revision number'

--- a/build/AzurePipelinesTemplates/MUX-PublishDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-PublishDevProject-Steps.yml
@@ -1,0 +1,13 @@
+steps:
+  - task: powershell@2
+    displayName: 'Copy files to staging dir'
+    inputs:
+      targetType: filePath
+      filePath: build\CopyFilesToStagingDir.ps1
+      arguments: -BuildOutputDir '$(buildOutputDir)' -PublishDir '$(Build.ArtifactStagingDirectory)' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: drop'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'drop'

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -36,6 +36,7 @@ PublishFile $FullBuildOutput\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd $Full
 PublishFile $FullBuildOutput\Microsoft.UI.Xaml\Generic.xaml $FullPublishDir\Microsoft.UI.Xaml\
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml.Design\Microsoft.UI.Xaml.Design.dll $FullPublishDir\Microsoft.UI.Xaml.Design\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\MUXControls.Test.dll $FullPublishDir\Test\
+PublishFile $FullBuildOutput\FrameworkPackage\*.appx $FullPublishDir\FrameworkPackage
 
 # Publish pdbs:
 $symbolsOutputDir = "$($FullPublishDir)\Symbols\"

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -36,7 +36,7 @@ PublishFile $FullBuildOutput\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd $Full
 PublishFile $FullBuildOutput\Microsoft.UI.Xaml\Generic.xaml $FullPublishDir\Microsoft.UI.Xaml\
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml.Design\Microsoft.UI.Xaml.Design.dll $FullPublishDir\Microsoft.UI.Xaml.Design\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\MUXControls.Test.dll $FullPublishDir\Test\
-PublishFile $FullBuildOutput\FrameworkPackage\*.appx $FullPublishDir\FrameworkPackage
+PublishFile $FullBuildOutput\FrameworkPackage\*.* $FullPublishDir\FrameworkPackage
 
 # Publish pdbs:
 $symbolsOutputDir = "$($FullPublishDir)\Symbols\"

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -32,26 +32,9 @@ jobs:
     value: $(Build.ArtifactStagingDirectory)
 
   steps:
-  - template: AzurePipelinesTemplates\MUX-BuildProject-Steps.yml
-    parameters:
-      solutionPath: MUXControls.sln
-      nugetConfigPath: nuget.config
-      appxPackageDir: $(appxPackageDir)
-      buildOutputDir: $(buildOutputDir)
-      publishDir: $(publishDir)
-
-  - task: powershell@2
-    displayName: 'Copy files to staging dir'
-    inputs:
-      targetType: filePath
-      filePath: build\CopyFilesToStagingDir.ps1
-      arguments: -BuildOutputDir '$(buildOutputDir)' -PublishDir '$(Build.ArtifactStagingDirectory)' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: drop'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'drop'
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+  
+  - template: AzurePipelinesTemplates\MUX-PublishDevProject-Steps.yml
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -23,26 +23,9 @@ jobs:
     value: $(Build.ArtifactStagingDirectory)
 
   steps:
-  - template: AzurePipelinesTemplates\MUX-BuildProject-Steps.yml
-    parameters:
-      solutionPath: MUXControls.sln
-      nugetConfigPath: nuget.config
-      appxPackageDir: $(appxPackageDir)
-      buildOutputDir: $(buildOutputDir)
-      publishDir: $(publishDir)
-
-  - task: powershell@2
-    displayName: 'Copy files to staging dir'
-    inputs:
-      targetType: filePath
-      filePath: build\CopyFilesToStagingDir.ps1
-      arguments: -BuildOutputDir '$(buildOutputDir)' -PublishDir '$(publishDir)' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: drop'
-    inputs:
-      PathtoPublish: '$(publishDir)'
-      artifactName: 'drop'
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+  
+  - template: AzurePipelinesTemplates\MUX-PublishDevProject-Steps.yml
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -46,13 +46,7 @@ jobs:
       branchVersion: true
       nugetVer: true
 
-  - template: AzurePipelinesTemplates\MUX-BuildProject-Steps.yml
-    parameters:
-      solutionPath: MUXControls.sln
-      nugetConfigPath: nuget.config
-      appxPackageDir: $(appxPackageDir)
-      buildOutputDir: $(buildOutputDir)
-      publishDir: $(publishDir)
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
 
   - task: PkgESCodeSign@10
     displayName: CodeSign
@@ -66,18 +60,7 @@ jobs:
     inputs:
       filename: '$(Build.SourcesDirectory)\tools\PublishSymbols\PublishSymbols.cmd'      
 
-  - task: powershell@2
-    displayName: 'Copy files to staging dir'
-    inputs:
-      targetType: filePath
-      filePath: build\CopyFilesToStagingDir.ps1
-      arguments: -BuildOutputDir '$(buildOutputDir)' -PublishDir '$(Build.ArtifactStagingDirectory)' -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish artifact: drop'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'drop'
+  - template: AzurePipelinesTemplates\MUX-PublishDevProject-Steps.yml
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -137,9 +137,13 @@ Write-Host $NugetCmdLine
 Invoke-Expression $NugetCmdLine
 if ($lastexitcode -ne 0)
 {
-    Exit $lastexitcode; 
     Write-Host "Nuget returned $lastexitcode"
+    Exit $lastexitcode; 
 }
+
+Write-Host
+Write-Host "SkipFrameworkPackage = $SkipFrameworkPackage"
+Write-Host
 
 if(-not $SkipFrameworkPackage)
 {
@@ -162,8 +166,8 @@ if(-not $SkipFrameworkPackage)
     Invoke-Expression $NugetCmdLine
     if ($lastexitcode -ne 0)
     {
-        Exit $lastexitcode; 
         Write-Host "Nuget returned $lastexitcode"
+        Exit $lastexitcode; 
     }
 }
 


### PR DESCRIPTION
Call MakeAppxHelper after each build to produce the framework package. I had to update the script a little to be able to pass in the pipeline's date/time so that it matches the nuget package. 

Also refactored the CI/PR/Release yml files to reduce duplication across them for the dev build steps.

Fixes #51 