### PR TITLE
Move FrameworkPackage generation to post-signing job

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
@@ -7,10 +7,6 @@ steps:
       buildOutputDir: $(buildOutputDir)
       publishDir: $(publishDir)
 
-  - script: |
-      call %Build_SourcesDirectory%\tools\MakeAppxHelper.cmd %BUILDPLATFORM% %BUILDCONFIGURATION% -builddate_yymm %BUILDDATE_YYMM% -builddate_dd $BUILDDATE_DD% -subversion %BUILDREVISION%
-      if %ERRORLEVEL% NEQ 0 (
-          echo ##vso[task.logissue type=error;] Make AppxHelper failed with exit code %ERRORLEVEL%
-          goto END
-      )
-    displayName: 'Make FrameworkPackage'
+  - template: MUX-MakeFrameworkPackages-Steps.yml
+    parameters:
+      buildOutputDir: $(buildOutputDir)

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -19,12 +19,7 @@ steps:
     inputs:
       filename: 'set'
 
-  - task: powershell@2
-    inputs:
-      targetType: filePath
-      filePath: build\Install-WindowsSdkISO.ps1
-      arguments: 18323
-    displayName: 'Install Insider SDK (18323)'
+  - template: MUX-InstallWindowsSDK-Steps.yml
 
   - template: MUX-InstallNuget-Steps.yml
 

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -19,7 +19,6 @@ jobs:
     pool:
       name: Package ES Lab E
 
-
   steps:
   - ${{if parameters.signConfig }}:
     - task: PkgESSetupBuild@10
@@ -30,7 +29,7 @@ jobs:
         nugetVer: true
 
   - template: MUX-PopulateBuildDateAndRevision-Steps.yml
-  
+
   - script: |
       echo parameters.jobName '${{ parameters.jobName }}'
       echo parameters.buildOutputDir '${{ parameters.buildOutputDir }}'
@@ -46,6 +45,19 @@ jobs:
       downloadPath: '$(Build.SourcesDirectory)\Artifacts'
 
   - template: MUX-InstallNuget-Steps.yml
+
+  - ${{if parameters.signConfig }}:
+    # Install SDK since the custom appx generation needs to resolve winmd types from it.
+    - template: MUX-InstallWindowsSDK-Steps.yml
+
+    # Re-create framework packages because 
+    - template: MUX-MakeFrameworkPackages-Steps.yml
+
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '${{ parameters.nupkgdir }}'
+        sourceFolder: '$(Build.SourcesDirectory)\Artifacts\drop'
+        Contents: '**\Microsoft.UI.Xaml*.appx'
 
   - task: powershell@2
     displayName: 'build-nupkg.ps1'

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -50,9 +50,10 @@ jobs:
     # Install SDK since the custom appx generation needs to resolve winmd types from it.
     - template: MUX-InstallWindowsSDK-Steps.yml
 
-    # Re-create framework packages because 
+    # Re-create framework packages because we made them in the build step against unsigned binaries.
     - template: MUX-MakeFrameworkPackages-Steps.yml
 
+    # Copy the re-made framework packages into the same location in the artifact drop to be republished at the end of the job.
     - task: CopyFiles@2
       inputs:
         targetFolder: '${{ parameters.nupkgdir }}'

--- a/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
@@ -1,0 +1,10 @@
+parameters:
+  sdkVersion: 18323
+
+steps:
+  - task: powershell@2
+    inputs:
+      targetType: filePath
+      filePath: build\Install-WindowsSdkISO.ps1
+      arguments: ${{ parameters.sdkVersion }}
+    displayName: 'Install Insider SDK (${{ parameters.sdkVersion }})'

