### PR TITLE
Reduce resource merge time from 2 minutes to < 1s

### DIFF
--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -505,7 +505,7 @@
   <Target Name="ComputeXamlGeneratedCompileInputs" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets" Condition="Exists('..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets')" />
-    <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.39\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.39\build\native\MUXCustomBuildTasks.targets')" />
+    <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets')" />
   </ImportGroup>
   <PropertyGroup>
     <MergedWinmdDirectory>$(OutDir)Merged</MergedWinmdDirectory>
@@ -550,212 +550,23 @@
   <PropertyGroup Condition="$(BuildingWithBuildExe) != 'true'">
     <GenerateXamlFileBeforeTargets>BeforeBuildGenerateSources;CompileXaml;Prep_ComputeProcessXamlFiles;CompilePageRequiringCustomCompilation</GenerateXamlFileBeforeTargets>
   </PropertyGroup>
-  <Target Name="GenerateRS1GenericXamlFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1StylePage)" Outputs="$(OutDir)Generic.xaml;$(OutDir)Generic.prefixed.xaml">
-    <Message Text="Generating default style XAML file for RS1..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)Generic.prefixed.xaml&quot; -XamlFileList &quot;@(RS1StylePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)Generic.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)Generic.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)Generic.prefixed.xaml&quot; -ForVersion RS1" FilesWritten="$(OutDir)Generic.xaml" />
-    <ItemGroup>
-      <FileReads Include="@(RS1StylePage)" />
-      <FileWrites Include="$(OutDir)Generic.xaml" />
-    </ItemGroup>
+ 
+  <Target Name="GenerateGenericResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
+    Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage);@(NineteenH1StylePage)" 
+    Outputs="$(OutDir)Generic.xaml;$(OutDir)rs1_generic.xaml;$(OutDir)rs2_generic.xaml;$(OutDir)rs3_generic.xaml;$(OutDir)rs4_generic.xaml;$(OutDir)rs5_generic.xaml;$(OutDir)19h1_generic.xaml;">
+      <Message Text="Generating generic resources XAML file " />
+      <BatchMergeXaml RS1Pages="@(RS1StylePage)" RS2Pages="@(RS2StylePage)"  RS3Pages="@(RS3StylePage)" 
+                      RS4Pages="@(RS4StylePage)" RS5Pages="@(RS5StylePage)"  N19H1Pages="@(NineteenH1StylePage)" 
+                      PostfixForGeneratedFile="_generic.xaml" OutputDirectory="$(OutDir)" />
+       <Copy SourceFiles="$(OutDir)rs1_generic.xaml" DestinationFiles="$(OutDir)Generic.xaml" />
   </Target>
