### PR TITLE
Add retries for finding CoreWindow

### DIFF
--- a/test/MUXControls.Test/Infra/Application.cs
+++ b/test/MUXControls.Test/Infra/Application.cs
@@ -117,8 +117,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 {
                     Verify.IsTrue(topWindowObj.Matches(_appFrameWindowCondition));
                     ApplicationFrameWindow = topWindowObj;
-                    UIObject coreWindowObject = null;
-                    bool didFindCoreWindow = false;
 
                     Log.Comment("Looking for CoreWindow...");
                     for (int retries = 0; retries < 5; ++retries)

--- a/test/MUXControls.Test/Infra/Application.cs
+++ b/test/MUXControls.Test/Infra/Application.cs
@@ -94,7 +94,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
             var topWindowCondition = _windowCondition.OrWith(_appFrameWindowCondition);
 
             UIObject topWindowObj = null;
-            bool didFindWindow = UIObject.Root.Children.TryFind(topWindowCondition, out topWindowObj);
+            bool didFindWindow = false;
+            try
+            {
+                didFindWindow = UIObject.Root.Children.TryFind(topWindowCondition, out topWindowObj);
+            }
+            catch (UIObjectNotFoundException)
+            {
+                didFindWindow = false;
+            }
 
             // Only try to launch the app if we couldn't find the window.
             if (doLaunch && !didFindWindow)

--- a/test/MUXControls.Test/Infra/Application.cs
+++ b/test/MUXControls.Test/Infra/Application.cs
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                     Log.Comment("Looking for CoreWindow...");
                     for (int retries = 0; retries < 5; ++retries)
                     {
-                        if(didFindCoreWindow = topWindowObj.Children.TryFind(_windowCondition, out coreWindowObject))
+                        if (topWindowObj.Children.TryFind(_windowCondition, out var coreWindowObject))
                         {
                             CoreWindow = coreWindowObject;
                             Log.Comment("Found CoreWindow.");


### PR DESCRIPTION
Sometimes we can't find CoreWindow and `topWindowObj.Children.Find(_windowCondition)` throws an UIObjectNotFound exception, which will cause multiple tests to fail in a row. Some examples:

https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=2931&view=ms.vss-test-web.build-test-results-tab

https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=2932&view=ms.vss-test-web.build-test-results-tab

Added retries for finding CoreWindow, also added tree dump when the lookup fails.