### PR TITLE
Close NavView pane when switching from expand mode to compact mode

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -580,7 +580,7 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
         MUX_FAIL_FAST();
     }
 
-
+    auto previousMode = DisplayMode();
     SetDisplayMode(displayMode, forceSetDisplayMode);
 
     if (displayMode == winrt::NavigationViewDisplayMode::Expanded && IsPaneVisible())
@@ -589,7 +589,13 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
         {
             OpenPane();
         }
-    }     
+    }
+
+    if (previousMode == winrt::NavigationViewDisplayMode::Expanded
+        && displayMode == winrt::NavigationViewDisplayMode::Compact)
+    {
+        ClosePane();
+    }
 }
 
 void NavigationView::OnPaneToggleButtonClick(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/)

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3763,6 +3763,32 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        // Test for issue 450 https://github.com/Microsoft/microsoft-ui-xaml/issues/450
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "D")]
+        public void CompactModeAutoPaneClosingTest()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+            {
+                // Unmaximize the window
+                KeyboardHelper.PressKey(Key.Down, ModifierKey.Windows, 1);
+
+                // Resize window quickly
+                KeyboardHelper.PressDownModifierKey(ModifierKey.Windows);
+                KeyboardHelper.PressKeySequence(new[] { Key.Left, Key.Right, Key.Left, Key.Right, Key.Left });
+                KeyboardHelper.ReleaseModifierKey(ModifierKey.Windows);
+
+                Wait.ForIdle();
+
+                CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
+                Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState);
+
+                // Maximize the window
+                KeyboardHelper.PressKey(Key.Right, ModifierKey.Windows, 1);
+                KeyboardHelper.PressKey(Key.Up, ModifierKey.Windows, 1);
+            }
+        }
+
         private void EnsurePaneHeaderCanBeModifiedHelper(RegressionTestType navviewMode)
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone2))

--- a/test/MUXControls.Test/Common/KeyboardHelper.cs
+++ b/test/MUXControls.Test/Common/KeyboardHelper.cs
@@ -124,6 +124,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common
             Wait.ForIdle();
         }
 
+        public static void PressKeySequence(Key[] keys)
+        {
+            string keystrokes = string.Empty;
+
+            foreach (var key in keys)
+            {
+                keystrokes += keyToKeyStringDictionary[key];
+            }
+
+            Log.Comment("Send text '{0}'.", keystrokes);
+            TextInput.SendText(keystrokes);
+            Wait.ForIdle();
+        }
+
         public static void PressDownModifierKey(ModifierKey modifierKey)
         {
             string keystrokes = string.Empty;


### PR DESCRIPTION
Fixes #450 

NavView pane sometimes gets stuck open when switching between expand and compact mode very quickly.

Explicitly close the pane after switching to compact mode.