### PR TITLE
Limit packages pushed to just the one in the root of the artifact drop

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -59,5 +59,5 @@ jobs:
       inputs:
         command: push
         publishVstsFeed: ${{ parameters.publishVstsFeed }}
-
+        packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
 


### PR DESCRIPTION
This fixes the current CI build break.