### PR TITLE
Fix issues with signing in the release pipeline

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -15,7 +15,23 @@ jobs:
   dependsOn:
     - ${{ parameters.dependsOn }}
 
+  # XES tasks need to be on PackageES machines.
+  ${{if parameters.signConfig }}:
+    pool:
+      name: Package ES Custom Demands Lab A
+      demands:
+        - ClientAlias -equals depcontrols2
+
+
   steps:
+  - ${{if parameters.signConfig }}:
+    - task: PkgESSetupBuild@10
+      displayName: 'XESSetupBuild'
+      inputs:
+        productName: dep.controls
+        branchVersion: true
+        nugetVer: true
+
   - template: MUX-PopulateBuildDateAndRevision-Steps.yml
   
   - script: |
@@ -48,6 +64,14 @@ jobs:
         -BuildArch ${{ parameters.primaryBuildArch }}
         -BuildFlavor ${{ parameters.buildFlavor }}
 
+  - ${{if parameters.signConfig }}:
+    - task: PkgESCodeSign@10
+      displayName: CodeSign
+      inputs:
+        signConfigXml: ${{ parameters.signConfig }}
+        inPathRoot: '${{ parameters.nupkgdir }}'
+        outPathRoot: '${{ parameters.nupkgdir }}\signed'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: nupkg'
     inputs:
@@ -61,19 +85,3 @@ jobs:
         command: push
         publishVstsFeed: ${{ parameters.publishVstsFeed }}
         packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
-
-  - ${{if parameters.signConfig }}:
-    - task: PkgESSetupBuild@10
-      displayName: 'XESSetupBuild'
-      inputs:
-        productName: dep.controls
-        branchVersion: true
-        nugetVer: true
-
-    - task: PkgESCodeSign@10
-      displayName: CodeSign
-      inputs:
-        signConfigXml: ${{ parameters.signConfig }}
-        inPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)'
-        outPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\signed'
-

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -63,6 +63,13 @@ jobs:
         packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
 
   - ${{if parameters.signConfig }}:
+    - task: PkgESSetupBuild@10
+      displayName: 'XESSetupBuild'
+      inputs:
+        productName: dep.controls
+        branchVersion: true
+        nugetVer: true
+
     - task: PkgESCodeSign@10
       displayName: CodeSign
       inputs:

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -8,6 +8,7 @@ parameters:
   primaryBuildArch: x86
   buildFlavor: Release
   publishVstsFeed: ''
