### PR TITLE
NavigationView header and hamburger button overlap fix

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1387,10 +1387,15 @@ void NavigationView::RaiseItemInvoked(winrt::IInspectable const& item,
 // forceSetDisplayMode: On first call to SetDisplayMode, force setting to initial values
 void NavigationView::SetDisplayMode(const winrt::NavigationViewDisplayMode& displayMode, bool forceSetDisplayMode)
 {
-    if (forceSetDisplayMode || DisplayMode() != displayMode)
-    {
-        UpdateVisualStateForDisplayModeGroup(displayMode);
+    auto changingDisplayMode = DisplayMode() != displayMode;
 
+    // Need to keep the VisualStateGroup "DisplayModeGroup" updated even if the actual
+    // display mode is not changed. This is due to the fact that there can be a transition between
+    // 'Minimal' and 'MinimalWithBackButton'.
+    UpdateVisualStateForDisplayModeGroup(displayMode);
+
+    if (forceSetDisplayMode || changingDisplayMode)
+    {
         // Update header visibility based on what the new display mode will be
         UpdateHeaderVisibility(displayMode);
 

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1387,14 +1387,12 @@ void NavigationView::RaiseItemInvoked(winrt::IInspectable const& item,
 // forceSetDisplayMode: On first call to SetDisplayMode, force setting to initial values
 void NavigationView::SetDisplayMode(const winrt::NavigationViewDisplayMode& displayMode, bool forceSetDisplayMode)
 {
-    auto changingDisplayMode = DisplayMode() != displayMode;
-
     // Need to keep the VisualStateGroup "DisplayModeGroup" updated even if the actual
     // display mode is not changed. This is due to the fact that there can be a transition between
     // 'Minimal' and 'MinimalWithBackButton'.
     UpdateVisualStateForDisplayModeGroup(displayMode);
 
-    if (forceSetDisplayMode || changingDisplayMode)
+    if (forceSetDisplayMode || DisplayMode() != displayMode)
     {
         // Update header visibility based on what the new display mode will be
         UpdateHeaderVisibility(displayMode);

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3775,7 +3775,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 getNavViewActiveVisualStatesButton.Invoke();
                 Wait.ForIdle();
 
-                var visualStateName = "MinimalWithBackButton";
+                const string visualStateName = "MinimalWithBackButton";
                 var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
                 Verify.IsFalse(result.GetText().Contains(visualStateName), "Active VisualStates should not include " + visualStateName);
 
@@ -3785,7 +3785,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Log.Comment("Get NavView Active VisualStates");
                 getNavViewActiveVisualStatesButton.Invoke();
-                visualStateName = "MinimalWithBackButton";
+                Wait.ForIdle();
                 Verify.IsTrue(result.GetText().Contains(visualStateName), "Active VisualStates should include " + visualStateName);
             }
         }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3749,6 +3749,47 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "D")]
+        public void EnsureDisplayModeGroupUpdatesWhenBackButtonVisibilityChanged()
+        {
+            using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),
+                             page2 = new TestSetupHelper("NavigationView Test"))
+            {
+                Log.Comment("Setup test page to be in the minimal display mode with the backbutton hidden...");
+                Log.Comment("Hide backbutton");
+                var backButtonCheckBox = new CheckBox(FindElement.ByName("BackButtonVisibilityCheckbox"));
+                backButtonCheckBox.Uncheck();
+                Wait.ForIdle();
+
+                Log.Comment("Change display mode to left minimal");
+                var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+                panelDisplayModeComboBox.SelectItemByName("LeftMinimal");
+                Wait.ForIdle();
+
+                TextBlock displayModeTextBox = new TextBlock(FindElement.ByName("DisplayModeTextBox"));
+                Verify.AreEqual(minimal, displayModeTextBox.DocumentText);
+
+                Log.Comment("Get NavView Active VisualStates");
+                var getNavViewActiveVisualStatesButton = new Button(FindElement.ByName("GetNavViewActiveVisualStates"));
+                getNavViewActiveVisualStatesButton.Invoke();
+                Wait.ForIdle();
+
+                var visualStateName = "MinimalWithBackButton";
+                var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
+                Verify.IsFalse(result.GetText().Contains(visualStateName), "Active VisualStates should not include " + visualStateName);
+
+                Log.Comment("Show backbutton");
+                backButtonCheckBox.Check();
+                Wait.ForIdle();
+
+                Log.Comment("Get NavView Active VisualStates");
+                getNavViewActiveVisualStatesButton.Invoke();
+                visualStateName = "MinimalWithBackButton";
+                Verify.IsTrue(result.GetText().Contains(visualStateName), "Active VisualStates should include " + visualStateName);
+            }
+        }
+
         private void EnsurePaneHeaderCanBeModifiedHelper(RegressionTestType navviewMode)
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone2))


### PR DESCRIPTION
Fix for #274 

Making the back button visible when the control is in 'Minimal' state does not properly update to the 'MinimalWithBackButton' state.