### PR TITLE
Provide compact dictionary

### DIFF
--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -218,6 +218,17 @@ $rs1_genericxaml =
 
 Set-Content -Value $rs1_genericxaml $fullOutputPath\rs1_themes_generic.xaml
 
+# Allow single URI to access Compact.xaml from both framework package and nuget package
+$compactxaml = 
+@"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="ms-appx://$PackageName/Microsoft.UI.Xaml/DensityStyles/Compact.xaml"/>
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>
+"@
+Set-Content -Value $compactxaml $fullOutputPath\Compact.xaml
+
 # AppxManifest needs some pieces generated per-flavor.
 $manifestContents = Get-Content $fullOutputPath\PackageContents\AppxManifest.xml
 $manifestContents = $manifestContents.Replace('$(PackageName)', "$PackageName")

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -122,4 +122,11 @@
     </Page>
   </ItemGroup>
   
+  <!-- Make this URI works in framework package "ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" -->
+  <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml">
+      <SubType>Designer</SubType>
+      <Link>Microsoft.UI.Xaml\DensityStyles\Compact.xaml</Link>
+    </Page>
+  </ItemGroup>
 </Project>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -32,5 +32,6 @@
     <file target="build\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-FrameworkPackage.targets"/>
     <file target="build\rs1_themes\generic.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\rs1_themes_generic.xaml"/>
+    <file target="build\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Compact.xaml"/>
   </files>
 </package>

--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -24,4 +24,6 @@
     <!-- DateTimeFlyoutBorderPadding is defined since RS5. set it here to ensure it's always defined. -->
     <Thickness x:Key="DateTimeFlyoutBorderPadding">0</Thickness>
 
+    <x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
+    <x:Double x:Key="ContentControlFontSize">14</x:Double>
 </ResourceDictionary>

--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -23,7 +23,4 @@
    
     <!-- DateTimeFlyoutBorderPadding is defined since RS5. set it here to ensure it's always defined. -->
     <Thickness x:Key="DateTimeFlyoutBorderPadding">0</Thickness>
-
-    <x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
-    <x:Double x:Key="ContentControlFontSize">14</x:Double>
 </ResourceDictionary>

--- a/dev/CommonStyles/DatePicker_themeresources.xaml
+++ b/dev/CommonStyles/DatePicker_themeresources.xaml
@@ -120,6 +120,9 @@
     <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
     <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,3,0,6</Thickness>
     
+    <Thickness x:Key="DatePickerHostPadding">0,3,0,6</Thickness>
+    <Thickness x:Key="DatePickerHostMonthPadding">9,3,0,6</Thickness>
+
     <Style TargetType="DatePicker">
         <Setter Property="Orientation" Value="Horizontal" />
         <Setter Property="IsTabStop" Value="False" />
@@ -295,7 +298,7 @@
                                 <TextBlock x:Name="DayTextBlock"
                                     Text="Day"
                                     TextAlignment="Center"
-                                    Padding="{ThemeResource DatePickerFlyoutPresenterItemPadding}"
+                                    Padding="{ThemeResource DatePickerHostPadding}"
                                     FontFamily="{TemplateBinding FontFamily}"
                                     FontWeight="{TemplateBinding FontWeight}"
                                     FontSize="{TemplateBinding FontSize}"
@@ -303,7 +306,7 @@
                                 <TextBlock x:Name="MonthTextBlock"
                                     Text="Month"
                                     TextAlignment="Left"
-                                    Padding="{ThemeResource DatePickerFlyoutPresenterMonthPadding}"
+                                    Padding="{ThemeResource DatePickerHostMonthPadding}"
                                     Margin="1,0,0,0"
                                     FontFamily="{TemplateBinding FontFamily}"
                                     FontWeight="{TemplateBinding FontWeight}"
@@ -312,7 +315,7 @@
                                 <TextBlock x:Name="YearTextBlock"
                                     Text="Year"
                                     TextAlignment="Center"
-                                    Padding="{ThemeResource DatePickerFlyoutPresenterItemPadding}"
+                                    Padding="{ThemeResource DatePickerHostPadding}"
                                     FontFamily="{TemplateBinding FontFamily}"
                                     FontWeight="{TemplateBinding FontWeight}"
                                     FontSize="{TemplateBinding FontSize}"

--- a/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
+++ b/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
@@ -119,8 +119,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             RunDensityTests("AppBarButtonDensityTest");
         }