-  <Target Name="GenerateRS2GenericXamlFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1StylePage);@(RS2StylePage)" Outputs="$(OutDir)rs2_generic.xaml;$(OutDir)rs2_generic.prefixed.xaml">
-    <Message Text="Generating default style XAML file for RS2..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs2_generic.prefixed.xaml&quot; -XamlFileList &quot;@(RS1StylePage);@(RS2StylePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs2_generic.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs2_generic.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs2_generic.prefixed.xaml&quot; -ForVersion RS2" FilesWritten="$(OutDir)rs2_generic.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS2GenericXamlFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1StylePage)" />
-      <FileReads Include="@(RS2StylePage)" />
-      <FileWrites Include="$(OutDir)rs2_generic.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS3GenericXamlFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage)" Outputs="$(OutDir)rs3_generic.xaml;$(OutDir)rs3_generic.prefixed.xaml">
-    <Message Text="Generating default style XAML file for RS3..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs3_generic.prefixed.xaml&quot; -XamlFileList &quot;@(RS1StylePage);@(RS2StylePage);@(RS3StylePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs3_generic.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs3_generic.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs3_generic.prefixed.xaml&quot; -ForVersion RS3" FilesWritten="$(OutDir)rs3_generic.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS3GenericXamlFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1StylePage)" />
-      <FileReads Include="@(RS2StylePage)" />
-      <FileReads Include="@(RS3StylePage)" />
-      <FileWrites Include="$(OutDir)rs3_generic.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS4GenericXamlFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage)" Outputs="$(OutDir)rs4_generic.xaml;$(OutDir)rs4_generic.prefixed.xaml">
-    <Message Text="Generating default style XAML file for RS4..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs4_generic.prefixed.xaml&quot; -XamlFileList &quot;@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs4_generic.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs4_generic.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs4_generic.prefixed.xaml&quot; -ForVersion RS4" FilesWritten="$(OutDir)rs4_generic.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS4GenericXamlFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1StylePage)" />
-      <FileReads Include="@(RS2StylePage)" />
-      <FileReads Include="@(RS3StylePage)" />
-      <FileReads Include="@(RS4StylePage)" />
-      <FileWrites Include="$(OutDir)rs4_generic.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS5GenericXamlFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage)" Outputs="$(OutDir)rs5_generic.xaml;$(OutDir)rs5_generic.prefixed.xaml">
-    <Message Text="Generating default style XAML file for RS5..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs5_generic.prefixed.xaml&quot; -XamlFileList &quot;@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs5_generic.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs5_generic.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs5_generic.prefixed.xaml&quot; -ForVersion RS5" FilesWritten="$(OutDir)rs5_generic.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS5GenericXamlFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1StylePage)" />
-      <FileReads Include="@(RS2StylePage)" />
-      <FileReads Include="@(RS3StylePage)" />
-      <FileReads Include="@(RS4StylePage)" />
-      <FileReads Include="@(RS5StylePage)" />
-      <FileWrites Include="$(OutDir)rs5_generic.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="Generate19H1GenericXamlFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage);@(NineteenH1StylePage)" Outputs="$(OutDir)19h1_generic.xaml;">
-    <Message Text="Generating default style XAML file for 19H1..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)19h1_generic.xaml&quot; -XamlFileList &quot;@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage);@(NineteenH1StylePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)19h1_generic.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="NineteenH1GenericXamlFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1StylePage)" />
-      <FileReads Include="@(RS2StylePage)" />
-      <FileReads Include="@(RS3StylePage)" />
-      <FileReads Include="@(RS4StylePage)" />
-      <FileReads Include="@(RS5StylePage)" />
-      <FileReads Include="@(NineteenH1StylePage)" />
-      <FileWrites Include="$(OutDir)19h1_generic.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS1ThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1ThemeResourcePage)" Outputs="$(OutDir)rs1_themeresources.xaml;$(OutDir)rs1_themeresources.prefixed.xaml">
-    <Message Text="Generating theme resources XAML file for RS1..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs1_themeresources.prefixed.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs1_themeresources.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs1_themeresources.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs1_themeresources.prefixed.xaml&quot; -ForVersion RS1" FilesWritten="$(OutDir)rs1_themeresources.xaml" />
-    <ItemGroup>
-      <FileReads Include="@(RS1ThemeResourcePage)" />
-      <FileWrites Include="$(OutDir)rs1_themeresources.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS2ThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage)" Outputs="$(OutDir)rs2_themeresources.xaml;$(OutDir)rs2_themeresources.prefixed.xaml">
-    <Message Text="Generating theme resources XAML file for RS2..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs2_themeresources.prefixed.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage);@(RS2ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs2_themeresources.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs2_themeresources.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs2_themeresources.prefixed.xaml&quot; -ForVersion RS2" FilesWritten="$(OutDir)rs2_themeresources.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS2ThemeResourceFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1ThemeResourcePage)" />
-      <FileReads Include="@(RS2ThemeResourcePage)" />
-      <FileWrites Include="$(OutDir)rs2_themeresources.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS3ThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage)" Outputs="$(OutDir)rs3_themeresources.xaml;$(OutDir)rs3_themeresources.prefixed.xaml">
-    <Message Text="Generating theme resources XAML files for RS3..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs3_themeresources.prefixed.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs3_themeresources.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs3_themeresources.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs3_themeresources.prefixed.xaml&quot; -ForVersion RS3" FilesWritten="$(OutDir)rs3_themeresources.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS3ThemeResourceFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1ThemeResourcePage)" />
-      <FileReads Include="@(RS2ThemeResourcePage)" />
-      <FileReads Include="@(RS3ThemeResourcePage)" />
-      <FileWrites Include="$(OutDir)rs3_themeresources.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS4ThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage)" Outputs="$(OutDir)rs4_themeresources.xaml;$(OutDir)rs4_themeresources.prefixed.xaml">
-    <Message Text="Generating theme resources XAML files for RS4..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs4_themeresources.prefixed.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs4_themeresources.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs4_themeresources.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs4_themeresources.prefixed.xaml&quot; -ForVersion RS4" FilesWritten="$(OutDir)rs4_themeresources.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS4ThemeResourceFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1ThemeResourcePage)" />
-      <FileReads Include="@(RS2ThemeResourcePage)" />
-      <FileReads Include="@(RS3ThemeResourcePage)" />
-      <FileReads Include="@(RS4ThemeResourcePage)" />
-      <FileWrites Include="$(OutDir)rs4_themeresources.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateRS5ThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage)" Outputs="$(OutDir)rs5_themeresources.xaml;$(OutDir)rs5_themeresources.prefixed.xaml">
-    <Message Text="Generating theme resources XAML file for RS5..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)rs5_themeresources.prefixed.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)rs5_themeresources.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)rs5_themeresources.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)rs5_themeresources.prefixed.xaml&quot; -ForVersion RS5" FilesWritten="$(OutDir)rs5_themeresources.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="RS5ThemeResourceFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1ThemeResourcePage)" />
-      <FileReads Include="@(RS2ThemeResourcePage)" />
-      <FileReads Include="@(RS3ThemeResourcePage)" />
-      <FileReads Include="@(RS4ThemeResourcePage)" />
-      <FileReads Include="@(RS5ThemeResourcePage)" />
-      <FileWrites Include="$(OutDir)rs5_themeresources.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="Generate19H1ThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage)" Outputs="$(OutDir)19h1_themeresources.xaml;$(OutDir)19h1_themeresources.prefixed.xaml">
-    <Message Text="Generating theme resources XAML file for 19H1..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)19h1_themeresources.prefixed.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)19h1_themeresources.prefixed.xaml" />
-    <RunPowershellScript Path="$(ScriptPath)StripConditionalXaml.ps1" Parameters="-ThemeResourceOutputFile &quot;$(OutDir)19h1_themeresources.xaml&quot; -ThemeResourceInputFile &quot;$(OutDir)19h1_themeresources.prefixed.xaml&quot; -ForVersion 19H1" FilesWritten="$(OutDir)19h1_themeresources.xaml" />
-    <!-- NB: We have to use CreateProperty here instead of PropertyGroup.
-         PropertyGroup values are always evaluated even when their enclosing target is skipped,
-         whereas CreateProperty has the TaskParameter ValueSetByTask that can be used
-         to only set a property if the target actually runs. -->
-    <CreateProperty Value="True">
-      <Output TaskParameter="ValueSetByTask" PropertyName="NineteenH1ThemeResourceFileNeedsCompilation" />
-    </CreateProperty>
-    <ItemGroup>
-      <FileReads Include="@(RS1ThemeResourcePage)" />
-      <FileReads Include="@(RS2ThemeResourcePage)" />
-      <FileReads Include="@(RS3ThemeResourcePage)" />
-      <FileReads Include="@(RS4ThemeResourcePage)" />
-      <FileReads Include="@(RS5ThemeResourcePage)" />
-      <FileReads Include="@(NineteenH1ThemeResourcePage)" />
-      <FileWrites Include="$(OutDir)19h1_themeresources.xaml" />
-    </ItemGroup>
+  <Target Name="GenerateThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
+    Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage)" 
+    Outputs="$(OutDir)rs1_themeresources.xaml;$(OutDir)rs2_themeresources.xaml;$(OutDir)rs3_themeresources.xaml;$(OutDir)rs4_themeresources.xaml;$(OutDir)rs5_themeresources.xaml;$(OutDir)19h1_themeresources.xaml;">
+      <Message Text="Generating theme resources XAML file " />
+      <BatchMergeXaml RS1Pages="@(RS1ThemeResourcePage)" RS2Pages="@(RS2ThemeResourcePage)"  RS3Pages="@(RS3ThemeResourcePage)" 
+                      RS4Pages="@(RS4ThemeResourcePage)" RS5Pages="@(RS5ThemeResourcePage)"  N19H1Pages="@(NineteenH1ThemeResourcePage)" 
+                      PostfixForGeneratedFile="_themeresources.xaml" OutputDirectory="$(OutDir)" />
   </Target>
   <Target Name="GenerateWUXCGenericXamlFile" DependsOnTargets="CategorizeSharedPages" Condition="$(BuildingWithBuildExe) == 'true'">
     <PropertyGroup>
