### PR TITLE
Adding ScrollViewer anchor registering/unregistering public methods

### DIFF
--- a/dev/ScrollViewer/APITests/ScrollViewerTests.cs
+++ b/dev/ScrollViewer/APITests/ScrollViewerTests.cs
@@ -22,12 +22,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
 using ScrollViewer = Microsoft.UI.Xaml.Controls.ScrollViewer;
+using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
 using ContentOrientation = Microsoft.UI.Xaml.Controls.ContentOrientation;
 using ScrollMode = Microsoft.UI.Xaml.Controls.ScrollMode;
 using InputKind = Microsoft.UI.Xaml.Controls.InputKind;
 using ChainingMode = Microsoft.UI.Xaml.Controls.ChainingMode;
 using RailingMode = Microsoft.UI.Xaml.Controls.RailingMode;
 using ZoomMode = Microsoft.UI.Xaml.Controls.ZoomMode;
+using ScrollerAnchorRequestedEventArgs = Microsoft.UI.Xaml.Controls.ScrollerAnchorRequestedEventArgs;
 using MUXControlsTestHooksLoggingMessageEventArgs = Microsoft.UI.Private.Controls.MUXControlsTestHooksLoggingMessageEventArgs;
 using ScrollViewerTestHooks = Microsoft.UI.Private.Controls.ScrollViewerTestHooks;
 
@@ -260,6 +262,74 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("Description", "Verifies anchor candidate registration and unregistration.")]
+        public void VerifyAnchorCandidateRegistration()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled on pre-RS2 because ScrollViewer not supported pre-RS2");
+                return;
+            }
+
+            using (PrivateLoggingHelper privateSVLoggingHelper = new PrivateLoggingHelper("ScrollViewer", "Scroller"))
+            {
+                int expectedAnchorCandidatesCount = 0;
+                Scroller scroller = null;
+                ScrollViewer scrollViewer = null;
+                Rectangle rectangleScrollViewerContent = null;
+                AutoResetEvent scrollViewerLoadedEvent = new AutoResetEvent(false);
+                AutoResetEvent scrollViewerAnchorRequestedEvent = new AutoResetEvent(false);
+
+                RunOnUIThread.Execute(() =>
+                {
+                    rectangleScrollViewerContent = new Rectangle();
+                    scrollViewer = new ScrollViewer();
+                    scrollViewer.HorizontalAnchorRatio = 0.1;
+                    scrollViewer.IsAnchoredAtHorizontalExtent = false;
+
+                    SetupDefaultUI(scrollViewer, rectangleScrollViewerContent, scrollViewerLoadedEvent);
+
+                    scrollViewer.AnchorRequested += (ScrollViewer sender, ScrollerAnchorRequestedEventArgs args) =>
+                    {
+                        Log.Comment("ScrollViewer.AnchorRequested event handler. args.AnchorCandidates.Count: " + args.AnchorCandidates.Count);
+                        Verify.IsNull(args.AnchorElement);
+                        Verify.AreEqual(expectedAnchorCandidatesCount, args.AnchorCandidates.Count);
+                        scrollViewerAnchorRequestedEvent.Set();
+                    };
+                });
+
+                WaitForEvent("Waiting for Loaded event", scrollViewerLoadedEvent);
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Log.Comment("Accessing inner Scroller control");
+                    scroller = ScrollViewerTestHooks.GetScrollerPart(scrollViewer);
+
+                    Log.Comment("Registering Rectangle as anchor candidate");
+                    scrollViewer.RegisterAnchorCandidate(rectangleScrollViewerContent);
+                    expectedAnchorCandidatesCount = 1;
+
+                    Log.Comment("Forcing Scroller layout");
+                    scroller.InvalidateArrange();
+                });
+
+                WaitForEvent("Waiting for AnchorRequested event", scrollViewerAnchorRequestedEvent);
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Log.Comment("Unregistering Rectangle as anchor candidate");
+                    scrollViewer.UnregisterAnchorCandidate(rectangleScrollViewerContent);
+                    expectedAnchorCandidatesCount = 0;
+
+                    Log.Comment("Forcing Scroller layout");
+                    scroller.InvalidateArrange();
+                });
+
+                WaitForEvent("Waiting for AnchorRequested event", scrollViewerAnchorRequestedEvent);
+            }
+        }
+
         private void SetupDefaultUI(
             ScrollViewer scrollViewer,
             Rectangle rectangleScrollViewerContent = null,
@@ -297,7 +367,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 scrollViewer.Loaded += (object sender, RoutedEventArgs e) =>
                 {
-                    Log.Comment("Scroller.Loaded event handler");
+                    Log.Comment("ScrollViewer.Loaded event handler");
                     scrollViewerLoadedEvent.Set();
                 };
             }