-        private void RunDensityTests(string buttonName)
-        
+
+        private void RunDensityTests(string buttonName)       
         {
             using (var setup = new TestSetupHelper("CommonStyles Tests"))
             {
@@ -131,6 +131,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 var densityTestResult = new TextBlock(FindElement.ByName("DensityTestResult")).GetText();
                 Verify.AreEqual(densityTestResult, "Pass", "We expect density test result is Pass");
+            }
+        }
+
+        [TestMethod]
+        public void RunCompactTests()        
+        {
+            using (var setup = new TestSetupHelper("Compact Tests"))
+            {
+                Log.Comment("Click on RunTest");
+                var button = new Button(FindElement.ByName("RunTest"));
+                button.Invoke();
+                Wait.ForIdle();
+
+                var testResult = new TextBlock(FindElement.ById("CompactTestResult")).GetText();
+                Verify.AreEqual(testResult, "Pass", "We expect compact test result is Pass"); // "Pass" string matches value used by MUXControlsTestApp.SimpleVerify
             }
         }
     }

--- a/dev/CommonStyles/TestUI/CommonStyles_TestUI.projitems
+++ b/dev/CommonStyles/TestUI/CommonStyles_TestUI.projitems
@@ -21,4 +21,16 @@
       <DependentUpon>CommonStylesPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
+    <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)CompactPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <IncludeInWindowsAppx>false</IncludeInWindowsAppx>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CompactPage.xaml.cs">
+      <DependentUpon>CompactPage.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/dev/CommonStyles/TestUI/CompactPage.xaml
+++ b/dev/CommonStyles/TestUI/CompactPage.xaml
@@ -1,0 +1,55 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="MUXControlsTestApp.CompactPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    >
+    <local:TestPage.Resources>
+        <ResourceDictionary Source="ms-appx:///Compact.xaml" />
+    </local:TestPage.Resources>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <StackPanel>
+            <muxc:NavigationView x:Name="Nav">
+                <muxc:NavigationView.MenuItems>
+                    <muxc:NavigationViewItem x:Name="NavItem1" Icon="Accept" Content="OK" />
+                    <muxc:NavigationViewItem Icon="Folder" Content="Folder" />
+                </muxc:NavigationView.MenuItems>
+            </muxc:NavigationView>
+
+            <TextBox x:Name="TextBox" Text="Density" Header="TextBox"/>
+            <PasswordBox x:Name="PasswordBox" Header="Password"/>
+            <AutoSuggestBox x:Name="AutoSuggestBox" Header="AutoSuggestBox" TextChanged="AutoSuggestBox_TextChanged" />
+            <RichEditBox x:Name="RichEditBox" Header="RichEditBox"/>
+
+            <ComboBox x:Name="ComboBox" Header="ComboBox">
+                <x:String>Blue</x:String>
+                <x:String>Green</x:String>
+            </ComboBox>
+            <DatePicker x:Name="DatePicker" Header="DatePicker"/>
+            <TimePicker x:Name="TimePicker" Header="TimePicker"/>
+
+            <ListView x:Name="ListView">
+                <x:String>Item 1</x:String>
+            </ListView>
+            <muxc:TreeView x:Name="TreeView">
+                <muxc:TreeView.RootNodes>
+                    <muxc:TreeViewNode Content="Flavors" IsExpanded="True">
+                        <muxc:TreeViewNode.Children>
+                            <muxc:TreeViewNode Content="Vanilla"/>
+                            <muxc:TreeViewNode Content="Strawberry"/>
+                            <muxc:TreeViewNode Content="Chocolate"/>
+                        </muxc:TreeViewNode.Children>
+                    </muxc:TreeViewNode>
+                </muxc:TreeView.RootNodes>
+            </muxc:TreeView>
+            <Button x:Name="RunTest" Content="RunTest" Click="RunTest_Click" />
+            <TextBox x:Name="CompactTestResult" AutomationProperties.Name="CompactTestResult" Text="Result"/>
+        </StackPanel>
+    </Grid>
+
+</local:TestPage>