@@ -1049,7 +860,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets'))" />
-    <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.39\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.39\build\native\MUXCustomBuildTasks.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets'))" />
   </Target>
   <Target Name="RunBinSkim" AfterTargets="AfterBuild" Condition="'$(Configuration)'=='Release' And $(BuildingWithBuildExe) != 'true'">
     <PropertyGroup>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -505,7 +505,7 @@
   <Target Name="ComputeXamlGeneratedCompileInputs" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets" Condition="Exists('..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets')" />
-    <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets')" />
+    <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets')" />
   </ImportGroup>
   <PropertyGroup>
     <MergedWinmdDirectory>$(OutDir)Merged</MergedWinmdDirectory>
@@ -557,7 +557,7 @@
       <Message Text="Generating generic resources XAML file " />
       <BatchMergeXaml RS1Pages="@(RS1StylePage)" RS2Pages="@(RS2StylePage)"  RS3Pages="@(RS3StylePage)" 
                       RS4Pages="@(RS4StylePage)" RS5Pages="@(RS5StylePage)"  N19H1Pages="@(NineteenH1StylePage)" 
-                      PostfixForGeneratedFile="_generic.xaml" OutputDirectory="$(OutDir)" />
+                      PostfixForGeneratedFile="generic" OutputDirectory="$(OutDir)" />
        <Copy SourceFiles="$(OutDir)rs1_generic.xaml" DestinationFiles="$(OutDir)Generic.xaml" />
   </Target>
   <Target Name="GenerateThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
@@ -566,7 +566,7 @@
       <Message Text="Generating theme resources XAML file " />
       <BatchMergeXaml RS1Pages="@(RS1ThemeResourcePage)" RS2Pages="@(RS2ThemeResourcePage)"  RS3Pages="@(RS3ThemeResourcePage)" 
                       RS4Pages="@(RS4ThemeResourcePage)" RS5Pages="@(RS5ThemeResourcePage)"  N19H1Pages="@(NineteenH1ThemeResourcePage)" 
-                      PostfixForGeneratedFile="_themeresources.xaml" OutputDirectory="$(OutDir)" />
+                      PostfixForGeneratedFile="themeresources" OutputDirectory="$(OutDir)" />
   </Target>
   <Target Name="GenerateWUXCGenericXamlFile" DependsOnTargets="CategorizeSharedPages" Condition="$(BuildingWithBuildExe) == 'true'">
     <PropertyGroup>
@@ -860,7 +860,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets'))" />
-    <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.43\build\native\MUXCustomBuildTasks.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets'))" />
   </Target>
   <Target Name="RunBinSkim" AfterTargets="AfterBuild" Condition="'$(Configuration)'=='Release' And $(BuildingWithBuildExe) != 'true'">
     <PropertyGroup>

--- a/dev/dll/packages.config
+++ b/dev/dll/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.CodeAnalysis.BinSkim" version="1.3.9" targetFramework="native" />
   <package id="Microsoft.Gsl" version="0.1.2.1" targetFramework="native" />
-  <package id="MUXCustomBuildTasks" version="1.0.39" targetFramework="native" />
+  <package id="MUXCustomBuildTasks" version="1.0.43" targetFramework="native" />
 </packages>

--- a/dev/dll/packages.config
+++ b/dev/dll/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.CodeAnalysis.BinSkim" version="1.3.9" targetFramework="native" />
   <package id="Microsoft.Gsl" version="0.1.2.1" targetFramework="native" />
-  <package id="MUXCustomBuildTasks" version="1.0.43" targetFramework="native" />
+  <package id="MUXCustomBuildTasks" version="1.0.44" targetFramework="native" />
 </packages>

--- a/nuget.config
+++ b/nuget.config
@@ -4,5 +4,6 @@
     <clear />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="MUXControls" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/DEPControls/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,5 @@
     <clear />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="MUXControls" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/DEPControls/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/tools/CustomTasks/BatchMergeXaml.cs
+++ b/tools/CustomTasks/BatchMergeXaml.cs
@@ -41,6 +41,7 @@ namespace CustomTasks
         }
 
         private List<string> filesWritten = new List<string>();
+        
         private string postfixForPrefixedGeneratedFile;
 
         // When generating merged file for RS5, we don't need to parse RS1-RS4 pages again, but put it in nextBaseFile like rs4_themeresources.prefix.xaml, then make it as the base of next merge.

