### PR TITLE
Fix return value of tracker_ref::get() to improve code generation

### DIFF
--- a/dev/inc/tracker_ref.h
+++ b/dev/inc/tracker_ref.h
@@ -255,7 +255,7 @@ public:
         }
     }
 
-    auto get() const
+    const T& get() const
     {
 #if _DEBUG
         // Do some debug validation to make sure that m_valueNoRef and the GetTrackerValue result don't


### PR DESCRIPTION
This makes it so that a temporary isn't needed for the return value and so that code like this doesn't addref/release into a local:

```c++
if (auto&& tracker = m_tracker.get())
{
    tracker.DoSomething();
}
```

And does as well as:

```c++
m_tracker.get().DoSomething();
```

And both of these got much better with this change because neither needs addref/release on the temporary.