### PR TITLE
Update VerifyNavigationViewItemIsSelectedWorks

### DIFF
--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -616,8 +616,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("NavViewTestSuite", "A")]
         public void VerifyNavigationViewItemIsSelectedWorks()
         {
-            using (IDisposable page1 = new TestSetupHelper("NavigationView Tests"),
-                            page2 = new TestSetupHelper("NavigationView Init Test"))
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Init Test" }))
             {
                 Log.Comment("Verify the 1st NavItem.IsSelected=true works");
                 UIObject item1 = FindElement.ByName("Albums");


### PR DESCRIPTION
We blocked nested TestSetupHelper for better test stability. Update VerifyNavigationViewItemIsSelectedWorks test to use the new array pattern.

https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=3873&view=ms.vss-test-web.build-test-results-tab