### PR TITLE
[AnimatedVisualPlayer]: Add Leak Object test for AVP

### DIFF
--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerLeakTestPage.xaml
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerLeakTestPage.xaml
@@ -1,0 +1,17 @@
+﻿<local:TestPage
+    x:Class="MUXControlsTestApp.AnimatedVisualPlayerLeakTestPage"
+    x:Name="AVPLeakTestPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+   
+    <Grid>
+        <RelativePanel x:Name="ParentPanel">
+            <Button x:Name="ToAnimatedVisualPlayerPageButton" AutomationProperties.Name="ToAnimatedVisualPlayerPageButton" Content="ToAnimatedVisualPlayerPage"/>
+        </RelativePanel>
+    </Grid>
+</local:TestPage>

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerLeakTestPage.xaml.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerLeakTestPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Composition;
+using AnimatedVisualPlayerTests;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace MUXControlsTestApp
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class AnimatedVisualPlayerLeakTestPage : TestPage
+    {
+        public AnimatedVisualPlayerLeakTestPage()
+        {
+            this.InitializeComponent();
+
+            ToAnimatedVisualPlayerPageButton.Click += delegate { Frame.NavigateWithoutAnimation(typeof(AnimatedVisualPlayerPage), 0); };
+        }
+    }
+}

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
@@ -73,6 +73,18 @@
                 AutomationProperties.Name="HittestingTextBox"
                 Text="None"
                 RelativePanel.Below="ReversePositivePlaybackRateAnimationTextBox"/>
+            <Button x:Name="ToLeakTestPageButton"
+                AutomationProperties.Name="ToLeakTestPageButton"
+                RelativePanel.Below="HittestingTextBox"/>
+            <TextBox x:Name="LeakTestCheckTextBox"
+                IsEnabled="False"
+                AutomationProperties.Name="LeakTestCheckTextBox"
+                Text="None"
+                RelativePanel.Below="ToLeakTestPageButton"/>
+            <Button x:Name="LeakTestCheckButton"
+                AutomationProperties.Name="LeakTestCheckButton"
+                Click="LeakTestCheckButton_Click"
+                RelativePanel.Below="LeakTestCheckTextBox"/>
             <controls:AnimatedVisualPlayer
                 x:Name="Player"
                 AutomationProperties.Name="Player"

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml.cs
@@ -24,6 +24,17 @@ namespace MUXControlsTestApp
         public AnimatedVisualPlayerPage()
         {
             this.InitializeComponent();
+
+            ToLeakTestPageButton.Click += delegate {
+                AnimatedVisualPlayer_TestUI.LeakTestObjects.PlayerWeakRef = new WeakReference<AnimatedVisualPlayer>(Player);
+                this.Frame.NavigateWithoutAnimation(typeof(AnimatedVisualPlayerLeakTestPage), null);
+            };
+
+            for (var i = 0; i < 3; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }            
         }
 
         private async void PlayButton_Click(object sender, RoutedEventArgs e)
@@ -109,7 +120,16 @@ namespace MUXControlsTestApp
         {
             HittestingTextBox.Text = Constants.PointerMovedText;
         }
-        
+
+        private void LeakTestCheckButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            object target = AnimatedVisualPlayer_TestUI.LeakTestObjects.PlayerWeakRef;
+            if (target != null)
+            {
+                LeakTestCheckTextBox.Text = Constants.NoLeakText;
+            }
+        }
+
         private async Task GetIsPlayingAsync()
         {
             //

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayer_TestUI.projitems
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayer_TestUI.projitems
@@ -10,6 +10,10 @@
     <Import_RootNamespace>AnimatedVisualPlayer_TestUI</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerLeakTestPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -17,9 +21,13 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerLeakTestPage.xaml.cs">
+      <DependentUpon>AnimatedVisualPlayerLeakTestPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerPage.xaml.cs">
       <DependentUpon>AnimatedVisualPlayerPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)LeakTestObjects.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LottieLogo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\inc\Constants.cs" />
   </ItemGroup>

--- a/dev/AnimatedVisualPlayer/TestUI/LeakTestObjects.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/LeakTestObjects.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if !BUILD_WINDOWS
+using AnimatedVisualPlayer = Microsoft.UI.Xaml.Controls.AnimatedVisualPlayer;
+#endif
+
+namespace MUXControlsTestApp
+{
+    namespace AnimatedVisualPlayer_TestUI
+    {
+        public static class LeakTestObjects
+        {
+            public static WeakReference<AnimatedVisualPlayer> PlayerWeakRef { get; set; }
+        }
+    }
+}

--- a/dev/AnimatedVisualPlayer/inc/Constants.cs
+++ b/dev/AnimatedVisualPlayer/inc/Constants.cs
@@ -6,7 +6,8 @@
     /// </summary>
     internal static class Constants
     {
-        public const string FalseText = "False";        
+        public const string FalseText = "False";
+        public const string NoLeakText = "No leak";
         public const string OneText = "1";
         public const string PlayingEndedText = "AnimatedVisualPlayer playing ended";
         public const string PointerMovedText = "Pointer moved";


### PR DESCRIPTION
This leak object test  is a pending task from WinUI_RS5 when we are moving AVP into WinUI_RS5 in VSTS repo. It is supposed to be done at that moment. This change is to add such leak object test for AVP by navigating page from AVP test page to leak test page then back to test page. GC is forced to be running during page navigation. And the AVP object is hooked up by a static weakreference object. When GC finishes, the target in this weakreference object should be null.