--- a/tools/CustomTasks/BatchMergeXaml.cs
+++ b/tools/CustomTasks/BatchMergeXaml.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace CustomTasks
+{
+    public class BatchMergeXaml : Task
+    {
+        [Required]
+        public ITaskItem[] RS1Pages { get; set; }
+
+        [Required]
+        public ITaskItem[] RS2Pages { get; set; }
+
+        [Required]
+        public ITaskItem[] RS3Pages { get; set; }
+
+        [Required]
+        public ITaskItem[] RS4Pages { get; set; }
+
+        [Required]
+        public ITaskItem[] RS5Pages { get; set; }
+
+        [Required]
+        public ITaskItem[] N19H1Pages { get; set; }
+
+        [Required]
+        public string PostfixForGeneratedFile { get; set; }
+
+        [Required]
+        public string OutputDirectory { get; set; }
+
+        [Output]
+        public string[] FilesWritten
+        {
+            get { return filesWritten.ToArray(); }
+        }
+
+        private List<string> filesWritten = new List<string>();
+        private string postfixForPrefixedGeneratedFile;
+
+        // When generating merged file for RS5, we don't need to parse RS1-RS4 pages again, but put it in nextBaseFile like rs4_themeresources.prefix.xaml, then make it as the base of next merge.
+        private string nextBaseFile = null;
+
+        private void ExecuteForTaskItems(ITaskItem[] items, string targetOSVersion)
+        {
+            MergedDictionary mergedDictionary = MergedDictionary.CreateMergedDicionary();
+            List<string> files = new List<string>();
+            if (nextBaseFile != null)
+            {
+                files.Add(nextBaseFile);
+            }
+            if (items != null)
+            {
+                foreach (ITaskItem item in items)
+                {
+                    string file = item.ItemSpec;
+                    if (File.Exists(file))
+                    {
+                        files.Add(file);
+                    }
+                    else
+                    {
+                        Log.LogError("Can't find page file " + file);
+                    }
+                }
+            }
+
+            int apiVersion = StripNamespaces.universalApiContractVersionMapping[targetOSVersion];
+            MergeAndGenerateXaml(mergedDictionary, files, targetOSVersion.ToLower(), apiVersion);
+        }
+
+        private void MergeAndGenerateXaml(MergedDictionary mergedDictionary, List<string> files, string targetOSVersion, int apiVersion)
+        {
+            Log.LogMessage("Merge and generate xaml Files for target os" + targetOSVersion);
+
+            foreach (string file in files)
+            {
+                try
+                {
+                    mergedDictionary.MergeContent(File.ReadAllText(file));
+                }
+                catch (Exception)
+                {
+                    Log.LogError("Exception found when merge file " + file);
+                    throw;
+                }
+            }
+
+            string content = mergedDictionary.ToString();
+
+            string name = targetOSVersion + PostfixForGeneratedFile;
+            string fullPath = Path.Combine(OutputDirectory, name);
+
+            string prefixedName = targetOSVersion + postfixForPrefixedGeneratedFile;
+            string prefixedFullPath = Path.Combine(OutputDirectory, prefixedName);
+
+            string strippedContent = StripNamespaces.StripNamespaceForAPIVersion(content, apiVersion);
+
+            filesWritten.Add(Utils.RewriteFileIfNecessary(prefixedFullPath, content));
+            filesWritten.Add(Utils.RewriteFileIfNecessary(fullPath, strippedContent));
+
+            nextBaseFile = prefixedFullPath;
+        }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(OutputDirectory) || !Directory.Exists(OutputDirectory))
+            {
+                Log.LogError("OutputDirectory is empty or not existing");
+            }
+
+            if (string.IsNullOrEmpty(PostfixForGeneratedFile) || !PostfixForGeneratedFile.EndsWith(".xaml"))
+            {
+                Log.LogError("PostfixForGeneratedFile is empty or extension name is not .xaml");
+            }
+
+            postfixForPrefixedGeneratedFile = PostfixForGeneratedFile.Substring(0, PostfixForGeneratedFile.Length - 5) + ".prefixed.xaml";
+
+            if (!Log.HasLoggedErrors)
+            {
+                ExecuteForTaskItems(RS1Pages, "RS1");
+                ExecuteForTaskItems(RS2Pages, "RS2");
+                ExecuteForTaskItems(RS3Pages, "RS3");
+                ExecuteForTaskItems(RS4Pages, "RS4");
+                ExecuteForTaskItems(RS5Pages, "RS5");
+                ExecuteForTaskItems(N19H1Pages, "19H1");
+            }
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/tools/CustomTasks/BatchMergeXaml.cs
+++ b/tools/CustomTasks/BatchMergeXaml.cs
@@ -27,6 +27,8 @@ namespace CustomTasks
         public ITaskItem[] N19H1Pages { get; set; }
 
         [Required]
+        // The output file format is like rs1_themeresources.xaml, rs2_generic.xaml, rs2_compact_generic.xaml.
+        // then PostfixForGeneratedFile is themeresources/generic/compact_generic here.
         public string PostfixForGeneratedFile { get; set; }
 
         [Required]
@@ -91,10 +93,10 @@ namespace CustomTasks
 
             string content = mergedDictionary.ToString();
 
-            string name = targetOSVersion + PostfixForGeneratedFile;
+            string name = targetOSVersion + "_" + PostfixForGeneratedFile + ".xaml";
             string fullPath = Path.Combine(OutputDirectory, name);
 
-            string prefixedName = targetOSVersion + postfixForPrefixedGeneratedFile;
+            string prefixedName = targetOSVersion + "_" + postfixForPrefixedGeneratedFile + ".xaml";
             string prefixedFullPath = Path.Combine(OutputDirectory, prefixedName);
 
             string strippedContent = StripNamespaces.StripNamespaceForAPIVersion(content, apiVersion);
@@ -112,12 +114,12 @@ namespace CustomTasks
                 Log.LogError("OutputDirectory is empty or not existing");
             }
 
