### PR TITLE
Add a basic VS Code browse and intellisense configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ bld/
 .vs/
 
 # Visual Studio Code cache/options directory
-.vscode/
+.vscode/.BROWSE*
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,49 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "compilerPath": "",
+            "includePath": [
+                "${workspaceFolder}/dev/Collections",
+                "${workspaceFolder}/dev/Common",
+                "${workspaceFolder}/dev/dll",
+                "${workspaceFolder}/dev/inc",
+                "${workspaceFolder}/dev/TreeView",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Platform",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/winrt",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Automation/Peers",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Controls",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Controls/Primitives",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Media",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Microsoft/UI/Composition/Effects",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Microsoft/UI/Private/Controls",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/Microsoft/UI/Private/Media",
+                "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/CppWinRT/Component/XamlTypeInfo",
+                "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\VC\\Tools\\MSVC\\14.16.27023\\include",
+                "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.18323.0\\shared",
+                "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.18323.0\\um",
+                "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.18323.0\\winrt",
+                "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.18323.0\\ucrt",
+                "${workspaceFolder}/dev/Telemetry",
+                "${workspaceFolder}/dev/Repeater"
+            ],
+            "defines": [],
+            "browse": {
+                "path": [
+                    "${workspaceFolder}/dev",
+                    "${workspaceFolder}/idl",
+                    "${workspaceFolder}/test",
+                    "${workspaceFolder}/BuildOutput/Intermediates/Microsoft.UI.Xaml/obj/"
+                ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": "${workspaceFolder}/.vscode/"
+            },
+            "windowsSdkVersion": "10.0.18323.0",
+            "configurationProvider": "microsoft.vscode-nmake-tools",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "C_Cpp.configurationWarnings": "Disabled",
+    "nmake.is-configuration-migrated": true,
+    "nmake.default-razzle-configuration": "amd64fre"
+}


### PR DESCRIPTION
I cobbled this together based on a very basic understanding of the VS Code C++ intellisense configuration support. Basically I got it to jump to some symbol definitions and header file definitions and so it seemed like a good enough start. If someone with more knowledge of VS Code and this config file wants to help, I would be very grateful.

But I figured this was worth checking in as is because it at least helps a little.