### PR TITLE
Allow varying height items in flow layout

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -531,7 +531,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         }
                     };
 
-                    SetPanelMinorSize(panel, om, 150);
+                    SetPanelMinorSize(panel, om, 180);
                     for (int i = 0; i < numItems; i++)
                     {
                         var child = new Button() { Content = i };

--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -515,6 +515,77 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
+        public void ValidateFlowLayoutVaryingHeights()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                foreach (ScrollOrientation scrollOrientation in Enum.GetValues(typeof(ScrollOrientation)))
+                {
+                    Log.Comment(string.Format("ScrollOrientation: {0}", scrollOrientation));
+                    var om = new OrientationBasedMeasures(scrollOrientation);
+                    const int numItems = 10;
+                    LayoutPanel panel = new LayoutPanel() {
+                        Layout = new FlowLayout() {
+                            Orientation = scrollOrientation.ToOrthogonalLayoutOrientation(),
+                            LineAlignment = FlowLayoutLineAlignment.Start
+                        }
+                    };
+
+                    SetPanelMinorSize(panel, om, 150);
+                    for (int i = 0; i < numItems; i++)
+                    {
+                        var child = new Button() { Content = i };
+                        if (scrollOrientation == ScrollOrientation.Vertical)
+                        {
+                            child.Width = 50;
+                            child.Height = 50 + i % 2 * 50;
+                        }
+                        else
+                        {
+                            child.Width = 50 + i % 2 * 50;
+                            child.Height = 50;
+                        }
+
+                        panel.Children.Add(child);
+                    }
+
+                    Content = panel;
+
+                    Content.UpdateLayout();
+                    int minItemSpacing = 0;
+                    int lineSpacing = 0;
+                    Log.Comment("Validate with no spacing");
+                    ValidateFlowLayoutChildrenLayoutBounds(
+                        om, 
+                        (i) => panel.Children[i], 
+                        minItemSpacing, 
+                        lineSpacing, 
+                        panel.Children.Count, 
+                        panel.DesiredSize,
+                        scrollOrientation == ScrollOrientation.Vertical? 50:100,
+                        scrollOrientation == ScrollOrientation.Vertical ? 100 : 50 );
+
+                    minItemSpacing = 10;
+                    lineSpacing = 10;
+                    ((FlowLayout)panel.Layout).MinRowSpacing = minItemSpacing;
+                    ((FlowLayout)panel.Layout).MinColumnSpacing = lineSpacing;
+                    Content.UpdateLayout();
+                    Log.Comment("Validate with spacing");
+                    ValidateFlowLayoutChildrenLayoutBounds(
+                        om,
+                        (i) => panel.Children[i], 
+                        minItemSpacing, 
+                        lineSpacing, 
+                        panel.Children.Count,
+                        panel.DesiredSize,
+                        scrollOrientation == ScrollOrientation.Vertical ? 50 : 100,
+                        scrollOrientation == ScrollOrientation.Vertical ? 100 : 50);
+
+                }
+            });
+        }
+
+        [TestMethod]
         public void ValidateFlowLayoutLineAlignment()
         {
             RunOnUIThread.Execute(() =>
@@ -1109,20 +1180,25 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             double minItemSpacing,
             double lineSpacing,
             int childCount,
-            Size desiredSize)
+            Size desiredSize, 
+            float? expectedItemWidth = null,
+            float? expectedItemHeight = null)
         {
             var expectedRect = om.MinorMajorRect(0, 0, 0, 0);
             double extentMajor = 0;
             double lineSize = 0;
+            Log.Comment("ValidateFlowLayoutChildrenLayoutBounds");
             for (int i = 0; i < childCount; i++)
             {
                 var child = (FrameworkElement)elementAtIndexFunc(i);
 
                 var layoutBounds = LayoutInformation.GetLayoutSlot(child);
-                expectedRect.Width = child.DesiredSize.Width;
-                expectedRect.Height = child.DesiredSize.Height;
+
+                expectedRect.Width = expectedItemWidth.HasValue ? expectedItemWidth.Value: child.DesiredSize.Width;
+                expectedRect.Height = expectedItemHeight.HasValue? expectedItemHeight.Value: child.DesiredSize.Height;
                 lineSize = Math.Max(lineSize, om.Major(child.DesiredSize));
 
+                Log.Comment(string.Format(@"Index:{0}, Expected:{1} Actual:{2}", i, expectedRect, layoutBounds));
                 Verify.AreEqual(expectedRect, layoutBounds);
 
                 extentMajor = om.MajorStart(expectedRect) + lineSize;
@@ -1134,6 +1210,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 }
             }
 