--- a/dev/CommonStyles/TestUI/CompactPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/CompactPage.xaml.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using System.Linq;
+using Common;
+using MUXControlsTestApp.Utilities;
+using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
+using NavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
+using System;
+
+namespace MUXControlsTestApp
+{
+    public sealed partial class CompactPage : TestPage
+    {
+        public CompactPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void AutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+            {
+                var suggestList = new List<string>();
+                suggestList.Add("001");
+                suggestList.Add("002");
+                suggestList.Add("003");
+                suggestList.Add("004");
+                suggestList.Add("005");
+
+                sender.ItemsSource = suggestList.Select(text => sender.Text + text);
+            }
+        }
+
+        private void VerifyHeight(SimpleVerify simpleVerify, FrameworkElement item, int expectHeight, string controlName)
+        {
+            if (item != null)
+            {
+                // Avoid Height because of CornerRadius
+                if (Math.Abs(item.ActualHeight - expectHeight) > 0.5)
+                {
+                    simpleVerify.IsEqual(item.ActualHeight.ToString(), expectHeight, controlName + ".ActualHeight=" + expectHeight);
+                }
+            }
+            else
+            {
+                simpleVerify.IsTrue(false, "Can't find " + controlName);
+            }
+        }
+
+        private void VerifyChildHeight(SimpleVerify simpleVerify, FrameworkElement item, string childXName, int expectHeight, string controlName)
+        {
+            FrameworkElement child = GetChild(item, childXName);
+            VerifyHeight(simpleVerify, child, expectHeight, controlName + "." + childXName);
+        }
+
+        private FrameworkElement GetChild(FrameworkElement item, string childXName)
+        {
+            FrameworkElement root = (item == null) ? null: (FrameworkElement)VisualTreeHelper.GetChild(item, 0);
+            FrameworkElement child = (root == null) ? null: (FrameworkElement)root.FindName(childXName);
+            return child;
+        }
+        private void RunTest_Click(object sender, RoutedEventArgs e)
+        {           
+            SimpleVerify simpleVerify = new SimpleVerify();
+            FrameworkElement item = ListView.FindElementOfTypeInSubtree<ListViewItem>();
+            VerifyHeight(simpleVerify, item, 32, "ListViewItem");
+            item = TreeView.FindElementOfTypeInSubtree<TreeViewItem>();
+            VerifyHeight(simpleVerify, item, 24, "TreeViewItem");
+
+            VerifyHeight(simpleVerify, NavItem1, 32, "NavigationViewItem");
+
+            VerifyChildHeight(simpleVerify, TextBox, "BorderElement", 24, "TextBox");
+            VerifyChildHeight(simpleVerify, PasswordBox, "BorderElement", 24, "PasswordBox");
+
+            // AutoSuggestBox used TextBox directly, so we check TextBox
+            FrameworkElement child = GetChild(AutoSuggestBox, "TextBox");
+            VerifyChildHeight(simpleVerify, child, "BorderElement", 24, "AutoSuggestBox.TextBox");
+
+            VerifyChildHeight(simpleVerify, RichEditBox, "BorderElement", 24, "RichEditBox");
+            VerifyChildHeight(simpleVerify, ComboBox, "Background", 24, "TextBox");
+
+            VerifyChildHeight(simpleVerify, TimePicker, "FlyoutButton", 24, "TimePicker");
+            VerifyChildHeight(simpleVerify, DatePicker, "FlyoutButton", 24, "DatePicker");
+
+            CompactTestResult.Text = simpleVerify.ToString();
+        }
+    }
+}

--- a/dev/CommonStyles/TimePicker_themeresources.xaml
+++ b/dev/CommonStyles/TimePicker_themeresources.xaml
@@ -118,6 +118,8 @@
     <x:Double x:Key="TimePickerFlyoutPresenterItemHeight">40</x:Double>
     <Thickness x:Key="TimePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
 
+    <Thickness x:Key="TimePickerHostPadding">0,3,0,6</Thickness>
+
     <Style TargetType="TimePicker">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
@@ -293,7 +295,7 @@
                                 <Border x:Name="FirstPickerHost" Grid.Column="0">
                                     <TextBlock x:Name="HourTextBlock"
                                         TextAlignment="Center"
-                                        Padding="{ThemeResource TimePickerFlyoutPresenterItemPadding}"
+                                        Padding="{ThemeResource TimePickerHostPadding}"
                                         FontFamily="{TemplateBinding FontFamily}"
                                         FontWeight="{TemplateBinding FontWeight}"
                                         FontSize="{TemplateBinding FontSize}"
@@ -307,7 +309,7 @@
                                 <Border x:Name="SecondPickerHost" Grid.Column="2">
                                     <TextBlock x:Name="MinuteTextBlock"
                                         TextAlignment="Center"
