### PR TITLE
Adding an animated scroll sample using repeater and scale animation

### DIFF
--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -29,6 +29,7 @@
             <Button x:Name="pinterestLayoutDemo">Pinterest Layout Demo</Button>
             <Button x:Name="flowLayoutDemo">Flow Layout Demo</Button>
             <Button x:Name="storeDemo">Store demo</Button>
+            <Button x:Name="animatedScrollDemo">Animated scroll demo</Button>
             <TextBlock>Selection Demo</TextBlock>
             <StackPanel Orientation="Horizontal">
                 <Button x:Name="flatSelectionDemo">Flat</Button>

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
@@ -106,6 +106,10 @@ namespace MUXControlsTestApp
                 Frame.NavigateWithoutAnimation(typeof(MUXControlsTestApp.Samples.Selection.TreeViewSample));
             };
 
+            animatedScrollDemo.Click += delegate {
+                Frame.NavigateWithoutAnimation(typeof(MUXControlsTestApp.Samples.ScaleAnimatedVerticalListDemo));
+            };
+
             noGroupingList.Click += delegate
             {
                 Frame.NavigateWithoutAnimation(typeof(ItemsViewWithDataPage),

--- a/dev/Repeater/TestUI/Repeater_TestUI.projitems
+++ b/dev/Repeater/TestUI/Repeater_TestUI.projitems
@@ -57,6 +57,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Samples\ScaleAnimatedVerticalListDemo.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Samples\Selection\Flat\FlatSample.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -117,6 +121,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Samples\ItemTemplateSamples\ItemTemplateDemo.xaml.cs">
       <DependentUpon>ItemTemplateDemo.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Samples\ScaleAnimatedVerticalListDemo.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\StackLayoutSamples\NonVirtual\NonVirtualStackLayoutSamplePage.xaml.cs">
       <DependentUpon>NonVirtualStackLayoutSamplePage.xaml</DependentUpon>
     </Compile>
@@ -185,5 +190,10 @@
     <Content Include="$(MSBuildThisFileDirectory)Images\recipe6.png" />
     <Content Include="$(MSBuildThisFileDirectory)Images\recipe7.png" />
     <Content Include="$(MSBuildThisFileDirectory)Images\recipe8.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="S:\Source\GitRepos\microsoft-ui-xaml2\dev\Repeater\TestUI\Samples\ScaleAnimatedVerticalListDemo.xaml.cs">
+      <DependentUpon>ScaleAnimatedVerticalListDemo.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/dev/Repeater/TestUI/Samples/ScaleAnimatedVerticalListDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/ScaleAnimatedVerticalListDemo.xaml
@@ -1,0 +1,21 @@
+﻿<Page
+    x:Class="MUXControlsTestApp.Samples.ScaleAnimatedVerticalListDemo"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <ScrollViewer x:Name="sv" Width="200" Height="150"  VerticalScrollBarVisibility="Hidden">
+            <mux:ItemsRepeater x:Name="repeater">
+                <mux:ItemsRepeater.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel>
+                            <Button Content="{Binding}" Height="30" Width="200" Click="OnItemClicked"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </mux:ItemsRepeater.ItemTemplate>
+            </mux:ItemsRepeater>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/dev/Repeater/TestUI/Samples/ScaleAnimatedVerticalListDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/ScaleAnimatedVerticalListDemo.xaml
@@ -6,13 +6,11 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <ScrollViewer x:Name="sv" Width="200" Height="150"  VerticalScrollBarVisibility="Hidden">
+        <ScrollViewer x:Name="sv" Width="200" Height="150" >
             <mux:ItemsRepeater x:Name="repeater">
                 <mux:ItemsRepeater.ItemTemplate>
                     <DataTemplate>
-                        <StackPanel>
-                            <Button Content="{Binding}" Height="30" Width="200" Click="OnItemClicked"/>
-                        </StackPanel>
+                        <Button Content="{Binding}" Click="OnItemClicked" GotFocus="OnItemGotFocus" HorizontalAlignment="Stretch"/>
                     </DataTemplate>
                 </mux:ItemsRepeater.ItemTemplate>
             </mux:ItemsRepeater>

--- a/dev/Repeater/TestUI/Samples/ScaleAnimatedVerticalListDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ScaleAnimatedVerticalListDemo.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Hosting;
+
+namespace MUXControlsTestApp.Samples
+{
+    public sealed partial class ScaleAnimatedVerticalListDemo : Page
+    {
+        public ScaleAnimatedVerticalListDemo()
+        {
+            this.InitializeComponent();
+            repeater.ItemsSource = Enumerable.Range(0, 100);
+            repeater.ElementPrepared += OnElementPrepared;
+        }
+
+        private void OnElementPrepared(Microsoft.UI.Xaml.Controls.ItemsRepeater sender, Microsoft.UI.Xaml.Controls.ItemsRepeaterElementPreparedEventArgs args)
+        {
+            var item = ElementCompositionPreview.GetElementVisual(args.Element);
+            var scrollProperties = ElementCompositionPreview.GetScrollViewerManipulationPropertySet(sv);
+            var scaleExpresion = scrollProperties.Compositor.CreateExpressionAnimation();
+
+            scaleExpresion.SetReferenceParameter("sv", scrollProperties);
+            scaleExpresion.SetReferenceParameter("item", item);
+            scaleExpresion.SetScalarParameter("svHeight", 150);
+            scaleExpresion.SetScalarParameter("itemHeight", 30);
+
+            scaleExpresion.Expression = "1 - abs((svHeight/2 - sv.Translation.Y) - (item.Offset.Y + itemHeight/2))*(.25/(svHeight/2))";
+
+
+            item.StartAnimation("Scale.X", scaleExpresion);
+            item.StartAnimation("Scale.Y", scaleExpresion);
+
+            var itemContent = ElementCompositionPreview.GetElementVisual((args.Element as Panel).Children[0]);
+
+            var offsetAnimation = scrollProperties.Compositor.CreateExpressionAnimation();
+            offsetAnimation.SetReferenceParameter("sv", scrollProperties);
+            offsetAnimation.SetReferenceParameter("item", item);
+            offsetAnimation.SetScalarParameter("svHeight", 150);
+            offsetAnimation.SetScalarParameter("itemHeight", 30);
+            offsetAnimation.SetScalarParameter("itemWidth", 200);
+
+            offsetAnimation.Expression = "abs((svHeight/2 - sv.Translation.Y) - (item.Offset.Y + itemHeight/2)) * itemWidth * (.18/(svHeight/2)) ";
+            itemContent.StartAnimation("Offset.X", offsetAnimation);
+        }
+
+        private void OnItemClicked(object sender, RoutedEventArgs e)
+        {
+            var button = sender as FrameworkElement;
+            var item = button.Parent as UIElement;
+
+            item.StartBringIntoView(new BringIntoViewOptions() {
+                VerticalAlignmentRatio = 0.5,
+                AnimationDesired = true,
+            });
+
+        }
+    }
+}


### PR DESCRIPTION
Adding a sample that I created a while ago to the repo that shows animations while scrolling to create a fancy looking list. 

[video.zip](https://github.com/Microsoft/microsoft-ui-xaml/files/2973581/video.zip)

Couple of hickups i hit while creating this.
1. scale animations don't seem to have an easy way to say scale origin as center. So as we scale down, we need to offset the item as well to keep it centered.
2. offset cannot be animated on a panel which is doing layout on the items. That means the containers offset cannot be animated - we need another element so that the offset works.