+            Log.Comment(string.Format(@"Extent Expected:{0} Actual:{1}", om.Major(desiredSize), extentMajor));
             Verify.AreEqual(extentMajor, om.Major(desiredSize));
         }
 

--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -556,14 +556,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     int lineSpacing = 0;
                     Log.Comment("Validate with no spacing");
                     ValidateFlowLayoutChildrenLayoutBounds(
-                        om, 
-                        (i) => panel.Children[i], 
-                        minItemSpacing, 
-                        lineSpacing, 
-                        panel.Children.Count, 
+                        om,
+                        (i) => panel.Children[i],
+                        minItemSpacing,
+                        lineSpacing,
+                        panel.Children.Count,
                         panel.DesiredSize,
-                        scrollOrientation == ScrollOrientation.Vertical? 50:100,
-                        scrollOrientation == ScrollOrientation.Vertical ? 100 : 50 );
+                        scrollOrientation == ScrollOrientation.Vertical ? 50 : 100,
+                        scrollOrientation == ScrollOrientation.Vertical ? 100 : 50);
 
                     minItemSpacing = 10;
                     lineSpacing = 10;
@@ -573,14 +573,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Log.Comment("Validate with spacing");
                     ValidateFlowLayoutChildrenLayoutBounds(
                         om,
-                        (i) => panel.Children[i], 
-                        minItemSpacing, 
-                        lineSpacing, 
+                        (i) => panel.Children[i],
+                        minItemSpacing,
+                        lineSpacing,
                         panel.Children.Count,
                         panel.DesiredSize,
                         scrollOrientation == ScrollOrientation.Vertical ? 50 : 100,
                         scrollOrientation == ScrollOrientation.Vertical ? 100 : 50);
