### PR TITLE
Rename a few api's in preparation for making ItemsRepeater public

### DIFF
--- a/dev/Repeater/APITests/ElementAnimatorTests.cs
+++ b/dev/Repeater/APITests/ElementAnimatorTests.cs
@@ -29,7 +29,7 @@ using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using AnimationContext = Microsoft.UI.Xaml.Controls.AnimationContext;
 #endif
 
@@ -70,11 +70,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #endif
                 };
 
-                Content = new ScrollAnchorProvider()
+                Content = new ItemsRepeaterScrollHost()
                 {
                     Width = 400,
                     Height = 800,
-                    Content = new ScrollViewer
+                    ScrollViewer = new ScrollViewer
                     {
                         Content = repeater
                     }

--- a/dev/Repeater/APITests/ElementFactoryTests.cs
+++ b/dev/Repeater/APITests/ElementFactoryTests.cs
@@ -27,7 +27,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #if !BUILD_WINDOWS
     using ElementFactoryGetArgs = Microsoft.UI.Xaml.Controls.ElementFactoryGetArgs;
     using ElementFactoryRecycleArgs = Microsoft.UI.Xaml.Controls.ElementFactoryRecycleArgs;
-    using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+    using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
     using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
     using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
     using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
@@ -432,7 +432,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        private ScrollAnchorProvider CreateAndInitializeRepeater(
+        private ItemsRepeaterScrollHost CreateAndInitializeRepeater(
             object itemsSource,
             VirtualizingLayout layout,
             object elementFactory,
@@ -449,11 +449,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #endif
             };
 
-            return new ScrollAnchorProvider()
+            return new ItemsRepeaterScrollHost()
             {
                 Width = 400,
                 Height = 400,
-                Content = new ScrollViewer()
+                ScrollViewer = new ScrollViewer()
                 {
                     Content = repeater
                 }

--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -29,7 +29,7 @@ using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFacto
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
 using FlowLayout = Microsoft.UI.Xaml.Controls.FlowLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using AnimationContext = Microsoft.UI.Xaml.Controls.AnimationContext;
 #endif
 
@@ -413,11 +413,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Content = repeater
             };
 
-            Content = new ScrollAnchorProvider()
+            Content = new ItemsRepeaterScrollHost()
             {
                 Width = 200,
                 Height = 200,
-                Content = scrollViewer
+                ScrollViewer = scrollViewer
             };
 
             Content.UpdateLayout();

--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -36,7 +36,7 @@ using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
 using FlowLayout = Microsoft.UI.Xaml.Controls.FlowLayout;
 using UniformGridLayout = Microsoft.UI.Xaml.Controls.UniformGridLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutContext;
 using LayoutContext = Microsoft.UI.Xaml.Controls.LayoutContext;
 using LayoutPanel = Microsoft.UI.Xaml.Controls.LayoutPanel;
@@ -846,11 +846,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         };
 
                         SetUpScrollViewerOrientation(scrollViewer, scrollOrientation);
-                        Content = new ScrollAnchorProvider()
+                        Content = new ItemsRepeaterScrollHost()
                         {
                             Width = 400,
                             Height = 400,
-                            Content = scrollViewer
+                            ScrollViewer = scrollViewer
                         };
 
                         Content.UpdateLayout();
@@ -918,8 +918,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     scrollViewer.Content = repeater;
                     scrollViewer.Width = scrollViewer.Height = 600;
 
-                    var tracker = new ScrollAnchorProvider();
-                    tracker.Content = scrollViewer;
+                    var tracker = new ItemsRepeaterScrollHost();
+                    tracker.ScrollViewer = scrollViewer;
 
                     Content = tracker;
                     Content.UpdateLayout();
@@ -1016,8 +1016,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         scrollViewer.Width = scrollViewer.Height = 200;
                         SetUpScrollViewerOrientation(scrollViewer, scrollOrientation);
 
-                        var tracker = new ScrollAnchorProvider();
-                        tracker.Content = scrollViewer;
+                        var tracker = new ItemsRepeaterScrollHost();
+                        tracker.ScrollViewer = scrollViewer;
                         Content = tracker;
 
                         repeater.ElementPrepared += (o, e) =>
@@ -1094,8 +1094,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Height = 200,
                 };
 
-                var anchorProvier = new ScrollAnchorProvider() {
-                    Content = scrollViewer
+                var anchorProvier = new ItemsRepeaterScrollHost() {
+                    ScrollViewer = scrollViewer
                 };
 
                 Content = anchorProvier;
@@ -1258,7 +1258,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         </DataTemplate>", content));
         }
 
-        private ScrollAnchorProvider CreateAndInitializeRepeater(
+        private ItemsRepeaterScrollHost CreateAndInitializeRepeater(
            OrientationBasedMeasures om,
            object itemsSource,
            VirtualizingLayout layout,
@@ -1285,11 +1285,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             };
 
             SetUpScrollViewerOrientation(scrollViewer, om.ScrollOrientation);
-            return new ScrollAnchorProvider()
+            return new ItemsRepeaterScrollHost()
             {
                 Width = 400,
                 Height = 400,
-                Content = scrollViewer
+                ScrollViewer = scrollViewer
             };
         }
 

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -35,7 +35,7 @@ using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
 using FlowLayout = Microsoft.UI.Xaml.Controls.FlowLayout;
 using UniformGridLayout = Microsoft.UI.Xaml.Controls.UniformGridLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutContext;
 using ElementRealizationOptions = Microsoft.UI.Xaml.Controls.ElementRealizationOptions;
 using LayoutContext = Microsoft.UI.Xaml.Controls.LayoutContext;
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        private ScrollAnchorProvider CreateAndInitializeRepeater(
+        private ItemsRepeaterScrollHost CreateAndInitializeRepeater(
            object itemsSource,
            VirtualizingLayout layout,
            object elementFactory,
@@ -154,11 +154,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Content = repeater
             };
 
-            return new ScrollAnchorProvider()
+            return new ItemsRepeaterScrollHost()
             {
                 Width = 400,
                 Height = 400,
-                Content = scrollViewer
+                ScrollViewer = scrollViewer
             };
         }
 

--- a/dev/Repeater/APITests/PhasingTests.cs
+++ b/dev/Repeater/APITests/PhasingTests.cs
@@ -25,7 +25,7 @@ using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 using ElementFactory = Microsoft.UI.Xaml.Controls.ElementFactory;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using RepeaterTestHooks = Microsoft.UI.Private.Controls.RepeaterTestHooks;
 #endif
 
@@ -84,11 +84,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     }
                 };
 
-                Content = new ScrollAnchorProvider()
+                Content = new ItemsRepeaterScrollHost()
                 {
                     Width = 400,
                     Height = 400,
-                    Content = new ScrollViewer
+                    ScrollViewer = new ScrollViewer
                     {
                         Content = repeater
                     }
@@ -157,11 +157,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     }
                 };
 
