### PR TITLE
If both PaneHeader and PaneTitle are set, use PaneHeader

### DIFF
--- a/dev/Generated/MetadataSummary.cs
+++ b/dev/Generated/MetadataSummary.cs
@@ -264,6 +264,7 @@ namespace CustomTasks
             NeedsPropChangedCallbackMetadata["NavigationView.OverflowLabelMode"] = true;
             NeedsPropChangedCallbackMetadata["NavigationView.PaneDisplayMode"] = true;
             NeedsPropChangedCallbackMetadata["NavigationView.PaneFooter"] = true;
+            NeedsPropChangedCallbackMetadata["NavigationView.PaneHeader"] = true;
             NeedsPropChangedCallbackMetadata["NavigationView.PaneTitle"] = true;
             NeedsPropChangedCallbackMetadata["NavigationView.PaneToggleButtonStyle"] = true;
             NeedsPropChangedCallbackMetadata["NavigationView.SelectedItem"] = true;

--- a/dev/Generated/NavigationView.properties.cpp
+++ b/dev/Generated/NavigationView.properties.cpp
@@ -353,7 +353,7 @@ void NavigationViewProperties::EnsureProperties()
                 winrt::name_of<winrt::NavigationView>(),
                 false /* isAttached */,
                 ValueHelper<winrt::UIElement>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnPropertyChanged));
     }
     if (!s_PaneTitleProperty)
     {

--- a/dev/Generated/NavigationViewTemplateSettings.properties.cpp
+++ b/dev/Generated/NavigationViewTemplateSettings.properties.cpp
@@ -11,6 +11,7 @@ CppWinRTActivatableClassWithDPFactory(NavigationViewTemplateSettings)
 GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_BackButtonVisibilityProperty{ nullptr };
 GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_LeftPaneVisibilityProperty{ nullptr };
 GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_OverflowButtonVisibilityProperty{ nullptr };
+GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_PaneTitleProperty{ nullptr };
 GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_PaneToggleButtonVisibilityProperty{ nullptr };
 GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_SingleSelectionFollowsFocusProperty{ nullptr };
 GlobalDependencyProperty NavigationViewTemplateSettingsProperties::s_TopPaddingProperty{ nullptr };
@@ -54,6 +55,17 @@ void NavigationViewTemplateSettingsProperties::EnsureProperties()
                 winrt::name_of<winrt::NavigationViewTemplateSettings>(),
                 false /* isAttached */,
                 ValueHelper<winrt::Visibility>::BoxValueIfNecessary(winrt::Visibility::Collapsed),
+                nullptr);
+    }
+    if (!s_PaneTitleProperty)
+    {
+        s_PaneTitleProperty =
+            InitializeDependencyProperty(
+                L"PaneTitle",
+                winrt::name_of<winrt::hstring>(),
+                winrt::name_of<winrt::NavigationViewTemplateSettings>(),
+                false /* isAttached */,
+                ValueHelper<winrt::hstring>::BoxedDefaultValue(),
                 nullptr);
     }
     if (!s_PaneToggleButtonVisibilityProperty)
@@ -107,6 +119,7 @@ void NavigationViewTemplateSettingsProperties::ClearProperties()
     s_BackButtonVisibilityProperty = nullptr;
     s_LeftPaneVisibilityProperty = nullptr;
     s_OverflowButtonVisibilityProperty = nullptr;
+    s_PaneTitleProperty = nullptr;
     s_PaneToggleButtonVisibilityProperty = nullptr;
     s_SingleSelectionFollowsFocusProperty = nullptr;
     s_TopPaddingProperty = nullptr;
