### PR TITLE
Adding snap points support to bring-into-view contributions

### DIFF
--- a/dev/Scroller/APITests/ScrollerBringIntoViewTests.cs
+++ b/dev/Scroller/APITests/ScrollerBringIntoViewTests.cs
@@ -22,6 +22,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 
 #if !BUILD_WINDOWS
 using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
+using ScrollerSnapPointAlignment = Microsoft.UI.Xaml.Controls.Primitives.ScrollerSnapPointAlignment;
+using ScrollerSnapPointIrregular = Microsoft.UI.Xaml.Controls.Primitives.ScrollerSnapPointIrregular;
 using AnimationMode = Microsoft.UI.Xaml.Controls.AnimationMode;
 using SnapPointsMode = Microsoft.UI.Xaml.Controls.SnapPointsMode;
 using ContentOrientation = Microsoft.UI.Xaml.Controls.ContentOrientation;
@@ -41,7 +43,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private const int c_defaultBringIntoViewUIStackPanelChildrenCount = 16;
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view.")]
         public void BringElementIntoHorizontalScrollerViewFromNearEdge()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -54,7 +56,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, with snap points.")]
+        public void BringElementIntoHorizontalScrollerViewWithSnapPoints()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
+            {
+                // Skipping this test since the BringIntoViewRequested event was introduced in RS4.
+                return;
+            }
+
+            BringElementIntoView(
+                orientation: Orientation.Horizontal,
+                expectedHorizontalOffset: 1134.0,
+                expectedVerticalOffset: 0.0,
+                options: null,
+                originalHorizontalOffset: 0.0,
+                originalVerticalOffset: 0.0,
+                originalZoomFactor: 1.0f,
+                applyOptionsInBringingIntoViewHandler: false,
+                applySnapPointsInBringingIntoViewHandler: true);
+        }
+
+        [TestMethod]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view.")]
         public void BringElementIntoVerticalScrollerViewFromNearEdge()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -67,7 +91,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view, starting from the maximum offset.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, with snap points.")]
+        public void BringElementIntoVerticalScrollerViewWithSnapPoints()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
+            {
+                // Skipping this test since the BringIntoViewRequested event was introduced in RS4.
+                return;
+            }
+
+            BringElementIntoView(
+                orientation: Orientation.Vertical,
+                expectedHorizontalOffset: 0.0,
+                expectedVerticalOffset: 1134.0,
+                options: null,
+                originalHorizontalOffset: 0.0,
+                originalVerticalOffset: 0.0,
+                originalZoomFactor: 1.0f,
+                applyOptionsInBringingIntoViewHandler: false,
+                applySnapPointsInBringingIntoViewHandler: true);
+        }
+
+        [TestMethod]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, starting from the maximum offset.")]
         public void BringElementIntoHorizontalScrollerViewFromFarEdge()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -87,7 +133,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view, starting from the maximum offset.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, starting from the maximum offset.")]
         public void BringElementIntoVerticalScrollerViewFromFarEdge()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -107,7 +153,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view, with left alignment.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, with left alignment.")]
         public void BringElementIntoHorizontalScrollerViewWithNearAlignment()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -124,7 +170,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view, with center alignment.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, with center alignment.")]
         public void BringElementIntoHorizontalScrollerViewWithMiddleAlignment()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -141,7 +187,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view, with right alignment.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, with right alignment.")]
         public void BringElementIntoHorizontalScrollerViewWithFarAlignment()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -158,7 +204,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view, with left alignment.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, with left alignment.")]
         public void BringElementIntoVerticalScrollerViewWithNearAlignment()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -175,7 +221,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view, with center alignment.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, with center alignment.")]
         public void BringElementIntoVerticalScrollerViewWithMiddleAlignment()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -192,7 +238,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view, with right alignment.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, with right alignment.")]
         public void BringElementIntoVerticalScrollerViewWithFarAlignment()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -209,7 +255,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view, with a shift.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, with a shift.")]
         public void BringElementIntoHorizontalScrollerViewWithOffset()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -226,7 +272,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view, with a shift.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, with a shift.")]
         public void BringElementIntoVerticalScrollerViewWithOffset()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -243,7 +289,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a horizontal Scroller into view, with a shift, starting from the maximum offset.")]
