### PR TITLE
Turning off Microsoft Telemetry collection in private builds.

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -84,6 +84,12 @@ if "%1" == "/UseInternalSDK" (
     shift
     goto :MoreArguments
 )
+if "%1" == "/EmitTelemetryEvents" (
+    REM echo EmitTelemetryEvents
+    set EMITTELEMETRYEVENTS=1
+    shift
+    goto :MoreArguments
+)
 if "%1" == "/project" (
     set PROJECTPATH=%~2
     shift
@@ -117,6 +123,7 @@ if "%BUILDLEANMUXFORTHESTOREAPP%" == "1" ( set EXTRAMSBUILDPARAMS=/p:BuildLeanMu
 if "%MUXFINAL%" == "1" ( set EXTRAMSBUILDPARAMS=/p:MUXFinalRelease=true )
 if "%USEINSIDERSDK%" == "1" ( set EXTRAMSBUILDPARAMS=/p:UseInsiderSDK=true )
 if "%USEINTERNALSDK%" == "1" ( set EXTRAMSBUILDPARAMS=/p:UseInternalSDK=true )
+if "%EMITTELEMETRYEVENTS%" == "1" ( set EXTRAMSBUILDPARAMS=/p:EmitTelemetryEvents=true )
 
 REM Need an explicit full path to MSBuild.exe or it will fall back to 14.0 for some reason
 set MSBUILDPATH=%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe
@@ -173,6 +180,7 @@ echo        /leanmux - build lean mux for the store
 echo        /muxfinal - build "final" bits which have the winmd stripped of experimental types
 echo        /UseInsiderSDK - build using insider SDK
 echo        /UseInternalSDK - build using internal SDK
+echo        /EmitTelemetryEvents - build with telemetry events turned on
 echo        /project ^<path^> - builds a specific project
 echo.
 

--- a/dev/Telemetry/TraceLogging.cpp
+++ b/dev/Telemetry/TraceLogging.cpp
@@ -115,12 +115,12 @@ void WINAPI LoggingProviderEnabledCallback(
 
 void RegisterTraceLogging()
 {
-#ifndef DISABLE_ALL_TRACELOGGING
+    HRESULT hr = S_OK;
 
-#ifndef DISABLE_TELEMETRY_TRACELOGGING
+#ifdef EMIT_TELEMETRY_EVENTS
     TraceLoggingRegisterEx(g_hTelemetryProvider, TelemetryProviderEnabledCallback, nullptr);
     //Generate the ActivityId used to track the session
-    HRESULT hr = CoCreateGuid(&g_TelemetryProviderActivityId);
+    hr = CoCreateGuid(&g_TelemetryProviderActivityId);
     if (FAILED(hr))
     {
         TraceLoggingWriteActivity(
@@ -133,9 +133,8 @@ void RegisterTraceLogging()
 
         g_TelemetryProviderActivityId = GUID_NULL;
     };
-#endif // !DISABLE_TELEMETRY_TRACELOGGING
+#endif // EMIT_TELEMETRY_EVENTS
 
-#ifndef DISABLE_PERF_TRACELOGGING
     TraceLoggingRegisterEx(g_hPerfProvider, PerfProviderEnabledCallback, nullptr);
     //Generate the ActivityId used to track the session
     hr = CoCreateGuid(&g_PerfProviderActivityId);
@@ -150,9 +149,7 @@ void RegisterTraceLogging()
 
         g_PerfProviderActivityId = GUID_NULL;
     };
-#endif // !DISABLE_PERF_TRACELOGGING
 
-#ifndef DISABLE_DEBUG_TRACELOGGING
     TraceLoggingRegisterEx(g_hLoggingProvider, LoggingProviderEnabledCallback, nullptr);
     //Generate the ActivityId used to track the session
     hr = CoCreateGuid(&g_LoggingProviderActivityId);
@@ -167,26 +164,14 @@ void RegisterTraceLogging()
 
         g_LoggingProviderActivityId = GUID_NULL;
     };
-#endif // !DISABLE_DEBUG_TRACELOGGING
-
-#endif // !DISABLE_ALL_TRACELOGGING
 }
 
 void UnRegisterTraceLogging()
 {
-#ifndef DISABLE_ALL_TRACELOGGING
-
-#ifndef DISABLE_TELEMETRY_TRACELOGGING
+#ifdef EMIT_TELEMETRY_EVENTS
     TraceLoggingUnregister(g_hTelemetryProvider);
-#endif // !DISABLE_TELEMETRY_TRACELOGGING
+#endif // EMIT_TELEMETRY_EVENTS
 
-#ifndef DISABLE_PERF_TRACELOGGING
     TraceLoggingUnregister(g_hPerfProvider);
-#endif // !DISABLE_PERF_TRACELOGGING
-
-#ifndef DISABLE_DEBUG_TRACELOGGING
     TraceLoggingUnregister(g_hLoggingProvider);
-#endif // !DISABLE_DEBUG_TRACELOGGING
-
-#endif // !DISABLE_ALL_TRACELOGGING
 }

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -136,9 +136,11 @@ checks in order to pass on all versions.
 ## Telemetry
 
 This project collects usage data and sends it to Microsoft to help improve our 
-products and services.
+products and services. Note however that no data collection is performed by default
+when using your private builds. Data collection is indeed dependent on an 
+EMIT_TELEMETRY_EVENTS preprocessor definition.
 
-If desired you can disable logging when building the project by following these 
+If desired you can enable data collection when building the project by following these 
 steps:
 
 1. In Microsoft Visual Studio's Solution Explorer window, right-click the 
@@ -148,11 +150,6 @@ steps:
 4. Select "All Platforms" in the Platform dropdown.
 5. Select "Configuration Properties", then "C/C++", then "Preprocessor" in the 
 left tree structure.
-6. In the entry called "Preprocessor Definitions":
-    * Add "DISABLE_TELEMETRY_TRACELOGGING;" to disable Microsoft telemetry 
-    logging alone. 
-    * Add "DISABLE_PERF_TRACELOGGING;" to disable performance logging alone.
-    * Add "DISABLE_DEBUG_TRACELOGGING;" to disable debug logging alone.
-    * Or simply add "DISABLE_ALL_TRACELOGGING;" to disable all three types of logging.
+6. In the entry called "Preprocessor Definitions", add "EMIT_TELEMETRY_EVENTS;".
 7. Click the "Apply" button.
 8. Recompile the project.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -142,15 +142,9 @@ must be defined during the build for data collection to be turned on.
 
 When using the Build.cmd script, you can use its /EmitTelemetryEvents option to define
 that variable.
-Or when building in Visual Studio, you can first define the System variable by following
-these steps:
+Or when building in Visual Studio, you can first define the environment variable in a
+Command Prompt window and then launch the solution from there:
 
-1. Start the Settings application from the Windows Start menu.
-2. Click the 'System' option.
-3. Click the 'About' option.
-4. Click the 'System info' link.
-5. Click the 'Advanced system settings' link.
-6. Click the 'Environment Variables ...' button.
-7. Add the System Variable EmitTelemetryEvents with the Value true.
-8. Click the 'OK' button.
-9. Recompile the project.
+1. In a Command Prompt window, set the required environment variable: set EmitTelemetryEvents=true
+2. Then from that same Command Prompt, open the Visual Studio solution: MUXControls.sln
+3. Recompile the solution in Visual Studio. The build will use that environment variable.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -137,19 +137,20 @@ checks in order to pass on all versions.
 
 This project collects usage data and sends it to Microsoft to help improve our 
 products and services. Note however that no data collection is performed by default
-when using your private builds. Data collection is indeed dependent on an 
-EMIT_TELEMETRY_EVENTS preprocessor definition.
+when using your private builds. An environment variable called "EmitTelemetryEvents"
+must be defined during the build for data collection to be turned on.
 
-If desired you can enable data collection when building the project by following these 
-steps:
+When using the Build.cmd script, you can use its /EmitTelemetryEvents option to define
+that variable.
+Or when building in Visual Studio, you can first define the System variable by following
+these steps:
 
-1. In Microsoft Visual Studio's Solution Explorer window, right-click the 
-"Microsoft.UI.Xaml (Universal Windows)" project. 
-2. Select the "Properties" menu.
-3. Select "All Configurations" in the Configuration dropdown.
-4. Select "All Platforms" in the Platform dropdown.
-5. Select "Configuration Properties", then "C/C++", then "Preprocessor" in the 
-left tree structure.
-6. In the entry called "Preprocessor Definitions", add "EMIT_TELEMETRY_EVENTS;".
-7. Click the "Apply" button.
-8. Recompile the project.
+1. Start the Settings application from the Windows Start menu.
+2. Click the 'System' option.
+3. Click the 'About' option.
+4. Click the 'System info' link.
+5. Click the 'Advanced system settings' link.
+6. Click the 'Environment Variables ...' button.
+7. Add the System Variable EmitTelemetryEvents with the Value true.
+8. Click the 'OK' button.
+9. Recompile the project.

--- a/environment.props
+++ b/environment.props
@@ -59,6 +59,9 @@
   <PropertyGroup Condition="$(UseInternalSDK) == 'true'">
     <DefineConstants>$(DefineConstants);USE_INTERNAL_SDK</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(EmitTelemetryEvents) == 'true'">
+    <DefineConstants>$(DefineConstants);EMIT_TELEMETRY_EVENTS</DefineConstants>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="$(BuildLeanMuxForTheStoreApp) == 'true'">
     <ClCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BUILD_LEAN_MUX_FOR_THE_STORE_APP</PreprocessorDefinitions>
@@ -82,6 +85,11 @@
     <Midl>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);USE_INSIDER_SDK</PreprocessorDefinitions>
     </Midl>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="$(EmitTelemetryEvents) == 'true'">
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);EMIT_TELEMETRY_EVENTS</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="$(BuildingWithBuildExe) == 'true'">
     <ClCompile>


### PR DESCRIPTION
Bug 20661722:

First step for turning off Microsoft Telemetry collection in private builds:
 - emissions with the MICROSOFT_KEYWORD_MEASURES flag are only turned on when the new EMIT_TELEMETRY_EVENTS preprocessor directive is defined.
 - removed the old DISABLE_ALL_TRACELOGGING, DISABLE_TELEMETRY_TRACELOGGING, DISABLE_PERF_TRACELOGGING, DISABLE_DEBUG_TRACELOGGING usage as the collected emissions are now turned off by default.
 - using Build.cmd /EmitTelemetryEvents  creates the EMITTELEMETRYEVENTS environment variable, and causes the EMIT_TELEMETRY_EVENTS preprocessor directive to be defined.

Next step: have official builds use the new EMITTELEMETRYEVENTS environment variable.