### PR TITLE
ColorSpectrum fractional width crash fix

### DIFF
--- a/dev/ColorPicker/APITests/ColorPickerTests.cs
+++ b/dev/ColorPicker/APITests/ColorPickerTests.cs
@@ -254,8 +254,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 colorSpectrum = new ColorSpectrum();
-                colorSpectrum.Width = 300.75;
-                colorSpectrum.Height = 300.75;
+
+                // 332.75 is the fractional value that caused a crash in Settings when DPI was set to 200%
+                // and text scaling was set to >160%.  It ensures that we exercise all of the round() fixes
+                // that we made in ColorSpectrum to ensure we always round fractional values instead of
+                // truncating them.
+                colorSpectrum.Width = 332.75;
+                colorSpectrum.Height = 332.75;
             });
 
             SetAsRootAndWaitForColorSpectrumFill(colorSpectrum);


### PR DESCRIPTION
We previously fixed an issue where ColorPicker would crash if its spectrum had a fractional width, but there were a couple other places as well where we were truncating rather than rounding.  These changes fix those remaining issues and update the value used in the test to a value that exercises every circumstance where we crashed because of this.