### PR TITLE
Make NuGet feed a queue time variable

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -41,8 +41,9 @@ jobs:
   parameters:
     jobName: CreateNugetPackage
     dependsOn: Build
+    # To publish the package to vsts feed, set queue time variable NuGetFeed = d62f8eac-f05c-4c25-bccb-21f98b95c95f
     # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
-    publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
+    publishVstsFeed: $(NuGetFeed)
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml


### PR DESCRIPTION
WinUI-MUX-CI-Experiments pipeline is using the same MUX-CI.yml as the CI pipeline, and it's publishing NuGet package to the same feed, which causes name collisions.

Added a queue time variable `NuGetFeed`, updated the variable in CI pipeline to use the existing feed. Experiments pipeline NuGetFeed is set to null so it won't publish the generated packages.