+        [TestProperty("Description", "Brings an element within a horizontal Scroller into view, with a shift, starting from the maximum offset.")]
         public void BringElementIntoHorizontalScrollerViewWithOffsetFromFarEdge()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -263,7 +309,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a vertical Scroller into view, with a shift, starting from the maximum offset.")]
+        [TestProperty("Description", "Brings an element within a vertical Scroller into view, with a shift, starting from the maximum offset.")]
         public void BringElementIntoVerticalScrollerViewWithOffsetFromFarEdge()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -283,7 +329,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a Scroller into view, with a TargetRect.")]
+        [TestProperty("Description", "Brings an element within a Scroller into view, with a TargetRect.")]
         public void BringElementIntoViewWithTargetRect()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -308,7 +354,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Description", "Brings an element with a Scroller into view, with a TargetRect and VerticalOffset.")]
+        [TestProperty("Description", "Brings an element within a Scroller into view, with a TargetRect and VerticalOffset.")]
         public void BringElementIntoViewWithAdjustmentInBringingIntoViewHandler()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
@@ -484,6 +530,32 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 1512.0 /*expectedInnerHorizontalOffset*/,
                 0.0 /*expectedInnerVerticalOffset*/,
                 options);
+        }
+
+        [TestMethod]
+        [TestProperty("Description", "Brings a nested element inside horizontal Scrollers into view, with snap points.")]
+        public void BringNestedElementIntoHorizontalScrollerViewWithSnapPoints()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
+            {
+                // Skipping this test since the BringIntoViewRequested event was introduced in RS4.
+                return;
+            }
+
+            BringElementInNestedScrollersIntoView(
+                orientation: Orientation.Horizontal,
+                expectedOuterHorizontalOffset: 1008.0,
+                expectedOuterVerticalOffset: 0.0,
+                expectedInnerHorizontalOffset: 1134.0,
+                expectedInnerVerticalOffset: 0.0,
+                options: null,
+                originalOuterHorizontalOffset: 0.0,
+                originalOuterVerticalOffset: 0.0,
+                originalOuterZoomFactor: 1.0f,
+                originalInnerHorizontalOffset: 0.0,
+                originalInnerVerticalOffset: 0.0,
+                originalInnerZoomFactor: 1.0f,
+                applySnapPointsInBringingIntoViewHandler: true);
         }
 
         [TestMethod]
@@ -736,7 +808,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             double originalHorizontalOffset = 0.0,
             double originalVerticalOffset = 0.0,
             float originalZoomFactor = 1.0f,
-            bool applyOptionsInBringingIntoViewHandler = false)
+            bool applyOptionsInBringingIntoViewHandler = false,
+            bool applySnapPointsInBringingIntoViewHandler = false)
         {
             Scroller scroller = null;
             AutoResetEvent scrollerLoadedEvent = new AutoResetEvent(false);
@@ -782,8 +855,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 scroller.BringingIntoView += (Scroller sender, ScrollerBringingIntoViewEventArgs args) =>
                 {
-                    Log.Comment("Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}",
-                        sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId);
+                    Log.Comment("Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}, SnapPointsMode={4}",
+                        sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId, args.SnapPointsMode);
                     bringIntoViewChangeId = args.ScrollInfo.OffsetsChangeId;
 
                     if (applyOptionsInBringingIntoViewHandler && options != null)
@@ -796,6 +869,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                         {
                             args.RequestEventArgs.TargetRect = (Rect)options.TargetRect;
                         }
+                    }
+
+                    if (applySnapPointsInBringingIntoViewHandler)
+                    {
+                        Log.Comment("Scroller.BringingIntoView - Applying mandatory snap points");
+                        AddSnapPoints(scroller: sender, stackPanel: (sender.Content as Border).Child as StackPanel);
+                        args.SnapPointsMode = SnapPointsMode.Default;
                     }
                 };
 
