### PR TITLE
Ensure column is reevaluated even when we get a valid anchor

### DIFF
--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -177,7 +177,17 @@ int FlowLayoutAlgorithm::GetAnchorIndex(
             if (m_elementManager.IsDataIndexRealized(anchorIndex))
             {
                 auto anchorBounds = m_elementManager.GetLayoutBoundsForDataIndex(anchorIndex);
-                anchorPosition = winrt::Point(anchorBounds.X, anchorBounds.Y);
+                if (needAnchorColumnRevaluation)
+                {
+                    // We were provided a valid anchor, but its position might be incorrect because for example it is in
+                    // the wrong column. We do know that the anchor is the first element in the row, so we can force the minor position
+                    // to start at 0.
+                    anchorPosition = MinorMajorPoint(0, anchorBounds.*MajorStart());
+                }
+                else
+                {
+                    anchorPosition = winrt::Point(anchorBounds.X, anchorBounds.Y);
+                }
             }
             else
             {

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -148,7 +148,6 @@ int FlowLayoutAlgorithm::GetAnchorIndex(
     {
         // Non virtualizing host, start generating from the element 0
         anchorIndex = m_context.get().ItemCountCore() > 0 ? 0 : -1;
-        //anchorPosition = default(Point);
     }
     else
     {


### PR DESCRIPTION
When we got a valid anchor from repeater, we used to start off of its bounds to lay everything else out. When the window is getting resized especially in uniform grid layout, it is possible for us to get into the situation where we get a valid anchor element but its bounds are no longer accurate because the window size changed and it might need to go to a new column. So Blindly using the previous bounds when the size changes can cause issues leading to some weird layout. There is a requirement in flow layout algorithm that we always pick an anchor that is in the start of the line, so we could set its minor position to 0 to avoid this situation. I don't have a test for this change since it is quite hard to simulate this situation and involves a bit of timing.

Issue #403