### PR TITLE
Allow customer to set Selection by NavigationViewItem.IsSelected

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3130,6 +3130,7 @@ void NavigationView::UpdateListViewItemSource()
     if (!dataSource)
     {
         dataSource = MenuItems();
+        UpdateSelectionForMenuItems();
     }
 
     // Always unset the data source first from old ListView, then set data source for new ListView.
@@ -3148,6 +3149,38 @@ void NavigationView::UpdateListViewItemSource()
     {
         InvalidateTopNavPrimaryLayout();
         UpdateSelectedItem();
+    }
+}
+
+void NavigationView::UpdateSelectionForMenuItems()
+{
+    // Allow customer to set selection by NavigationViewItem.IsSelected.
+    // If there are more than two items are set IsSelected=true, the first one is actually selected.
+    // If SelectedItem is set, IsSelected is ignored.
+    //         <NavigationView.MenuItems>
+    //              <NavigationViewItem Content = "Collection" IsSelected = "True" / >
+    //         </NavigationView.MenuItems>
+    if (!SelectedItem() && !m_shouldIgnoreNextSelectionChange)
+    {
+        if (auto menuItems = MenuItems().try_as<winrt::IVector<winrt::IInspectable>>())
+        {
+            for (int i = 0; i < static_cast<int>(menuItems.Size()); i++)
+            {
+                if (auto item = menuItems.GetAt(i).try_as<winrt::NavigationViewItem>())
+                {
+                    if (item.IsSelected())
+                    {
+                        auto scopeGuard = gsl::finally([this]()
+                            {
+                                m_shouldIgnoreNextSelectionChange = false;
+                            });
+                        m_shouldIgnoreNextSelectionChange = true;
+                        SelectedItem(item);
+                        break;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -158,6 +158,7 @@ private:
     void UpdateTopNavListViewItemSource(const winrt::IInspectable& items);
     void UpdateListViewItemsSource(const winrt::ListView& listView, const winrt::IInspectable& itemsSource);
     void UpdateListViewItemSource();
+    void UpdateSelectionForMenuItems();
 
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
     void OnLayoutUpdated(const winrt::IInspectable& sender, const winrt::IInspectable& e);

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -626,6 +626,25 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("NavViewTestSuite", "A")]
+        public void VerifyNavigationViewItemIsSelectedWorks()
+        {
+            using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),
+                            page2 = new TestSetupHelper("NavigationView Init Test"))
+            {
+                Log.Comment("Verify the 1st NavItem.IsSelected=true works");
+                UIObject item1 = FindElement.ByName("Albums");
+                Verify.IsNotNull(item1);
+                Verify.IsTrue(Convert.ToBoolean(item1.GetProperty(UIProperty.Get("SelectionItem.IsSelected"))));
+
+                Log.Comment("Verify the 2nd NavItem.IsSelected=true is ignored");
+                UIObject item2 = FindElement.ByName("People");
+                Verify.IsNotNull(item2);
+                Verify.IsFalse(Convert.ToBoolean(item2.GetProperty(UIProperty.Get("SelectionItem.IsSelected"))));
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "A")]
         public void ItemSourceTest()
         {
             using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),

--- a/dev/NavigationView/TestUI/NavigationViewInitPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewInitPage.xaml
@@ -10,39 +10,50 @@
     mc:Ignorable="d">
 
     <Grid Background="Plum">
-        <controls:NavigationView x:Name="NavView"
-            AutomationProperties.Name="NavView"
-            AutomationProperties.AutomationId="NavView"
-            CompactModeThresholdWidth="480"
-            IsSettingsVisible="False"
-            IsPaneToggleButtonVisible="False"
-            AlwaysShowHeader="False"
-            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <StackPanel>
+            <controls:NavigationView x:Name="NavView"
+                AutomationProperties.Name="NavView"
+                AutomationProperties.AutomationId="NavView"
+                CompactModeThresholdWidth="480"
+                IsSettingsVisible="False"
+                IsPaneToggleButtonVisible="False"
+                AlwaysShowHeader="False"
+                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-            <StackPanel Orientation="Vertical" Margin="8,0,0,0">
-                <TextBlock Margin="0,8" Text="This tests the initial state of the control, and the ItemsSource property."/>
-                <Button x:Name="AddItemButton" AutomationProperties.Name="AddItemButton" Content="Add Item" Click="AddButton_Click"/>
-                <Button x:Name="RemoveItemButton" AutomationProperties.Name="RemoveItemButton" Content="Remove Item" Click="RemoveButton_Click"/>
-                <Button x:Name="ChangeToIEnumerableButton" AutomationProperties.Name="ChangeToIEnumerableButton" Content="Make it IEnumerable" Click="ChangeToIEnumerableButton_Clicks"/>
-                <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Content="Flip Orientation" Click="FlipOrientation_Click"/>
+                <StackPanel Orientation="Vertical" Margin="8,0,0,0">
+                    <TextBlock Margin="0,8" Text="This tests the initial state of the control, and the ItemsSource property."/>
+                    <Button x:Name="AddItemButton" AutomationProperties.Name="AddItemButton" Content="Add Item" Click="AddButton_Click"/>
+                    <Button x:Name="RemoveItemButton" AutomationProperties.Name="RemoveItemButton" Content="Remove Item" Click="RemoveButton_Click"/>
+                    <Button x:Name="ChangeToIEnumerableButton" AutomationProperties.Name="ChangeToIEnumerableButton" Content="Make it IEnumerable" Click="ChangeToIEnumerableButton_Clicks"/>
+                    <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Content="Flip Orientation" Click="FlipOrientation_Click"/>
                 
-                <StackPanel>
-                    <Button x:Name="SwitchFrame" AutomationProperties.Name="SwitchFrame" Content="SwitchFrame" Click="SwitchFrame_Click" />
-                    <TextBlock x:Name="MyLocationResult" AutomationProperties.Name="MyLocationResult" Text="Unknown"/>
+                    <StackPanel>
+                        <Button x:Name="SwitchFrame" AutomationProperties.Name="SwitchFrame" Content="SwitchFrame" Click="SwitchFrame_Click" />
+                        <TextBlock x:Name="MyLocationResult" AutomationProperties.Name="MyLocationResult" Text="Unknown"/>
 
-                    <StackPanel Orientation="Horizontal">
-                        <Frame x:Name="Frame1" Width="200" Height="200">
-                            <controls:NavigationView x:Name="NavView2" IsBackButtonVisible="Collapsed" IsSettingsVisible="False" PaneDisplayMode="Top" ItemInvoked="NavView2_ItemInvoked">
-                                <controls:NavigationView.MenuItems>
-                                    <controls:NavigationViewItem Icon="Accept" Content="MyLocation" AutomationProperties.Name="MyLocation" />
-                                </controls:NavigationView.MenuItems>
-                            </controls:NavigationView>
-                        </Frame>
-                        <Frame x:Name="Frame2" Width="200" Height="200"/>
+                        <StackPanel Orientation="Horizontal">
+                            <Frame x:Name="Frame1" Width="200" Height="200">
+                                <controls:NavigationView x:Name="NavView2" IsBackButtonVisible="Collapsed" IsSettingsVisible="False" PaneDisplayMode="Top" ItemInvoked="NavView2_ItemInvoked">
+                                    <controls:NavigationView.MenuItems>
+                                        <controls:NavigationViewItem Icon="Accept" Content="MyLocation" AutomationProperties.Name="MyLocation" />
+                                    </controls:NavigationView.MenuItems>
+                                </controls:NavigationView>
+                            </Frame>
+                            <Frame x:Name="Frame2" Width="200" Height="200"/>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
-            </StackPanel>
-        </controls:NavigationView>
+            </controls:NavigationView>
+            <controls:NavigationView x:Name="NavView3"
+                AutomationProperties.Name="NavView3"
+                AutomationProperties.AutomationId="NavView3" >
+                <controls:NavigationView.MenuItems>
+                    <controls:NavigationViewItem Content="Collection" />
+                    <controls:NavigationViewItem Content="Albums" IsSelected="True" />
+                    <controls:NavigationViewItem Content="People" IsSelected="True" />
+                </controls:NavigationView.MenuItems>
+            </controls:NavigationView>
+        </StackPanel>
     </Grid>
 
 </local:TestPage>


### PR DESCRIPTION
There are two ways to set selection to NavigationView during initialization:
1. NavigaitonView.SelectedItem
2. NavigationViewItem.IsSelected.
Without this fix, Only SelectedItem is supported. Now I sync the flag from NavigationViewItem.IsSelected to SelectedItem during setup. Because NavigationView doesn't support multiple selection, If there are two IsSelected are set, only the first IsSelected works.

<UIXaml:NavigationView.MenuItems>
<UIXaml:NavigationViewItem Content="Collection" IsSelected="True" />
<UIXaml:NavigationViewItem Content="Albums" />
<UIXaml:NavigationViewItem Content="People" />
</UIXaml:NavigationView.MenuItems>