### PR TITLE
Change release pipeline to use hosted agents for build

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -29,7 +29,7 @@ jobs:
       displayName: 'XESSetupBuild'
       inputs:
         productName: dep.controls
-        branchVersion: true
+        branchVersion: false
         nugetVer: true
 
   - template: MUX-PopulateBuildDateAndRevision-Steps.yml

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -24,12 +24,9 @@ jobs:
         buildConfiguration: 'Release'
 
   variables:
-  - name: appxPackageDir
-    value: $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
-  - name: buildOutputDir
-    value: $(Build.SourcesDirectory)\BuildOutput
-  - name: publishDir
-    value: $(Build.ArtifactStagingDirectory)
+    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+    publishDir : $(Build.ArtifactStagingDirectory)
 
   steps:
   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -9,10 +9,12 @@ jobs:
     displayName: 'Component Detection'
 
 - job: Build
+  # Skip the build job if we are reusing the output of a previous build.
+  # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
+  condition:
+    eq(variables['useBuildOutputFromBuildId'],'') 
   pool:
-    name: Package ES Custom Demands Lab A
-    demands:
-      - ClientAlias -equals depcontrols2
+    vmImage: 'VS2017-Win2016'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10
@@ -31,42 +33,87 @@ jobs:
         buildConfiguration: 'Release'
 
   variables:
-  - name: appxPackageDir
-    value: $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
-  - name: buildOutputDir
-    value: $(Build.BinariesDirectory)
-  - name: publishDir
-    value: $(Build.ArtifactStagingDirectory)
+    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+    publishDir : $(Build.ArtifactStagingDirectory)
+
+  steps:
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+
+  - template: AzurePipelinesTemplates\MUX-PublishDevProject-Steps.yml
+
+- job: SignBinariesAndPublishSymbols
+  dependsOn: Build
+  condition:
+    in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+  pool:
+    name: Package ES Custom Demands Lab A
+    demands:
+      - ClientAlias -equals depcontrols2
 
   steps:
   - task: PkgESSetupBuild@10
     displayName: 'XESSetupBuild'
     inputs:
       productName: dep.controls
-      branchVersion: true
+      branchVersion: false
       nugetVer: true
 
-  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+  - task: DownloadBuildArtifacts@0 
+    condition:
+      eq(variables['useBuildOutputFromBuildId'],'')
+    inputs: 
+      artifactName: drop 
+      downloadPath: '$(Build.ArtifactStagingDirectory)'
+
+  - task: DownloadBuildArtifacts@0 
+    condition:
+      ne(variables['useBuildOutputFromBuildId'],'')
+    inputs: 
+      buildType: specific
+      buildVersionToDownload: specific
+      project: 'f05f4dbf-3077-427d-91e0-b66d9e4ca374'
+      pipeline: 35915
+      buildId: $(useBuildOutputFromBuildId)
+      artifactName: drop 
+      downloadPath: '$(Build.ArtifactStagingDirectory)'
+
+  - task: CmdLine@1
+    displayName: 'Display build machine environment variables'
+    inputs:
+      filename: 'set'
+
+  - script: cmd /c dir /s /b $(Build.ArtifactStagingDirectory)
+    displayName: Dump artifact staging directory
+
+  - template: AzurePipelinesTemplates\MUX-PopulateBuildDateAndRevision-Steps.yml
+
+  - task: powershell@2
+    inputs:
+      targetType: filePath
+      filePath: $(Build.SourcesDirectory)\tools\PublishSymbols\PublishSymbols.ps1
+      arguments: -localDirectory "$(Build.ArtifactStagingDirectory)\drop" -Verbose
+    displayName: 'Publish Symbols'
 
   - task: PkgESCodeSign@10
     displayName: CodeSign
     inputs:
       signConfigXml: '$(Build.SourcesDirectory)\build\SignConfig.xml'
-      inPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)'
-      outPathRoot: '$(buildOutputDir)\$(buildConfiguration)\$(buildPlatform)\signed'
+      inPathRoot: '$(Build.ArtifactStagingDirectory)\drop'
+      outPathRoot: '$(Build.ArtifactStagingDirectory)\drop'
 
-  - task: CmdLine@1
-    displayName: 'Publish Symbol'
+  # Re-publish signed artifacts to the drop.
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish artifact: drop'
     inputs:
-      filename: '$(Build.SourcesDirectory)\tools\PublishSymbols\PublishSymbols.cmd'      
-
-  - template: AzurePipelinesTemplates\MUX-PublishDevProject-Steps.yml
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\drop'
+      artifactName: 'drop'
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
   parameters:
     jobName: CreateNugetPackage
