### PR TITLE
Fix visibility and namespace of a couple AutomationPeer types

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayerAutomationPeer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayerAutomationPeer.idl
@@ -1,4 +1,4 @@
-[WUXC_VERSION_INTERNAL]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass AnimatedVisualPlayerAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {

--- a/dev/DropDownButton/DropDownButtonAutomationPeer.idl
+++ b/dev/DropDownButton/DropDownButtonAutomationPeer.idl
@@ -3,5 +3,5 @@
 unsealed runtimeclass DropDownButtonAutomationPeer : Windows.UI.Xaml.Automation.Peers.ButtonAutomationPeer,
 Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
 {
-    DropDownButtonAutomationPeer(DropDownButton owner);
+    DropDownButtonAutomationPeer(MU_XC_NAMESPACE.DropDownButton owner);
 }

--- a/dev/RadioButtons/RadioButtonsAutomationPeer.idl
+++ b/dev/RadioButtons/RadioButtonsAutomationPeer.idl
@@ -1,4 +1,4 @@
-[WUXC_VERSION_MUXONLY]
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass RadioButtonsListViewItemAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemAutomationPeer
 {

--- a/dev/RadioButtons/RadioButtonsAutomationPeer.idl
+++ b/dev/RadioButtons/RadioButtonsAutomationPeer.idl
@@ -1,4 +1,4 @@
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass RadioButtonsListViewItemAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemAutomationPeer
 {

--- a/dev/Repeater/APITests/AccessibilityTests.cs
+++ b/dev/Repeater/APITests/AccessibilityTests.cs
@@ -30,7 +30,7 @@ using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 using ItemsSourceView = Microsoft.UI.Xaml.Controls.ItemsSourceView;
 using ElementFactory = Microsoft.UI.Xaml.Controls.ElementFactory;
 using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutContext;
-using RepeaterAutomationPeer = Microsoft.UI.Xaml.Controls.RepeaterAutomationPeer;
+using RepeaterAutomationPeer = Microsoft.UI.Xaml.Automation.Peers.RepeaterAutomationPeer;
 #endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests

--- a/dev/Repeater/RepeaterAutomationPeer.idl
+++ b/dev/Repeater/RepeaterAutomationPeer.idl
@@ -1,4 +1,4 @@
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass RepeaterAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {

--- a/dev/Repeater/RepeaterAutomationPeer.idl
+++ b/dev/Repeater/RepeaterAutomationPeer.idl
@@ -2,5 +2,5 @@
 [webhosthidden]
 unsealed runtimeclass RepeaterAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
-    RepeaterAutomationPeer(ItemsRepeater owner);
+    RepeaterAutomationPeer(MU_XC_NAMESPACE.ItemsRepeater owner);
 }

--- a/dev/Scroller/ScrollerAutomationPeer.idl
+++ b/dev/Scroller/ScrollerAutomationPeer.idl
@@ -2,5 +2,5 @@
 [webhosthidden]
 unsealed runtimeclass ScrollerAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
-    ScrollerAutomationPeer(Scroller owner);
+    ScrollerAutomationPeer(MU_XCP_NAMESPACE.Scroller owner);
 }

--- a/dev/SplitButton/SplitButtonAutomationPeer.idl
+++ b/dev/SplitButton/SplitButtonAutomationPeer.idl
@@ -1,10 +1,10 @@
-[WUXC_VERSION_RS5]
+﻿[WUXC_VERSION_RS5]
 [webhosthidden]
 unsealed runtimeclass SplitButtonAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,
 Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,
 Windows.UI.Xaml.Automation.Provider.IInvokeProvider
 {
-    SplitButtonAutomationPeer(SplitButton owner);
+    SplitButtonAutomationPeer(MU_XC_NAMESPACE.SplitButton owner);
 }
 
 [WUXC_VERSION_RS5]
@@ -13,5 +13,5 @@ unsealed runtimeclass ToggleSplitButtonAutomationPeer : Windows.UI.Xaml.Automati
 Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,
 Windows.UI.Xaml.Automation.Provider.IToggleProvider
 {
-    ToggleSplitButtonAutomationPeer(ToggleSplitButton owner);
+    ToggleSplitButtonAutomationPeer(MU_XC_NAMESPACE.ToggleSplitButton owner);
 }

--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -241,7 +241,6 @@ namespace MU_XC_NAMESPACE
 #include <NavigationView\NavigationView.idl>
 #include <ParallaxView\ParallaxView.idl>
 #include <Repeater\ItemsRepeater.idl>
-#include <Repeater\RepeaterAutomationPeer.idl>
 #include <Scroller\Scroller.idl>
 #include <LayoutPanel\LayoutPanel.idl>
 
@@ -322,6 +321,7 @@ namespace MU_XAP_NAMESPACE
 #include <RatingControl\RatingControlAutomationPeer.idl>
 #include <TreeView\TreeViewAutomationPeers.idl>
 #include <RadioButtons\RadioButtonsAutomationPeer.idl>
+#include <Repeater\RepeaterAutomationPeer.idl>
 #endif
 }
 

--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -264,9 +264,7 @@ namespace MU_XC_NAMESPACE
 #include <SwipeControl\SwipeControl.idl>
 #include <TreeView\TreeView.idl>
 #include <SplitButton\SplitButton.idl>
-#include <SplitButton\SplitButtonAutomationPeer.idl>
 #include <DropDownButton\DropDownButton.idl>
-#include <DropDownButton\DropDownButtonAutomationPeer.idl>
 #include <RadioButtons\RadioButtons.idl>
 #include <RadioMenuFlyoutItem\RadioMenuFlyoutItem.idl>
 #include <TeachingTip\TeachingTip.idl>
@@ -296,7 +294,6 @@ namespace MU_XCP_NAMESPACE
 #endif
 #include <NavigationView\NavigationViewItemPresenter.idl>
 #include <Scroller\ScrollerPrimitives.idl>
-#include <Scroller\ScrollerAutomationPeer.idl>
 }
 
 namespace MU_XM_NAMESPACE
@@ -322,6 +319,9 @@ namespace MU_XAP_NAMESPACE
 #include <TreeView\TreeViewAutomationPeers.idl>
 #include <RadioButtons\RadioButtonsAutomationPeer.idl>
 #include <Repeater\RepeaterAutomationPeer.idl>
+#include <SplitButton\SplitButtonAutomationPeer.idl>
+#include <DropDownButton\DropDownButtonAutomationPeer.idl>
+#include <Scroller\ScrollerAutomationPeer.idl>
 #endif
 }
 


### PR DESCRIPTION
I did a scrub of our public/preview types and these were mismatched.