### PR TITLE
Teaching tip second popup for light dismiss

### DIFF
--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -63,26 +63,53 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 OpenTeachingTip();
                 CloseTeachingTipProgrammatically();
                 var message0 = GetTeachingTipDebugMessage(0);
+                var message1 = GetTeachingTipDebugMessage(1);
+                Verify.IsTrue(message0.ToString().Contains("Closing"));
                 Verify.IsTrue(message0.ToString().Contains("Programmatic"));
+                Verify.IsTrue(message1.ToString().Contains("Closed"));
+                Verify.IsTrue(message1.ToString().Contains("Programmatic"));
 
                 SetBleedingContent(BleedingContentOptions.NoContent);
                 OpenTeachingTip();
                 PressXCloseButton();
                 var message2 = GetTeachingTipDebugMessage(2);
+                var message3 = GetTeachingTipDebugMessage(3);
                 var message4 = GetTeachingTipDebugMessage(4);
                 Verify.IsTrue(message2.ToString().Contains("Close Button Clicked"));
+                Verify.IsTrue(message3.ToString().Contains("Closing"));
+                Verify.IsTrue(message3.ToString().Contains("CloseButton"));
+                Verify.IsTrue(message4.ToString().Contains("Closed"));
                 Verify.IsTrue(message4.ToString().Contains("CloseButton"));
 
                 EnableLightDismiss(true);
                 OpenTeachingTip();
                 CloseTeachingTipProgrammatically();
+                var message5 = GetTeachingTipDebugMessage(5);
                 var message6 = GetTeachingTipDebugMessage(6);
+                Verify.IsTrue(message5.ToString().Contains("Closing"));
+                Verify.IsTrue(message5.ToString().Contains("Programmatic"));
+                Verify.IsTrue(message6.ToString().Contains("Closed"));
                 Verify.IsTrue(message6.ToString().Contains("Programmatic"));
 
                 OpenTeachingTip();
-                message2.Tap();
+                CloseTeachingTipByLightDismiss();
                 var message7 = GetTeachingTipDebugMessage(7);
+                var message8 = GetTeachingTipDebugMessage(8);
+                Verify.IsTrue(message7.ToString().Contains("Closing"));
                 Verify.IsTrue(message7.ToString().Contains("LightDismiss"));
+                Verify.IsTrue(message8.ToString().Contains("Closed"));
+                Verify.IsTrue(message8.ToString().Contains("LightDismiss"));
+
+                OpenTeachingTip();
+                PressXCloseButton();
+                var message9 = GetTeachingTipDebugMessage(9);
+                var message10 = GetTeachingTipDebugMessage(10);
+                var message11 = GetTeachingTipDebugMessage(11);
+                Verify.IsTrue(message9.ToString().Contains("Close Button Clicked"));
+                Verify.IsTrue(message10.ToString().Contains("Closing"));
+                Verify.IsTrue(message10.ToString().Contains("CloseButton"));
+                Verify.IsTrue(message11.ToString().Contains("Closed"));
+                Verify.IsTrue(message11.ToString().Contains("CloseButton"));
             }
         }
 