-                Content = new ScrollAnchorProvider()
+                Content = new ItemsRepeaterScrollHost()
                 {
                     Width = 400,
                     Height = 400,
-                    Content = new ScrollViewer
+                    ScrollViewer = new ScrollViewer
                     {
                         Content = repeater
                     }

--- a/dev/Repeater/APITests/RecyclePoolTests.cs
+++ b/dev/Repeater/APITests/RecyclePoolTests.cs
@@ -26,7 +26,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 #endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
@@ -161,11 +161,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 root.Children.Add(repeater1);
                 root.Children.Add(repeater2);
 
-                Content = new ScrollAnchorProvider()
+                Content = new ItemsRepeaterScrollHost()
                 {
                     Width = 400,
                     Height = 400,
-                    Content = new ScrollViewer()
+                    ScrollViewer = new ScrollViewer()
                     {
                         Content = root
                     }

--- a/dev/Repeater/APITests/RepeaterFocusTests.cs
+++ b/dev/Repeater/APITests/RepeaterFocusTests.cs
@@ -29,7 +29,7 @@ using ElementFactory = Microsoft.UI.Xaml.Controls.ElementFactory;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 #endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
@@ -153,7 +153,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 .ToArray();
         }
 
-        private static ScrollAnchorProvider CreateAndInitializeRepeater(
+        private static ItemsRepeaterScrollHost CreateAndInitializeRepeater(
            object itemsSource,
            VirtualizingLayout layout,
            ElementFactory elementFactory,
@@ -177,11 +177,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Content = repeater
             };
 
-            return new ScrollAnchorProvider()
+            return new ItemsRepeaterScrollHost()
             {
                 Width = 400,
                 Height = 400,
-                Content = scrollViewer
+                ScrollViewer = scrollViewer
             };
         }
     }

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -25,7 +25,7 @@ using ItemsSourceView = Microsoft.UI.Xaml.Controls.ItemsSourceView;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using System.Collections.ObjectModel;
 using System.Threading;
 #endif
@@ -60,11 +60,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     // Layout = new StackLayout(),
                 };
 
-                Content = new ScrollAnchorProvider()
+                Content = new ItemsRepeaterScrollHost()
                 {
                     Width = 400,
                     Height = 800,
-                    Content = new ScrollViewer
+                    ScrollViewer = new ScrollViewer
                     {
                         Content = repeater
                     }
@@ -94,10 +94,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
                 };
 