-            if (string.IsNullOrEmpty(PostfixForGeneratedFile) || !PostfixForGeneratedFile.EndsWith(".xaml"))
+            if (string.IsNullOrEmpty(PostfixForGeneratedFile))
             {
-                Log.LogError("PostfixForGeneratedFile is empty or extension name is not .xaml");
+                Log.LogError("PostfixForGeneratedFile is empty");
             }
 
-            postfixForPrefixedGeneratedFile = PostfixForGeneratedFile.Substring(0, PostfixForGeneratedFile.Length - 5) + ".prefixed.xaml";
+            postfixForPrefixedGeneratedFile = PostfixForGeneratedFile + ".prefixed";
 
             if (!Log.HasLoggedErrors)
             {

--- a/tools/CustomTasks/CustomTasks.csproj
+++ b/tools/CustomTasks/CustomTasks.csproj
@@ -52,9 +52,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BatchMergeXaml.cs" />
     <Compile Include="DependencyPropertyCodeGen.cs" />
+    <Compile Include="GenerateMergedXaml.cs" />
+    <Compile Include="MergedDictionary.cs" />
     <Compile Include="RunPowershellScript.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StripNamespaces.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tools/CustomTasks/DependencyPropertyCodeGen.cs
+++ b/tools/CustomTasks/DependencyPropertyCodeGen.cs
@@ -857,24 +857,7 @@ void {0}Properties::{1}(winrt::event_token const& token)
 
         private void RewriteFileIfNecessary(string path, string contents)
         {
-            bool rewrite = true;
-            var fullPath = Path.GetFullPath(path);
-            try
-            {
-                string existingContents = File.ReadAllText(fullPath);
-                if (String.Equals(existingContents, contents))
-                {
-                    rewrite = false;
-                }
-            }
-            catch
-            {
-            }
-
-            if (rewrite)
-            {
-                File.WriteAllText(fullPath, contents);
-            }
+            var fullPath = Utils.RewriteFileIfNecessary(path, contents);
 
             _pendingFilesWritten.Add(fullPath);
         }

--- a/tools/CustomTasks/GenerateMergedXaml.cs
+++ b/tools/CustomTasks/GenerateMergedXaml.cs
@@ -1,0 +1,68 @@
+﻿using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace CustomTasks
+{
+    public class GenerateMergedXaml : Task
+    {
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        [Required]
+        public string XamlFileGenerated
+        {
+            get; set;
+        }
+
+        [Required]
+        public string ForOSVersion
+        {
+            get; set;
+        }
+
+        [Output]
+        public string[] FilesWritten
+        {
+            get; set;
+        }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(ForOSVersion) || !StripNamespaces.universalApiContractVersionMapping.ContainsKey(ForOSVersion))
+            {
+                Log.LogError("Unknown OS version, and valid version is ", string.Join(",", StripNamespaces.universalApiContractVersionMapping.Keys));
+            }
+
+            MergedDictionary mergedDictionary = MergedDictionary.CreateMergedDicionary();
+            foreach (ITaskItem item in Sources)
+            {
+                string file = item.ItemSpec;
+                if (File.Exists(file))
+                {
+                    mergedDictionary.MergeContent(File.ReadAllText(file));
+                }
+                else
+                {
+                    Log.LogError("Error to look for file " + item.ItemSpec);
+                }
+
+            }
+
+            int apiVersion = StripNamespaces.universalApiContractVersionMapping[ForOSVersion];
+            string content = mergedDictionary.ToString();
+
+            string prefixedName = XamlFileGenerated.Substring(0, XamlFileGenerated.Length - 5) + ".prefixed.xaml";
+            string strippedContent = StripNamespaces.StripNamespaceForAPIVersion(content, apiVersion);
+
+            string[] filesWritten = new string[2];
+            filesWritten[0] = Utils.RewriteFileIfNecessary(prefixedName, content);
+            filesWritten[1] = Utils.RewriteFileIfNecessary(XamlFileGenerated, strippedContent);
+
+            FilesWritten = filesWritten;
+
+            return !Log.HasLoggedErrors;
+        }
+
+    }
+}

