### PR TITLE
Fix bad vsm setter for IconBorder.Child

### DIFF
--- a/dev/Generated/TeachingTipTemplateSettings.properties.cpp
+++ b/dev/Generated/TeachingTipTemplateSettings.properties.cpp
@@ -8,6 +8,7 @@
 
 CppWinRTActivatableClassWithDPFactory(TeachingTipTemplateSettings)
 
+GlobalDependencyProperty TeachingTipTemplateSettingsProperties::s_IconElementProperty{ nullptr };
 GlobalDependencyProperty TeachingTipTemplateSettingsProperties::s_TopLeftHighlightMarginProperty{ nullptr };
 GlobalDependencyProperty TeachingTipTemplateSettingsProperties::s_TopRightHighlightMarginProperty{ nullptr };
 
@@ -18,6 +19,17 @@ TeachingTipTemplateSettingsProperties::TeachingTipTemplateSettingsProperties()
 
 void TeachingTipTemplateSettingsProperties::EnsureProperties()
 {
+    if (!s_IconElementProperty)
+    {
+        s_IconElementProperty =
+            InitializeDependencyProperty(
+                L"IconElement",
+                winrt::name_of<winrt::IconElement>(),
+                winrt::name_of<winrt::TeachingTipTemplateSettings>(),
+                false /* isAttached */,
+                ValueHelper<winrt::IconElement>::BoxedDefaultValue(),
+                nullptr);
+    }
     if (!s_TopLeftHighlightMarginProperty)
     {
         s_TopLeftHighlightMarginProperty =
@@ -44,8 +56,19 @@ void TeachingTipTemplateSettingsProperties::EnsureProperties()
 
 void TeachingTipTemplateSettingsProperties::ClearProperties()
 {
+    s_IconElementProperty = nullptr;
     s_TopLeftHighlightMarginProperty = nullptr;
     s_TopRightHighlightMarginProperty = nullptr;
+}
+
+void TeachingTipTemplateSettingsProperties::IconElement(winrt::IconElement const& value)
+{
+    static_cast<TeachingTipTemplateSettings*>(this)->SetValue(s_IconElementProperty, ValueHelper<winrt::IconElement>::BoxValueIfNecessary(value));
+}
+
+winrt::IconElement TeachingTipTemplateSettingsProperties::IconElement()
+{
+    return ValueHelper<winrt::IconElement>::CastOrUnbox(static_cast<TeachingTipTemplateSettings*>(this)->GetValue(s_IconElementProperty));
 }
 
 void TeachingTipTemplateSettingsProperties::TopLeftHighlightMargin(winrt::Thickness const& value)

--- a/dev/Generated/TeachingTipTemplateSettings.properties.h
+++ b/dev/Generated/TeachingTipTemplateSettings.properties.h
@@ -9,15 +9,20 @@ class TeachingTipTemplateSettingsProperties
 public:
     TeachingTipTemplateSettingsProperties();
 
+    void IconElement(winrt::IconElement const& value);
+    winrt::IconElement IconElement();
+
     void TopLeftHighlightMargin(winrt::Thickness const& value);
     winrt::Thickness TopLeftHighlightMargin();
 
     void TopRightHighlightMargin(winrt::Thickness const& value);
     winrt::Thickness TopRightHighlightMargin();
 
+    static winrt::DependencyProperty IconElementProperty() { return s_IconElementProperty; }
     static winrt::DependencyProperty TopLeftHighlightMarginProperty() { return s_TopLeftHighlightMarginProperty; }
     static winrt::DependencyProperty TopRightHighlightMarginProperty() { return s_TopRightHighlightMarginProperty; }
 
+    static GlobalDependencyProperty s_IconElementProperty;
     static GlobalDependencyProperty s_TopLeftHighlightMarginProperty;
     static GlobalDependencyProperty s_TopRightHighlightMarginProperty;
 

--- a/dev/TeachingTip/InteractionTests/TeachingTipTestPageElements.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTestPageElements.cs
@@ -203,6 +203,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
         private CheckBox tipFollowsTargetCheckBox;
 
+        public ComboBox GetIconComboBox()
+        {
+            return GetElement(ref iconComboBox, "IconComboBox");
+        }
+        private ComboBox iconComboBox;
+
+        public Button GetSetIconButton()
+        {
+            return GetElement(ref setIconButton, "SetIconButton");
+        }
+        private Button setIconButton;
+
         public UIObject GetTeachingTip()
         {
             return GetElement(ref teachingTip, "TeachingTip");
@@ -243,6 +255,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             BlueSquare,
             Image,
             NoContent
+        }
+
+        public enum IconOptions
+        {
+            People,
+            NoIcon
         }
     }
 }

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -276,6 +276,25 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void NoIconDoesNotCrash()
+        {
+            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            {
+                elements = new TeachingTipTestPageElements();
+
+                ScrollTargetIntoView();
+                ScrollBy(10);
+
+                SetIcon(IconOptions.NoIcon);
+                OpenTeachingTip();
+                CloseTeachingTipProgrammatically();
+                SetIcon(IconOptions.People);
+                OpenTeachingTip();
+                SetIcon(IconOptions.NoIcon);
+            }
+        }
+
         private void ScrollTargetIntoView()
         {
             elements.GetBringTargetIntoViewButton().Invoke();
@@ -399,6 +418,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     break;
             }
             elements.GetSetBleedingContentButton().Invoke();
