### PR TITLE
Modifying Test Value for AppBarButtonRevealStyles API Test

### DIFF
--- a/dev/Materials/Reveal/APITests/RevealTests.cs
+++ b/dev/Materials/Reveal/APITests/RevealTests.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     public class RevealTests
     {
         //Bug 19007647: ApiTests.RevealTests.ValidateAppBarButtonRevealStyles failing in master
-        //[TestMethod]
+        [TestMethod]
         public void ValidateAppBarButtonRevealStyles()
         {
             AppBarButton buttonLabelsOnRight = null;
@@ -40,8 +40,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                         <CommandBar xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
                             DefaultLabelPosition='Right'
                             IsOpen='True'>
-                            <AppBarButton Label='button' Icon='Accept' Style='{StaticResource AppBarButtonRevealLabelsOnRightStyle}'/>
-                            <AppBarToggleButton Label='button' Icon='Accept' Style='{StaticResource AppBarToggleButtonRevealLabelsOnRightStyle}'/>
+                            <AppBarButton Label='button' Icon='Accept'/>
+                            <AppBarToggleButton Label='button' Icon='Accept'/>
                             <CommandBar.SecondaryCommands>
                                 <AppBarButton Label='Supercalifragilisticexpialidocious' Style='{StaticResource AppBarButtonRevealOverflowStyle}'/>
                                 <AppBarToggleButton Label='Supercalifragilisticexpialidocious' Style='{StaticResource AppBarToggleButtonRevealOverflowStyle}'/>
@@ -60,7 +60,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                const double expectedLabelsOnRightWidth = 88;
+                const double expectedLabelsOnRightWidth = 84;
                 const double expectedOverflowWidth = 264;
 
                 Verify.AreEqual(expectedLabelsOnRightWidth, buttonLabelsOnRight.ActualWidth);

--- a/dev/Materials/Reveal/APITests/RevealTests.cs
+++ b/dev/Materials/Reveal/APITests/RevealTests.cs
@@ -24,7 +24,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     [TestClass]
     public class RevealTests
     {
-        //Bug 19007647: ApiTests.RevealTests.ValidateAppBarButtonRevealStyles failing in master
         [TestMethod]
         public void ValidateAppBarButtonRevealStyles()
         {


### PR DESCRIPTION
This is resolving the test failure in ValidateAppBarButtonRevealStyles caused by the expected button width value changing with the newest release. The expected test value was updated to the desired value from most recent builds. This fix resolves bug 19007647. It also includes some small suggested style changes in the XAML test code, removing the default style from primary button declaration.