--- a/tools/CustomTasks/MergedDictionary.cs
+++ b/tools/CustomTasks/MergedDictionary.cs
@@ -1,0 +1,368 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+
+
+namespace CustomTasks
+{
+    public class MergedDictionary
+    {
+        public static MergedDictionary CreateMergedDicionary()
+        {
+            var document = new XmlDocument();
+            return new MergedDictionary(document);
+        }
+
+        public override string ToString()
+        {
+            var xmlDoc = (XmlDocument)GetXaml();
+
+            StringWriter sw = new StringWriter();
+            XmlWriterSettings settings = new XmlWriterSettings { Indent = true, OmitXmlDeclaration = true, Encoding = Encoding.UTF8 };
+            XmlWriter writer = XmlWriter.Create(sw, settings);
+            xmlDoc.WriteTo(writer);
+            writer.Flush();
+            return Utils.UnEscapeAmpersand(sw.ToString());
+        }
+
+        public void MergeContent(String content)
+        {
+            content = Utils.EscapeAmpersand(content);
+
+            var document = new XmlDocument();
+            document.LoadXml(content);
+
+            Dictionary<string, string> standardNamespaceDictionary = new Dictionary<string, string>();
+            Dictionary<string, string> xmlnsReplacementDictionary = new Dictionary<string, string>();
+
+            GenerateStandardNameSpaces(document, standardNamespaceDictionary, xmlnsReplacementDictionary);
+            foreach (KeyValuePair<string, string> entry in standardNamespaceDictionary)
+            {
+                AddNamespace(entry.Key, entry.Value);
+            }
+            foreach (XmlNode node in document.ChildNodes)
+            {
+                if (node.Name == "ResourceDictionary")
+                {
+                    foreach (XmlNode xmlNode in node.ChildNodes)
+                    {
+                        AddNode(xmlNode, xmlnsReplacementDictionary);
+                    }
+                }
+            }
+        }
+
+        private MergedDictionary(XmlDocument document) : this(document, null) { }
+
+        private MergedDictionary(XmlDocument document, MergedDictionary parentDictionary)
+        {
+            owningDocument = document;
+            xmlElement = owningDocument.CreateElement("ResourceDictionary", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+
+            if (parentDictionary == null)
+            {
+                xmlElement = owningDocument.AppendChild(xmlElement) as XmlElement;
+                xmlElement.SetAttribute("xmlns:x", "http://schemas.microsoft.com/winfx/2006/xaml");
+            }
+
+            nodeList = new List<XmlNode>();
+            nodeListNodesToIgnore = new List<int>();
+            nodeKeyToNodeListIndexDictionary = new Dictionary<string, int>();
+            mergedThemeDictionaryByKeyDictionary = new Dictionary<string, MergedDictionary>();
+            namespaceList = new List<string>();
+            this.parentDictionary = parentDictionary;
+        }
+
+        private void AddNamespace(string xmlnsString, string namespaceString)
+        {
+            if (!namespaceList.Contains(namespaceString))
+            {
+                xmlElement.SetAttribute("xmlns:" + xmlnsString, namespaceString);
+                namespaceList.Add(namespaceString);
+            }
+        }
+
+        private void AddNode(XmlNode node, Dictionary<string, string> xmlnsReplacementDictionary)
+        {
+            // Remove Comment
+            if (node is XmlComment)
+            {
+                return;
+            }
+
+            node = owningDocument.ImportNode(node, true);
+            ReplaceNamespacePrefix(node, xmlnsReplacementDictionary);
+
+            if (node.Name == "ResourceDictionary.ThemeDictionaries")
+            {
+                // This will be a list of either ResourceDictionaries or comments.
+                // We'll figure out what the ResourceDictionaries' keys are,
+                // then either add their contents to the existing theme dictionaries we have,
+                // or create new ones if we've found new keys.
+                foreach (XmlNode childNode in node.ChildNodes)
+                {
+                    string nodeKey = GetKey(childNode);
+
+                    if (nodeKey == null || nodeKey.Length == 0)
+                    {
+                        continue;
+                    }
+                    else if (nodeKey == "Dark")
+                    {
+                        // If we don't specify the dictionary "Dark", then "Default" will be used instead.
+                        // Having both of those, however, will result in "Default" never being used, even
+                        // if it contains something that "Dark" does not.
+                        // Since we're merging everything into a single dictionary, we need to standardize
+                        // to only one of the two. Since most dictionaries use "Default", we'll go with that.
+                        nodeKey = "Default";
+                    }
+
+                    MergedDictionary mergedThemeDictionary = null;
+
+                    if (mergedThemeDictionaryByKeyDictionary.TryGetValue(nodeKey, out mergedThemeDictionary) == false)
+                    {
+                        mergedThemeDictionary = new MergedDictionary(owningDocument, this);
+                        mergedThemeDictionaryByKeyDictionary.Add(nodeKey, mergedThemeDictionary);
+                    }
+
+                    foreach (XmlNode resourceDictionaryChild in childNode.ChildNodes)
+                    {
+                        mergedThemeDictionary.AddNode(resourceDictionaryChild, xmlnsReplacementDictionary);
+                    }
+                }
+            }
+            else
+            {
+                // First, we need to check if this is a node with a key.  If it is, then we'll replace
+                // the previous node we saw with this key, in order to have only one entry per key.
+                // if it's not, or if we haven't seen a previous node with this key, then we'll just
+                // add it to our list.
+                string nodeKey = GetKey(node);
+
+                if (nodeKey.Length == 0 || !nodeKeyToNodeListIndexDictionary.ContainsKey(nodeKey))
+                {
+                    if (nodeKey.Length != 0)
+                    {
+                        nodeKeyToNodeListIndexDictionary.Add(nodeKey, nodeList.Count);
+                    }
+
+                    nodeList.Add(node);
+                }
+                else
+                {
+                    int previousNodeIndex = nodeKeyToNodeListIndexDictionary[nodeKey];
+                    nodeList[previousNodeIndex] = node;
+                }
+
+                if (nodeKey.Length > 0 && parentDictionary != null)
+                {
+                    parentDictionary.RemoveAncestorNodesWithKey(nodeKey);
+                }
+
+                if (nodeKey.Length > 0 && parentDictionary != null)
+                {
+                    parentDictionary.RemoveAncestorNodesWithKey(nodeKey);
+                }
+            }
+        }
+
+        private XmlNode GetXaml()
+        {
+            if (mergedThemeDictionaryByKeyDictionary.Keys.Count > 0)
+            {
+                XmlElement themeDictionariesElement = owningDocument.CreateElement("ResourceDictionary.ThemeDictionaries", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+                xmlElement.AppendChild(themeDictionariesElement);
+
+                foreach (string themeDictionaryKey in mergedThemeDictionaryByKeyDictionary.Keys)
+                {
+                    XmlElement themeResourceDictionaryElement = mergedThemeDictionaryByKeyDictionary[themeDictionaryKey].GetXaml() as XmlElement;
+                    themeDictionariesElement.AppendChild(themeResourceDictionaryElement);
+                    themeResourceDictionaryElement.SetAttribute("Key", "http://schemas.microsoft.com/winfx/2006/xaml", themeDictionaryKey);
+                }
+            }
+
+            for (int i = 0; i < nodeList.Count; i++)
+            {
+                if (!nodeListNodesToIgnore.Contains(i))
+                {
+                    // We may have null placeholders left over that were never found.  If there are,
+                    // that's not necessarily an indication that something's wrong - for example,
+                    // we might have nodes that are part of the built-in list of theme resources.
+                    // We'll just ignore null nodes.
+                    XmlNode node = nodeList[i];
+
+                    if (node != null)
+                    {
+                        xmlElement.AppendChild(node);
+                    }
+                }
+            }
+
+            if (parentDictionary == null)
+            {
+                return owningDocument;
+            }
+            else
+            {
+                return xmlElement;
+            }
+        }
+
+        private static void ReplaceNamespacePrefix(XmlNode currentNode, Dictionary<string, string> xmlnsReplacementDictionary)
+        {
+            if (currentNode.Prefix != null && currentNode.Prefix.Length > 0)
+            {
+                if (xmlnsReplacementDictionary.ContainsKey(currentNode.Prefix))
+                {
+                    currentNode.Prefix = xmlnsReplacementDictionary[currentNode.Prefix];
+                }
+            }
+
+            // We also want to check the node's attributes for any of the prefixes -
+            // e.g. Style.TargetType may contain an instance of "local:..."
+            if (currentNode.Attributes != null)
+            {
+                foreach (XmlAttribute attribute in currentNode.Attributes)
+                {
+                    if (attribute.Value != null)
+                    {
+                        foreach (string xmlnsToReplace in xmlnsReplacementDictionary.Keys)
+                        {
+                            attribute.Value = attribute.Value.Replace(xmlnsToReplace + ":", xmlnsReplacementDictionary[xmlnsToReplace] + ":");
+                        }
+                    }
+                }
+            }
+
+            foreach (XmlNode node in currentNode.ChildNodes)
+            {
+                ReplaceNamespacePrefix(node, xmlnsReplacementDictionary);
+            }
+        }
+
+        private static string GetKey(XmlNode node)
+        {
+            if (node.Attributes == null)
+            {
+                return string.Empty;
+            }
+
+            string key = string.Empty;
+
+            foreach (XmlAttribute attribute in node.Attributes)
+            {
+                if (attribute.Name == "x:Key" || attribute.Name == "x:Name")
+                {
+                    key = attribute.Value;
+                    break;
+                }
+            }
+
+            // If we didn't find an "x:Key" or "x:Name" attribute, then try looking for a "TargetType" attribute
+            // if this is a "Style" tag - that functions in the same way.
+            if (key.Length == 0 && node.Name == "Style" && node.Attributes != null)
+            {
+                foreach (XmlAttribute attribute in node.Attributes)
+                {
+                    if (attribute.Name == "TargetType")
+                    {
+                        key = attribute.Value;
+                        break;
+                    }
+                }
+            }
+
+            if (key.Length > 0)
+            {
+                // If this node has a key and a conditional-inclusion namespace, we'll attach a prefix
+                // to the key corresponding to the condition we checked in order to allow multiple such nodes
+                // with the same key to exist.
+                int indexOfContractPresent = node.NamespaceURI.IndexOf("IsApiContract");
+
+                if (indexOfContractPresent >= 0)
+                {
+                    key = node.NamespaceURI.Substring(indexOfContractPresent) + ":" + key;
+                }
+            }
+
+            return key;
+        }
+
+        private static Dictionary<string, string> standardNameDictionary = new Dictionary<string, string> {
+            { "using:Microsoft.UI.Xaml.Controls", "controls" },
+            { "using:Microsoft.UI.Xaml.Controls.Primitives", "primitives" },
+            { "using:Microsoft.UI.Xaml.Media", "media" },
+            { "http://schemas.microsoft.com/winfx/2006/xaml", "x"},
+        };
+
+        private static string _conditionalXamlPattern = @"http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContract(Not|)Present\(Windows.Foundation.UniversalApiContract,([0-9]+)\)";
+        private static string GetStandardNamespace(string name, string value)
+        {
+            var match = Regex.Match(value, _conditionalXamlPattern);
+            if (match.Success)
+            {
+                return "contract" + match.Groups[2].Captures[0].Value + match.Groups[1].Captures[0].Value + "Present";
+            }
+            if (standardNameDictionary.ContainsKey(value))
+            {
+                return standardNameDictionary[value];
+            }
+            return name;
+        }
+
+        private static void GenerateStandardNameSpaces(XmlDocument document, Dictionary<string, string> standardNamespaceDictionary, Dictionary<string, string> toBeReplacedDictionary)
+        {
+            foreach (XmlNode node in document.ChildNodes)
+            {
+                if (node.Name == "ResourceDictionary")
+                {
+                    foreach (XmlAttribute att in node.Attributes)
+                    {
+                        if (att.Name.StartsWith("xmlns:"))
+                        {
+                            string name = att.Name.Substring(6); // exclude "xmlns:"
+                            string stardardName = GetStandardNamespace(name, att.Value);
+                            standardNamespaceDictionary.Add(stardardName, att.Value);
+
+                            if (!name.Equals(stardardName))
+                            {
+                                toBeReplacedDictionary.Add(name, stardardName);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void RemoveAncestorNodesWithKey(string key)
+        {
+            if (nodeKeyToNodeListIndexDictionary.ContainsKey(key))
+            {
+                nodeListNodesToIgnore.Add(nodeKeyToNodeListIndexDictionary[key]);
+            }
+
+            if (parentDictionary != null)
+            {
+                parentDictionary.RemoveAncestorNodesWithKey(key);
+            }
+        }
+
+        private XmlElement xmlElement;
+        private XmlDocument owningDocument;
+        private List<XmlNode> nodeList;
+
+        // We'll want to remove nodes from the node list if a child dictionary has the same node,
+        // but if we just removed the nodes then the values in nodeKeyToNodeListIndexDictionary would be wrong.
+        // To make things easier, we'll instead just mark those nodes as ones to ignore rather than actually
+        // removing them from the list.
+        private List<int> nodeListNodesToIgnore;
+
+        private Dictionary<string, int> nodeKeyToNodeListIndexDictionary;
+        private Dictionary<string, MergedDictionary> mergedThemeDictionaryByKeyDictionary;
+        private List<string> namespaceList;
+        private MergedDictionary parentDictionary;
+    }
+}

--- a/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.nuspec
+++ b/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>MUXCustomBuildTasks</id>
-    <version>1.0.43</version>
+    <version>1.0.44</version>
     <title>MUXCustomBuildTasks</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.nuspec
+++ b/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>MUXCustomBuildTasks</id>
-    <version>1.0.39</version>
+    <version>1.0.43</version>
     <title>MUXCustomBuildTasks</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.targets
+++ b/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.targets
@@ -3,4 +3,6 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="RunPowershellScript" AssemblyFile="CustomTasks.dll" />
   <UsingTask TaskName="DependencyPropertyCodeGen" AssemblyFile="CustomTasks.dll" />
+  <UsingTask TaskName="GenerateMergedXaml" AssemblyFile="CustomTasks.dll" />
+  <UsingTask TaskName="BatchMergeXaml" AssemblyFile="CustomTasks.dll" />
 </Project>

--- a/tools/CustomTasks/StripNamespaces.cs
+++ b/tools/CustomTasks/StripNamespaces.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace CustomTasks
+{
+    class StripNamespaces
+    {
+
+        public static Dictionary<string, int> universalApiContractVersionMapping = new Dictionary<string, int>()
+        {
+            { "RS1", 3 },
+            { "RS2", 4 },
+            { "RS3", 5 },
+            { "RS4", 6 },
+            { "RS5", 7 },
+            { "19H1", 8}
+        };
+
+        static List<string> BuildNamespaceToBeRemoved(int apiVersion)
+        {            
+            List<string> namespaces = new List<string>();
+            for (int i = apiVersion; i >= universalApiContractVersionMapping.Values.Min(); i--)
+            {
+                namespaces.Add("http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract," + i +")");
+            }
+
+            for (int i = apiVersion + 1; i <= universalApiContractVersionMapping.Values.Max(); i++)
+            {
+                namespaces.Add("http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract," + i + ")");
+            }
+
+            return namespaces;
+        }
+
+        static List<string> BuildRegexPatternToBeReplaced()
+        {
+            List<string> patterns = new List<string>();
+
+            string conditionalPatternAll = "contract[0-9]+(Not|)Present";
+
+            // xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+            patterns.Add("(?m)xmlns:" + conditionalPatternAll + "=\"[^\"]+\"");
+            
+            // Remove tag only contract5NotPresent:
+            patterns.Add(conditionalPatternAll + ":");
+            return patterns;
+        }
+
+        public static string StripNamespaceForAPIVersion(string content, int apiVersion)
+        {
+            content = Utils.EscapeAmpersand(content);
+            // strip all elements and attributes in specific NotPresent namespace which is <= api version or Present > api version
+            var namespaceToBeRemoved = BuildNamespaceToBeRemoved(apiVersion);
+            string newContent = StripNamespace(content, namespaceToBeRemoved);
+
+            // replace all conditional xaml
+            foreach (var pattern in BuildRegexPatternToBeReplaced())
+            {
+                newContent = Regex.Replace(newContent, pattern, "", RegexOptions.Multiline);
+            }
+            return Utils.UnEscapeAmpersand(newContent);
+        }
+
+        static string StripNamespace(string xml, List<string> namespaceToBeRemoved)
+        {
+            var doc = XDocument.Parse(xml);
+
+            //get all elements in specific namespace and remove
+            doc.Descendants()
+           .Where(o => namespaceToBeRemoved.Contains(o.Name.Namespace.NamespaceName))
+           .Remove();
+
+            //get all attributes in specific namespace and remove
+            doc.Descendants()
+           .Attributes()
+           .Where(o => namespaceToBeRemoved.Contains(o.Name.Namespace.NamespaceName))
+           .Remove();
+
+            //remove attributes in root
+            doc.Root.Attributes()
+                .Where(o => namespaceToBeRemoved.Contains(o.Name.Namespace.NamespaceName))
+                .Remove();
+
+            return Utils.DocumentToString(writer => doc.WriteTo(writer));
+        }
+    }
+}

--- a/tools/CustomTasks/Utils.cs
+++ b/tools/CustomTasks/Utils.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace CustomTasks
+{
+    class Utils
+    {
+        //The XmlWriter can't handle &#xE0E5 unless we escape/unescape the ampersand
+        public static string UnEscapeAmpersand(string s)
+        {
+            return s.Replace("&amp;", "&");
+        }
+
+        public static string EscapeAmpersand(string s)
+        {
+            return s.Replace("&", "&amp;");
+        }
+
+        public static string DocumentToString(Action<XmlWriter> action)
+        {
+            StringWriter sw = new StringWriter();
+            XmlWriterSettings settings = new XmlWriterSettings { Indent = true, OmitXmlDeclaration = true, Encoding = Encoding.UTF8 };
+            XmlWriter writer = XmlWriter.Create(sw, settings);
+            action(writer);
+            writer.Flush();
+            return Utils.UnEscapeAmpersand(sw.ToString());
+        }
+
+        public static string RewriteFileIfNecessary(string path, string contents)
+        {
+            bool rewrite = true;
+            var fullPath = Path.GetFullPath(path);
+            try
+            {
+                string existingContents = File.ReadAllText(fullPath);
+                if (String.Equals(existingContents, contents))
+                {
+                    rewrite = false;
+                }
+            }
+            catch
+            {
+            }
+
+            if (rewrite)
+            {
+                File.WriteAllText(fullPath, contents);
+            }
+
+            return fullPath;
+        }
+    }
+}


### PR DESCRIPTION
Create msbuild task and simplify the mergedxaml process. From the testing, the new process would reduce the time from 2+ minutes to hundreds ms.
It's base on:
1. the RunPowerShell launch and execution time
2. Compile C# application in PowerShell
3, Some old logic we don't use anymore like Sorting.

Nearly all GenerateMergedXaml.cs are copied from GenerateMergedXaml.ps1.
I rewrite everything about strip namespace part. StripNamespaces.cs is a replacement of StripConditionalXaml.ps1