+        }
+
+        private void SetIcon(IconOptions icon)
+        {
+            switch(icon)
+            {
+                case IconOptions.People:
+                    elements.GetIconComboBox().SelectItemByName("People Icon");
+                    break;
+                default:
+                    elements.GetIconComboBox().SelectItemByName("No Icon");
+                    break;
+            }
+            elements.GetSetIconButton().Invoke();
         }
 
         private double GetTipVerticalOffset()

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -759,21 +759,16 @@ void TeachingTip::OnIsOpenChanged()
 
 void TeachingTip::OnIconSourceChanged()
 {
+    auto templateSettings = winrt::get_self<::TeachingTipTemplateSettings>(TemplateSettings());
     if (auto source = IconSource())
     {
+        templateSettings->IconElement(SharedHelpers::MakeIconElementFrom(source));
         winrt::VisualStateManager::GoToState(*this, L"Icon"sv, false);
-        if (m_iconBorder)
-        {
-            m_iconBorder.get().Child(SharedHelpers::MakeIconElementFrom(source));
-        }
     }
     else
     {
+        templateSettings->IconElement(nullptr);
         winrt::VisualStateManager::GoToState(*this, L"NoIcon"sv, false);
-        if (m_iconBorder)
-        {
-            m_iconBorder.get().Child(nullptr);
-        }
     }
 }
 

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -770,6 +770,10 @@ void TeachingTip::OnIconSourceChanged()
     else
     {
         winrt::VisualStateManager::GoToState(*this, L"NoIcon"sv, false);
+        if (m_iconBorder)
+        {
+            m_iconBorder.get().Child(nullptr);
+        }
     }
 }
 

--- a/dev/TeachingTip/TeachingTip.idl
+++ b/dev/TeachingTip/TeachingTip.idl
@@ -69,8 +69,11 @@ unsealed runtimeclass TeachingTipTemplateSettings : Windows.UI.Xaml.DependencyOb
     Windows.UI.Xaml.Thickness TopRightHighlightMargin;
     Windows.UI.Xaml.Thickness TopLeftHighlightMargin;
 
+    Windows.UI.Xaml.Controls.IconElement IconElement;
+
     static Windows.UI.Xaml.DependencyProperty TopRightHighlightMarginProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty TopLeftHighlightMarginProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty IconElementProperty{ get; };
 }
 
 [WUXC_VERSION_PREVIEW]

--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -489,7 +489,7 @@
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
 
-                                                <Border x:Name="IconBorder" Grid.Column="0"/>
+                                                <Border x:Name="IconBorder" Grid.Column="0" Child="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IconElement}"/>
                                                 <StackPanel x:Name="TitlesStackPanel" Grid.Column="1">
                                                     <TextBlock x:Name="TitleTextBlock" Grid.Column="0" Text="{TemplateBinding Title}" TextWrapping="WrapWholeWords" FontWeight="SemiBold"/>
                                                     <TextBlock x:Name="SubtextTextBlock" Grid.Row="1" Text="{TemplateBinding Subtext}" TextWrapping="WrapWholeWords"/>

--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -113,7 +113,6 @@
                                 <VisualState x:Name="NoIcon">
                                     <VisualState.Setters>
                                         <Setter Target="IconBorder.Margin" Value="{StaticResource TeachingTipIconPresenterMarginWithoutIcon}"/>
-                                        <Setter Target="IconBorder.Child" Value=""/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml
@@ -110,11 +110,11 @@
                 <Button AutomationProperties.Name="SetBleedingContentButton" Click="OnSetBleedingContentButtonClicked" Grid.Row ="1" Grid.Column="1">Set</Button>
 
                 <TextBlock Grid.Row="2" Text="Icon:" Foreground="Red"/>
-                <ComboBox x:Name="IconComboBox" SelectedIndex="0" Grid.Row ="3">
+                <ComboBox x:Name="IconComboBox" AutomationProperties.Name="IconComboBox" SelectedIndex="0" Grid.Row ="3">
                     <ComboBoxItem x:Name="IconPeople">People Icon</ComboBoxItem>
                     <ComboBoxItem x:Name="IconNo">No Icon</ComboBoxItem>
                 </ComboBox>
-                <Button Click="OnSetIconButtonClicked" Grid.Column="1" Grid.Row ="3">Set</Button>
+                <Button AutomationProperties.Name="SetIconButton" Click="OnSetIconButtonClicked" Grid.Column="1" Grid.Row ="3">Set</Button>
 
                 <TextBlock Grid.Row="4" Text="Title:" Foreground="Red"/>
                 <ComboBox x:Name="TitleComboBox" Grid.Row ="5">


### PR DESCRIPTION
Fix an issue with trying to set the icon border's child from a vsm setter.  The value we were passing throws an error when a debugger is attached, also since we have to set the value from code behind the control can get into a state where the vsm setter doesn't work even when the correct value is supplied. Instead we'll set the no icon value from code behind as well.

Fixes #349