-                                        Padding="{ThemeResource TimePickerFlyoutPresenterItemPadding}"
+                                        Padding="{ThemeResource TimePickerHostPadding}"
                                         FontFamily="{TemplateBinding FontFamily}"
                                         FontWeight="{TemplateBinding FontWeight}"
                                         FontSize="{TemplateBinding FontSize}"
@@ -321,7 +323,7 @@
                                 <Border x:Name="ThirdPickerHost" Grid.Column="4">
                                     <TextBlock x:Name="PeriodTextBlock"
                                         TextAlignment="Center"
-                                        Padding="{ThemeResource TimePickerFlyoutPresenterItemPadding}"
+                                        Padding="{ThemeResource TimePickerHostPadding}"
                                         FontFamily="{TemplateBinding FontFamily}"
                                         FontWeight="{TemplateBinding FontWeight}"
                                         FontSize="{TemplateBinding FontSize}"

--- a/dev/dll/DensityStyles/Compact.xaml
+++ b/dev/dll/DensityStyles/Compact.xaml
@@ -5,6 +5,8 @@
     <Style TargetType="TextBlock" >
         <Setter Property="FontSize" Value="14" />
     </Style>
+    <x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
+    <x:Double x:Key="ContentControlFontSize">14</x:Double>
     <x:Double x:Key="TextControlThemeMinHeight">24</x:Double>
     <Thickness x:Key="TextControlThemePadding">2,1,6,0</Thickness>
     <x:Double x:Key="ListViewItemMinHeight">32</x:Double>

--- a/dev/dll/DensityStyles/Compact.xaml
+++ b/dev/dll/DensityStyles/Compact.xaml
@@ -1,0 +1,19 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary 
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">   
+    <Style TargetType="TextBlock" >
+        <Setter Property="FontSize" Value="14" />
+    </Style>
+    <x:Double x:Key="TextControlThemeMinHeight">24</x:Double>
+    <Thickness x:Key="TextControlThemePadding">2,1,6,0</Thickness>
+    <x:Double x:Key="ListViewItemMinHeight">32</x:Double>
+    <x:Double x:Key="TreeViewItemMinHeight">24</x:Double>
+    <Thickness x:Key="TimePickerHostPadding">0,0,0,1</Thickness>
+    <Thickness x:Key="DatePickerHostPadding">0,0,0,1</Thickness>
+    <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
+    <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
+    <Thickness x:Key="ComboBoxMinHeight">24</Thickness>
+    <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness>
+    <x:Double x:Key="NavigationViewItemOnLeftMinHeight">32</x:Double>
+</ResourceDictionary>

--- a/dev/dll/DensityStyles/CompactDatePickerTimePickerFlyout.xaml
+++ b/dev/dll/DensityStyles/CompactDatePickerTimePickerFlyout.xaml
@@ -1,0 +1,16 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+
+<!-- This is tuned compact parameters for RS5+ os, customer has no way to use it directly right now. -->
+<ResourceDictionary 
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"> 
+    <x:Double x:Key="TimePickerFlyoutPresenterItemHeight">32</x:Double>           
+    <x:Double x:Key="TimePickerFlyoutPresenterHighlightHeight">32</x:Double>
+    <x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">33</x:Double>
+    <Thickness x:Key="TimePickerFlyoutPresenterItemPadding">0,0,0,1</Thickness>
+    <x:Double x:Key="DatePickerFlyoutPresenterItemHeight">32</x:Double>
+    <x:Double x:Key="DatePickerFlyoutPresenterHighlightHeight">32</x:Double>
+    <x:Double x:Key="DatePickerFlyoutPresenterAcceptDismissHostGridHeight">33</x:Double>
+    <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,0,0,1</Thickness>
+    <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,0,0,1</Thickness>
+</ResourceDictionary>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -365,6 +365,16 @@
       <ThemeResource>true</ThemeResource>
       <Link>Themes\%(Filename)%(Extension)</Link>
     </Page>