-    dependsOn: Build
+    dependsOn: SignBinariesAndPublishSymbols
     # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
     # publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -114,8 +114,6 @@ jobs:
   parameters:
     jobName: CreateNugetPackage
     dependsOn: SignBinariesAndPublishSymbols
-    # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
-    # publishVstsFeed: 'd62f8eac-f05c-4c25-bccb-21f98b95c95f'
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
  
 # Build solution that depends on nuget package

--- a/build/SignConfig.xml
+++ b/build/SignConfig.xml
@@ -2,7 +2,13 @@
 <SignConfigXML>
   <job platform="" configuration="" dest="__INPATHROOT__" jobname="dep.controls" approvers="">
     <!-- Overwrite the input files to simplify downstream things like nuget and framework package generation. -->
-    <file src="__INPATHROOT__\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" signType="AuthenticodeFormer" dest="__INPATHROOT__\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" />
-    <file src="__INPATHROOT__\Microsoft.UI.Xaml\Microsoft.UI.Xaml.winmd" signType="AuthenticodeFormer" dest="__INPATHROOT__\Microsoft.UI.Xaml\Microsoft.UI.Xaml.winmd" />
+    <file src="__INPATHROOT__\Release\x86\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\x86\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" />
+    <file src="__INPATHROOT__\Release\x86\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\x86\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" />
+    <file src="__INPATHROOT__\Release\x64\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\x64\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" />
+    <file src="__INPATHROOT__\Release\x64\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\x64\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" />
+    <file src="__INPATHROOT__\Release\arm\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\arm\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" />
+    <file src="__INPATHROOT__\Release\arm\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\arm\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" />
+    <file src="__INPATHROOT__\Release\arm64\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\arm64\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll" />
+    <file src="__INPATHROOT__\Release\arm64\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" signType="AuthenticodeFormer" dest="__INPATHROOT__\Release\arm64\Microsoft.UI.Xaml\sdk\Microsoft.UI.Xaml.winmd" />
   </job>
 </SignConfigXML>

--- a/tools/PublishSymbols/PublishSymbols.cmd
+++ b/tools/PublishSymbols/PublishSymbols.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-%~dp0\..\PowershellWrapper.cmd %~dpn0.ps1 %*

--- a/tools/PublishSymbols/PublishSymbols.ps1
+++ b/tools/PublishSymbols/PublishSymbols.ps1
@@ -1,3 +1,9 @@
+[CmdLetBinding()]
+Param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$localDirectory
+)
+
 Push-Location $PSScriptRoot
 
 [xml]$customProps = (Get-Content ..\..\custom.props)
@@ -14,21 +20,20 @@ $buildVersion = $versionMajor + "." + $versionMinor + "." + $env:BUILD_BUILDNUMB
 
 Write-Host "Build = $buildVersion"
 
-$buildId="$($env:BUILD_BUILDNUMBER)_$($env:BUILDCONFIGURATION)_$($env:BUILDPLATFORM)"
-$localDirectory=$env:BUILD_BINARIESDIRECTORY + "\" + $env:BUILDCONFIGURATION + "\" + $env:BUILDPLATFORM + "\Microsoft.UI.Xaml"
-$directory = "$env:XES_DFSDROP\$env:XES_RELATIVEOUTPUTROOT\Microsoft.UI.Xaml"
+$buildId="$($env:BUILD_BUILDNUMBER)"
+$directory = "$env:XES_DFSDROP"
 
 Write-Host "Local path: '$localDirectory'"
 Write-Host "Build share: '$directory'"
 
-Copy-Item -Recurse "$localDirectory" "$directory"
+Copy-Item -Recurse -Verbose "$localDirectory" "$directory"
 
 Write-Host "buildId = $buildId"
 
 Copy-Item pdb_index_template.ini pdb_index.ini
 Add-Content pdb_index.ini "Build=$buildVersion"
 
-\\symbols\Tools\createrequest.cmd -i .\pdb_index.ini -d .\requests -c -a -b $buildId -e Release -g $directory
+\\symbols\Tools\createrequest.cmd -i .\pdb_index.ini -d .\requests -c -a -b $buildId -e Release -g $directory -r
 
 if ($lastexitcode -ne 0)
 {


### PR DESCRIPTION
The release pipeline was using our old internal self-hosted VMs for doing builds. This was playing with fire. These VMs started getting build errors trying to build the project. Instead of trying to repair them, I'm going to take this opportunity to fix the release pipeline to build in the same configuration as the PR/CI pipelines and then just use the self-hosted VMs for code signing.

This means that code signing doesn't run in each build step, it runs as a step after the build is done so the sign config now signs the result of all builds and then updates the drop folder and then the nuget generation works off that.