### PR TITLE
Fix TreeViewItem left padding

### DIFF
--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -2589,7 +2589,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         private void TapOnFlyoutTreeViewRootItemChevron()
         {
-            TapOnTreeViewAt(40, 20, "GetFlyoutItemCount");
+            // Chevron has 12px left padding, and it's 12px wide. 
+            // 18 is the center point of chevron.
+            TapOnTreeViewAt(18, 20, "GetFlyoutItemCount");
         }
 
         private UIObject LabelFirstItem()

--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -323,7 +323,7 @@
                                                                 </VisualState>
                                                             </VisualStateGroup>
                                                         </VisualStateManager.VisualStateGroups>
-                                                        <Grid VerticalAlignment="Stretch">
+                                                        <Grid VerticalAlignment="Stretch" HorizontalAlignment="Right">
                                                             <Rectangle x:Name="NormalRectangle"
                                                                 VerticalAlignment="Center" HorizontalAlignment="Center"
                                                                 Fill="{ThemeResource CheckBoxCheckBackgroundFillUnchecked}"

--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -103,7 +103,7 @@
                                 <VisualState x:Name="NotDragging" />
                                 <VisualState x:Name="MultipleDraggingPrimary">
                                     <VisualState.Setters>
-                                        <Setter Target="MultiArrangeOverlayTextBorder.Opacity" Value="1" />
+                                        <Setter Target="MultiArrangeOverlayTextBorder.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -354,7 +354,7 @@
                                             IsTabStop="False"
                                             AutomationProperties.AccessibilityView="Raw"/>
                                 <Border x:Name="MultiArrangeOverlayTextBorder"
-                                    Opacity="0"
+                                    Visibility="Collapsed"
                                     IsHitTestVisible="False"
                                     MinWidth="20"
                                     Height="20"

--- a/dev/TreeView/TreeViewItem_rs1.xaml
+++ b/dev/TreeView/TreeViewItem_rs1.xaml
@@ -230,7 +230,7 @@
                                                             </VisualState>
                                                         </VisualStateGroup>
                                                     </VisualStateManager.VisualStateGroups>
-                                                    <Grid VerticalAlignment="Stretch">
+                                                    <Grid VerticalAlignment="Stretch" HorizontalAlignment="Right">
                                                         <Rectangle x:Name="NormalRectangle" VerticalAlignment="Center" HorizontalAlignment="Center"
                                                         Fill="{ThemeResource CheckBoxCheckBackgroundFillUnchecked}"
                                                         Stroke="{ThemeResource CheckBoxCheckBackgroundStrokeUnchecked}"

--- a/dev/TreeView/TreeViewItem_rs1.xaml
+++ b/dev/TreeView/TreeViewItem_rs1.xaml
@@ -98,7 +98,7 @@
                                 <VisualState x:Name="NotDragging" />
                                 <VisualState x:Name="MultipleDraggingPrimary">
                                     <VisualState.Setters>
-                                        <Setter Target="MultiArrangeOverlayTextBorder.Opacity" Value="1" />
+                                        <Setter Target="MultiArrangeOverlayTextBorder.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -267,7 +267,7 @@
                                             IsTabStop="False"
                                             AutomationProperties.AccessibilityView="Raw" />
                                 <Border x:Name="MultiArrangeOverlayTextBorder"
-                                    Opacity="0"
+                                    Visibility="Collapsed"
                                     IsHitTestVisible="False"
                                     MinWidth="20"
                                     Height="20"


### PR DESCRIPTION
Fixes #380

MultiArrangeOverlayText is used to show the number indicator when dragging multiple items, we set opacity to 0 when we want to hide it, but it's still taking up the space.

Setting visibility to Collapsed now so it doesn't leave footprint when it's supposed to be gone.

Also, per figma file below, we want 12px left and right paddings around CheckBox. Currently the CheckBox root grid is 32px and the rectangle is 20px, center aligned, which creates 6px left and right paddings. Chevron itself has 12px left padding, so currently CheckBox has 6px left padding and 18px right padding in total. Updated the rectangle grid to be right aligned to its parent, which gives us 12px left padding and 0 right padding. Plus the 12px chevron left padding, we got 12px left and right paddings around the CheckBox.

![image](https://user-images.githubusercontent.com/20667023/54157845-61a1d880-4406-11e9-9485-e5f4de70928f.png)

Before/after comparison:

![before-no-checkbox](https://user-images.githubusercontent.com/4424330/54459282-7f7f7e00-4723-11e9-8ea8-1739d8c11258.jpg) ![after-no-checkbox](https://user-images.githubusercontent.com/4424330/54459299-8ad2a980-4723-11e9-89e3-f0fe71097459.jpg)

![before-with-checkbox](https://user-images.githubusercontent.com/4424330/54459302-8dcd9a00-4723-11e9-9e6a-08b44e25354d.jpg) ![after-with-checkbox](https://user-images.githubusercontent.com/4424330/54462681-d722e700-472d-11e9-9ade-76a2d0d7d7b3.jpg)