-                Content = new ScrollAnchorProvider() {
+                Content = new ItemsRepeaterScrollHost() {
                     Width = 400,
                     Height = 800,
-                    Content = new ScrollViewer {
+                    ScrollViewer = new ScrollViewer {
                         Content = repeater
                     }
                 };
@@ -181,12 +181,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             ManualResetEvent viewChanged = new ManualResetEvent(false);
             RunOnUIThread.Execute(() =>
             {
-                var anchorProvider = (ScrollAnchorProvider)XamlReader.Load(
-                  @"<controls:ScrollAnchorProvider Width='400' Height='600'
+                var anchorProvider = (ItemsRepeaterScrollHost)XamlReader.Load(
+                  @"<controls:ItemsRepeaterScrollHost Width='400' Height='600'
                      xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
                      xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
                      xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
-                    <controls:ScrollAnchorProvider.Resources>
+                    <controls:ItemsRepeaterScrollHost.Resources>
                         <DataTemplate x:Key='ItemTemplate' >
                             <TextBlock Text='{Binding}' />
                         </DataTemplate>
@@ -196,11 +196,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                                 <controls:ItemsRepeater ItemTemplate='{StaticResource ItemTemplate}' ItemsSource='{Binding}' VerticalCacheLength='0'/>
                             </StackPanel>
                         </DataTemplate>
-                    </controls:ScrollAnchorProvider.Resources>
+                    </controls:ItemsRepeaterScrollHost.Resources>
                     <ScrollViewer x:Name='scrollviewer'>
                         <controls:ItemsRepeater x:Name='rootRepeater' ItemTemplate='{StaticResource GroupTemplate}' VerticalCacheLength='0' />
                     </ScrollViewer>
-                </controls:ScrollAnchorProvider>");
+                </controls:ItemsRepeaterScrollHost>");
 
                 rootRepeater = (ItemsRepeater)anchorProvider.FindName("rootRepeater");
                 scrollViewer = (ScrollViewer)anchorProvider.FindName("scrollviewer");

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -35,7 +35,7 @@ using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutC
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 #endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
@@ -777,11 +777,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Content = repeater
                 };
 
-                Content = new ScrollAnchorProvider()
+                Content = new ItemsRepeaterScrollHost()
                 {
                     Width = 200,
                     Height = 200,
-                    Content = sv
+                    ScrollViewer = sv
                 };
             });
 

--- a/dev/Repeater/APITests/ViewportTests.cs
+++ b/dev/Repeater/APITests/ViewportTests.cs
@@ -38,7 +38,7 @@ using LayoutContext = Microsoft.UI.Xaml.Controls.LayoutContext;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
 using UniformGridLayout = Microsoft.UI.Xaml.Controls.UniformGridLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
 using ScrollCompletedEventArgs = Microsoft.UI.Xaml.Controls.ScrollCompletedEventArgs;
 using ZoomCompletedEventArgs = Microsoft.UI.Xaml.Controls.ZoomCompletedEventArgs;
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         // [TestMethod] Temporarily disabled for bug 18866003
-        public void ValidateScrollAnchorProviderScenario()
+        public void ValidateItemsRepeaterScrollHostScenario()
         {
             var realizationRects = new List<Rect>();
             var scrollViewer = (ScrollViewer)null;
@@ -133,11 +133,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     }
                 };
 
-                var tracker = new ScrollAnchorProvider()
+                var tracker = new ItemsRepeaterScrollHost()
                 {
                     Width = 200,
                     Height = 300,
-                    Content = scrollViewer
+                    ScrollViewer = scrollViewer
                 };
 
                 Content = tracker;

--- a/dev/Repeater/ItemsRepeater.idl
+++ b/dev/Repeater/ItemsRepeater.idl
@@ -252,7 +252,7 @@ unsealed runtimeclass VirtualizingLayoutContext : LayoutContext
 
     overridable Windows.Foundation.Rect RealizationRectCore();
 
-    overridable Windows.UI.Xaml.UIElement GetElementAtCore(Int32 index, ElementRealizationOptions options);
+    overridable Windows.UI.Xaml.UIElement GetOrCreateElementAtCore(Int32 index, ElementRealizationOptions options);
     overridable void RecycleElementCore(Windows.UI.Xaml.UIElement element);
 
     overridable Int32 RecommendedAnchorIndexCore{ get; };
@@ -334,11 +334,13 @@ unsealed runtimeclass ElementAnimator
     protected void OnBoundsChangeAnimationCompleted(Windows.UI.Xaml.UIElement element);
 }
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 runtimeclass ScrollAnchorProvider : Windows.UI.Xaml.Controls.ContentControl
 {
     ScrollAnchorProvider();
+
+    Windows.UI.Xaml.UIElement AnchorElement{ get; };
 
     Double HorizontalAnchorRatio { get; set; };
     Double VerticalAnchorRatio { get; set; };

--- a/dev/Repeater/ItemsRepeater.idl
+++ b/dev/Repeater/ItemsRepeater.idl
@@ -6,7 +6,7 @@ runtimeclass VirtualizingLayoutContext;
 runtimeclass Layout;
 runtimeclass VirtualizingLayout;
 runtimeclass ElementAnimator;
-runtimeclass ScrollAnchorProvider;
+runtimeclass ItemsRepeaterScrollHost;
 runtimeclass ItemsRepeaterElementPreparedEventArgs;
 runtimeclass ItemsRepeaterElementClearingEventArgs;
 runtimeclass ItemsRepeaterElementIndexChangedEventArgs;
@@ -336,11 +336,14 @@ unsealed runtimeclass ElementAnimator
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
-runtimeclass ScrollAnchorProvider : Windows.UI.Xaml.Controls.ContentControl
+[contentproperty("ScrollViewer")]
+runtimeclass ItemsRepeaterScrollHost : Windows.UI.Xaml.FrameworkElement
 {
-    ScrollAnchorProvider();
+    ItemsRepeaterScrollHost();
 
-    Windows.UI.Xaml.UIElement AnchorElement{ get; };
+    Windows.UI.Xaml.Controls.ScrollViewer ScrollViewer { get; set; };
+
+    Windows.UI.Xaml.UIElement CurrentAnchor{ get; };
 
     Double HorizontalAnchorRatio { get; set; };
     Double VerticalAnchorRatio { get; set; };

--- a/dev/Repeater/ItemsRepeaterScrollHost.cpp
+++ b/dev/Repeater/ItemsRepeaterScrollHost.cpp
@@ -4,19 +4,43 @@
 #include <pch.h>
 #include <common.h>
 #include "ItemsRepeater.common.h"
-#include "ScrollAnchorProvider.h"
+#include "ItemsRepeaterScrollHost.h"
 #include "DoubleUtil.h"
 
-CppWinRTActivatableClassWithBasicFactory(ScrollAnchorProvider)
+CppWinRTActivatableClassWithBasicFactory(ItemsRepeaterScrollHost)
 
-ScrollAnchorProvider::ScrollAnchorProvider()
+ItemsRepeaterScrollHost::ItemsRepeaterScrollHost()
 {
-    IsTabStop(false);
+}
+
+winrt::UIElement ItemsRepeaterScrollHost::CurrentAnchor()
+{
+    return GetAnchorElement();
+}
+
+winrt::FxScrollViewer ItemsRepeaterScrollHost::ScrollViewer()
+{
+    winrt::FxScrollViewer value = nullptr;
+    auto children = Children();
+    if (children.Size() > 0)
+    {
+        value = children.GetAt(0).try_as<winrt::FxScrollViewer>();
+    }
+
+    return value;
+}
+
+void ItemsRepeaterScrollHost::ScrollViewer(winrt::FxScrollViewer const& value)
+{
+    m_scrollViewer.set(value);
+    auto children = Children();
+    children.Clear();
+    children.Append(value);
 }
 
 #pragma region IFrameworkElementOverrides
 
-winrt::Size ScrollAnchorProvider::ArrangeOverride(winrt::Size const& finalSize)
+winrt::Size ItemsRepeaterScrollHost::ArrangeOverride(winrt::Size const& finalSize)
 {
     winrt::Size result;
     if (SharedHelpers::IsRS5OrHigher())
@@ -71,28 +95,28 @@ winrt::Size ScrollAnchorProvider::ArrangeOverride(winrt::Size const& finalSize)
 
 #pragma region IScrollAnchorProvider
 
-double ScrollAnchorProvider::HorizontalAnchorRatio()
+double ItemsRepeaterScrollHost::HorizontalAnchorRatio()
 {
     return m_horizontalEdge;
 }
 
-void ScrollAnchorProvider::HorizontalAnchorRatio(double value)
+void ItemsRepeaterScrollHost::HorizontalAnchorRatio(double value)
 {
     m_horizontalEdge = value;
 }
 
-double ScrollAnchorProvider::VerticalAnchorRatio()
+double ItemsRepeaterScrollHost::VerticalAnchorRatio()
 {
     return m_verticalEdge;
 }
 
-void ScrollAnchorProvider::VerticalAnchorRatio(double value)
+void ItemsRepeaterScrollHost::VerticalAnchorRatio(double value)
 {
     m_verticalEdge = value;
 }
 
 // TODO: this API should go on UIElement.
-void ScrollAnchorProvider::StartBringIntoView(
+void ItemsRepeaterScrollHost::StartBringIntoView(
     winrt::UIElement const& element,
     double alignmentX,
     double alignmentY,
@@ -111,53 +135,54 @@ void ScrollAnchorProvider::StartBringIntoView(
         !!animate };
 }
 
-bool ScrollAnchorProvider::IsHorizontallyScrollable()
+bool ItemsRepeaterScrollHost::IsHorizontallyScrollable()
 {
     return true;
 }
 
-bool ScrollAnchorProvider::IsVerticallyScrollable()
+bool ItemsRepeaterScrollHost::IsVerticallyScrollable()
 {
     return true;
 }
 
-winrt::UIElement ScrollAnchorProvider::AnchorElement()
+winrt::UIElement ItemsRepeaterScrollHost::AnchorElement()
 {
     return GetAnchorElement();
 }
 
-winrt::event_token ScrollAnchorProvider::ViewportChanged(winrt::ViewportChangedEventHandler const& value)
+
+winrt::event_token ItemsRepeaterScrollHost::ViewportChanged(winrt::ViewportChangedEventHandler const& value)
 {
     return m_viewportChanged.add(value);
 }
 
-void ScrollAnchorProvider::ViewportChanged(winrt::event_token const& token)
+void ItemsRepeaterScrollHost::ViewportChanged(winrt::event_token const& token)
 {
     m_viewportChanged.remove(token);
 }
 
-winrt::event_token ScrollAnchorProvider::PostArrange(winrt::PostArrangeEventHandler const& value)
+winrt::event_token ItemsRepeaterScrollHost::PostArrange(winrt::PostArrangeEventHandler const& value)
 {
     return m_postArrange.add(value);
 }
 
-void ScrollAnchorProvider::PostArrange(winrt::event_token const& token)
+void ItemsRepeaterScrollHost::PostArrange(winrt::event_token const& token)
 {
     m_postArrange.remove(token);
 }
 
-winrt::event_token ScrollAnchorProvider::ConfigurationChanged(
+winrt::event_token ItemsRepeaterScrollHost::ConfigurationChanged(
     winrt::ConfigurationChangedEventHandler const& /*value*/)
 {
     return {};
 }
 
-void ScrollAnchorProvider::ConfigurationChanged(
+void ItemsRepeaterScrollHost::ConfigurationChanged(
     winrt::event_token const& /*token*/)
 {
 }
 
-void ScrollAnchorProvider::RegisterAnchorCandidate(winrt::UIElement const& element)
+void ItemsRepeaterScrollHost::RegisterAnchorCandidate(winrt::UIElement const& element)
 {
     if (HorizontalAnchorRatio() != DoubleUtil::NaN || VerticalAnchorRatio() != DoubleUtil::NaN)
     {
@@ -184,7 +209,7 @@ void ScrollAnchorProvider::RegisterAnchorCandidate(winrt::UIElement const& eleme
     }
 }
 
-void ScrollAnchorProvider::UnregisterAnchorCandidate(winrt::UIElement const& element)
+void ItemsRepeaterScrollHost::UnregisterAnchorCandidate(winrt::UIElement const& element)
 {
     const auto elem = element;
     const auto it = std::find_if(m_candidates.cbegin(), m_candidates.cend(), [&elem](const CandidateInfo& c) { return c.Element() == elem; });
@@ -196,7 +221,7 @@ void ScrollAnchorProvider::UnregisterAnchorCandidate(winrt::UIElement const& ele
     }
 }
 
-winrt::Rect ScrollAnchorProvider::GetRelativeViewport(
+winrt::Rect ItemsRepeaterScrollHost::GetRelativeViewport(
     winrt::UIElement const& element)
 {
     const auto scrollViewer = TryGetScrollViewer();
@@ -230,7 +255,7 @@ winrt::Rect ScrollAnchorProvider::GetRelativeViewport(
 
 #pragma endregion
 
-void ScrollAnchorProvider::ApplyPendingChangeView(const winrt::FxScrollViewer& scrollViewer)
+void ItemsRepeaterScrollHost::ApplyPendingChangeView(const winrt::FxScrollViewer& scrollViewer)
 {
     auto bringIntoView = m_pendingBringIntoView;
     MUX_ASSERT(!bringIntoView.ChangeViewCalled());
@@ -260,7 +285,7 @@ void ScrollAnchorProvider::ApplyPendingChangeView(const winrt::FxScrollViewer& s
             scrollViewer.ExtentHeight() - scrollViewer.ViewportHeight()))) };
     bringIntoView.ChangeViewOffset(changeViewOffset);
 
-    REPEATER_TRACE_INFO(L"ScrollAnchorProvider scroll to absolute offset (%.0f, %.0f) \n", changeViewOffset.X, changeViewOffset.Y);
+    REPEATER_TRACE_INFO(L"ItemsRepeaterScrollHost scroll to absolute offset (%.0f, %.0f) \n", changeViewOffset.X, changeViewOffset.Y);
     scrollViewer.ChangeView(
         box_value(static_cast<double>(changeViewOffset.X)).as<winrt::IReference<double>>(),
         box_value(static_cast<double>(changeViewOffset.Y)).as<winrt::IReference<double>>(),
@@ -270,7 +295,7 @@ void ScrollAnchorProvider::ApplyPendingChangeView(const winrt::FxScrollViewer& s
     m_pendingBringIntoView = std::move(bringIntoView);
 }
 
-double ScrollAnchorProvider::TrackElement(const winrt::UIElement& element, winrt::Rect previousBounds, const winrt::FxScrollViewer& scrollViewer)
+double ItemsRepeaterScrollHost::TrackElement(const winrt::UIElement& element, winrt::Rect previousBounds, const winrt::FxScrollViewer& scrollViewer)
 {
     const auto bounds = winrt::LayoutInformation::GetLayoutSlot(element.as<winrt::FrameworkElement>());
     const auto transformer = element.TransformToVisual(scrollViewer.ContentTemplateRoot());
@@ -334,25 +359,23 @@ double ScrollAnchorProvider::TrackElement(const winrt::UIElement& element, winrt
     return pendingViewportShift;
 }
 
-winrt::FxScrollViewer ScrollAnchorProvider::TryGetScrollViewer()
+winrt::FxScrollViewer ItemsRepeaterScrollHost::TryGetScrollViewer()
 {
     if (!m_scrollViewer)
     {
         // PERF: This operation is expensive especially since it gets invoked every time
         // CalculateDistance is called.
-        m_scrollViewer.set(Content().try_as<winrt::FxScrollViewer>());
-
         if (m_scrollViewer)
         {
-            m_scrollViewer.get().ViewChanging({ this, &ScrollAnchorProvider::OnScrollViewerViewChanging });
-            m_scrollViewer.get().ViewChanged({ this, &ScrollAnchorProvider::OnScrollViewerViewChanged });
-            m_scrollViewer.get().SizeChanged({ this, &ScrollAnchorProvider::OnScrollViewerSizeChanged });
+            m_scrollViewer.get().ViewChanging({ this, &ItemsRepeaterScrollHost::OnScrollViewerViewChanging });
+            m_scrollViewer.get().ViewChanged({ this, &ItemsRepeaterScrollHost::OnScrollViewerViewChanged });
+            m_scrollViewer.get().SizeChanged({ this, &ItemsRepeaterScrollHost::OnScrollViewerSizeChanged });
         }
     }
     return m_scrollViewer.get();
 }
 
-winrt::UIElement ScrollAnchorProvider::GetAnchorElement(_Out_opt_ winrt::Rect* relativeBounds)
+winrt::UIElement ItemsRepeaterScrollHost::GetAnchorElement(_Out_opt_ winrt::Rect* relativeBounds)
 {
     if (m_isAnchorElementDirty)
     {
@@ -418,14 +441,14 @@ winrt::UIElement ScrollAnchorProvider::GetAnchorElement(_Out_opt_ winrt::Rect* r
     return m_anchorElement.get();
 }
 
-void ScrollAnchorProvider::OnScrollViewerViewChanging(
+void ItemsRepeaterScrollHost::OnScrollViewerViewChanging(
     const winrt::IInspectable& sender,
     const winrt::ScrollViewerViewChangingEventArgs& args)
 {
     m_viewportChanged(*this, false /* isFinal */);
 }
 
-void ScrollAnchorProvider::OnScrollViewerViewChanged(
+void ItemsRepeaterScrollHost::OnScrollViewerViewChanged(
     winrt::IInspectable const&,
     winrt::ScrollViewerViewChangedEventArgs const& args)
 {
@@ -445,7 +468,7 @@ void ScrollAnchorProvider::OnScrollViewerViewChanged(
     m_viewportChanged(*this, isFinal);
 }
 
-void ScrollAnchorProvider::OnScrollViewerSizeChanged(
+void ItemsRepeaterScrollHost::OnScrollViewerSizeChanged(
     const winrt::IInspectable& sender,
     const winrt::SizeChangedEventArgs& args)
 {

--- a/dev/Repeater/ItemsRepeaterScrollHost.h
+++ b/dev/Repeater/ItemsRepeaterScrollHost.h
@@ -14,6 +14,7 @@ public:
 
 #pragma region IFrameworkElementOverrides
 
+    winrt::Size MeasureOverride(winrt::Size const& availableSize);
     winrt::Size ArrangeOverride(winrt::Size const& finalSize);
 
 #pragma endregion
@@ -76,7 +77,6 @@ public:
 private:
     void ApplyPendingChangeView(const winrt::FxScrollViewer& scrollViewer);
     double TrackElement(const winrt::UIElement& element, winrt::Rect previousBounds, const winrt::FxScrollViewer& scrollViewer);
-    winrt::FxScrollViewer TryGetScrollViewer();
     winrt::UIElement GetAnchorElement(_Out_opt_ winrt::Rect* relativeBounds = nullptr);
 
     void OnScrollViewerViewChanging(const winrt::IInspectable& sender, const winrt::ScrollViewerViewChangingEventArgs& args);
@@ -157,7 +157,6 @@ private:
 
     std::vector<CandidateInfo> m_candidates;
 
-    tracker_ref<winrt::FxScrollViewer> m_scrollViewer{ this };
     tracker_ref<winrt::UIElement> m_anchorElement{ this };
     winrt::Rect m_anchorElementRelativeBounds{};
     // Whenever the m_candidates list changes, we set this to true.
@@ -183,4 +182,9 @@ private:
 
     event_source<winrt::ViewportChangedEventHandler> m_viewportChanged{ this };
     event_source<winrt::PostArrangeEventHandler> m_postArrange{ this };
+
+    winrt::FxScrollViewer::ViewChanging_revoker m_scrollViewerViewChanging{};
+    winrt::FxScrollViewer::ViewChanged_revoker m_scrollViewerViewChanged{};
+    winrt::FxScrollViewer::SizeChanged_revoker m_scrollViewerSizeChanged{};
+
 };

--- a/dev/Repeater/ItemsRepeaterScrollHost.h
+++ b/dev/Repeater/ItemsRepeaterScrollHost.h
@@ -3,14 +3,14 @@
 
 #pragma once
 
-#include "ScrollAnchorProvider.g.h"
+#include "ItemsRepeaterScrollHost.g.h"
 
 // TODO: move to framework level element tracking.
-class ScrollAnchorProvider :
-    public ReferenceTracker<ScrollAnchorProvider, winrt::implementation::ScrollAnchorProviderT, winrt::cloaked<winrt::IRepeaterScrollingSurface>, winrt::composable>
+class ItemsRepeaterScrollHost :
+    public ReferenceTracker<ItemsRepeaterScrollHost, DeriveFromPanelHelper_base, winrt::ItemsRepeaterScrollHost, winrt::cloaked<winrt::IRepeaterScrollingSurface>>
 {
 public:
-    ScrollAnchorProvider();
+    ItemsRepeaterScrollHost();
 
 #pragma region IFrameworkElementOverrides
 
@@ -28,7 +28,11 @@ public:
 
     void VerticalAnchorRatio(double value);
 
-    winrt::UIElement AnchorElement();
+    winrt::UIElement CurrentAnchor();
+
+    winrt::FxScrollViewer ScrollViewer();
+    
+    void ScrollViewer(winrt::FxScrollViewer const& value);
 
 #pragma endregion
 
@@ -37,6 +41,8 @@ public:
     bool IsHorizontallyScrollable();
 
     bool IsVerticallyScrollable();
+
+    winrt::UIElement AnchorElement();
 
     winrt::event_token ViewportChanged(winrt::ViewportChangedEventHandler const& value);
 

--- a/dev/Repeater/LayoutContextAdapter.cpp
+++ b/dev/Repeater/LayoutContextAdapter.cpp
@@ -53,7 +53,7 @@ winrt::IInspectable LayoutContextAdapter::GetItemAtCore(int index)
     return nullptr;
 }
 
-winrt::UIElement LayoutContextAdapter::GetElementAtCore(int index, winrt::ElementRealizationOptions const& options)
+winrt::UIElement LayoutContextAdapter::GetOrCreateElementAtCore(int index, winrt::ElementRealizationOptions const& options)
 {
     if (auto context = m_nonVirtualizingContext.get())
     {

--- a/dev/Repeater/LayoutContextAdapter.h
+++ b/dev/Repeater/LayoutContextAdapter.h
@@ -24,7 +24,7 @@ public:
 
     int32_t ItemCountCore();
     winrt::IInspectable GetItemAtCore(int index);
-    winrt::UIElement GetElementAtCore(int index, winrt::ElementRealizationOptions const& options);
+    winrt::UIElement GetOrCreateElementAtCore(int index, winrt::ElementRealizationOptions const& options);
     void RecycleElementCore(winrt::UIElement const& element);
     int32_t GetElementIndexCore(winrt::UIElement const& element);
 

--- a/dev/Repeater/Repeater.vcxitems
+++ b/dev/Repeater/Repeater.vcxitems
@@ -59,7 +59,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)SelectionTreeHelper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)StackLayout.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)StackLayoutState.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)ScrollAnchorProvider.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)ItemsRepeaterScrollHost.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)InspectingDataSource.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)RecyclingElementFactory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)IFlowLayoutAlgorithmDelegates.h" />
@@ -98,7 +98,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ItemsRepeaterElementIndexChangedEventArgs.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ItemsRepeaterElementPreparedEventArgs.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ItemsSourceViewFactory.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)ScrollAnchorProvider.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)ItemsRepeaterScrollHost.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ElementManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ItemTemplateWrapper.cpp" Condition="$(BuildingWithBuildExe) != 'true'" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LayoutContextAdapter.cpp" />

--- a/dev/Repeater/RepeaterLayoutContext.cpp
+++ b/dev/Repeater/RepeaterLayoutContext.cpp
@@ -24,7 +24,7 @@ int32_t RepeaterLayoutContext::ItemCountCore()
     return 0;
 }
 
-winrt::UIElement RepeaterLayoutContext::GetElementAtCore(int index, winrt::ElementRealizationOptions const& options)
+winrt::UIElement RepeaterLayoutContext::GetOrCreateElementAtCore(int index, winrt::ElementRealizationOptions const& options)
 {
     return winrt::get_self<ItemsRepeater>(GetOwner())->GetElementImpl(index, 
         (options & winrt::ElementRealizationOptions::ForceCreate) == winrt::ElementRealizationOptions::ForceCreate,

--- a/dev/Repeater/RepeaterLayoutContext.h
+++ b/dev/Repeater/RepeaterLayoutContext.h
@@ -28,7 +28,7 @@ public:
 #pragma region IVirtualizingLayoutContextOverrides
 
     int32_t ItemCountCore();
-    winrt::UIElement GetElementAtCore(int index, winrt::ElementRealizationOptions const& options);
+    winrt::UIElement GetOrCreateElementAtCore(int index, winrt::ElementRealizationOptions const& options);
 
     winrt::IInspectable GetItemAtCore(int index);
     void RecycleElementCore(winrt::UIElement const& element);

--- a/dev/Repeater/ScrollAnchorProvider.h
+++ b/dev/Repeater/ScrollAnchorProvider.h
@@ -28,13 +28,7 @@ public:
 
     void VerticalAnchorRatio(double value);
 
-    void StartBringIntoView(
-        winrt::UIElement const& element,
-        double alignmentX,
-        double alignmentY,
-        double offsetX,
-        double offsetY,
-        bool animate);
+    winrt::UIElement AnchorElement();
 
 #pragma endregion
 
@@ -43,8 +37,6 @@ public:
     bool IsHorizontallyScrollable();
 
     bool IsVerticallyScrollable();
-
-    winrt::UIElement AnchorElement();
 
     winrt::event_token ViewportChanged(winrt::ViewportChangedEventHandler const& value);
 
@@ -66,6 +58,14 @@ public:
         winrt::UIElement const& element);
 
 #pragma endregion
+
+    void StartBringIntoView(
+        winrt::UIElement const& element,
+        double alignmentX,
+        double alignmentY,
+        double offsetX,
+        double offsetY,
+        bool animate);
 
 private:
     void ApplyPendingChangeView(const winrt::FxScrollViewer& scrollViewer);

--- a/dev/Repeater/TestUI/Samples/ActivityFeedDemo/ActivityFeedSamplePage.xaml
+++ b/dev/Repeater/TestUI/Samples/ActivityFeedDemo/ActivityFeedSamplePage.xaml
@@ -20,7 +20,7 @@
         </controls:RecyclingElementFactory>
     </Page.Resources>
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <controls:ScrollAnchorProvider x:Name="tracker"  >
+        <controls:ItemsRepeaterScrollHost x:Name="tracker"  >
             <ScrollViewer x:Name="scrollViewer">
                 <controls:ItemsRepeater x:Name="repeater">
                     <controls:ItemsRepeater.Layout>
@@ -28,6 +28,6 @@
                     </controls:ItemsRepeater.Layout>
                 </controls:ItemsRepeater>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/AnimationsDemoPage.xaml
+++ b/dev/Repeater/TestUI/Samples/AnimationsDemoPage.xaml
@@ -84,11 +84,11 @@
                 </StackPanel>
             </SplitView.Pane>
             <SplitView.Content>
-                <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1" HorizontalAlignment="Center">
+                <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1" HorizontalAlignment="Center">
                     <ScrollViewer x:Name="scroller">
                         <controls:ItemsRepeater x:Name="repeater" Animator="{StaticResource SharedAnimator}" />
                     </ScrollViewer>
-                </controls:ScrollAnchorProvider>
+                </controls:ItemsRepeaterScrollHost>
             </SplitView.Content>
         </SplitView>
     </Grid>

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml
@@ -37,13 +37,13 @@
             <Button x:Name="goBackButton">Back</Button>
         </StackPanel>
 
-        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1">
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1">
             <ScrollViewer x:Name="scrollViewer">
                 <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0" Background="LightBlue"/>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
 
-        <!-- No ScrollAnchorProvider for RS5+. ScrollViewer can do the anchoring itself-->
+        <!-- No ItemsRepeaterScrollHost for RS5+. ScrollViewer can do the anchoring itself-->
         <!--controls:ScrollViewer x:Name="scrollViewer" Height="500">
             <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0" />
                 <controls:ItemsRepeater.Layout>
@@ -52,7 +52,7 @@
             </controls:ItemsRepeater>
         </-->
 
-        <!-- No ScrollAnchorProvider for RS5+. ScrollViewer can do the anchoring itself -->
+        <!-- No ItemsRepeaterScrollHost for RS5+. ScrollViewer can do the anchoring itself -->
         <!-- ScrollViewer x:Name="scrollViewer" Grid.Row="1">
             <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0">
                 <controls:ItemsRepeater.Layout>

--- a/dev/Repeater/TestUI/Samples/CircleLayoutDemo/CircleLayoutSamplePage.xaml
+++ b/dev/Repeater/TestUI/Samples/CircleLayoutDemo/CircleLayoutSamplePage.xaml
@@ -29,7 +29,7 @@
             </LinearGradientBrush>
         </Grid.Background>
 
-        <controls:ScrollAnchorProvider x:Name="tracker">
+        <controls:ItemsRepeaterScrollHost x:Name="tracker">
             <ScrollViewer>
                 <StackPanel>
                     <Button x:Name="bringIntoView">Bring Into View</Button>
@@ -49,6 +49,6 @@
                     </Grid>
                 </StackPanel>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
@@ -47,7 +47,7 @@
             </StackPanel>
         </StackPanel>
 
-        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1" >
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1" >
             <ScrollViewer x:Name="scrollViewer">
                 <controls:ItemsRepeater x:Name="repeater">
                     <controls:ItemsRepeater.Layout>
@@ -58,6 +58,6 @@
                     </controls:ItemsRepeater.Animator>
                 </controls:ItemsRepeater>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/Defaults.xaml
+++ b/dev/Repeater/TestUI/Samples/Defaults.xaml
@@ -15,10 +15,10 @@
             <Button x:Name="goBackButton">Back</Button>
         </StackPanel>
 
-        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1">
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1">
             <ScrollViewer>
                 <controls:ItemsRepeater ItemsSource="{x:Bind Data}" />
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/ItemTemplateSamples/ItemTemplateDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/ItemTemplateSamples/ItemTemplateDemo.xaml
@@ -22,7 +22,7 @@
         </Grid.ColumnDefinitions>
         <StackPanel>
             <TextBlock>DataTemplate Sample:</TextBlock>
-            <controls:ScrollAnchorProvider Height="400" Width="150">
+            <controls:ItemsRepeaterScrollHost Height="400" Width="150">
                 <ScrollViewer>
                     <controls:ItemsRepeater x:Name="repeater0"
                                             ItemsSource="{x:Bind Data}"
@@ -34,11 +34,11 @@
                         </controls:ItemsRepeater.ItemTemplate>
                     </controls:ItemsRepeater>
                 </ScrollViewer>
-            </controls:ScrollAnchorProvider>
+            </controls:ItemsRepeaterScrollHost>
         </StackPanel>
         <StackPanel Grid.Column="1">
             <TextBlock>DataTemplateSelector Sample:</TextBlock>
-            <controls:ScrollAnchorProvider Height="400" Width="150">
+            <controls:ItemsRepeaterScrollHost Height="400" Width="150">
                 <ScrollViewer>
                     <controls:ItemsRepeater x:Name="repeater1" 
                                             ItemsSource="{x:Bind Data}"
@@ -59,11 +59,11 @@
                         </controls:ItemsRepeater.ItemTemplate>
                     </controls:ItemsRepeater>
                 </ScrollViewer>
-            </controls:ScrollAnchorProvider>
+            </controls:ItemsRepeaterScrollHost>
         </StackPanel>
         <StackPanel Grid.Column="2">
             <TextBlock>ElementFactory Single Template Sample:</TextBlock>
-            <controls:ScrollAnchorProvider Height="400" Width="150">
+            <controls:ItemsRepeaterScrollHost Height="400" Width="150">
                 <ScrollViewer>
                     <controls:ItemsRepeater x:Name="repeater2" 
                                             ItemsSource="{x:Bind Data}"
@@ -77,11 +77,11 @@
                         </controls:ItemsRepeater.ItemTemplate>
                     </controls:ItemsRepeater>
                 </ScrollViewer>
-            </controls:ScrollAnchorProvider>
+            </controls:ItemsRepeaterScrollHost>
         </StackPanel>
         <StackPanel Grid.Column="3">
             <TextBlock>ElementFactory Multiple Template Sample:</TextBlock>
-            <controls:ScrollAnchorProvider Height="400" Width="150">
+            <controls:ItemsRepeaterScrollHost Height="400" Width="150">
                 <ScrollViewer>
                     <controls:ItemsRepeater x:Name="repeater3" 
                                             ItemsSource="{x:Bind Data}"
@@ -100,7 +100,7 @@
                         </controls:ItemsRepeater.ItemTemplate>
                     </controls:ItemsRepeater>
                 </ScrollViewer>
-            </controls:ScrollAnchorProvider>
+            </controls:ItemsRepeaterScrollHost>
         </StackPanel>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/ItemsViewWithDataPage.xaml
+++ b/dev/Repeater/TestUI/Samples/ItemsViewWithDataPage.xaml
@@ -157,12 +157,12 @@
             <Button x:Name="scrollButton" Margin="20 0 0 0">Scroll</Button>
         </StackPanel>
 
-        <!--With ScrollAnchorProvider for testing downlevel-->
-        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1" >
+        <!--With ItemsRepeaterScrollHost for testing downlevel-->
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1" >
             <ScrollViewer x:Name="scrollViewer">
                 <controls:ItemsRepeater x:Name="rootRepeater" VerticalCacheLength="0" />
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
 
         <!-- No Element Tracker for RS5+. ScrollViewer can do the anchoring itself -->
         <!--<ScrollViewer x:Name="scrollViewer" Grid.Row="1">

--- a/dev/Repeater/TestUI/Samples/Selection/Flat/FlatSample.xaml
+++ b/dev/Repeater/TestUI/Samples/Selection/Flat/FlatSample.xaml
@@ -68,7 +68,7 @@
             </StackPanel>
         </StackPanel>
 
-        <controls:ScrollAnchorProvider Grid.Row="2" >
+        <controls:ItemsRepeaterScrollHost Grid.Row="2" >
             <ScrollViewer>
                 <local:SelectionContainer SelectionModel="{StaticResource selectionModel}">
                     <controls:ItemsRepeater x:Name="repeater"  >
@@ -78,7 +78,7 @@
                     </controls:ItemsRepeater>
                 </local:SelectionContainer>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
 
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/Selection/Grouped/GroupedSample.xaml
+++ b/dev/Repeater/TestUI/Samples/Selection/Grouped/GroupedSample.xaml
@@ -67,7 +67,7 @@
             <TextBlock Text="{x:Bind selectionModel.SelectedItem, Mode=OneWay}" />
         </StackPanel>
 
-        <controls:ScrollAnchorProvider Grid.Row="2" >
+        <controls:ItemsRepeaterScrollHost Grid.Row="2" >
             <ScrollViewer>
                 <local:SelectionContainer SelectionModel="{StaticResource selectionModel}">
                     <controls:ItemsRepeater x:Name="repeater" 
@@ -76,6 +76,6 @@
                     </controls:ItemsRepeater>
                 </local:SelectionContainer>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/Selection/TreeView/TreeViewSample.xaml
+++ b/dev/Repeater/TestUI/Samples/Selection/TreeView/TreeViewSample.xaml
@@ -88,7 +88,7 @@
                 <TextBlock Text="{x:Bind selectionModel.SelectedItem, Mode=OneWay}" />
             </StackPanel>
         </StackPanel>
-        <controls:ScrollAnchorProvider Grid.Row="1">
+        <controls:ItemsRepeaterScrollHost Grid.Row="1">
             <ScrollViewer>
                 <local:SelectionContainer SelectionModel="{StaticResource selectionModel}">
                     <controls:ItemsRepeater 
@@ -98,6 +98,6 @@
                     ItemTemplate="{StaticResource elementFactory}" />
                 </local:SelectionContainer>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/StackLayoutSamples/Virtual/PinterestLayoutSamplePage.xaml
+++ b/dev/Repeater/TestUI/Samples/StackLayoutSamples/Virtual/PinterestLayoutSamplePage.xaml
@@ -36,7 +36,7 @@
             <TextBlock x:Name="tb">10</TextBlock>
             <Button Content="BringIntoView" x:Name="bringIntoView"/>
         </StackPanel>
-        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1" >
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1" >
             <ScrollViewer>
                 <controls:ItemsRepeater x:Name="repeater">
                     <controls:ItemsRepeater.Layout>
@@ -44,6 +44,6 @@
                     </controls:ItemsRepeater.Layout>
                 </controls:ItemsRepeater>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/StackLayoutSamples/Virtual/VirtualizingStackLayoutSamplePage.xaml
+++ b/dev/Repeater/TestUI/Samples/StackLayoutSamples/Virtual/VirtualizingStackLayoutSamplePage.xaml
@@ -36,7 +36,7 @@
             <TextBlock x:Name="tb">10</TextBlock>
             <Button Content="BringIntoView" x:Name="bringIntoView"/>
         </StackPanel>
-        <controls:ScrollAnchorProvider x:Name="tracker" Grid.Row="1" >
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1" >
             <ScrollViewer>
                 <controls:ItemsRepeater x:Name="repeater" >
                     <controls:ItemsRepeater.Layout>
@@ -44,6 +44,6 @@
                     </controls:ItemsRepeater.Layout>
                 </controls:ItemsRepeater>
             </ScrollViewer>
-        </controls:ScrollAnchorProvider>
+        </controls:ItemsRepeaterScrollHost>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/StackLayoutSamples/Virtual/VirtualizingUniformStackLayoutSamplePage.xaml
+++ b/dev/Repeater/TestUI/Samples/StackLayoutSamples/Virtual/VirtualizingUniformStackLayoutSamplePage.xaml
@@ -21,7 +21,7 @@
     <Grid>
 
         <StackPanel>
-            <controls:ScrollAnchorProvider x:Name="tracker" Height="400">
+            <controls:ItemsRepeaterScrollHost x:Name="tracker" Height="400">
                 <ScrollViewer>
                     <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0">
                         <controls:ItemsRepeater.Layout>
@@ -29,7 +29,7 @@
                         </controls:ItemsRepeater.Layout>
                     </controls:ItemsRepeater>
                 </ScrollViewer>
-            </controls:ScrollAnchorProvider>
+            </controls:ItemsRepeaterScrollHost>
             <StackPanel Grid.Column="2">
                 <TextBlock x:Name="tb">10</TextBlock>
                 <Button Content="BringIntoView" x:Name="bringIntoView"/>

--- a/dev/Repeater/VirtualizingLayoutContext.cpp
+++ b/dev/Repeater/VirtualizingLayoutContext.cpp
@@ -23,16 +23,16 @@ winrt::IInspectable VirtualizingLayoutContext::GetItemAt(int index)
 
 winrt::UIElement VirtualizingLayoutContext::GetOrCreateElementAt(int index)
 {
-    // Calling this way because GetElementAtCore is ambiguous.
+    // Calling this way because GetOrCreateElementAtCore is ambiguous.
     // Use .as instead of try_as because try_as uses non-delegating inner and we need to call the outer for overrides.
-    return get_strong().as<winrt::IVirtualizingLayoutContextOverrides>().GetElementAtCore(index, winrt::ElementRealizationOptions::None);
+    return get_strong().as<winrt::IVirtualizingLayoutContextOverrides>().GetOrCreateElementAtCore(index, winrt::ElementRealizationOptions::None);
 }
 
 winrt::UIElement VirtualizingLayoutContext::GetOrCreateElementAt(int index, winrt::ElementRealizationOptions const& options)
 {
-    // Calling this way because GetElementAtCore is ambiguous.
+    // Calling this way because GetOrCreateElementAtCore is ambiguous.
     // Use .as instead of try_as because try_as uses non-delegating inner and we need to call the outer for overrides.
-    return get_strong().as<winrt::IVirtualizingLayoutContextOverrides>().GetElementAtCore(index, options);
+    return get_strong().as<winrt::IVirtualizingLayoutContextOverrides>().GetOrCreateElementAtCore(index, options);
 }
 
 void VirtualizingLayoutContext::RecycleElement(winrt::UIElement const& element)
@@ -69,7 +69,7 @@ winrt::IInspectable VirtualizingLayoutContext::GetItemAtCore(int /*index*/)
     throw winrt::hresult_not_implemented();
 }
 
-winrt::UIElement VirtualizingLayoutContext::GetElementAtCore(int /*index*/, winrt::ElementRealizationOptions const& /* options */)
+winrt::UIElement VirtualizingLayoutContext::GetOrCreateElementAtCore(int /*index*/, winrt::ElementRealizationOptions const& /* options */)
 {
     throw winrt::hresult_not_implemented();
 }

--- a/dev/Repeater/VirtualizingLayoutContext.h
+++ b/dev/Repeater/VirtualizingLayoutContext.h
@@ -29,7 +29,7 @@ public:
 #pragma region IVirtualizingLayoutContextOverrides
     virtual int32_t ItemCountCore();
     virtual winrt::IInspectable GetItemAtCore(int index);
-    virtual winrt::UIElement GetElementAtCore(int index, winrt::ElementRealizationOptions const& options);
+    virtual winrt::UIElement GetOrCreateElementAtCore(int index, winrt::ElementRealizationOptions const& options);
     virtual void RecycleElementCore(winrt::UIElement const& element);
 
     virtual winrt::Rect RealizationRectCore();

--- a/dev/ScrollViewer/ScrollViewer.cpp
+++ b/dev/ScrollViewer/ScrollViewer.cpp
@@ -176,7 +176,7 @@ void ScrollViewer::RegisterAnchorCandidate(winrt::UIElement const& element)
             scrollerAsAnchorProvider.RegisterAnchorCandidate(element);
             return;
         }
-        throw winrt::hresult_error(E_INVALID_OPERATION, s_iScrollAnchorProviderNotImpl);
+        throw winrt::hresult_error(E_INVALID_OPERATION, s_IScrollAnchorProviderNotImpl);
     }
     throw winrt::hresult_error(E_INVALID_OPERATION, s_noScrollerPart);
 }
@@ -192,7 +192,7 @@ void ScrollViewer::UnregisterAnchorCandidate(winrt::UIElement const& element)
             scrollerAsAnchorProvider.UnregisterAnchorCandidate(element);
             return;
         }
-        throw winrt::hresult_error(E_INVALID_OPERATION, s_iScrollAnchorProviderNotImpl);
+        throw winrt::hresult_error(E_INVALID_OPERATION, s_IScrollAnchorProviderNotImpl);
     }
     throw winrt::hresult_error(E_INVALID_OPERATION, s_noScrollerPart);
 }

--- a/dev/ScrollViewer/ScrollViewer.h
+++ b/dev/ScrollViewer/ScrollViewer.h
@@ -243,7 +243,7 @@ private:
     static constexpr std::wstring_view s_horizontalScrollBarPartName{ L"PART_HorizontalScrollBar"sv };
     static constexpr std::wstring_view s_verticalScrollBarPartName{ L"PART_VerticalScrollBar"sv };
     static constexpr std::wstring_view s_scrollBarsSeparatorPartName{ L"PART_ScrollBarsSeparator"sv };
-    static constexpr std::wstring_view s_iScrollAnchorProviderNotImpl{ L"Template part named PART_Scroller does not implement IScrollAnchorProvider."sv };
+    static constexpr std::wstring_view s_IScrollAnchorProviderNotImpl{ L"Template part named PART_Scroller does not implement IScrollAnchorProvider."sv };
     static constexpr std::wstring_view s_noScrollerPart{ L"No template part named PART_Scroller was loaded."sv };
 
     winrt::com_ptr<ScrollBarController> m_horizontalScrollBarController{ nullptr };

--- a/dev/dll/WinRtType.tt
+++ b/dev/dll/WinRtType.tt
@@ -42,10 +42,10 @@
             var winRtTypeName = MapToWinRtName(winmdType);
             CppAbiName = MapToAbiName(winmdType);
             CppAbiInterfaceName = MapToAbiInterfaceName(winmdType);
-
+			var cppFullTypeName = (CppNamespace != null ? (CppNamespace + "::" ) : "") + winRtTypeName;
             WinRtFullName = string.Join(".", winRtNamespace, winRtTypeName).TrimStart('.');
             MetadataFullName = GetMetadataFullName(WinRtFullName);
-            CppWinRtName = winmdType.IsPrimitive ? GetPrimitiveTypeName(winRtTypeName) : string.Format("winrt::{0}", winRtTypeName);
+            CppWinRtName = winmdType.IsPrimitive ? GetPrimitiveTypeName(winRtTypeName) : string.Format("winrt::{0}", cppFullTypeName);
 
             ListWinRtTypes = GetCollectionTypes(winmdType, typeof(IList<>));
             MapWinRtTypes = GetCollectionTypes(winmdType, typeof(IDictionary<,>));
@@ -96,12 +96,6 @@
                 case "IObservableVector`1":
                     name = "IObservableVector";
                     break;
-				case "ScrollViewer":
-					if(winmdType.FullName == "Windows.UI.Xaml.Controls.ScrollViewer")
-					{
-						name = "FxScrollViewer";
-					}
-					break;
             }
 
             return name;

--- a/dev/dll/WinRtType.tt
+++ b/dev/dll/WinRtType.tt
@@ -96,6 +96,12 @@
                 case "IObservableVector`1":
                     name = "IObservableVector";
                     break;
+				case "ScrollViewer":
+					if(winmdType.FullName == "Windows.UI.Xaml.Controls.ScrollViewer")
+					{
+						name = "FxScrollViewer";
+					}
+					break;
             }
 
             return name;

