### PR TITLE
Catch exceptions from TestEnvironment.LogDumpTree

### DIFF
--- a/test/MUXControls.Test/Infra/Application.cs
+++ b/test/MUXControls.Test/Infra/Application.cs
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
             if (CoreWindow == null)
             {
                 // We expect to have a window by this point.
-                TestEnvironment.LogDumpTree(UIObject.Root);
+                LogDumpTree();
                 throw new UIObjectNotFoundException("Could not find application window.");
             }
 
@@ -233,7 +233,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 catch (UIObjectNotFoundException)
                 {
                     Log.Error("Could not find the view scaling CheckBox.");
-                    TestEnvironment.LogDumpTree(UIObject.Root);
+                    LogDumpTree();
                     throw;
                 }
             }
@@ -262,7 +262,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 {
                     Log.Comment("Failed to launch app. Exception: " + ex.ToString());
                     Log.Comment("Dumping UIA tree...");
-                    TestEnvironment.LogDumpTree(UIObject.Root);
+                    LogDumpTree();
 
                     if (retries < MaxLaunchRetries)
                     {
@@ -335,7 +335,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 else
                 {
                     Log.Comment("Application.Close: Failed to find close app invoker: {0}", closeAppInvoker);
-                    TestEnvironment.LogDumpTree(UIObject.Root);
+                    LogDumpTree();
                 }
 
                 // We'll wait until the window closes.  For some reason, ProcessClosedWaiter
@@ -549,5 +549,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 #endif
 
         #endregion
+
+        private void LogDumpTree()
+        {
+            try
+            {
+                TestEnvironment.LogDumpTree(UIObject.Root);
+            }
+            catch(Exception e)
+            {
+                Log.Comment(e.Message);
+            }
+        }
     }
 }


### PR DESCRIPTION
When things go wrong during test initialization, we dump the visual tree and retry a few times. But the tree dump function itself can throw exception too, that will block the future retries since we didn't handle it.

Added catch block for LogDumpTree to unblock the retries.

Failure caused by this issue:
https://helixexternaldrops.blob.core.windows.net/helix-job-6b987ed4-2db7-4ecb-da625351f76f486da2531c68822bfead/InteractionTests.ScrollerTestsWithAutomationPeer/te.wtl?sv=2017-07-29&sr=c&sig=4PrjfaVa%2Bt83OWUHdpj9JHoBH%2Brz7PKGNQwF4NueSnw%3D&se=2019-03-04T20%3A53%3A36Z&sp=rl