@@ -848,7 +928,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             float originalOuterZoomFactor = 1.0f,
             double originalInnerHorizontalOffset = 0.0,
             double originalInnerVerticalOffset = 0.0,
-            float originalInnerZoomFactor = 1.0f)
+            float originalInnerZoomFactor = 1.0f,
+            bool applySnapPointsInBringingIntoViewHandler = false)
         {
             Scroller outerScroller = null;
             Scroller innerScroller = null;
@@ -884,7 +965,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             if (originalInnerZoomFactor != 1.0f)
             {
-                ZoomTo(innerScroller, originalInnerZoomFactor, 0.0f, 0.0f, AnimationMode.Disabled, SnapPointsMode.Ignore);                
+                ZoomTo(innerScroller, originalInnerZoomFactor, 0.0f, 0.0f, AnimationMode.Disabled, SnapPointsMode.Ignore);
             }
 
             if (originalInnerHorizontalOffset != 0 || originalInnerVerticalOffset != 0)
@@ -912,9 +993,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 innerScroller.BringingIntoView += (Scroller sender, ScrollerBringingIntoViewEventArgs args) =>
                 {
-                    Log.Comment("Inner Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}",
-                        sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId);
+                    Log.Comment("Inner Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}, SnapPointsMode={4}",
+                        sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId, args.SnapPointsMode);
                     innerBringIntoViewChangeId = args.ScrollInfo.OffsetsChangeId;
+
+                    if (applySnapPointsInBringingIntoViewHandler)
+                    {
+                        Log.Comment("Scroller.BringingIntoView - Applying mandatory snap points");
+                        AddSnapPoints(scroller: sender, stackPanel: (sender.Content as Border).Child as StackPanel);
+                        args.SnapPointsMode = SnapPointsMode.Default;
+                    }
                 };
 
                 outerScroller.ViewChanged += delegate (Scroller sender, object args)
@@ -934,9 +1022,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 outerScroller.BringingIntoView += (Scroller sender, ScrollerBringingIntoViewEventArgs args) =>
                 {
-                    Log.Comment("Outer Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}",
-                        sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId);
+                    Log.Comment("Outer Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}, SnapPointsMode={4}",
+                        sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId, args.SnapPointsMode);
                     outerBringIntoViewChangeId = args.ScrollInfo.OffsetsChangeId;
+
+                    if (applySnapPointsInBringingIntoViewHandler)
+                    {
+                        Log.Comment("Scroller.BringingIntoView - Applying mandatory snap points");
+                        AddSnapPoints(scroller: sender, stackPanel: (sender.Content as Border).Child as StackPanel);
+                        args.SnapPointsMode = SnapPointsMode.Default;
+                    }
                 };
 
                 UIElement targetElement = ((innerScroller.Content as Border).Child as StackPanel).Children[12];
@@ -1047,7 +1142,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Verify.AreEqual(innerScrollViewer.HorizontalOffset, expectedInnerHorizontalOffset);
                 Verify.AreEqual(innerScrollViewer.VerticalOffset, expectedInnerVerticalOffset);
-                
+
                 Verify.AreEqual(outerScrollViewer.HorizontalOffset, expectedOuterHorizontalOffset);
                 Verify.AreEqual(outerScrollViewer.VerticalOffset, expectedOuterVerticalOffset);
             });
@@ -1106,7 +1201,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 Log.Comment("Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}",
                     sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId);
