### PR TITLE
TeachingTip buttons should stretch

### DIFF
--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -500,11 +500,13 @@
                                                         <ColumnDefinition Width="*"/>
                                                     </Grid.ColumnDefinitions>
                                                     <Button x:Name="ActionButton"
+                                                            HorizontalAlignment="Stretch"
                                                             Content="{TemplateBinding ActionButtonContent}"
                                                             Style="{TemplateBinding ActionButtonStyle}" 
                                                             Command="{TemplateBinding ActionButtonCommand}"
                                                             CommandParameter="{TemplateBinding ActionButtonCommandParameter}"/>
                                                     <Button x:Name="CloseButton"
+                                                            HorizontalAlignment="Stretch"
                                                             Content="{TemplateBinding CloseButtonContent}"
                                                             Style="{TemplateBinding CloseButtonStyle}"
                                                             Command="{TemplateBinding CloseButtonCommand}"


### PR DESCRIPTION
TeachingTip's built in buttons should stretch to 50% of the tips width regardless of the size of their content in order to match the spec.