@@ -306,7 +376,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 scrollViewer.Unloaded += (object sender, RoutedEventArgs e) =>
                 {
-                    Log.Comment("Scroller.Unloaded event handler");
+                    Log.Comment("ScrollViewer.Unloaded event handler");
                     scrollViewerUnloadedEvent.Set();
                 };
             }

--- a/dev/ScrollViewer/APITests/ScrollViewerTests.cs
+++ b/dev/ScrollViewer/APITests/ScrollViewerTests.cs
@@ -283,7 +283,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     rectangleScrollViewerContent = new Rectangle();
                     scrollViewer = new ScrollViewer();
                     scrollViewer.HorizontalAnchorRatio = 0.1;
-                    scrollViewer.IsAnchoredAtHorizontalExtent = false;
 
                     SetupDefaultUI(scrollViewer, rectangleScrollViewerContent, scrollViewerLoadedEvent);
 

--- a/dev/ScrollViewer/ScrollViewer.cpp
+++ b/dev/ScrollViewer/ScrollViewer.cpp
@@ -162,6 +162,26 @@ void ScrollViewer::InputKind(winrt::InputKind const& value)
     SetValue(s_InputKindProperty, box_value(value));
 }
 
+void ScrollViewer::RegisterAnchorCandidate(winrt::UIElement const& element)
+{
+    SCROLLVIEWER_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+
+    if (auto scroller = m_scroller.get())
+    {
+        scroller.RegisterAnchorCandidate(element);
+    }
+}
+
+void ScrollViewer::UnregisterAnchorCandidate(winrt::UIElement const& element)
+{
+    SCROLLVIEWER_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+
+    if (auto scroller = m_scroller.get())
+    {
+        scroller.UnregisterAnchorCandidate(element);
+    }
+}
+
 int32_t ScrollViewer::ChangeOffsets(
     winrt::ScrollerChangeOffsetsOptions const& options)
 {

--- a/dev/ScrollViewer/ScrollViewer.cpp
+++ b/dev/ScrollViewer/ScrollViewer.cpp
@@ -164,22 +164,38 @@ void ScrollViewer::InputKind(winrt::InputKind const& value)
 
 void ScrollViewer::RegisterAnchorCandidate(winrt::UIElement const& element)
 {
-    SCROLLVIEWER_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+    SCROLLVIEWER_TRACE_VERBOSE(*this, TRACE_MSG_METH_PTR, METH_NAME, this, element);
 
     if (auto scroller = m_scroller.get())
     {
-        scroller.RegisterAnchorCandidate(element);
+        const winrt::Controls::IScrollAnchorProvider scrollerAsAnchorProvider = scroller.try_as<winrt::Controls::IScrollAnchorProvider>();
+
+        if (scrollerAsAnchorProvider)
+        {
+            scrollerAsAnchorProvider.RegisterAnchorCandidate(element);
+            return;
+        }
+        throw winrt::hresult_error(E_INVALID_OPERATION, s_iScrollAnchorProviderNotImpl);
     }
+    throw winrt::hresult_error(E_INVALID_OPERATION, s_noScrollerPart);
 }
 
 void ScrollViewer::UnregisterAnchorCandidate(winrt::UIElement const& element)
 {
-    SCROLLVIEWER_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+    SCROLLVIEWER_TRACE_VERBOSE(*this, TRACE_MSG_METH_PTR, METH_NAME, this, element);
 
     if (auto scroller = m_scroller.get())
     {
-        scroller.UnregisterAnchorCandidate(element);
+        const winrt::Controls::IScrollAnchorProvider scrollerAsAnchorProvider = scroller.try_as<winrt::Controls::IScrollAnchorProvider>();
+
+        if (scrollerAsAnchorProvider)
+        {
+            scrollerAsAnchorProvider.UnregisterAnchorCandidate(element);
+            return;
+        }
+        throw winrt::hresult_error(E_INVALID_OPERATION, s_iScrollAnchorProviderNotImpl);
     }
+    throw winrt::hresult_error(E_INVALID_OPERATION, s_noScrollerPart);
 }
 
 int32_t ScrollViewer::ChangeOffsets(

--- a/dev/ScrollViewer/ScrollViewer.cpp
+++ b/dev/ScrollViewer/ScrollViewer.cpp
@@ -168,9 +168,7 @@ void ScrollViewer::RegisterAnchorCandidate(winrt::UIElement const& element)
 
     if (auto scroller = m_scroller.get())
     {
-        const winrt::Controls::IScrollAnchorProvider scrollerAsAnchorProvider = scroller.try_as<winrt::Controls::IScrollAnchorProvider>();
-
-        if (scrollerAsAnchorProvider)
+        if (const auto scrollerAsAnchorProvider = scroller.try_as<winrt::Controls::IScrollAnchorProvider>())
         {
             scrollerAsAnchorProvider.RegisterAnchorCandidate(element);
             return;
@@ -186,9 +184,7 @@ void ScrollViewer::UnregisterAnchorCandidate(winrt::UIElement const& element)
 
     if (auto scroller = m_scroller.get())
     {
-        const winrt::Controls::IScrollAnchorProvider scrollerAsAnchorProvider = scroller.try_as<winrt::Controls::IScrollAnchorProvider>();
-
-        if (scrollerAsAnchorProvider)
+        if (const auto scrollerAsAnchorProvider = scroller.try_as<winrt::Controls::IScrollAnchorProvider>())
         {
             scrollerAsAnchorProvider.UnregisterAnchorCandidate(element);
             return;

--- a/dev/ScrollViewer/ScrollViewer.h
+++ b/dev/ScrollViewer/ScrollViewer.h
@@ -230,6 +230,8 @@ private:
     static constexpr std::wstring_view s_horizontalScrollBarPartName{ L"PART_HorizontalScrollBar"sv };
     static constexpr std::wstring_view s_verticalScrollBarPartName{ L"PART_VerticalScrollBar"sv };
     static constexpr std::wstring_view s_scrollBarsSeparatorPartName{ L"PART_ScrollBarsSeparator"sv };
+    static constexpr std::wstring_view s_iScrollAnchorProviderNotImpl{ L"Template part named PART_Scroller does not implement IScrollAnchorProvider."sv };
+    static constexpr std::wstring_view s_noScrollerPart{ L"No template part named PART_Scroller was loaded."sv };
 
     winrt::com_ptr<ScrollBarController> m_horizontalScrollBarController{ nullptr };
     winrt::com_ptr<ScrollBarController> m_verticalScrollBarController{ nullptr };

--- a/dev/ScrollViewer/ScrollViewer.h
+++ b/dev/ScrollViewer/ScrollViewer.h
@@ -62,6 +62,8 @@ public:
     winrt::InputKind InputKind();
     void InputKind(winrt::InputKind const& value);
 
+    void RegisterAnchorCandidate(winrt::UIElement const& element);
+    void UnregisterAnchorCandidate(winrt::UIElement const& element);
     int32_t ChangeOffsets(winrt::ScrollerChangeOffsetsOptions const& options);
     int32_t ChangeOffsetsWithAdditionalVelocity(winrt::ScrollerChangeOffsetsWithAdditionalVelocityOptions const& options);
     int32_t ChangeZoomFactor(winrt::ScrollerChangeZoomFactorOptions const& options);

--- a/dev/ScrollViewer/ScrollViewer.idl
+++ b/dev/ScrollViewer/ScrollViewer.idl
@@ -79,6 +79,8 @@ unsealed runtimeclass ScrollViewer : Windows.UI.Xaml.Controls.Control
     [MUX_DEFAULT_VALUE("ScrollViewer::s_defaultAnchorRatio")]
     [MUX_PROPERTY_VALIDATION_CALLBACK("ValidateAnchorRatio")]
     Double VerticalAnchorRatio { get; set; };
+    void RegisterAnchorCandidate(Windows.UI.Xaml.UIElement element);
+    void UnregisterAnchorCandidate(Windows.UI.Xaml.UIElement element);
     Int32 ChangeOffsets(ScrollerChangeOffsetsOptions options);
     Int32 ChangeOffsetsWithAdditionalVelocity(ScrollerChangeOffsetsWithAdditionalVelocityOptions options);
     Int32 ChangeZoomFactor(ScrollerChangeZoomFactorOptions options);

--- a/dev/inc/ErrorHandling.h
+++ b/dev/inc/ErrorHandling.h
@@ -6,6 +6,10 @@
 #include <windows.h>
 #include <exception>
 
+#ifndef E_INVALID_OPERATION
+#define E_INVALID_OPERATION HRESULT_FROM_WIN32(ERROR_INVALID_OPERATION)
+#endif
+
 // CATCH_RETURN macro should be used in all ABI methods like this:
 // IFACEMETHODIMP CFoo::Bar(...) try
 // {


### PR DESCRIPTION
Issue #264 

The ScrollViewer is now exposing two new RegisterAnchorCandidate/UnregisterAnchorCandidate methods to explicitly register and unregister anchor candidates. The calls are being forwarded to the inner Scroller's IAnchorProvider implementation (with the same method signatures RegisterAnchorCandidate & UnregisterAnchorCandidate).

Added new VerifyAnchorCandidateRegistration test to exercise the two new methods.