### PR TITLE
Move off self-hosted VMs in code signing tasks

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -18,9 +18,7 @@ jobs:
   # XES tasks need to be on PackageES machines.
   ${{if parameters.signConfig }}:
     pool:
-      name: Package ES Custom Demands Lab A
-      demands:
-        - ClientAlias -equals depcontrols2
+      name: Package ES Lab E
 
 
   steps:

--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -2,9 +2,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: LocalizationHandoff
   pool:
-    name: Package ES Custom Demands Lab A
-    demands:
-      - ClientAlias -equals depcontrols2
+    name: Package ES Lab E
 
   steps:
   - task: PkgESSetupBuild@10

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -47,9 +47,7 @@ jobs:
   condition:
     in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
   pool:
-    name: Package ES Custom Demands Lab A
-    demands:
-      - ClientAlias -equals depcontrols2
+    name: Package ES Lab E
 
   steps:
   - task: PkgESSetupBuild@10


### PR DESCRIPTION
I changed our builds to move off self-hosted VMs but code signing was still on our custom VMs. This should enable us to decommission the self-hosted VMs.