### PR TITLE
Fixed inability to disable sound in Top NavView Flyout

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -284,7 +284,7 @@
                                                     ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
                                                     SingleSelectionFollowsFocus="False"
                                                     IsItemClickEnabled="True"
-                                                    ElementSoundMode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ElementSoundMode}">
+                                                    ElementSoundMode="{TemplateBinding ElementSoundMode}">
                                                     <ListView.ItemContainerTransitions>
                                                         <TransitionCollection />
                                                     </ListView.ItemContainerTransitions>

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -263,13 +263,12 @@
                                     <Button 
                                         x:Name="TopNavOverflowButton"
                                         Grid.Column="4"
-
                                         Content="More"
                                         Style="{StaticResource NavigationViewOverflowButtonStyleWhenPaneOnTop}"
                                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.OverflowButtonVisibility}">
 
                                         <Button.Flyout>
-                                            <Flyout Placement="Bottom">
+                                            <Flyout Placement="Bottom" ElementSoundMode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ElementSoundMode}">
                                                 <Flyout.FlyoutPresenterStyle>
                                                     <Style TargetType="FlyoutPresenter">
                                                         <Setter Property="Padding" Value="0,8" />
@@ -284,7 +283,8 @@
                                                     ItemContainerStyle="{TemplateBinding MenuItemContainerStyle}"
                                                     ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
                                                     SingleSelectionFollowsFocus="False"
-                                                    IsItemClickEnabled="True">
+                                                    IsItemClickEnabled="True"
+                                                    ElementSoundMode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ElementSoundMode}">
                                                     <ListView.ItemContainerTransitions>
                                                         <TransitionCollection />
                                                     </ListView.ItemContainerTransitions>


### PR DESCRIPTION
Fixes #338 

The Top NavView overflow flyout was not picking up NavigationView's "ElementSoundMode" because it is not an ancestor. Added bindings in order to have the flyout (and its content) properly pick up this value.