### PR TITLE
CommandBarFlyout Narrator fix

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -229,24 +229,22 @@ void CommandBarFlyoutCommandBar::UpdateFlowsFromAndFlowsTo()
                 primaryCommandAsControl.IsTabStop();
         };
 
-        // If we have a more button, then that's the last element in our primary items list.
-        // Otherwise, we'll find the last focusable element in the primary commands.
-        if (m_moreButton)
+        auto primaryCommands = PrimaryCommands();
+        for (int i = static_cast<int>(primaryCommands.Size() - 1); i >= 0; i--)
+        {
+            auto primaryCommand = primaryCommands.GetAt(i);
+            if (isElementFocusable(primaryCommand))
+            {
+                m_currentPrimaryItemsEndElement.set(primaryCommand.try_as<winrt::FrameworkElement>());
+                break;
+            }
+        }
+
+        // If we have a more button and at least one focusable primary item, then
+        // we'll use the more button as the last element in our primary items list.
+        if (m_moreButton && m_currentPrimaryItemsEndElement)
         {
             m_currentPrimaryItemsEndElement.set(m_moreButton.get());
-        }
-        else
-        {
-            auto primaryCommands = PrimaryCommands();
-            for (int i = static_cast<int>(primaryCommands.Size() - 1); i >= 0; i--)
-            {
-                auto primaryCommand = primaryCommands.GetAt(i);
-                if (isElementFocusable(primaryCommand))
-                {
-                    m_currentPrimaryItemsEndElement.set(primaryCommand.try_as<winrt::FrameworkElement>());
-                    break;
-                }
-            }
         }
 
         for (const auto& secondaryCommand : SecondaryCommands())

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -252,5 +252,36 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.Tap(showCommandBarFlyoutButton);
             }
         }
+
+        [TestMethod]
+        public void VerifyFlowsToAndFromIsNotSetWithoutPrimaryCommands()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled pre-RS2 because CommandBarFlyout is not supported pre-RS2");
+                return;
+            }
+
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with no primary commands");
+                ToggleButton isFlyoutOpenCheckBox = FindElement.ById<ToggleButton>("IsFlyoutOpenCheckBox");
+
+                Log.Comment("Tapping on a button to show the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+
+                Log.Comment("Retrieving the undo button's automation element object.");
+                FindElement.ById("UndoButton6").SetFocus();
+                Wait.ForIdle();
+                var undoButtonElement = AutomationElement.FocusedElement;
+
+                Log.Comment("Verifying that the undo button does not point at the more button using FlowsFrom.");
+                var flowsFromCollection = (AutomationElementCollection)undoButtonElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_FlowsFromPropertyId));
+                Verify.AreEqual(0, flowsFromCollection.Count);
+
+                Log.Comment("Tapping on a button to hide the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+            }
+        }
     }
 }

--- a/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
@@ -113,6 +113,14 @@
                     <AppBarButton x:Name="SelectAllButton5" AutomationProperties.AutomationId="SelectAllButton5" Label="Select all" Click="OnElementClicked" />
                 </muxc:CommandBarFlyout.SecondaryCommands>
             </muxc:CommandBarFlyout>
+            <muxc:CommandBarFlyout Placement="Right" x:Name="Flyout6" AutomationProperties.AutomationId="Flyout6" Opened="OnFlyoutOpened" Closed="OnFlyoutClosed">
+                <muxc:CommandBarFlyout.SecondaryCommands>
+                    <AppBarButton x:Name="UndoButton6" AutomationProperties.AutomationId="UndoButton6" Label="Undo" Icon="Undo" Click="OnElementClicked" />
+                    <AppBarButton x:Name="RedoButton6" AutomationProperties.AutomationId="RedoButton6" Label="Redo" Icon="Redo" Click="OnElementClicked" />
+                    <AppBarButton x:Name="SelectAllButton6" AutomationProperties.AutomationId="SelectAllButton6" Label="Select all" Click="OnElementClicked" />
+                    <AppBarToggleButton x:Name="FavoriteToggleButton6" AutomationProperties.AutomationId="FavoriteToggleButton6" Label="Favorite" Icon="Favorite" Checked="OnElementChecked" Unchecked="OnElementUnchecked" />
+                </muxc:CommandBarFlyout.SecondaryCommands>
+            </muxc:CommandBarFlyout>
         </Grid.Resources>
         <ScrollViewer>
             <StackPanel>