+  signConfig: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -60,4 +61,12 @@ jobs:
         command: push
         publishVstsFeed: ${{ parameters.publishVstsFeed }}
         packagesToPush: $(Build.ArtifactStagingDirectory)/*.nupkg
+
+  - ${{if parameters.signConfig }}:
+    - task: PkgESCodeSign@10
+      displayName: CodeSign
+      inputs:
+        signConfigXml: ${{ parameters.signConfig }}
+        inPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)'
+        outPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\signed'
 

--- a/build/AzurePipelinesTemplates/MUX-PopulateBuildDateAndRevision-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-PopulateBuildDateAndRevision-Steps.yml
@@ -4,6 +4,12 @@ steps:
     # We can't use those variables here (they only work in the *name* of the top level Yaml), so
     # pull them out here and set the variables for use in the nuget package version.
   - powershell: |
+      # Some builds have "-branchname" appended, but when this happens the environment variable 
+      # TFS_BUILDNUMBER has the un-modified version.
+      if ($env:TFS_BUILDNUMBER)
+      {
+        $env:BUILD_BUILDNUMBER = $env:TFS_BUILDNUMBER
+      }
       $yymm = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 10, 4)
       $dd = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 5, 2)
       $revision = $env:BUILD_BUILDNUMBER.substring($env:BUILD_BUILDNUMBER.length - 3, 3)

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -69,6 +69,7 @@ jobs:
     dependsOn: Build
     # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
     # publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
+    signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml

--- a/build/NuGetSignConfig.xml
+++ b/build/NuGetSignConfig.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
-  <job platform="" configuration="" dest="__OUTPATHROOT__" jobname="dep.controls" approvers="">
-    <file src="__INPATHROOT__\PostBuild\Microsoft.UI.Xaml*.nupkg" signType="Nuget" />
+  <job platform="" configuration="" dest="__INPATHROOT__" jobname="dep.controls" approvers="">
+    <file src="__INPATHROOT__\Microsoft.UI.Xaml*.nupkg" signType="Nuget" />
   </job>
-  <job platform="" configuration="" dest="__OUTPATHROOT__\FrameworkPackage" jobname="dep.controls" approvers="">
-    <file src="__INPATHROOT__\PostBuild\FrameworkPackage\Microsoft.UI.Xaml*.nupkg" signType="Nuget" />
+  <job platform="" configuration="" dest="__INPATHROOT__\FrameworkPackage" jobname="dep.controls" approvers="">
+    <file src="__INPATHROOT__\FrameworkPackage\Microsoft.UI.Xaml*.nupkg" signType="Nuget" />
   </job>
 </SignConfigXML>

--- a/build/SourceIndexing/IndexPdbs.ps1
+++ b/build/SourceIndexing/IndexPdbs.ps1
@@ -70,6 +70,7 @@ COMMITID=$CommitId
 HTTP_ALIAS=https://raw.githubusercontent.com/%ORGANIZATION%/%REPO%/%COMMITID%/
 HTTP_EXTRACT_TARGET=%HTTP_ALIAS%%var2%
 SRCSRVTRG=%HTTP_EXTRACT_TARGET%
+SRC_INDEX=public
 SRCSRV: source files ---------------------------------------
 $($mappedFiles -join "`r`n")
 SRCSRV: end ------------------------------------------------

--- a/tools/PublishSymbols/PublishSymbols.ps1
+++ b/tools/PublishSymbols/PublishSymbols.ps1
@@ -14,11 +14,16 @@ $buildVersion = $versionMajor + "." + $versionMinor + "." + $env:BUILD_BUILDNUMB
 
 Write-Host "Build = $buildVersion"
 
-$buildId=$env:BUILD_BUILDNUMBER + "_" + $env:BUILDCONFIGURATION
-$directory=$env:BUILD_BINARIESDIRECTORY + "\" + $env:BUILDCONFIGURATION + "\" + $env:BUILDPLATFORM + "\Microsoft.UI.Xaml"
+$buildId="$($env:BUILD_BUILDNUMBER)_$($env:BUILDCONFIGURATION)_$($env:BUILDPLATFORM)"
+$localDirectory=$env:BUILD_BINARIESDIRECTORY + "\" + $env:BUILDCONFIGURATION + "\" + $env:BUILDPLATFORM + "\Microsoft.UI.Xaml"
+$directory = "$env:XES_DFSDROP\$env:XES_RELATIVEOUTPUTROOT\Microsoft.UI.Xaml"
+
+Write-Host "Local path: '$localDirectory'"
+Write-Host "Build share: '$directory'"
+
+Copy-Item -Recurse "$localDirectory" "$directory"
 
 Write-Host "buildId = $buildId"
-Write-Host "directory = $directory"
 
 Copy-Item pdb_index_template.ini pdb_index.ini
 Add-Content pdb_index.ini "Build=$buildVersion"


### PR DESCRIPTION
Add signing to the nuget package. I forgot this part of the pipeline when converting to yml. This required a bit of conditional logic in the nuget creation job and also changes to the sign config xml because the drop layout is different in the yml-based pipelines.

I also noticed that the symbol publishing was happening but wasn't succeeding (but no error was returned) because we gave it a location with no files. The script requires that it's pointed at a UNC path so I added that to the publishing script.

Finally I also was discussing with the symbol server people and they need us to add "SRC_INDEX=public" in order to skip stripping the pdbs when publishing them to MSDL.