### PR TITLE
Update DevCmd script to use VSWhere

### DIFF
--- a/DevCmd.cmd
+++ b/DevCmd.cmd
@@ -6,14 +6,11 @@ set PATH=%PATH%;%~dp0\tools
 
 call %~dp0\tools\addaliases.cmd
 
-powershell -Command "&{ 'set _VSINSTALLDIR15=' + (Get-ItemProperty 'HKLM:\software\wow6432node\Microsoft\VisualStudio\SxS\vs7' -Name '15.0').'15.0' }" > %TEMP%\vsinstalldir.bat
-call %TEMP%\vsinstalldir.bat
+"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -requires Microsoft.Component.MSBuild -property InstallationPath > %TEMP%\vsinstalldir.txt
 
-IF EXIST "%_VSINSTALLDIR15%" (
-    call "%_VSINSTALLDIR15%\Common7\Tools\VsDevCmd.bat"
-) ELSE (
-    call "%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Enterprise\Common7\Tools\VsDevCmd.bat"
-)
+set /p _VSINSTALLDIR15=<%TEMP%\vsinstalldir.txt
+
+call "%_VSINSTALLDIR15%\Common7\Tools\VsDevCmd.bat"
 
 pushd %~dp0
 


### PR DESCRIPTION
I updated DevCmd to try to pull the VS installation from the registry but that wasn't working on one of my machines. But I also must have had amnesia because I had used this "VSWhere" utility in the RunLocWorkflow script and forgot about it when trying to make DevCmd more robust.