-                Log.Comment("RequestEventArgs - AnimationDesired={0}, Handled={1}, HorizontalAlignmentRatio={2}, VerticalAlignmentRatio={3}", 
+                Log.Comment("RequestEventArgs - AnimationDesired={0}, Handled={1}, HorizontalAlignmentRatio={2}, VerticalAlignmentRatio={3}",
                     args.RequestEventArgs.AnimationDesired,
                     args.RequestEventArgs.Handled,
                     args.RequestEventArgs.HorizontalAlignmentRatio,
@@ -1247,8 +1342,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             outerScroller.BringingIntoView += (Scroller sender, ScrollerBringingIntoViewEventArgs args) =>
             {
-                Log.Comment("Outer Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}",
-                    sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId);
+                Log.Comment("Outer Scroller.BringingIntoView Scroller={0} - TargetHorizontalOffset={1}, TargetVerticalOffset={2}, OffsetsChangeId={3}, SnapPointsMode={4}",
+                    sender.Name, args.TargetHorizontalOffset, args.TargetVerticalOffset, args.ScrollInfo.OffsetsChangeId, args.SnapPointsMode);
                 Log.Comment("RequestEventArgs - AnimationDesired={0}, Handled={1}, HorizontalAlignmentRatio={2}, VerticalAlignmentRatio={3}",
                     args.RequestEventArgs.AnimationDesired,
                     args.RequestEventArgs.Handled,
@@ -1331,6 +1426,82 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             Log.Comment("Setting window content");
             MUXControlsTestApp.App.TestContentRoot = outerScrollViewer;
+        }
+
+        private void AddSnapPoints(Scroller scroller, StackPanel stackPanel)
+        {
+            Verify.IsNotNull(scroller);
+
+            if (stackPanel == null || stackPanel.Children.Count == 0)
+            {
+                return;
+            }
+
+            Log.Comment("Populating snap points for " + scroller.Name + ":");
+
+            ScrollerSnapPointIrregular sspi;
+            GeneralTransform gt = stackPanel.TransformToVisual(scroller.Content);
+            Point stackPanelOriginPoint = new Point();
+            stackPanelOriginPoint = gt.TransformPoint(stackPanelOriginPoint);
+
+            if (stackPanel.Orientation == Orientation.Horizontal)
+            {
+                sspi = new ScrollerSnapPointIrregular(stackPanelOriginPoint.X, ScrollerSnapPointAlignment.Near);
+                Log.Comment("Adding horizontal snap point to " + scroller.Name + " at value " + stackPanelOriginPoint.X);
+                scroller.HorizontalSnapPoints.Add(sspi);
+            }
+            else
+            {
+                sspi = new ScrollerSnapPointIrregular(stackPanelOriginPoint.Y, ScrollerSnapPointAlignment.Near);
+                Log.Comment("Adding vertical snap point to " + scroller.Name + " at value " + stackPanelOriginPoint.Y);
+                scroller.VerticalSnapPoints.Add(sspi);
+            }
+
+            foreach (UIElement child in stackPanel.Children)
+            {
+                FrameworkElement childAsFE = child as FrameworkElement;
+
+                if (childAsFE != null)
+                {
+                    gt = childAsFE.TransformToVisual(stackPanel);
+                    Point childOriginPoint = new Point();
+                    childOriginPoint = gt.TransformPoint(childOriginPoint);
+
+                    double snapPointValue = 0.0;
+                    Thickness margin = childAsFE.Margin;
+
+                    if (stackPanel.Orientation == Orientation.Horizontal)
+                    {
+                        snapPointValue = margin.Right + childAsFE.ActualWidth + childOriginPoint.X;
+                        if (snapPointValue <= scroller.ScrollableWidth)
+                        {
+                            sspi = new ScrollerSnapPointIrregular(snapPointValue, ScrollerSnapPointAlignment.Near);
+                            Log.Comment("Adding horizontal snap point to " + scroller.Name + " at value " + snapPointValue);
+                            scroller.HorizontalSnapPoints.Add(sspi);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        snapPointValue = margin.Bottom + childAsFE.ActualHeight + childOriginPoint.Y;
+                        if (snapPointValue <= scroller.ScrollableHeight)
+                        {
+                            sspi = new ScrollerSnapPointIrregular(snapPointValue, ScrollerSnapPointAlignment.Near);
+                            Log.Comment("Adding vertical snap point to " + scroller.Name + " at value " + snapPointValue);
+                            scroller.VerticalSnapPoints.Add(sspi);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                AddSnapPoints(scroller, child as StackPanel);
+            }
         }
     }
 }

--- a/dev/Scroller/Scroller.cpp
+++ b/dev/Scroller/Scroller.cpp
@@ -1455,10 +1455,8 @@ void Scroller::ComputeBringIntoViewTargetOffsets(
     const double scrollableWidth = ScrollableWidth();
     const double scrollableHeight = ScrollableHeight();
 
-    targetZoomedHorizontalOffsetTmp = std::max(0.0, targetZoomedHorizontalOffsetTmp);
-    targetZoomedVerticalOffsetTmp = std::max(0.0, targetZoomedVerticalOffsetTmp);
-    targetZoomedHorizontalOffsetTmp = std::min(scrollableWidth, targetZoomedHorizontalOffsetTmp);
-    targetZoomedVerticalOffsetTmp = std::min(scrollableHeight, targetZoomedVerticalOffsetTmp);
+    targetZoomedHorizontalOffsetTmp = std::clamp(targetZoomedHorizontalOffsetTmp, 0.0, scrollableWidth);
+    targetZoomedVerticalOffsetTmp = std::clamp(targetZoomedVerticalOffsetTmp, 0.0, scrollableHeight);
 
     const double offsetX = requestEventArgs.HorizontalOffset();
     const double offsetY = requestEventArgs.VerticalOffset();
@@ -1510,10 +1508,8 @@ void Scroller::ComputeBringIntoViewTargetOffsets(
         targetZoomedHorizontalOffsetTmp = ComputeValueAfterSnapPoints(targetZoomedHorizontalOffsetTmp, m_sortedConsolidatedVerticalSnapPoints);
 
         // Make sure the target offsets are within the scrollable boundaries
-        targetZoomedHorizontalOffsetTmp = std::max(0.0, targetZoomedHorizontalOffsetTmp);
-        targetZoomedVerticalOffsetTmp = std::max(0.0, targetZoomedVerticalOffsetTmp);
-        targetZoomedHorizontalOffsetTmp = std::min(scrollableWidth, targetZoomedHorizontalOffsetTmp);
-        targetZoomedVerticalOffsetTmp = std::min(scrollableHeight, targetZoomedVerticalOffsetTmp);
+        targetZoomedHorizontalOffsetTmp = std::clamp(targetZoomedHorizontalOffsetTmp, 0.0, scrollableWidth);
+        targetZoomedVerticalOffsetTmp = std::clamp(targetZoomedVerticalOffsetTmp, 0.0, scrollableHeight);
 
         MUX_ASSERT(targetZoomedHorizontalOffsetTmp >= 0.0);
         MUX_ASSERT(targetZoomedVerticalOffsetTmp >= 0.0);

--- a/dev/Scroller/Scroller.h
+++ b/dev/Scroller/Scroller.h
@@ -258,12 +258,13 @@ private:
     winrt::float2 ComputeCenterPointerForMouseWheelZooming(const winrt::UIElement& content, const winrt::Point& pointerPosition) const;
     void ComputeBringIntoViewTargetOffsets(
         const winrt::UIElement& content,
+        const winrt::SnapPointsMode& snapPointsMode,
         const winrt::BringIntoViewRequestedEventArgs& requestEventArgs,
         _Out_ double* targetZoomedHorizontalOffset,
         _Out_ double* targetZoomedVerticalOffset,
         _Out_ double* appliedOffsetX,
         _Out_ double* appliedOffsetY,
-        _Out_ winrt::Rect* targetRect) const;
+        _Out_ winrt::Rect* targetRect);
 
     void EnsureExpressionAnimationSources();
     void EnsureInteractionTracker();
@@ -526,7 +527,8 @@ private:
         double targetZoomedHorizontalOffset,
         double targetZoomedVerticalOffset,
         const winrt::BringIntoViewRequestedEventArgs& requestEventArgs,
-        int32_t offsetsChangeId);
+        int32_t offsetsChangeId,
+        _Inout_ winrt::SnapPointsMode* snapPointsMode);
 
     // Event handlers
     void OnCompositionTargetRendering(

--- a/dev/Scroller/Scroller.idl
+++ b/dev/Scroller/Scroller.idl
@@ -166,6 +166,7 @@ runtimeclass ZoomCompletedEventArgs
 [webhosthidden]
 runtimeclass ScrollerBringingIntoViewEventArgs
 {
+    SnapPointsMode SnapPointsMode { get; set; };
     Windows.UI.Xaml.BringIntoViewRequestedEventArgs RequestEventArgs { get; };
     Double TargetHorizontalOffset { get; };
     Double TargetVerticalOffset { get; };

--- a/dev/Scroller/ScrollerBringingIntoViewEventArgs.cpp
+++ b/dev/Scroller/ScrollerBringingIntoViewEventArgs.cpp
@@ -6,6 +6,16 @@
 #include "ScrollerTrace.h"
 #include "ScrollerBringingIntoViewEventArgs.h"
 
+winrt::SnapPointsMode ScrollerBringingIntoViewEventArgs::SnapPointsMode()
+{
+    return m_snapPointsMode;
+}
+
+void ScrollerBringingIntoViewEventArgs::SnapPointsMode(winrt::SnapPointsMode snapPointsMode)
+{
+    m_snapPointsMode = snapPointsMode;
+}
+
 winrt::BringIntoViewRequestedEventArgs ScrollerBringingIntoViewEventArgs::RequestEventArgs()
 {
     return m_requestEventArgs;

--- a/dev/Scroller/ScrollerBringingIntoViewEventArgs.h
+++ b/dev/Scroller/ScrollerBringingIntoViewEventArgs.h
@@ -20,6 +20,8 @@ public:
     }
 
     // IScrollerBringingIntoViewEventArgs overrides
+    winrt::SnapPointsMode SnapPointsMode();
+    void SnapPointsMode(winrt::SnapPointsMode snapPointsMode);
     winrt::BringIntoViewRequestedEventArgs RequestEventArgs();
     double TargetHorizontalOffset();
     double TargetVerticalOffset();
@@ -47,6 +49,7 @@ public:
     void TargetOffsets(double targetHorizontalOffset, double targetVerticalOffset);
 
 private:
+    winrt::SnapPointsMode m_snapPointsMode{ winrt::SnapPointsMode::Ignore };
     winrt::BringIntoViewRequestedEventArgs m_requestEventArgs{ nullptr };
     double m_targetHorizontalOffset{ 0.0 };
     double m_targetVerticalOffset{ 0.0 };

--- a/dev/Scroller/TestUI/ScrollerBringIntoViewPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerBringIntoViewPage.xaml
@@ -12,22 +12,32 @@
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.Resources>
-            <controls:RecyclePool x:Key="recyclePool"/>
-            <controls:RecyclingElementFactory x:Name="repeater1ElementFactory" RecyclePool="{StaticResource recyclePool}">
+            <controls:RecyclePool x:Key="recyclePool1"/>
+            <controls:RecyclePool x:Key="recyclePool2"/>
+            <controls:RecyclePool x:Key="recyclePool3"/>
+            <controls:RecyclePool x:Key="recyclePool4"/>
+            <controls:RecyclingElementFactory x:Name="repeater1ElementFactory" RecyclePool="{StaticResource recyclePool1}">
                 <DataTemplate x:Key="Item" x:DataType="x:String">
                     <Border BorderThickness="3" BorderBrush="Chartreuse" Width="100" Height="100" Margin="3" Background="BlanchedAlmond">
                         <TextBox Text="{x:Bind}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
                 </DataTemplate>
             </controls:RecyclingElementFactory>
-            <controls:RecyclingElementFactory x:Name="repeater2ElementFactory" RecyclePool="{StaticResource recyclePool}">
+            <controls:RecyclingElementFactory x:Name="repeater2ElementFactory" RecyclePool="{StaticResource recyclePool2}">
                 <DataTemplate x:Key="Item" x:DataType="x:String">
                     <Border BorderThickness="3" BorderBrush="Chartreuse" Width="100" Height="100" Margin="3" Background="BlanchedAlmond">
                         <TextBox Text="{x:Bind}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
                 </DataTemplate>
             </controls:RecyclingElementFactory>
-            <controls:RecyclingElementFactory x:Name="repeater3ElementFactory" RecyclePool="{StaticResource recyclePool}">
+            <controls:RecyclingElementFactory x:Name="repeater3ElementFactory" RecyclePool="{StaticResource recyclePool3}">
+                <DataTemplate x:Key="Item" x:DataType="x:String">
+                    <Border BorderThickness="3" BorderBrush="Chartreuse" Width="100" Height="100" Margin="3" Background="BlanchedAlmond">
+                        <TextBox Text="{x:Bind}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </DataTemplate>
+            </controls:RecyclingElementFactory>
+            <controls:RecyclingElementFactory x:Name="repeater4ElementFactory" RecyclePool="{StaticResource recyclePool4}">
                 <DataTemplate x:Key="Item" x:DataType="x:String">
                     <Border BorderThickness="3" BorderBrush="Chartreuse" Width="100" Height="100" Margin="3" Background="BlanchedAlmond">
                         <TextBox Text="{x:Bind}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
@@ -50,9 +60,11 @@
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Nesting combination:" Margin="1" VerticalAlignment="Center"/>
                 <ComboBox x:Name="cmbNestingCombination" Margin="1" SelectedIndex="0" SelectionChanged="CmbNestingCombination_SelectionChanged">
-                    <ComboBoxItem>Scroller in Scroller</ComboBoxItem>
-                    <ComboBoxItem>Scroller in ScrollViewer</ComboBoxItem>
-                    <ComboBoxItem>ScrollViewer in Scroller</ComboBoxItem>
+                    <ComboBoxItem>Scroller in Scroller (1)</ComboBoxItem>
+                    <ComboBoxItem>Scroller in Scroller (2)</ComboBoxItem>
+                    <ComboBoxItem>Scroller in WUX ScrollViewer</ComboBoxItem>
+                    <ComboBoxItem>WUX ScrollViewer in Scroller</ComboBoxItem>
+                    <ComboBoxItem>WUX ScrollViewer in WUX ScrollViewer</ComboBoxItem>
                 </ComboBox>
             </StackPanel>
             <controlsPrimitives:Scroller x:Name="outerScroller" Width="400" Height="400" Margin="1" Background="ForestGreen" VerticalAlignment="Bottom" ZoomMode="Enabled">
@@ -121,6 +133,119 @@
                     </Border>
                     <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
                         <TextBox x:Name="TextBox140A" Text="TextBox140" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </StackPanel>
+            </controlsPrimitives:Scroller>
+            <controlsPrimitives:Scroller x:Name="outerScroller3" Width="400" Height="400" Margin="1" Background="ForestGreen"
+                VerticalAlignment="Bottom" ZoomMode="Enabled" Visibility="Collapsed">
+                <StackPanel Width="400">
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox00E" Text="TextBox00" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox01E" Text="TextBox01" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox10E" Text="TextBox10" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox11E" Text="TextBox11" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox20E" Text="TextBox20" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox21E" Text="TextBox21" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox30E" Text="TextBox30" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox31E" Text="TextBox31" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox40E" Text="TextBox40" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox41E" Text="TextBox41" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <controlsPrimitives:Scroller x:Name="innerScroller3" Width="400" Height="300" Background="AliceBlue"
+                        HorizontalAlignment="Left" VerticalAlignment="Top" ContentOrientation="Vertical" ZoomMode="Enabled" VerticalScrollChainingMode="Always">
+                        <StackPanel Width="400">
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox00F" Text="TextBox00" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox01F" Text="TextBox01" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox10F" Text="TextBox10" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox11F" Text="TextBox11" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox20F" Text="TextBox20" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox21F" Text="TextBox21" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox30F" Text="TextBox30" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox31F" Text="TextBox31" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox40F" Text="TextBox40" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox41F" Text="TextBox41" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox50F" Text="TextBox50" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox61F" Text="TextBox61" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox70F" Text="TextBox70" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox71F" Text="TextBox71" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="9" Background="LightGoldenrodYellow">
+                                <TextBox x:Name="TextBox80F" Text="TextBox80" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="9" Background="LightSeaGreen">
+                                <TextBox x:Name="TextBox81F" Text="TextBox81" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </StackPanel>
+                    </controlsPrimitives:Scroller>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox100E" Text="TextBox100" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox110E" Text="TextBox110" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox120E" Text="TextBox120" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox130E" Text="TextBox130" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox140E" Text="TextBox140" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                     </Border>
                 </StackPanel>
             </controlsPrimitives:Scroller>
@@ -264,10 +389,81 @@
                     </Border>
                 </StackPanel>
             </controlsPrimitives:Scroller>
+            <ScrollViewer x:Name="outerScrollViewer2" Width="400" Height="400" Margin="1" Background="ForestGreen" VerticalAlignment="Bottom"
+                ZoomMode="Enabled" Visibility="Collapsed">
+                <StackPanel Width="400">
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox00D" Text="TextBox00" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox01D" Text="TextBox01" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox10D" Text="TextBox10" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox11D" Text="TextBox11" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox20D" Text="TextBox20" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox21D" Text="TextBox21" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox30D" Text="TextBox30" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox31D" Text="TextBox31" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                            <TextBox x:Name="TextBox40D" Text="TextBox40" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <Border BorderThickness="3" BorderBrush="Tomato" Width="300" Height="100" Margin="3" Background="LightSteelBlue">
+                            <TextBox x:Name="TextBox41D" Text="TextBox41" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </StackPanel>
+                    <ScrollViewer x:Name="innerScrollViewer2" Width="400" Height="300" Background="AliceBlue"
+                        HorizontalAlignment="Left" VerticalAlignment="Top" ZoomMode="Enabled">
+                        <Border x:Name="border4" BorderThickness="3" BorderBrush="Chartreuse" Margin="15" Background="Beige">
+                            <controls:ItemsRepeater x:Name="repeater4" Margin="30">
+                                <controls:ItemsRepeater.Layout>
+                                    <controls:UniformGridLayout MinItemWidth="125" MinItemHeight="125" MinRowSpacing="10" MinColumnSpacing="10"/>
+                                </controls:ItemsRepeater.Layout>
+                            </controls:ItemsRepeater>
+                        </Border>
+                    </ScrollViewer>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox100D" Text="TextBox100" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox110D" Text="TextBox110" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox120D" Text="TextBox120" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox130D" Text="TextBox130" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <Border BorderThickness="3" BorderBrush="LawnGreen" Width="300" Height="100" Margin="3" Background="LightGreen">
+                        <TextBox x:Name="TextBox140D" Text="TextBox140" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                </StackPanel>
+            </ScrollViewer>
         </StackPanel>
 
         <Grid Grid.Column="1" Margin="1">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -322,9 +518,10 @@
             </StackPanel>
 
             <CheckBox x:Name="chkCancelOperationInBringingIntoView" Content="Cancel Operation in BringingIntoView?" Grid.Row="10" Grid.ColumnSpan="2"/>
+            <CheckBox x:Name="chkIgnoreSnapPoints" Content="Ignore Snap Points?" IsChecked="True" Grid.Row="11" Grid.ColumnSpan="2"/>
 
             <Button x:Name="btnStartBringIntoView" Content="StartBringIntoView" Margin="1,4,1,1" 
-                Grid.Row="11" Grid.ColumnSpan="2" Click="BtnStartBringIntoView_Click" HorizontalAlignment="Stretch"/>
+                Grid.Row="12" Grid.ColumnSpan="2" Click="BtnStartBringIntoView_Click" HorizontalAlignment="Stretch"/>
         </Grid>
 
         <Grid Grid.Column="2" Margin="1" Background="LightYellow">


### PR DESCRIPTION
Part of Issue #264:

Adding SnapPointsMode read-write property to ScrollerBringingIntoViewEventArgs class so app can opt into applying snap points when a Scroller participates in a bring-into-view operation. The default behavior is unchanged as the SnapPointsMode is set to Ignore by default.