### PR TITLE
Make sure we do not devirtualize when uniform grid layout is flowing in scroll direction

### DIFF
--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -433,9 +433,20 @@ bool FlowLayoutAlgorithm::ShouldContinueFillingUpSpace(
     {
         auto realizationRect = m_context.get().RealizationRect();
         auto elementBounds = m_elementManager.GetLayoutBoundsForDataIndex(index);
+
+        auto elementMajorStart = elementBounds.*MajorStart();
+        auto elementMajorEnd = MajorEnd(elementBounds);
+        auto rectMajorStart = realizationRect.*MajorStart();
+        auto rectMajorEnd = MajorEnd(realizationRect);
+
+        auto elementMinorStart = elementBounds.*MinorStart();
+        auto elementMinorEnd = MinorEnd(elementBounds);
+        auto rectMinorStart = realizationRect.*MinorStart();
+        auto rectMinorEnd = MinorEnd(realizationRect);
+
         shouldContinue =
-            (direction == GenerateDirection::Forward && elementBounds.*MajorStart() < MajorEnd(realizationRect)) ||
-            (direction == GenerateDirection::Backward && MajorEnd(elementBounds) > realizationRect.*MajorStart());
+            (direction == GenerateDirection::Forward && elementMajorStart < rectMajorEnd && elementMinorStart < rectMinorEnd) ||
+            (direction == GenerateDirection::Backward && elementMajorEnd > rectMajorStart && elementMinorEnd > rectMinorStart);
     }
 
     return shouldContinue;

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -444,6 +444,8 @@ bool FlowLayoutAlgorithm::ShouldContinueFillingUpSpace(
         auto rectMinorStart = realizationRect.*MinorStart();
         auto rectMinorEnd = MinorEnd(realizationRect);
 
+        // Ensure that both minor and major directions are taken into consideration so that if the scrolling direction
+        // is the same as the flow direction we still stop at the end of the viewport rectangle.
         shouldContinue =
             (direction == GenerateDirection::Forward && elementMajorStart < rectMajorEnd && elementMinorStart < rectMinorEnd) ||
             (direction == GenerateDirection::Backward && elementMajorEnd > rectMajorStart && elementMinorEnd > rectMinorStart);

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -261,6 +261,7 @@ void ViewportManagerWithPlatformFeatures::OnCacheBuildActionCompleted()
 
 void ViewportManagerWithPlatformFeatures::OnEffectiveViewportChanged(winrt::FrameworkElement const& sender, winrt::EffectiveViewportChangedEventArgs const& args)
 {
+    REPEATER_TRACE_INFO(L"%ls: \tEffectiveViewportChanged event callback \n", GetLayoutId().data());
     UpdateViewport(args.EffectiveViewport());
 
     m_pendingViewportShift = {};


### PR DESCRIPTION
When the scroll orientation is the same as uniform grid's flow orientation, we should make sure that we don't end up devirtualizing.

Issue #407 