@@ -121,6 +129,7 @@
                 <Button x:Name="FlyoutTarget3" Content="Show tall CommandBarFlyout" Margin="10" Click="OnFlyoutTarget3Click" />
                 <Button x:Name="FlyoutTarget4" Content="Show max-width CommandBarFlyout" Margin="10" Click="OnFlyoutTarget4Click" />
                 <Button x:Name="FlyoutTarget5" Content="Show CommandBarFlyout with sub-menu" Margin="10" Click="OnFlyoutTarget5Click" />
+                <Button x:Name="FlyoutTarget6" Content="Show CommandBarFlyout with no primary commands" Margin="10" Click="OnFlyoutTarget6Click" />
             </StackPanel>
         </ScrollViewer>
         <StackPanel Grid.Row="1">

--- a/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml.cs
+++ b/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml.cs
@@ -35,18 +35,21 @@ namespace MUXControlsTestApp
                 UndoButton3.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Z, Modifiers = VirtualKeyModifiers.Control });
                 UndoButton4.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Z, Modifiers = VirtualKeyModifiers.Control });
                 UndoButton5.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Z, Modifiers = VirtualKeyModifiers.Control });
+                UndoButton6.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Z, Modifiers = VirtualKeyModifiers.Control });
 
                 RedoButton1.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Y, Modifiers = VirtualKeyModifiers.Control });
                 RedoButton2.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Y, Modifiers = VirtualKeyModifiers.Control });
                 RedoButton3.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Y, Modifiers = VirtualKeyModifiers.Control });
                 RedoButton4.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Y, Modifiers = VirtualKeyModifiers.Control });
                 RedoButton5.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Y, Modifiers = VirtualKeyModifiers.Control });
+                RedoButton6.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.Y, Modifiers = VirtualKeyModifiers.Control });
 
                 SelectAllButton1.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.A, Modifiers = VirtualKeyModifiers.Control });
                 SelectAllButton2.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.A, Modifiers = VirtualKeyModifiers.Control });
                 SelectAllButton3.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.A, Modifiers = VirtualKeyModifiers.Control });
                 SelectAllButton4.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.A, Modifiers = VirtualKeyModifiers.Control });
                 SelectAllButton5.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.A, Modifiers = VirtualKeyModifiers.Control });
+                SelectAllButton6.KeyboardAccelerators.Add(new KeyboardAccelerator() { Key = VirtualKey.A, Modifiers = VirtualKeyModifiers.Control });
             }
 
             if (ApiInformation.IsPropertyPresent("Windows.UI.Xaml.UIElement", "ContextFlyout"))
@@ -56,6 +59,7 @@ namespace MUXControlsTestApp
                 FlyoutTarget3.ContextFlyout = Flyout3;
                 FlyoutTarget4.ContextFlyout = Flyout4;
                 FlyoutTarget5.ContextFlyout = Flyout5;
+                FlyoutTarget6.ContextFlyout = Flyout6;
             }
 
             if (ApiInformation.IsEnumNamedValuePresent("Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode", "TopEdgeAlignedLeft"))
@@ -65,6 +69,7 @@ namespace MUXControlsTestApp
                 Flyout3.Placement = FlyoutPlacementMode.TopEdgeAlignedLeft;
                 Flyout4.Placement = FlyoutPlacementMode.TopEdgeAlignedLeft;
                 Flyout5.Placement = FlyoutPlacementMode.TopEdgeAlignedLeft;
+                Flyout6.Placement = FlyoutPlacementMode.TopEdgeAlignedLeft;
             }
         }
 
@@ -133,11 +138,16 @@ namespace MUXControlsTestApp
             ShowFlyoutAt(Flyout5, FlyoutTarget5);
         }
 
-        private void ShowFlyoutAt(FlyoutBase flyout, FrameworkElement targetElement)
+        private void OnFlyoutTarget6Click(object sender, RoutedEventArgs e)
+        {
+            ShowFlyoutAt(Flyout6, FlyoutTarget6, FlyoutShowMode.Standard);
+        }
+
+        private void ShowFlyoutAt(FlyoutBase flyout, FrameworkElement targetElement, FlyoutShowMode showMode = FlyoutShowMode.Transient)
         {
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
             {
-                flyout.ShowAt(targetElement, new FlyoutShowOptions { Placement = FlyoutPlacementMode.TopEdgeAlignedLeft, ShowMode = FlyoutShowMode.Transient });
+                flyout.ShowAt(targetElement, new FlyoutShowOptions { Placement = FlyoutPlacementMode.TopEdgeAlignedLeft, ShowMode = showMode });
             }
             else
             {


### PR DESCRIPTION
To ensure Narrator can work with a CommandBarFlyout properly, we link together the end of the primary commands and the start of the secondary commands using the FlowsTo and FlowsFrom automation properties.  However, in the case where we have no primary commands, we shouldn't be linking the first secondary command to the more button, as it's hidden.