+    <Page Include="$(MSBuildProjectDirectory)\DensityStyles\Compact.xaml">
+      <SubType>Designer</SubType>
+      <ThemeResource>true</ThemeResource>
+      <Link>DensityStyles\%(Filename)%(Extension)</Link>
+    </Page>
+    <Page Include="$(MSBuildProjectDirectory)\DensityStyles\CompactDatePickerTimePickerFlyout.xaml">
+      <SubType>Designer</SubType>
+      <ThemeResource>true</ThemeResource>
+      <Link>DensityStyles\%(Filename)%(Extension)</Link>
+    </Page>    
     <Page Include="$(OutDir)rs1_themeresources.xaml">
       <SubType>Designer</SubType>
       <ThemeResource>true</ThemeResource>

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -227,6 +227,7 @@
     <Content Include="$(MSBuildThisFileDirectory)\Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="$(MSBuildThisFileDirectory)\Assets\StoreLogo.png" />
     <Content Include="$(MSBuildThisFileDirectory)\Assets\Wide310x150Logo.scale-200.png" />
+    <Content Include="$(MSBuildThisFileDirectory)\..\..\dev\dll\DensityStyles\Compact.xaml" />
   </ItemGroup>
   <ItemGroup>
     <AppContent Include="@(Content)" />

--- a/test/MUXControlsTestApp/TestInventory.cs
+++ b/test/MUXControlsTestApp/TestInventory.cs
@@ -30,6 +30,7 @@ namespace MUXControlsTestApp
             Tests.Add(new TestDeclaration("DropDownButton Tests", typeof(DropDownButtonPage)));
             Tests.Add(new TestDeclaration("CommandBarFlyout Tests", typeof(CommandBarFlyoutMainPage)));
             Tests.Add(new TestDeclaration("CommonStyles Tests", typeof(CommonStylesPage)));
+            Tests.Add(new TestDeclaration("Compact Tests", typeof(CompactPage)));
             Tests.Add(new TestDeclaration("RadioButtons Tests", typeof(RadioButtonsPage)));
             Tests.Add(new TestDeclaration("RadioMenuFlyoutItem Tests", typeof(RadioMenuFlyoutItemPage)));
 #endif


### PR DESCRIPTION
How to implement compact is discussed in #98 . It allows customer to try compact before that feature comes out.

# Examples:
```
<Page.Resources>
                <ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/Density/Compact.xaml"/>
</Page.Resources>
```

```
<Page.Resources>
    <Style TargetType="TextBlock" >
        <Setter Property="FontSize" Value="14" />
    </Style>
    <x:Double x:Key="TextControlThemeMinHeight">24</x:Double>
    <Thickness x:Key="TextControlThemePadding">2,1,6,0</Thickness>
    <x:Double x:Key="ListViewItemMinHeight">32</x:Double>
    <x:Double x:Key="TreeViewItemMinHeight">24</x:Double>
    <Thickness x:Key="TimePickerHostPadding">0,0,0,1</Thickness>
    <Thickness x:Key="DatePickerHostPadding">0,0,0,1</Thickness>
    <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
    <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
    <Thickness x:Key="ComboBoxMinHeight">24</Thickness>
    <Thickness x:Key="ComboBoxPadding">12,1,0,3</Thickness>
    <x:Double x:Key="NavigationViewItemOnLeftMinHeight">32</x:Double>
</Page.Resources>
```

# Impacted controls
TimePicker, DatePicker, ToggleSwitch, PasswordBox, AutoSuggestBox, RichEditBox, ListViewItem, TreeViewItem, NavigationViewItem, ComboBox

DatePickerHostPadding/DatePickerHostMonthPadding is used in DatePicker style, and DatePickerFlyoutPresenterItemPadding/DatePickerFlyoutPresenterMonthPadding are decoupled from DatePicker style because flyout only read DatePickerFlyoutPresenterItemPadding and DatePickerFlyoutPresenterMonthPadding  on rs5+ os, and also it should be in Application.Resource. But DatePicker style itself can downlevel to any version without any problem.
We have TimePickerHostPadding for TimePicker too, and it's separated from TimePickerFlyoutPresenterItemPadding

# Possible usage out side of MergedDictionary.

1.  Copy dll/Density/`Compact.xaml` to your Resources

2. Framework or nuget package: 
        `<ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" />`


# Known issues
1. It doesn't work if we use Compact.xaml in merged dictionary, for example:
```
        <ResourceDictionary>
            <ResourceDictionary.MergedDictionaries>
                <ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/Density/Compact.xaml"/>
            </ResourceDictionary.MergedDictionaries>
        </ResourceDictionary>
```

2. We don't have a good way to override the settings for TimePickerFlyout and DatePickerFlyout yet. Below scenario doesn't work
` <ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/Density/CompactDatePickerTimePickerFlyout.xaml"/>`