-
                 }
             });
         }

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -276,6 +276,11 @@ void FlowLayoutAlgorithm::Generate(
 
         int previousIndex = anchorIndex;
         int currentIndex = anchorIndex + step;
+        auto anchorBounds = m_elementManager.GetLayoutBoundsForDataIndex(anchorIndex);
+        float lineOffset = anchorBounds.*MajorStart();
+        float lineMajorSize = anchorBounds.*MajorSize();
+        int countInLine = 1;
+        bool lineNeedsReposition = false;
 
         while (m_elementManager.IsIndexValidInData(currentIndex) &&
             ShouldContinueFillingUpSpace(previousIndex, direction))
@@ -288,10 +293,7 @@ void FlowLayoutAlgorithm::Generate(
             // Lay it out.
             auto previousElement = m_elementManager.GetRealizedElement(previousIndex);
             winrt::Rect currentBounds = winrt::Rect{ 0, 0, desiredSize.Width, desiredSize.Height };
-
-            // TODO: Support varying MajorSize items
             auto previousElementBounds = m_elementManager.GetLayoutBoundsForDataIndex(previousIndex);
-            auto previousLineMajorSize = previousElementBounds.*MajorSize();
 
             if (direction == GenerateDirection::Forward)
             {
@@ -300,13 +302,37 @@ void FlowLayoutAlgorithm::Generate(
                 {
                     // No more space in this row. wrap to next row.
                     currentBounds.*MinorStart() = 0;
-                    currentBounds.*MajorStart() = previousElementBounds.*MajorStart() + previousLineMajorSize + static_cast<float>(lineSpacing);
+                    currentBounds.*MajorStart() = previousElementBounds.*MajorStart() + lineMajorSize + static_cast<float>(lineSpacing);
+
+                    if (lineNeedsReposition)
+                    {
+                        // reposition the previous line (countInLine items)
+                        for (int i = 0; i < countInLine; i++)
+                        {
+                            auto dataIndex = currentIndex - 1 - i;
+                            if (dataIndex != anchorIndex)
+                            {
+                                auto bounds = m_elementManager.GetLayoutBoundsForDataIndex(dataIndex);
+                                bounds.*MajorSize() = lineMajorSize;
+                                m_elementManager.SetLayoutBoundsForDataIndex(dataIndex, bounds);
+                            }
+                        }
+                    }
+
+                    // Setup for next line.
+                    lineMajorSize = currentBounds.*MajorSize();
+                    lineOffset = currentBounds.*MajorStart();
+                    lineNeedsReposition = false;
+                    countInLine = 1;
                 }
                 else
                 {
                     // More space is available in this row.
                     currentBounds.*MinorStart() = previousElementBounds.*MinorStart() + previousElementBounds.*MinorSize() + static_cast<float>(minItemSpacing);
-                    currentBounds.*MajorStart() = previousElementBounds.*MajorStart();
+                    currentBounds.*MajorStart() = lineOffset;
+                    lineMajorSize = std::max(lineMajorSize, currentBounds.*MajorSize());
+                    lineNeedsReposition = previousElementBounds.*MajorSize() != currentBounds.*MajorSize();
+                    countInLine++;
                 }
             }
             else
@@ -317,17 +343,44 @@ void FlowLayoutAlgorithm::Generate(
                 {
                     // Does not fit, wrap to the previous row
                     const auto availableSizeMinor = availableSize.*Minor();
-                    currentBounds.*MinorStart() =
-                        std::isfinite(availableSizeMinor) ?
-                        availableSizeMinor - desiredSize.*Minor() :
-                        0.0f;
-                    currentBounds.*MajorStart() = previousElementBounds.*MajorStart() - desiredSize.*Major() - static_cast<float>(lineSpacing);
+                    currentBounds.*MinorStart() = std::isfinite(availableSizeMinor) ? availableSizeMinor - desiredSize.*Minor() : 0.0f;
+                    currentBounds.*MajorStart() = lineOffset - desiredSize.*Major() - static_cast<float>(lineSpacing);
+
+                    if (lineNeedsReposition)
+                    {
+                        auto previousLineOffset = m_elementManager.GetLayoutBoundsForDataIndex(currentIndex + countInLine + 1).*MajorStart();
+                        // reposition the previous line (countInLine items)
+                        for (int i = 0; i < countInLine; i++)
+                        {
+                            auto dataIndex = currentIndex + 1 + i;
+                            if (dataIndex != anchorIndex)
+                            {
+                                auto bounds = m_elementManager.GetLayoutBoundsForDataIndex(dataIndex);
+                                bounds.*MajorStart() = previousLineOffset - lineMajorSize - static_cast<float>(lineSpacing);
+                                bounds.*MajorSize() = lineMajorSize;
+                                m_elementManager.SetLayoutBoundsForDataIndex(dataIndex, bounds);
+                                REPEATER_TRACE_INFO(L"%ls: \t Corrected Layout bounds of element %d are (%.0f,%.0f,%.0f,%.0f). \n",
+                                    layoutId.data(),
+                                    dataIndex,
+                                    bounds.X, bounds.Y, bounds.Width, bounds.Height);
+                            }
+                        }
+                    }
+
+                    // Setup for next line.
+                    lineMajorSize = currentBounds.*MajorSize();
+                    lineOffset = currentBounds.*MajorStart();
+                    lineNeedsReposition = false;
+                    countInLine = 1;
                 }
                 else
                 {
                     // Fits in this row. put it in the previous position
                     currentBounds.*MinorStart() = previousElementBounds.*MinorStart() - desiredSize.*Minor() - static_cast<float>(minItemSpacing);
-                    currentBounds.*MajorStart() = previousElementBounds.*MajorStart();
+                    currentBounds.*MajorStart() = lineOffset;
+                    lineMajorSize = std::max(lineMajorSize, currentBounds.*MajorSize());
+                    lineNeedsReposition = previousElementBounds.*MajorSize() != currentBounds.*MajorSize();
+                    countInLine++;
                 }
             }
 

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -310,12 +310,9 @@ void FlowLayoutAlgorithm::Generate(
                         for (int i = 0; i < countInLine; i++)
                         {
                             auto dataIndex = currentIndex - 1 - i;
-                            if (dataIndex != anchorIndex)
-                            {
-                                auto bounds = m_elementManager.GetLayoutBoundsForDataIndex(dataIndex);
-                                bounds.*MajorSize() = lineMajorSize;
-                                m_elementManager.SetLayoutBoundsForDataIndex(dataIndex, bounds);
-                            }
+                            auto bounds = m_elementManager.GetLayoutBoundsForDataIndex(dataIndex);
+                            bounds.*MajorSize() = lineMajorSize;
+                            m_elementManager.SetLayoutBoundsForDataIndex(dataIndex, bounds);
                         }
                     }
 

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -27,6 +27,7 @@
             <Button x:Name="virtualFixedStackLayoutDemo">Virtual Fixed Stack Layout Demo</Button>
             <Button x:Name="virtualStackLayoutDemo">Virtual Variable Stack Layout Demo (Estimated)</Button>
             <Button x:Name="pinterestLayoutDemo">Pinterest Layout Demo</Button>
+            <Button x:Name="flowLayoutDemo">Flow Layout Demo</Button>
             <Button x:Name="storeDemo">Store demo</Button>
             <TextBlock>Selection Demo</TextBlock>
             <StackPanel Orientation="Horizontal">

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
@@ -76,6 +76,11 @@ namespace MUXControlsTestApp
                 Frame.NavigateWithoutAnimation(typeof(PinterestLayoutSamplePage));
             };
 
+            flowLayoutDemo.Click += delegate 
+            {
+                Frame.NavigateWithoutAnimation(typeof(FlowLayoutDemoPage));
+            };
+
             activityFeedLayoutDemo.Click += delegate
             {
                 Frame.NavigateWithoutAnimation(typeof(ActivityFeedSamplePage));

--- a/dev/Repeater/TestUI/Repeater_TestUI.projitems
+++ b/dev/Repeater/TestUI/Repeater_TestUI.projitems
@@ -44,6 +44,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Samples\FlowLayoutDemoPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Samples\ItemsViewWithDataPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -106,6 +110,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Samples\CircleLayoutDemo\CircleLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\Defaults.xaml.cs">
       <DependentUpon>Defaults.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Samples\FlowLayoutDemoPage.xaml.cs">
+      <DependentUpon>FlowLayoutDemoPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Samples\ItemTemplateSamples\ItemTemplateDemo.xaml.cs">
       <DependentUpon>ItemTemplateDemo.xaml</DependentUpon>

--- a/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml
+++ b/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml
@@ -1,0 +1,31 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Page
+    x:Class="MUXControlsTestApp.Samples.FlowLayoutDemoPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp.Samples"
+    xmlns:mux="using:Microsoft.UI.Xaml.Controls">
+
+    <ScrollViewer Margin="12">
+        <mux:ItemsRepeater x:Name="repeater"
+                              HorizontalAlignment="Center"
+                              HorizontalCacheLength="0"
+                              VerticalCacheLength="0">
+            <mux:ItemsRepeater.Layout>
+                <mux:FlowLayout  LineAlignment="Start" MinRowSpacing="10" MinColumnSpacing="10"/>
+            </mux:ItemsRepeater.Layout>
+            <mux:ItemsRepeater.ItemTemplate>
+                <DataTemplate x:DataType="local:MyItem">
+                    <AppBarButton MinWidth="96"
+                          Label="{x:Bind Label}"
+                          BorderBrush="Black"
+                          BorderThickness="1">
+                        <AppBarButton.Icon>
+                            <SymbolIcon Symbol="{x:Bind Icon}"/>
+                        </AppBarButton.Icon>
+                    </AppBarButton>
+                </DataTemplate>
+            </mux:ItemsRepeater.ItemTemplate>
+        </mux:ItemsRepeater>
+    </ScrollViewer>
+</Page>

--- a/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml
+++ b/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml
@@ -6,7 +6,7 @@
     xmlns:local="using:MUXControlsTestApp.Samples"
     xmlns:mux="using:Microsoft.UI.Xaml.Controls">
 
-    <ScrollViewer Margin="12">
+    <ScrollViewer Width="180">
         <mux:ItemsRepeater x:Name="repeater"
                               HorizontalAlignment="Center"
                               HorizontalCacheLength="0"
@@ -16,14 +16,12 @@
             </mux:ItemsRepeater.Layout>
             <mux:ItemsRepeater.ItemTemplate>
                 <DataTemplate x:DataType="local:MyItem">
-                    <AppBarButton MinWidth="96"
-                          Label="{x:Bind Label}"
+                    <Button Width="50"
+                          Content="{x:Bind Label}"
+                            Height="{x:Bind Height}"
                           BorderBrush="Black"
                           BorderThickness="1">
-                        <AppBarButton.Icon>
-                            <SymbolIcon Symbol="{x:Bind Icon}"/>
-                        </AppBarButton.Icon>
-                    </AppBarButton>
+                    </Button>
                 </DataTemplate>
             </mux:ItemsRepeater.ItemTemplate>
         </mux:ItemsRepeater>

--- a/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace MUXControlsTestApp.Samples
+{
+    public sealed partial class FlowLayoutDemoPage : Page
+    {
+        public FlowLayoutDemoPage()
+        {
+            this.InitializeComponent();
+
+            Random r = new Random();
+            repeater.ItemsSource = (from i in Enumerable.Range(0, 1000)
+                               select new MyItem() {
+                                   Icon = (Symbol)(r.Next((int)0xE100, (int)0xE200)),
+                                   Label = i.ToString() + " " + LoremIpsum.Substring(0, Math.Max(5, r.Next(LoremIpsum.Length)))
+                               }).ToList();
+        }
+
+        private const string LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+    }
+
+    public class MyItem
+    {
+        public string Label { get; set; }
+        public Symbol Icon { get; set; }
+    }
+}

--- a/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml.cs
@@ -27,5 +27,5 @@ namespace MUXControlsTestApp.Samples
     {
         public string Label { get; set; }
         public float Height { get; set; }
-    }
+    } 
 }

--- a/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/FlowLayoutDemoPage.xaml.cs
@@ -15,20 +15,17 @@ namespace MUXControlsTestApp.Samples
         {
             this.InitializeComponent();
 
-            Random r = new Random();
             repeater.ItemsSource = (from i in Enumerable.Range(0, 1000)
                                select new MyItem() {
-                                   Icon = (Symbol)(r.Next((int)0xE100, (int)0xE200)),
-                                   Label = i.ToString() + " " + LoremIpsum.Substring(0, Math.Max(5, r.Next(LoremIpsum.Length)))
+                                   Label = i.ToString(),
+                                   Height = 50 + i % 2 * 50
                                }).ToList();
         }
-
-        private const string LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
     }
 
     public class MyItem
     {
         public string Label { get; set; }
-        public Symbol Icon { get; set; }
+        public float Height { get; set; }
     }
 }


### PR DESCRIPTION
Adding support to make all items in a line take the same size as the tallest one. Still working through some flakiness that is causing layout cycles especially when the estimations don't settle. I think I need to find a more general solution to get the estimates to settle. Will keep working at it, but this change gets the basics working.

Internal Issue: https://microsoft.visualstudio.com/OS/_queries/edit/18098455