@@ -286,7 +313,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             if(elements.GetIsOpenCheckBox().ToggleState != ToggleState.On)
             {
-                elements.GetShowButton().Invoke();
+                elements.GetShowButton().Tap();
                 if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
                 {
                     WaitForUnchecked(elements.GetIsIdleCheckBox());
@@ -301,6 +328,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             if (elements.GetIsOpenCheckBox().ToggleState != ToggleState.Off)
             {
                 elements.GetCloseButton().Invoke();
+                if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
+                {
+                    WaitForUnchecked(elements.GetIsIdleCheckBox());
+                }
+                WaitForUnchecked(elements.GetIsOpenCheckBox());
+                WaitForChecked(elements.GetIsIdleCheckBox());
+            }
+        }
+
+        private void CloseTeachingTipByLightDismiss()
+        {
+            if (elements.GetIsOpenCheckBox().ToggleState != ToggleState.Off)
+            {
+                elements.GetLstTeachingTipEvents().Tap();
                 if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
                 {
                     WaitForUnchecked(elements.GetIsIdleCheckBox());

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -806,7 +806,7 @@ void TeachingTip::OnIsLightDismissEnabledChanged()
     if (IsLightDismissEnabled())
     {
         winrt::VisualStateManager::GoToState(*this, L"LightDismiss"sv, false);
-        if (auto lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get())
+        if (auto&& lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get())
         {
             lightDismissIndicatorPopup.IsLightDismissEnabled(true);
             m_lightDismissIndicatorPopupClosedRevoker = lightDismissIndicatorPopup.Closed(winrt::auto_revoke, { this, &TeachingTip::OnLightDismissIndicatorPopupClosed });
@@ -815,14 +815,11 @@ void TeachingTip::OnIsLightDismissEnabledChanged()
     else
     {
         winrt::VisualStateManager::GoToState(*this, L"NormalDismiss"sv, false);
-        if (auto lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get())
+        if (auto&& lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get())
         {
             lightDismissIndicatorPopup.IsLightDismissEnabled(false);
         }
-        if (m_lightDismissIndicatorPopupClosedRevoker)
-        {
-            m_lightDismissIndicatorPopupClosedRevoker.revoke();
-        }
+        m_lightDismissIndicatorPopupClosedRevoker.revoke();
     }
 }
 
@@ -945,11 +942,11 @@ void TeachingTip::ClosePopupWithAnimationIfAvailable()
 
 void TeachingTip::ClosePopup()
 {
-    if (m_popup)
+    if (auto&& popup = m_popup.get())
     {
-        m_popup.get().IsOpen(false);
+        popup.IsOpen(false);
     }
-    if (auto lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get())
+    if (auto&& lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get())
     {
         lightDismissIndicatorPopup.IsOpen(false);
     }
@@ -1168,7 +1165,7 @@ void TeachingTip::StartContractToClose()
 winrt::TeachingTipPlacementMode TeachingTip::DetermineEffectivePlacement()
 {
     auto placement = Placement();
-    if(placement != winrt::TeachingTipPlacementMode::Auto)
+    if (placement != winrt::TeachingTipPlacementMode::Auto)
     {
         return placement;
     }

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -703,12 +703,7 @@ void TeachingTip::OnIsOpenChanged()
             m_popup.set(winrt::Popup());
             m_popupClosedRevoker = m_popup.get().Closed(winrt::auto_revoke, { this, &TeachingTip::OnPopupClosed });
         }
-        if (IsLightDismissEnabled())
-        {
-            auto lightDismissIndicatorPopup = m_lightDismissIndicatorPopup.get();
-            lightDismissIndicatorPopup.IsLightDismissEnabled(true);
-            m_lightDismissIndicatorPopupClosedRevoker = lightDismissIndicatorPopup.Closed(winrt::auto_revoke, { this, &TeachingTip::OnLightDismissIndicatorPopupClosed });
-        }
+        OnIsLightDismissEnabledChanged();
         if (!m_contractAnimation)
         {
             CreateContractAnimation();

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -57,7 +57,6 @@ private:
     winrt::Popup::Closed_revoker m_lightDismissIndicatorPopupClosedRevoker{};
     winrt::Window::SizeChanged_revoker m_windowSizeChangedRevoker{};
     void CreateLightDismissIndicatorPopup();
-    void RemoveLightDismissIndicatorPopup();
     void UpdateBeak();
     void PositionPopup();
     void PositionTargetedPopup();

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -54,7 +54,10 @@ private:
     winrt::FrameworkElement::EffectiveViewportChanged_revoker m_targetEffectiveViewportChangedRevoker{};
     winrt::FrameworkElement::LayoutUpdated_revoker m_targetLayoutUpdatedRevoker{};
     winrt::Popup::Closed_revoker m_popupClosedRevoker{};
+    winrt::Popup::Closed_revoker m_lightDismissIndicatorPopupClosedRevoker{};
     winrt::Window::SizeChanged_revoker m_windowSizeChangedRevoker{};
+    void CreateLightDismissIndicatorPopup();
+    void RemoveLightDismissIndicatorPopup();
     void UpdateBeak();
     void PositionPopup();
     void PositionTargetedPopup();
@@ -81,6 +84,7 @@ private:
     void OnCloseButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);
     void OnActionButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);
     void OnPopupClosed(const winrt::IInspectable&, const winrt::IInspectable&);
+    void OnLightDismissIndicatorPopupClosed(const winrt::IInspectable&, const winrt::IInspectable&);
 
     void RaiseClosingEvent();
     void ClosePopupWithAnimationIfAvailable();
@@ -101,6 +105,7 @@ private:
     void EstablishShadows();
 
     tracker_ref<winrt::Popup> m_popup{ this };
+    tracker_ref<winrt::Popup> m_lightDismissIndicatorPopup{ this };
 
     tracker_ref<winrt::Grid> m_beakOcclusionGrid{ this };
     tracker_ref<winrt::Grid> m_contentRootGrid{ this };


### PR DESCRIPTION
Up until now TeachingTip did not animate when it closed due to light dismiss. This is because there is no event that occurs when a popup is closing due to light dismiss so we have no way to intercept the close and play our animation first. To work around this I've created a second popup which has no content and sits underneath the teaching tip and is put into light dismiss mode instead of the primary popup. Then when this popup closes due to light dismiss we know we are supposed to close the primary popup as well.