### PR TITLE
Re-enable localization handoff as yaml pipeline

### DIFF
--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -1,0 +1,15 @@
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+jobs:
+- job: LocalizationHandoff
+  pool:
+    name: Package ES Custom Demands Lab A
+
+  steps:
+  - template: AzurePipelinesTemplates\MUX-PopulateBuildDateAndRevision-Steps.yml
+
+  - task: CmdLine@1
+    displayName: 'Run Loc Workflow'
+    inputs:
+      filename: '$(Build.SourcesDirectory)\tools\VSTSRunLocWorkflow.cmd'
+
+

--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -3,8 +3,17 @@ jobs:
 - job: LocalizationHandoff
   pool:
     name: Package ES Custom Demands Lab A
+    demands:
+      - ClientAlias -equals depcontrols2
 
   steps:
+  - task: PkgESSetupBuild@10
+    displayName: 'XESSetupBuild'
+    inputs:
+      productName: dep.controls
+      branchVersion: true
+      nugetVer: true
+
   - template: AzurePipelinesTemplates\MUX-PopulateBuildDateAndRevision-Steps.yml
 
   - task: CmdLine@1

--- a/tools/VSTSRunLocWorkflow.cmd
+++ b/tools/VSTSRunLocWorkflow.cmd
@@ -5,6 +5,11 @@ setlocal
 	exit /B 1
 )
 
+@if not defined BUILDREVISION (
+	echo ERROR: Expecting BUILDREVISION to be set
+	exit /B 1
+)
+
 call %~dp0\..\build\localization\RunLocWorkflow.cmd Daily-%BUILDDATE%.%BUILDREVISION%
 
 REM Undo any changes that were made since we are just doing handoff and the process will automatically hand back.

--- a/tools/VSTSRunLocWorkflow.cmd
+++ b/tools/VSTSRunLocWorkflow.cmd
@@ -1,11 +1,11 @@
 setlocal
 
-@if not defined XES_NUGETPACKVERSIONNOBETA (
-	echo ERROR: Expecting XES_NUGETPACKVERSIONNOBETA to be set
+@if not defined BUILDDATE (
+	echo ERROR: Expecting BUILDDATE to be set
 	exit /B 1
 )
 
-call %~dp0\..\build\localization\RunLocWorkflow.cmd Daily-%XES_NUGETPACKVERSIONNOBETA%
+call %~dp0\..\build\localization\RunLocWorkflow.cmd Daily-%BUILDDATE%.%BUILDREVISION%
 
 REM Undo any changes that were made since we are just doing handoff and the process will automatically hand back.
 pushd %~dp0\..


### PR DESCRIPTION
Adding back a pipeline that runs the localization script to hand off the resw files for localization. The pipeline is going to be configured to run daily (per the recommendation from the localization team).