@@ -141,6 +154,16 @@ void NavigationViewTemplateSettingsProperties::OverflowButtonVisibility(winrt::V
 winrt::Visibility NavigationViewTemplateSettingsProperties::OverflowButtonVisibility()
 {
     return ValueHelper<winrt::Visibility>::CastOrUnbox(static_cast<NavigationViewTemplateSettings*>(this)->GetValue(s_OverflowButtonVisibilityProperty));
+}
+
+void NavigationViewTemplateSettingsProperties::PaneTitle(winrt::hstring const& value)
+{
+    static_cast<NavigationViewTemplateSettings*>(this)->SetValue(s_PaneTitleProperty, ValueHelper<winrt::hstring>::BoxValueIfNecessary(value));
+}
+
+winrt::hstring NavigationViewTemplateSettingsProperties::PaneTitle()
+{
+    return ValueHelper<winrt::hstring>::CastOrUnbox(static_cast<NavigationViewTemplateSettings*>(this)->GetValue(s_PaneTitleProperty));
 }
 
 void NavigationViewTemplateSettingsProperties::PaneToggleButtonVisibility(winrt::Visibility const& value)

--- a/dev/Generated/NavigationViewTemplateSettings.properties.h
+++ b/dev/Generated/NavigationViewTemplateSettings.properties.h
@@ -18,6 +18,9 @@ public:
     void OverflowButtonVisibility(winrt::Visibility const& value);
     winrt::Visibility OverflowButtonVisibility();
 
+    void PaneTitle(winrt::hstring const& value);
+    winrt::hstring PaneTitle();
+
     void PaneToggleButtonVisibility(winrt::Visibility const& value);
     winrt::Visibility PaneToggleButtonVisibility();
 
@@ -33,6 +36,7 @@ public:
     static winrt::DependencyProperty BackButtonVisibilityProperty() { return s_BackButtonVisibilityProperty; }
     static winrt::DependencyProperty LeftPaneVisibilityProperty() { return s_LeftPaneVisibilityProperty; }
     static winrt::DependencyProperty OverflowButtonVisibilityProperty() { return s_OverflowButtonVisibilityProperty; }
+    static winrt::DependencyProperty PaneTitleProperty() { return s_PaneTitleProperty; }
     static winrt::DependencyProperty PaneToggleButtonVisibilityProperty() { return s_PaneToggleButtonVisibilityProperty; }
     static winrt::DependencyProperty SingleSelectionFollowsFocusProperty() { return s_SingleSelectionFollowsFocusProperty; }
     static winrt::DependencyProperty TopPaddingProperty() { return s_TopPaddingProperty; }
@@ -41,6 +45,7 @@ public:
     static GlobalDependencyProperty s_BackButtonVisibilityProperty;
     static GlobalDependencyProperty s_LeftPaneVisibilityProperty;
     static GlobalDependencyProperty s_OverflowButtonVisibilityProperty;
+    static GlobalDependencyProperty s_PaneTitleProperty;
     static GlobalDependencyProperty s_PaneToggleButtonVisibilityProperty;
     static GlobalDependencyProperty s_SingleSelectionFollowsFocusProperty;
     static GlobalDependencyProperty s_TopPaddingProperty;

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -2598,6 +2598,11 @@ void NavigationView::OnPropertyChanged(const winrt::DependencyPropertyChangedEve
     else if (property == s_PaneTitleProperty)
     {
         UpdatePaneToggleSize();
+        UpdatePaneTitleInTemplateSettings();
+    }
+    else if (property == s_PaneHeaderProperty)
+    {
+        UpdatePaneTitleInTemplateSettings();
     }
     else if (property == s_IsBackButtonVisibleProperty)
     {
@@ -3318,6 +3323,13 @@ void NavigationView::UpdateTitleBarPadding()
             GetTemplateSettings()->TopPadding(topPadding);
         }
     }
+}
+
+void NavigationView::UpdatePaneTitleInTemplateSettings()
+{
+    // PaneTitle is introduced in RS4, but it's a string, PaneHeader would deprecate PaneTitle
+    // Make TemplateSettings.PaneTitle to empty when PaneHeader exists.
+    GetTemplateSettings()->PaneTitle(PaneHeader() ? L"" : PaneTitle());
 }
 
 void NavigationView::UpdateSelectedItem()

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -191,6 +191,7 @@ private:
     void OnTitleBarMetricsChanged(const winrt::IInspectable& sender, const winrt::IInspectable& args);
     void OnTitleBarIsVisibleChanged(const winrt::CoreApplicationViewTitleBar& sender, const winrt::IInspectable& args);
     void UpdateTitleBarPadding();
+    void UpdatePaneTitleInTemplateSettings();
 
     void RaiseDisplayModeChanged(const winrt::NavigationViewDisplayMode& displayMode);
     void AnimateSelectionChanged(const winrt::IInspectable& lastItem, const winrt::IInspectable& currentItem);

--- a/dev/NavigationView/NavigationView.idl
+++ b/dev/NavigationView/NavigationView.idl
@@ -1,4 +1,4 @@
-[WUXC_VERSION_RS3]
+﻿[WUXC_VERSION_RS3]
 [webhosthidden]
 enum NavigationViewDisplayMode
 {
@@ -135,6 +135,12 @@ unsealed runtimeclass NavigationViewTemplateSettings : Windows.UI.Xaml.Dependenc
     static Windows.UI.Xaml.DependencyProperty TopPaneVisibilityProperty { get; };
     static Windows.UI.Xaml.DependencyProperty LeftPaneVisibilityProperty { get; };
     static Windows.UI.Xaml.DependencyProperty SingleSelectionFollowsFocusProperty { get; };
+
+    [WUXC_VERSION_MUXONLY]
+    {
+        String PaneTitle{ get; };
+        static Windows.UI.Xaml.DependencyProperty PaneTitleProperty{ get; };
+    }
 }
 
 [WUXC_VERSION_RS3]
@@ -234,7 +240,7 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
     {
         [MUX_DEFAULT_VALUE("winrt::NavigationViewPaneDisplayMode::Auto")]
         NavigationViewPaneDisplayMode PaneDisplayMode { get; set; };
-        [MUX_PROPERTY_CHANGED_CALLBACK(FALSE)]
+        [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
         Windows.UI.Xaml.UIElement PaneHeader { get; set; };
         [MUX_PROPERTY_CHANGED_CALLBACK(FALSE)]
         Windows.UI.Xaml.UIElement PaneCustomContent { get; set; };

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -180,7 +180,7 @@
                                     <TextBlock
                                         x:Name="PaneTitleTextBlock" 
                                         Grid.Column="0"
-                                        Text="{TemplateBinding PaneTitle}"
+                                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.PaneTitle}"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
                                         Style="{StaticResource NavigationViewItemHeaderTextStyle}"/>

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -2844,6 +2844,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "C")]
+        public void VerifyPaneTitleIsEmptyWhenPaneHeaderIsSet()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+            {
+                TextBlock paneTitleTextBlock = new TextBlock(FindElement.ByName("NavView Test"));
+
+                Verify.AreNotEqual("", paneTitleTextBlock.DocumentText, "Verify that the pane title is not empty");
+
+                Button changePaneTitleButton = new Button(FindElement.ByName("ChangePaneHeader"));
+                changePaneTitleButton.Invoke();
+                Wait.ForIdle();
+
+                Verify.AreEqual("", paneTitleTextBlock.DocumentText, "Verify that the pane title is empty");
+            }
+        }
 
         [TestMethod]
         [TestProperty("NavViewTestSuite", "C")]


### PR DESCRIPTION
PaneTitle is just a string, and we introduced PaneHeader to replace it. If both are set, use PaneHeader.