--- a/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
@@ -1,0 +1,27 @@
+parameters:
+  buildOutputDir: '$(Build.SourcesDirectory)\Artifacts\drop'
+
+steps:
+  - powershell: |
+      $platforms = @("x86", "x64", "arm", "arm64")
+      $configs = @("debug", "release")
+      foreach ($platform in $platforms)
+      {
+        foreach ($config in $configs)
+        {
+          $rootPath = "${{ parameters.buildOutputDir }}\$config\$platform"
+          Write-Host ""
+          Write-Host "Checking for $rootPath"
+          Write-Host ""
+          if (Test-Path $rootPath)
+          {
+            $env:BUILDOUTPUT_OVERRIDE = $rootPath
+            & $env:Build_SourcesDirectory\tools\MakeAppxHelper.cmd $platform $config -builddate_yymm $env:BUILDDATE_YYMM -builddate_dd $env:BUILDDATE_DD -subversion $env:BUILDREVISION
+            if ($lastexitcode -ne 0) {
+                Write-Host ##vso[task.logissue type=error;] Make AppxHelper $platform $config failed with exit code $lastexitcode
+                Exit 1
+            }
+          }
+        }
+      }
+    displayName: 'Make FrameworkPackages'

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -54,8 +54,8 @@ jobs:
       inputs: 
         buildType: specific
         buildVersionToDownload: specific