--- a/test/IXMPTestApp/Tests/MetadataProviderTests.cs
+++ b/test/IXMPTestApp/Tests/MetadataProviderTests.cs
@@ -58,7 +58,7 @@ namespace IXMPTestApp.Tests
 
                 Log.Comment("Loading ItemsRepeater...");
                 XamlReader.Load(@"
-                    <controls:ScrollAnchorProvider
+                    <controls:ItemsRepeaterScrollHost
                         xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
                         xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
                         xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
@@ -79,7 +79,7 @@ namespace IXMPTestApp.Tests
                                 </controls:ItemsRepeater.ItemTemplate>
                             </controls:ItemsRepeater>
                         </ScrollViewer>
-                    </controls:ScrollAnchorProvider>");
+                    </controls:ItemsRepeaterScrollHost>");
 
                 Log.Comment("Loading SwipeControl...");
                 XamlReader.Load(@"

--- a/test/MUXControlsAdhocApp/RepeaterPages/PerfComparisonPage.xaml.cs
+++ b/test/MUXControlsAdhocApp/RepeaterPages/PerfComparisonPage.xaml.cs
@@ -76,10 +76,10 @@ namespace MUXControlsAdhocApp.RepeaterPages
 
             repeater.VerticalCacheLength = 4.0;
             repeater.XYFocusKeyboardNavigation = Windows.UI.Xaml.Input.XYFocusKeyboardNavigationMode.Enabled;
-            var tracker = new ScrollAnchorProvider();
+            var tracker = new ItemsRepeaterScrollHost();
             var scrollViewer = new Windows.UI.Xaml.Controls.ScrollViewer();
             
-            tracker.Content = scrollViewer;
+            tracker.ScrollViewer = scrollViewer;
             scrollViewer.Content = repeater;
             scrollViewer.IsTabStop = false;
             host.Child = tracker;

--- a/test/MUXControlsAdhocApp/RepeaterPages/PerfComparisonPage.xaml.cs
+++ b/test/MUXControlsAdhocApp/RepeaterPages/PerfComparisonPage.xaml.cs
@@ -20,7 +20,7 @@ using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
 using ElementFactory = Microsoft.UI.Xaml.Controls.ElementFactory;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
-using ScrollAnchorProvider = Microsoft.UI.Xaml.Controls.ScrollAnchorProvider;
+using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using SelectTemplateEventArgs = Microsoft.UI.Xaml.Controls.SelectTemplateEventArgs;
 #endif
 


### PR DESCRIPTION
Changed GetElementCore to GetOrCreateElementCore
Make ScrollAnchorProvider public and expose AnchorElement.

Pending tests for AnchorElement.

https://github.com/Microsoft/microsoft-ui-xaml-specs/blob/c079d62f6f0013c24f9a6c1f070bcc1d6186bfd6/active/ItemsRepeaterScrollHost/ItemsRepeaterScrollHost.md

Fixes #460
Fixes #446