### PR TITLE
Fix NuGetFeed variable check

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -43,7 +43,8 @@ jobs:
     dependsOn: Build
     # To publish the package to vsts feed, set queue time variable NuGetFeed = d62f8eac-f05c-4c25-bccb-21f98b95c95f
     # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
-    publishVstsFeed: $(NuGetFeed)
+    ${{ if ne(variables['NuGetFeed'], '') }}:
+      publishVstsFeed: $(NuGetFeed)
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml


### PR DESCRIPTION
Follow up fix for #388. We added a queue time variable `NuGetFeed` in that PR, but when the variable is not set, it's passing raw the string `$(NuGetFeed)` to `publishVstsFeed` instead of null, which breaks MUX-CI-Experiments pipeline since we don't set NuGetFeed there. Create a PR for the fix to unblock people from using the experiments pipeline.