-        project: '66f07283-7714-4cbf-be8f-73dfb782cfdc'
-        pipeline: 22
+        project: $(System.TeamProjectId)
+        pipeline: $(System.DefinitionId)
         buildId: $(useBuildOutputFromBuildId)
         artifactName: drop 
         downloadPath: '$(artifactsDir)'

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -1,6 +1,6 @@
 [CmdLetBinding()]
 Param(
-    [string]$inputs,
+    [string]$inputDirectory,
     [string]$outputDirectory,
     [string]$Platform,
     [string]$Configuration,
@@ -9,7 +9,6 @@ Param(
     [int]$Subversion = "000",
     [string]$builddate_yymm,
     [string]$builddate_dd,
-    [string]$TestAppManifest,
     [string]$WindowsSdkBinDir,
     [string]$BasePackageName,
     [string]$PackageNameSuffix)
@@ -36,8 +35,8 @@ $fullOutputPath = [IO.Path]::GetFullPath($outputDirectory)
 Write-Host "MakeFrameworkPackage: $fullOutputPath" -ForegroundColor Magenta 
 # Write-Output "Path: $env:PATH"
 
-$output = mkdir -Force $fullOutputPath\PackageContents
-$output = mkdir -Force $fullOutputPath\Resources
+mkdir -Force $fullOutputPath\PackageContents | Out-Null
+mkdir -Force $fullOutputPath\Resources | Out-Null
 
 Copy-IntoNewDirectory FrameworkPackageContents\* $fullOutputPath\PackageContents
 
@@ -46,33 +45,30 @@ Copy-IntoNewDirectory PriConfig\* $fullOutputPath
 $KitsRoot10 = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots" -Name KitsRoot10).KitsRoot10
 $WindowsSdkBinDir = Join-Path $KitsRoot10 "bin\x86"
 
-$scriptDirectory = Split-Path -Path $script:MyInvocation.MyCommand.Path -Parent
-
 $ActivatableTypes = ""
 
 # Copy over and add to the manifest file list the .dll, .winmd for the inputs. Also copy the .pri
 # but don't list it because it will be merged together.
-ForEach ($input in ($inputs -split ";"))
-{
-    Write-Output "Input: $input"
-    $inputBaseFileName = [System.IO.Path]::GetFileNameWithoutExtension($input)
-    $inputBasePath = Split-Path $input -Parent
-    
-    Copy-IntoNewDirectory "$inputBasePath\$inputBaseFileName.dll" $fullOutputPath\PackageContents
-    Copy-IntoNewDirectory "$inputBasePath\$inputBaseFileName.pri" $fullOutputPath\Resources
-    Copy-IntoNewDirectory "$inputBasePath\sdk\$inputBaseFileName.winmd" $fullOutputPath\PackageContents
 
-    Write-Verbose "Copying $inputBasePath\Themes"
-    Copy-IntoNewDirectory -IfExists $inputBasePath\Themes $fullOutputPath\PackageContents\Microsoft.UI.Xaml
+Write-Output "Input: $inputDirectory"
+$inputBaseFileName = "Microsoft.UI.Xaml"
+$inputBasePath = $inputDirectory
 
-    [xml]$sdkPropsContent = Get-Content $PSScriptRoot\..\..\sdkversion.props
-    $highestSdkVersion = $sdkPropsContent.GetElementsByTagName("*").'#text' -match "10." | Sort-Object | Select-Object -Last 1
-    $sdkReferencesPath=$kitsRoot10 + "References\" + $highestSdkVersion;    
-    $foundationWinmdPath = gci -Recurse $sdkReferencesPath"\Windows.Foundation.FoundationContract" -Filter "Windows.Foundation.FoundationContract.winmd" | select -ExpandProperty FullName
-    $universalWinmdPath = gci -Recurse $sdkReferencesPath"\Windows.Foundation.UniversalApiContract" -Filter "Windows.Foundation.UniversalApiContract.winmd" | select -ExpandProperty FullName
-    $refrenceWinmds = $foundationWinmdPath + ";" + $universalWinmdPath
-    $classes = Get-ActivatableTypes $inputBasePath\$inputBaseFileName.winmd  $refrenceWinmds  | Sort-Object -Property FullName
-    Write-Host $classes.Length Types found.
+Copy-IntoNewDirectory "$inputBasePath\$inputBaseFileName.dll" $fullOutputPath\PackageContents
+Copy-IntoNewDirectory "$inputBasePath\$inputBaseFileName.pri" $fullOutputPath\Resources
+Copy-IntoNewDirectory "$inputBasePath\sdk\$inputBaseFileName.winmd" $fullOutputPath\PackageContents
+
+Write-Verbose "Copying $inputBasePath\Themes"
+Copy-IntoNewDirectory -IfExists $inputBasePath\Themes $fullOutputPath\PackageContents\Microsoft.UI.Xaml
+
+[xml]$sdkPropsContent = Get-Content $PSScriptRoot\..\..\sdkversion.props
+$highestSdkVersion = $sdkPropsContent.GetElementsByTagName("*").'#text' -match "10." | Sort-Object | Select-Object -Last 1
+$sdkReferencesPath=$kitsRoot10 + "References\" + $highestSdkVersion;    
+$foundationWinmdPath = Get-ChildItem -Recurse $sdkReferencesPath"\Windows.Foundation.FoundationContract" -Filter "Windows.Foundation.FoundationContract.winmd" | Select-Object -ExpandProperty FullName
+$universalWinmdPath = Get-ChildItem -Recurse $sdkReferencesPath"\Windows.Foundation.UniversalApiContract" -Filter "Windows.Foundation.UniversalApiContract.winmd" | Select-Object -ExpandProperty FullName
+$refrenceWinmds = $foundationWinmdPath + ";" + $universalWinmdPath
+$classes = Get-ActivatableTypes $inputBasePath\sdk\$inputBaseFileName.winmd  $refrenceWinmds  | Sort-Object -Property FullName
+Write-Host $classes.Length Types found.
 @"
 "$inputBaseFileName.dll" "$inputBaseFileName.dll"
 "$inputBaseFileName.winmd" "$inputBaseFileName.winmd" 
@@ -84,19 +80,19 @@ ForEach ($input in ($inputs -split ";"))
         <Path>$inputBaseFileName.dll</Path>
 
 "@
-    ForEach ($class in $classes)
-    {
-        $className = $class.fullname
-        #Write-Host "Activatable type : $className"
-        $ActivatableTypes += "        <ActivatableClass ActivatableClassId=`"$className`" ThreadingModel=`"both`" />`r`n"
-    }
 
-    $ActivatableTypes += @"
+ForEach ($class in $classes)
+{
+    $className = $class.fullname
+    #Write-Host "Activatable type : $className"
+    $ActivatableTypes += "        <ActivatableClass ActivatableClassId=`"$className`" ThreadingModel=`"both`" />`r`n"
+}
+
+$ActivatableTypes += @"
       </InProcessServer>
     </Extension>
 
 "@
-}
 
 Copy-IntoNewDirectory ..\..\dev\Materials\Acrylic\Assets\NoiseAsset_256x256_PNG.png $fullOutputPath\Assets
 
@@ -266,7 +262,7 @@ Write-Host $makeappx
 cmd /c $makeappx
 if ($LastExitCode -ne 0) { Exit 1 }
 
-if ($env:TFS_ToolsDirectory -and ($env:BUILD_DEFINITIONNAME -match "_release") -and $env:UseSimpleSign)
+if ($env:TFS_ToolsDirectory -and ($env:BUILD_DEFINITIONNAME -match "release") -and $env:UseSimpleSign)
 {
     # From MakeAppxBundle in the XES tools
     $signToolPath = $env:TFS_ToolsDirectory + "\bin\SimpleSign.exe"

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -70,8 +70,8 @@ jobs:
     inputs: 
       buildType: specific
       buildVersionToDownload: specific
-      project: 'f05f4dbf-3077-427d-91e0-b66d9e4ca374'
-      pipeline: 35915
+      project: $(System.TeamProjectId)
+      pipeline: $(System.DefinitionId)
       buildId: $(useBuildOutputFromBuildId)
       artifactName: drop 
       downloadPath: '$(Build.ArtifactStagingDirectory)'

--- a/tools/MakeAppxHelper.cmd
+++ b/tools/MakeAppxHelper.cmd
@@ -29,20 +29,19 @@ if "%TFS_BUILDCONFIGURATION%" EQU "" (
 
 set BasePackageName=Microsoft.UI.Xaml
 
-if "%XES_OUTDIR%" == "" (
-	set WinMDInputs=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\Microsoft.UI.Xaml\Microsoft.UI.Xaml.winmd
+echo BUILDOUTPUT_OVERRIDE = %BUILDOUTPUT_OVERRIDE%
+if "%BUILDOUTPUT_OVERRIDE%" == "" (
+	set InputDirectory=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\Microsoft.UI.Xaml
 	set OutputDirectory=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\FrameworkPackage
-	set TestAppManifest=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\MUXControlsTestApp\AppxManifest.xml
 ) else (
-	set WinMDInputs=%XES_OUTDIR%\Microsoft.UI.Xaml\Microsoft.UI.Xaml.winmd
-	set OutputDirectory=%XES_OUTDIR%\FrameworkPackage
-	set TestAppManifest=%XES_OUTDIR%\MUXControlsTestApp\AppxManifest.xml
+	set InputDirectory=%BUILDOUTPUT_OVERRIDE%\Microsoft.UI.Xaml
+	set OutputDirectory=%BUILDOUTPUT_OVERRIDE%\FrameworkPackage
 )
 
-call ..\build\FrameworkPackage\MakeFrameworkPackage.cmd -Inputs '%WinMDInputs%' ^
+call ..\build\FrameworkPackage\MakeFrameworkPackage.cmd -InputDirectory '%InputDirectory%' ^
 -OutputDirectory '%OutputDirectory%' -BasePackageName '%BasePackageName%' -PackageNameSuffix 2.1 ^
 -Platform %TFS_PLATFORM% -Configuration %TFS_BUILDCONFIGURATION% ^
--TestAppManifest %TestAppManifest% %3 %4 %5 %6 %7 %8 %9
+ %3 %4 %5 %6 %7 %8 %9
 
 if %ERRORLEVEL% NEQ 0 (
 	@echo ##vso[task.logissue type=error;] MakeFrameworkPackage failed with exit code %ERRORLEVEL%


### PR DESCRIPTION
This change refactors the yaml that was invoking the framework package into a helper that can be invoked from the build (for PR builds) and then from the Nuget generation job (post-signing). 

I had to fix up the MakeFrameworkPackage.ps1 script a bit because it was generating the activatable types list from wrong winmd (the "internal" one, not the sdk directory one), and that was uncovered when running against the artifact drop which only has the sdk one. 
