### PR TITLE
Fix element already in tree crash in nested repeater scenario

### DIFF
--- a/dev/Repeater/APITests/RecyclePoolTests.cs
+++ b/dev/Repeater/APITests/RecyclePoolTests.cs
@@ -189,5 +189,35 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 }
             });
         }
+
+        // When the owner is not the same, the element we get out of the recycle
+        // pool should be disconnected from its previous parent.
+        [TestMethod]
+        public void ValidateChildRemovedFromParentWhenOwnerIsDifferent()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var element = new Button();
+                const string key1 = "Key1";
+                const string key2 = "Key2";
+
+                RecyclePool pool = new RecyclePool();
+                var parent1 = new StackPanel();
+                var child1 = new Button();
+                var child2 = new Button();
+                parent1.Children.Add(child1);
+                parent1.Children.Add(child2);
+                
+                pool.PutElement(child1, key1);
+                pool.PutElement(child2, key2);
+
+                var parent2 = new StackPanel();
+                // Recycle the second child for a different parent. It should be disconnected
+                var recycled1 = (FrameworkElement)pool.TryGetElement(key2, parent2);
+                Verify.IsNull(recycled1.Parent);
+                var recycled2 = (FrameworkElement)pool.TryGetElement(key1, parent2);
+                Verify.IsNull(recycled2.Parent);
+            });
+        }
     }
 }

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -171,6 +171,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        // Ensure that scrolling a nested repeater works when the 
+        // Itemtemplates are data templates.
         [TestMethod]
         public void NestedRepeaterWithDataTemplateScenario()
         {
@@ -220,6 +222,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Content = anchorProvider;
             });
 
+            // scroll down several times to cause recycling of elements
             for (int i = 1; i < 10; i++)
             {
                 IdleSynchronizer.Wait();

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -26,6 +26,8 @@ using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFacto
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
 using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using System.Collections.ObjectModel;
+using System.Threading;
 #endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
@@ -167,6 +169,73 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.Background = blueBrush;
                 Verify.AreSame(blueBrush, repeater.Background);
             });
+        }
+
+        [TestMethod]
+        public void NestedRepeaterWithDataTemplateScenario()
+        {
+            ItemsRepeater rootRepeater = null;
+            ScrollViewer scrollViewer = null;
+            ManualResetEvent viewChanged = new ManualResetEvent(false);
+            RunOnUIThread.Execute(() =>
+            {
+                var anchorProvider = (ScrollAnchorProvider)XamlReader.Load(
+                  @"<controls:ScrollAnchorProvider Width='400' Height='600'
+                     xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                     xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                    <controls:ScrollAnchorProvider.Resources>
+                        <DataTemplate x:Key='ItemTemplate' >
+                            <TextBlock Text='{Binding}' />
+                        </DataTemplate>
+                        <DataTemplate x:Key='GroupTemplate'>
+                            <StackPanel>
+                                <TextBlock Text='{Binding}' />
+                                <controls:ItemsRepeater ItemTemplate='{StaticResource ItemTemplate}' ItemsSource='{Binding}' VerticalCacheLength='0'/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </controls:ScrollAnchorProvider.Resources>
+                    <ScrollViewer x:Name='scrollviewer'>
+                        <controls:ItemsRepeater x:Name='rootRepeater' ItemTemplate='{StaticResource GroupTemplate}' VerticalCacheLength='0' />
+                    </ScrollViewer>
+                </controls:ScrollAnchorProvider>");
+
+                rootRepeater = (ItemsRepeater)anchorProvider.FindName("rootRepeater");
+                scrollViewer = (ScrollViewer)anchorProvider.FindName("scrollviewer");
+                scrollViewer.ViewChanged += (sender, args) =>
+                {
+                    if (!args.IsIntermediate)
+                    {
+                        viewChanged.Set();
+                    }
+                };
+
+                var itemsSource = new ObservableCollection<ObservableCollection<int>>();
+                for (int i = 0; i < 100; i++)
+                {
+                    itemsSource.Add(new ObservableCollection<int>(Enumerable.Range(0, 5)));
+                };
+
+                rootRepeater.ItemsSource = itemsSource;
+                Content = anchorProvider;
+            });
+
+            for (int i = 1; i < 10; i++)
+            {
+                IdleSynchronizer.Wait();
+                RunOnUIThread.Execute(() =>
+                {
+                    scrollViewer.ChangeView(null, i * 200, null);
+                });
+
+                Verify.IsTrue(viewChanged.WaitOne(DefaultWaitTimeInMS));
+                viewChanged.Reset();
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Verify.AreEqual(i * 200, scrollViewer.VerticalOffset);
+                });
+            }
         }
     }
 }

--- a/dev/Repeater/RecyclePool.cpp
+++ b/dev/Repeater/RecyclePool.cpp
@@ -104,7 +104,12 @@ winrt::UIElement RecyclePool::TryGetElementCore(
                 if (panel)
                 {
                     unsigned int childIndex = 0;
-                    MUX_ASSERT(panel.Children().IndexOf(elementInfo.Element(), childIndex));
+                    bool found = panel.Children().IndexOf(elementInfo.Element(), childIndex);
+                    if (!found)
+                    {
+                        throw winrt::hresult_error(E_FAIL, L"Repeater's child not found in its Children collection.");
+                    }
+
                     panel.Children().RemoveAt(childIndex);
                 }
             }

--- a/dev/Repeater/RecyclePool.cpp
+++ b/dev/Repeater/RecyclePool.cpp
@@ -107,7 +107,7 @@ winrt::UIElement RecyclePool::TryGetElementCore(
                     bool found = panel.Children().IndexOf(elementInfo.Element(), childIndex);
                     if (!found)
                     {
-                        throw winrt::hresult_error(E_FAIL, L"Repeater's child not found in its Children collection.");
+                        throw winrt::hresult_error(E_FAIL, L"ItemsRepeater's child not found in its Children collection.");
                     }
 
                     panel.Children().RemoveAt(childIndex);


### PR DESCRIPTION
An incorrect usage of assert caused release builds to remove the wrong element from the children collection. I added a unit and integration test as well.

Fixes #428 