### PR TITLE
Support incremental compilation for xaml file change

### DIFF
--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -3,7 +3,6 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildProjectDirectory)\..\..\mux.controls.props" Condition="Exists('$(MSBuildProjectDirectory)\..\..\mux.controls.props') And $(BuildingWithBuildExe) != 'true'" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\environment.props" />
-  <Import Project="$(MSBuildProjectDirectory)\..\..\SdkVersion.props" Condition="$(BuildingWithBuildExe) == 'true'" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\ProjectConfigurations.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{ad0c90b0-4845-4d4b-88f1-86f653f8171b}</ProjectGuid>
@@ -28,16 +27,6 @@
     <DisableEmbeddedXbf Condition="'$(Configuration)'=='Release'">false</DisableEmbeddedXbf>
     <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
   </PropertyGroup>
-  <!-- Temporary hack: This should really go into the product-common props/targets file -->
-  <PropertyGroup Condition="$(BuildingWithBuildExe) == 'true'">
-    <DefaultBuildArchName>x86</DefaultBuildArchName>
-    <BuildArchName Condition="'$(Platform)' == 'Win32'">x86</BuildArchName>
-    <BuildArchName Condition="'$(Platform)' == 'x64'">amd64</BuildArchName>
-    <BuildArchName Condition="'$(Platform)' == 'arm'">arm</BuildArchName>
-    <BuildArchName Condition="'$(Platform)' == 'arm64'">arm64</BuildArchName>
-    <BuildArchName Condition="'$(Platform)' == 'AnyCPU'">$(DefaultBuildArchName)</BuildArchName>
-    <BuildArchName Condition="'$(BuildArchName)' == ''">$(DefaultBuildArchName)</BuildArchName>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Use64BitLinker)' == 'true' AND '$(BuildingWithBuildExe)' == 'true'">
     <OacrLinkTool>$(OSBuildToolsRoot)\vc\HostX64\$(BuildArchName)\link.exe</OacrLinkTool>
     <LinkToolPath>$(OSBuildToolsRoot)\vc\HostX64\$(BuildArchName)</LinkToolPath>
@@ -47,10 +36,6 @@
       <LinkTrackerFrameworkPath>$(MSBuildToolsPath)\amd64</LinkTrackerFrameworkPath>
       <LinkTrackerSdkPath>$(MSBuildToolsPath)\amd64</LinkTrackerSdkPath>
   </PropertyGroup> -->
-  <PropertyGroup Condition="$(BuildingWithBuildExe) == 'true'">
-    <!-- Needed to binplace the DLLs and PDBs to the binaries directory. -->
-    <TargetDestination>retail</TargetDestination>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -193,39 +178,15 @@
     </Midl>
     <Link>
       <ModuleDefinitionFile>Microsoft.UI.Xaml.def</ModuleDefinitionFile>
-      <GenerateDebugInformation Condition="'$(Configuration)'=='Debug' Or $(BuildingWithBuildExe) == 'true'">$(GenerateDebugInformation)</GenerateDebugInformation>
+      <GenerateDebugInformation Condition="'$(Configuration)'=='Debug'">$(GenerateDebugInformation)</GenerateDebugInformation>
       <AdditionalDependencies Condition="$(BuildingWithBuildExe) != 'true'">dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <!-- Microsoft.UI.winmd will contain the definition of both public, preview and private types. -->
       <WindowsMetadataFile Condition="$(BuildingWithBuildExe) != 'true'">$(OutDir)\Microsoft.UI.winmd</WindowsMetadataFile>
-      <AdditionalDependencies Condition="$(BuildingWithBuildExe) == 'true'">
-        $(OneCoreBaseLibPath)\bcp47langs.lib;
-        $(OneCoreComLibPath)\combasep.lib;
-        $(OneCorePrivSdkLibPath)\onecoreuap_internal.lib;
-        $(OneCoreShellLibPath)\calleridentity.lib;
-        $(MinCoreSdkLibPath)\mincore.lib;
-        $(MinCoreSdkLibPath)\mincore_legacy.lib;
-        $(MinCoreSdkLibPath)\mincore_obsolete.lib;
-        $(MinWinSdkLibPath)\ntdll.lib;
-        $(SdkLibPath)\dxguid.lib;
-        $(SdkLibPath)\muiload.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\allocation\lib\$(ObjectDirectory)\Windows.UI.Xaml.Allocation.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\allocation\stubs\$(ObjectDirectory)\Windows.UI.Xaml.Allocation.stubs.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\base\lib\$(ObjectDirectory)\Windows.UI.Xaml.Base.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\criticalsection\lib\$(ObjectDirectory)\Windows.UI.Xaml.CriticalSection.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\dependencyLocator\lib\$(ObjectDirectory)\Windows.UI.Xaml.DependencyLocator.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\math\lib\$(ObjectDirectory)\Windows.UI.Xaml.Math.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\quirks\lib\$(ObjectDirectory)\Windows.UI.Xaml.Quirks.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\runtimeenabledfeatures\lib\$(ObjectDirectory)\Windows.UI.Xaml.RuntimeEnabledFeatures.lib;
-        $(OBJECT_ROOT)\onecoreuap\windows\dxaml\xcp\components\terminateProcessOnOOM\lib\$(ObjectDirectory)\Windows.UI.Xaml.TerminateProcessOnOOM.lib;
-        %(AdditionalDependencies)
-      </AdditionalDependencies>
-      <AppContainer Condition="$(BuildingWithBuildExe) == 'true'">no</AppContainer>
       <GenerateMapFile>true</GenerateMapFile>
       <LinkTimeCodeGeneration Condition="'$(Configuration)'=='Release'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <ClCompile>
       <DisableSpecificWarnings>4100;4189;4467;4702;6326;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="$(BuildingWithBuildExe) == 'true'">4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories);
         $(MSBuildProjectDirectory)\..\inc;
@@ -246,30 +207,6 @@
         %(AdditionalIncludeDirectories);
         $(MiniWindowsSDKIncludePath);
       </AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="$(BuildingWithBuildExe) == 'true'">
-        %(AdditionalIncludeDirectories);
-        $(MSBuildProjectDirectory)\..\..;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Platform;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Component;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Component\Automation\Peers;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Component\Controls;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Component\Controls\Primitives;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Component\Media;
-        $(ObjectPath)\..\..\winrt\$(ObjectDirectory)\Component\Microsoft\UI\Composition\Effects;
-        $(PUBLIC_ROOT)\internal\onecorebase\inc;
-        $(PUBLIC_ROOT)\internal\onecorecom\inc;
-        $(PUBLIC_ROOT)\onecore\private\com\inc;
-        $(PUBLIC_ROOT)\internal\onecoreuapwindows\inc;
-        $(PUBLIC_ROOT)\internal\sdk\inc\wil;
-        $(PUBLIC_ROOT)\internal\minwin\priv_sdk\inc;
-        $(PUBLIC_ROOT)\internal\mincore\priv_sdk\inc;
-        $(MinCoreInternalPrivSdkIncPathL);
-        $(SDXROOT)\onecoreuap\windows\dxaml\xcp\components\dependencyLocator\inc;
-        $(SDXROOT)\onecoreuap\windows\dxaml\xcp\components\base\inc;
-        $(SDXROOT)\onecoreuap\windows\dxaml\xcp\components\SatelliteBase\inc;
-        $(SDXROOT)\onecoreuap\windows\dxaml\xcp\inc;
-      </AdditionalIncludeDirectories>
-      <MultiProcessorCompilation Condition="$(BuildingWithBuildExe) == 'true'">true</MultiProcessorCompilation>
       <AdditionalOptions>/std:c++17 /bigobj %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(BuildingWithBuildExe) != 'true'">/Wv:18 /Zm1000 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions>%(AdditionalOptions) /await</AdditionalOptions>
@@ -282,25 +219,12 @@
       <ControlFlowGuard Condition="'$(Configuration)'=='Release'">Guard</ControlFlowGuard>
       <StringPooling Condition="'$(Configuration)'=='Release'">true</StringPooling>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="$(BuildingWithBuildExe) == 'true'">_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE;WIN32_LEAN_AND_MEAN;UNICODE;_UNICODE;__WRL_STRICT__;__WRL_FORCE_INSPECTABLE_CLASS_MACRO__;_WCTYPE_INLINE_DEFINED;_STL140_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(BuildingWithBuildExe) != 'true'">DISABLE_WINRT_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">MinSpace</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MinSpace</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MinSpace</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">MinSpace</Optimization>
     </ClCompile>
-    <ResourceCompile Condition="$(BuildingWithBuildExe) == 'true'">
-      <AdditionalIncludeDirectories>
-        %(AdditionalIncludeDirectories);
-        $(SDXROOT)\onecoreuap\windows\dxaml\xcp\components\SatelliteBase\inc;
-      </AdditionalIncludeDirectories>
-      <!--
-      We need to provide rc.exe with an rc config file in order to produce a .muires file alongside
-      the main res file. The former contains the language dependent resources while the latter contains
-      the language neutral resources. The rc config file tells rc.exe how to split the resources between
-      the two. -->
-      <AdditionalOptions>%(AdditionalOptions) -q $(RazzleToolPath)\MUI.RCConfig</AdditionalOptions>
-    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\inc\BoxHelpers.h" />
@@ -321,15 +245,12 @@
     <ClInclude Include="..\inc\CollectionHelper.h" />
     <ClInclude Include="MUXControlsFactory.h" Condition="$(BuildingWithBuildExe) != 'true'" />
     <ClInclude Include="pch.h" />
-    <ClInclude Include="ResourceHelper.h" Condition="$(BuildingWithBuildExe) == 'true'" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="XamlControlsResources.h" />
     <ClInclude Include="XamlMember.h" />
     <ClInclude Include="XamlMetadataProvider.h" />
     <ClInclude Include="XamlMetadataProviderGenerated.h" />
     <ClInclude Include="XamlType.h" />
-    <None Include="$(OutDir)ResourceHelper.Images.g.h" Condition="$(BuildingWithBuildExe) == 'true'" />
-    <None Include="$(OutDir)ResourceHelper.Strings.g.h" Condition="$(BuildingWithBuildExe) == 'true'" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CommandingHelpers.cpp" />
@@ -338,7 +259,6 @@
     <ClCompile Include="DoubleUtil.cpp" />
     <ClCompile Include="DownlevelHelper.cpp" />
     <ClCompile Include="FloatUtil.cpp" />
-    <ClCompile Include="ResourceHelper.cpp" Condition="$(BuildingWithBuildExe) == 'true'" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -346,7 +266,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\XamlControlsResources.properties.cpp" />
     <ClCompile Include="XamlControlsResources.cpp" />
     <ClCompile Include="XamlMember.cpp" />
-    <ClCompile Include="XamlMetadataDependencyLocator.cpp" Condition="$(BuildingWithBuildExe) == 'true'" />
     <ClCompile Include="XamlMetadataProvider.cpp" />
     <ClCompile Include="$(OutDir)XamlMetadataProviderGenerated.cpp" />
     <ClCompile Include="XamlType.cpp" />
@@ -464,13 +383,6 @@
       <Value>$(OutDir)\sdk\Microsoft.UI.Xaml.winmd</Value>
     </T4ParameterValues>
   </ItemGroup>
-  <ItemGroup Condition="$(BuildingWithBuildExe) == 'true'">
-    <ResourceCompile Include="Microsoft.UI.Xaml.rc" />
-    <PublishGenerated Include="$(OutDir)MUXControls.xaml">
-      <DestinationFile>$(PUBLIC_ROOT)\internal\onecoreuapwindows\inc\DEPControls.xaml</DestinationFile>
-    </PublishGenerated>
-    <BinplaceLinked Include="$(ObjectPath)\$(ObjectDirectory)$(TargetFileName)" />
-  </ItemGroup>
   <ItemGroup>
     <!-- This natvis support is not ready for prime time 
     <Natvis Include="$(IntermediateOutputPath)CppWinRT\Platform\winrt\cppwinrt.natvis" Condition="$(BuildingWithBuildExe) != 'true'">
@@ -563,7 +475,15 @@
       <BatchMergeXaml RS1Pages="@(RS1StylePage)" RS2Pages="@(RS2StylePage)"  RS3Pages="@(RS3StylePage)" 
                       RS4Pages="@(RS4StylePage)" RS5Pages="@(RS5StylePage)"  N19H1Pages="@(NineteenH1StylePage)" 
                       PostfixForGeneratedFile="generic" OutputDirectory="$(OutDir)" />
-       <Copy SourceFiles="$(OutDir)rs1_generic.xaml" DestinationFiles="$(OutDir)Generic.xaml" />
+      <Copy SourceFiles="$(OutDir)rs1_generic.xaml" DestinationFiles="$(OutDir)Generic.xaml" />
+
+      <!-- NB: We have to use CreateProperty here instead of PropertyGroup.	
+      PropertyGroup values are always evaluated even when their enclosing target is skipped,	
+      whereas CreateProperty has the TaskParameter ValueSetByTask that can be used	
+      to only set a property if the target actually runs. -->	
+      <CreateProperty Value="True">	
+        <Output TaskParameter="ValueSetByTask" PropertyName="GenericXamlFileNeedsCompilation" />	
+      </CreateProperty>	  
   </Target>
   <Target Name="GenerateThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
     Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage)" 
@@ -572,7 +492,7 @@
       <BatchMergeXaml RS1Pages="@(RS1ThemeResourcePage)" RS2Pages="@(RS2ThemeResourcePage)"  RS3Pages="@(RS3ThemeResourcePage)" 
                       RS4Pages="@(RS4ThemeResourcePage)" RS5Pages="@(RS5ThemeResourcePage)"  N19H1Pages="@(NineteenH1ThemeResourcePage)" 
                       PostfixForGeneratedFile="themeresources" OutputDirectory="$(OutDir)" />
-  </Target>
+
   <Target Name="GenerateCompactThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
     Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage);@(CompactPage)" 
     Outputs="$(OutDir)rs1_compact_themeresources.xaml;$(OutDir)rs2_compact_themeresources.xaml;$(OutDir)rs3_compact_themeresources.xaml;$(OutDir)rs4_compact_themeresources.xaml;$(OutDir)rs5_compact_themeresources.xaml;$(OutDir)19h1_compact_themeresources.xaml;">
@@ -580,84 +500,14 @@
       <BatchMergeXaml RS1Pages="@(RS1ThemeResourcePage);@(CompactPage)" RS2Pages="@(RS2ThemeResourcePage);@(CompactPage)"  RS3Pages="@(RS3ThemeResourcePage);@(CompactPage)" 
                       RS4Pages="@(RS4ThemeResourcePage);@(CompactPage)" RS5Pages="@(RS5ThemeResourcePage);@(CompactPage)"  N19H1Pages="@(NineteenH1ThemeResourcePage);@(CompactPage)" 
                       PostfixForGeneratedFile="compact_themeresources" OutputDirectory="$(OutDir)" />
+     <!-- NB: We have to use CreateProperty here instead of PropertyGroup.	
+      PropertyGroup values are always evaluated even when their enclosing target is skipped,	
+      whereas CreateProperty has the TaskParameter ValueSetByTask that can be used	
+      to only set a property if the target actually runs. -->	
+      <CreateProperty Value="True">	
+        <Output TaskParameter="ValueSetByTask" PropertyName="ThemeResourceFileNeedsCompilation" />	
+      </CreateProperty>	
   </Target>
-  <Target Name="GenerateWUXCGenericXamlFile" DependsOnTargets="CategorizeSharedPages" Condition="$(BuildingWithBuildExe) == 'true'">
-    <PropertyGroup>
-      <GenericWuxcPath>$(OutDir)\GenericWuxcXaml</GenericWuxcPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <!-- The WUXC generic.xaml file shouldn't include any non-public types. -->
-      <RS1StylePage Remove="@(RS1StylePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS2StylePage Remove="@(RS2StylePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS3StylePage Remove="@(RS3StylePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS4StylePage Remove="@(RS4StylePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS5StylePage Remove="@(RS5StylePage)" Condition="'%(IsPublic)' != 'true'" />
-      <NineteenH1StylePage Remove="@(NineteenH1StylePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS1ThemeResourcePage Remove="@(RS1ThemeResourcePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS2ThemeResourcePage Remove="@(RS2ThemeResourcePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS3ThemeResourcePage Remove="@(RS3ThemeResourcePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS4ThemeResourcePage Remove="@(RS4ThemeResourcePage)" Condition="'%(IsPublic)' != 'true'" />
-      <RS5ThemeResourcePage Remove="@(RS5ThemeResourcePage)" Condition="'%(IsPublic)' != 'true'" />
-      <NineteenH1ThemeResourcePage Remove="@(NineteenH1ThemeResourcePage)" Condition="'%(IsPublic)' != 'true'" />
-    </ItemGroup>
-    <MakeDir Directories="$(GenericWuxcPath)" Condition="!Exists('$(GenericWuxcPath)')" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs1.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs1.xaml&quot; -XamlFileList &quot;@(RS1StylePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs1.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs2.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs2.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs1.xaml;@(RS2StylePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs2.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs3.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs3.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs2.xaml;@(RS3StylePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs3.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs4.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs4.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs3.xaml;@(RS4StylePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs4.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs5.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs5.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs4.xaml;@(RS5StylePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs5.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_19h1.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_19h1.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs5.xaml;@(NineteenH1StylePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_19h1.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs1_themeresources.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs1_themeresources.xaml&quot; -XamlFileList &quot;@(RS1ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs1_themeresources.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs2_themeresources.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs2_themeresources.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs1.xaml;@(RS2ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs2_themeresources.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs3_themeresources.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs3_themeresources.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs2.xaml;@(RS3ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs3_themeresources.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs4_themeresources.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs4_themeresources.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs3.xaml;@(RS4ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs4_themeresources.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_rs5_themeresources.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_rs5_themeresources.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs4.xaml;@(RS5ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_rs5_themeresources.xaml" />
-    <Message Text="Generating $(GenericWuxcPath)\generic_wuxc_19h1_themeresources.xaml..." />
-    <RunPowershellScript Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(GenericWuxcPath)\generic_wuxc_19h1_themeresources.xaml&quot; -XamlFileList &quot;$(GenericWuxcPath)\generic_wuxc_rs5.xaml;@(NineteenH1ThemeResourcePage)&quot; -DependencyHandling Reorder -RemoveComments -RemoveMUXPrefixFromResourceKeys" FilesWritten="$(OutDir)generic_wuxc_19h1_themeresources.xaml" />
-  </Target>
-  <Target Name="GeneratePrivateXamlFiles" BeforeTargets="PublishFilesGenerated" Condition="$(BuildingWithBuildExe) == 'true'" Inputs="@(SharedPage)" Outputs="$(OutDir)MUXControls.xaml">
-    <ItemGroup>
-      <PrivateSharedPage Include="@(SharedPage)" Condition="'%(IsPublic)' != 'true' And '%(IncludeInWindowsAppx)' == 'true'" />
-    </ItemGroup>
-    <!-- If there are private shared pages, we'll merge them into MUXControls.xaml.
-         Otherwise, we'll just output a blank MUXControls.xaml file. -->
-    <Message Condition="'@(PrivateSharedPage)' != ''" Text="Generating merged private XAML file for WUXC..." />
-    <RunPowershellScript Condition="'@(PrivateSharedPage)' != ''" Path="$(ScriptPath)GenerateMergedXaml.ps1" Parameters="-MergedXamlFilePath &quot;$(OutDir)MUXControls.xaml&quot; -XamlFileList &quot;@(PrivateSharedPage)&quot; -DependencyHandling Reorder -RemoveComments" FilesWritten="$(OutDir)MUXControls.xaml" />
-    <CopyWithReplacements Condition="'@(PrivateSharedPage)' != ''" SourceFiles="$(OutDir)MUXControls.xaml" DestinationFiles="$(OutDir)MUXControls.xaml" Patterns="Microsoft.UI.Xaml;Microsoft.UI.Private.Controls;Microsoft.UI.Private.Media" Replacements="Windows.UI.Xaml;Windows.UI.Xaml.Controls;Windows.UI.Xaml.Media" />
-    <Message Condition="'@(PrivateSharedPage)' == ''" Text="No private XAML files. Outputting a blank private XAML file for WUXC..." />
-    <Delete Condition="'@(PrivateSharedPage)' == '' And Exists('$(OutDir)MUXControls.xaml')" Files="$(OutDir)MUXControls.xaml" />
-    <Touch Condition="'@(PrivateSharedPage)' == ''" Files="$(OutDir)MUXControls.xaml" AlwaysCreate="True" />
-    <ItemGroup>
-      <FileWrites Include="$(OutDir)MUXControls.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="RemoveXamlFiles" BeforeTargets="MarkupCompilePass1" Condition="$(BuildingWithBuildExe) == 'true'">
-    <ItemGroup>
-      <!-- On the Windows side, we bake our public XAML into WUX's generic.xaml and publish our private XAML to be included by apps,
-           so we don't want to actually compile any XAML files there. -->
-      <Page Remove="@(Page)" />
-      <!-- Xaml compiler complains if it gets *no* pages, so throw it a bone and leave a simple one in, 
-           it doesn't matter which one as long as it doesn't have a file name the same as a type in the project. -->
-      <Page Include="$(MSBuildThisFileDirectory)..\Common\Common_themeresources.xaml" />
-    </ItemGroup>
-  </Target>
-  <Target Name="RemoveXamlFilesBeforeCreateWinMD" BeforeTargets="CreateWinMD" Condition="$(BuildingWithBuildExe) == 'true'">
-    <ItemGroup>
-      <!-- On the Windows side, we bake our public XAML into WUX's generic.xaml and publish our private XAML to be included by apps,
-           so we don't want to actually compile any XAML files there. -->
-      <Page Remove="@(Page)" />
-    </ItemGroup>
   </Target>
   <Target Name="RemovePageRequiringCustomCompilation" AfterTargets="BeforeBuildGenerateSources" BeforeTargets="MarkupCompilePass2" Condition="'@(PageRequiringCustomCompilation)' != '' And $(BuildingWithBuildExe) != 'true'">
     <Message Text="RemovePageRequiringCustomCompilation" />
@@ -697,16 +547,16 @@
       <XamlReferencesToCompile Condition="'$(Language)'!='C++'" Include="@(ReferencePath)" />
     </ItemGroup>
     <ItemGroup>
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_generic' And ('$(RS2GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_generic.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_generic' And ('$(RS3GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_generic.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_generic' And ('$(RS4GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_generic.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_generic' And ('$(RS5GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_generic.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_generic' And ('$(NineteenH1GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_generic.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_themeresources' And ('$(RS2ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_themeresources' And ('$(RS3ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_themeresources' And ('$(RS4ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_themeresources' And ('$(RS5ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_themeresources' And ('$(NineteenH1ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_generic' And ('$(GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_generic.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_generic' And ('$(GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_generic.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_generic' And ('$(GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_generic.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_generic' And ('$(GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_generic.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_generic' And ('$(GenericXamlFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_generic.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_themeresources.xbf'))" />
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_compact_themeresources' And ('$(RS2ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_compact_themeresources.xbf'))" />
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_compact_themeresources' And ('$(RS3ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_compact_themeresources.xbf'))" />
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_compact_themeresources' And ('$(RS4ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_compact_themeresources.xbf'))" />
@@ -828,43 +678,6 @@
   </Target>
   <Target Name="RunDependencyPropertyCodeGen" AfterTargets="CreateReferenceWinmds" BeforeTargets="ClCompile" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="$(OutDir)Microsoft.UI.winmd" Outputs="@(DependencyPropertyCodeGenOutputs);$(MSBuildProjectDirectory)\..\Generated\AcrylicBrush.properties.cpp">
     <DependencyPropertyCodeGen WinMDInput="$(OutDir)Microsoft.UI.winmd" References="@(ProjectionWinMD)" OutputDirectory="$(MSBuildProjectDirectory)\..\Generated" />
-  </Target>
-  <Target Name="XamlMetadataCodeGenWUXC" AfterTargets="MarkupCompilePass1" BeforeTargets="ClCompile" Condition="$(BuildingWithBuildExe) == 'true'" Inputs="$(ObjectPath)\..\..\idl\$(ObjectDirectory)\microsoft.ui.xaml.winmd;$(ObjectPath)\..\..\idl\$(ObjectDirectory)\microsoft.ui.private.winmd;$(ObjectPath)\..\..\idl\$(ObjectDirectory)\muxcontrolscontract.winmd;$(ObjectPath)\..\..\idl\$(ObjectDirectory)\effects.winmd;$(SdkMetadataPath)\windows.winmd;XamlMetadataProviderGenerated.tt;CommonHelpers.tt;WinRtType.tt" Outputs="$(OutDir)XamlMetadataProviderGenerated.cpp">
-    <PropertyGroup>
-      <LocalWinmdPath>$(ObjectPath)\..\..\idl\$(ObjectDirectory)</LocalWinmdPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <MetadataWinmd Include="$(SdkMetadataPath)\windows.winmd" />
-      <MetadataWinmd Include="$(SdkMetadataPath)\internal\windows.ui.winmd" />
-    </ItemGroup>
-    <ItemGroup>
-      <ReferenceWinmd Include="$(LocalWinmdPath)\microsoft.ui.xaml.winmd" />
-      <ReferenceWinmd Include="$(LocalWinmdPath)\effects.winmd" />
-      <ReferenceWinmd Include="$(SdkMetadataPath)\windows.winmd" />
-      <ReferenceWinmd Include="$(SdkMetadataPath)\internal\*.winmd" />
-    </ItemGroup>
-    <ItemGroup>
-      <TypeHintWinmd Include="$(LocalWinmdPath)\microsoft.ui.xaml.winmd" />
-    </ItemGroup>
-    <PropertyGroup>
-      <ParameterValuesString>-ParameterValuesString 'MetadataWinmdPaths=@(MetadataWinmd),ReferenceWinmds=@(ReferenceWinmd),TypeHintWinmds=@(TypeHintWinmd)'</ParameterValuesString>
-    </PropertyGroup>
-    <RunPowershellScript Path="$(ScriptPath)ProcessTextTemplate.ps1" Parameters="-FilePath XamlMetadataProviderGenerated.tt -OutputPath $(OutDir)XamlMetadataProviderGenerated.cpp $(ParameterValuesString)" />
-    <ItemGroup>
-      <FileWrites Include="$(OutDir)XamlMetadataProviderGenerated.cpp" />
-    </ItemGroup>
-  </Target>
-  <Target Name="GenerateResourceDefinitions" BeforeTargets="PrepareForBuild" Condition="$(BuildingWithBuildExe) == 'true'" Inputs="@(PRIResource);$(ScriptPath)GenerateSystemDllStringResources.ps1;$(ScriptPath)GenerateSystemDllImageResources.ps1" Outputs="$(OutDir)Microsoft.UI.Xaml.Strings.g.rc;$(OutDir)Microsoft.UI.Xaml.Images.g.rc;$(OutDir)ResourceHelper.Strings.g.h;$(OutDir)ResourceHelper.Images.g.h">
-    <Message Text="Generating resource definitions..." />
-    <MakeDir Directories="$(OutDir)" Condition="!Exists('$(OutDir)')" />
-    <RunPowershellScript Path="$(ScriptPath)GenerateSystemDllStringResources.ps1" Parameters="-ReswPaths &quot;@(PRIResource-&gt;WithMetadataValue('IsPreviewResource', 'False'))&quot; -OutputPath &quot;$(OutDir)Microsoft.UI.Xaml.Strings.g.rc&quot; -ResourceHelperOutputPath &quot;$(OutDir)ResourceHelper.Strings.g.h&quot;" FilesWritten="$(OutDir)Microsoft.UI.Xaml.Strings.g.rc;$(OutDir)ResourceHelper.Strings.g.h" />
-    <RunPowershellScript Path="$(ScriptPath)GenerateSystemDllImageResources.ps1" Parameters="-ImagePaths &quot;@(Image)&quot; -OutputPath &quot;$(OutDir)Microsoft.UI.Xaml.Images.g.rc&quot; -ResourceHelperOutputPath &quot;$(OutDir)ResourceHelper.Images.g.h&quot;" FilesWritten="$(OutDir)Microsoft.UI.Xaml.Images.g.rc;$(OutDir)ResourceHelper.Images.g.h" />
-    <ItemGroup>
-      <FileWrites Include="$(OutDir)Microsoft.UI.Xaml.Images.g.rc" />
-      <FileWrites Include="$(OutDir)Microsoft.UI.Xaml.Strings.g.rc" />
-      <FileWrites Include="$(OutDir)ResourceHelper.Images.g.h" />
-      <FileWrites Include="$(OutDir)ResourceHelper.Strings.g.h" />
-    </ItemGroup>
   </Target>
   <Target Name="WorkAroundFastUpToDateCheckBug" AfterTargets="_GenerateProjectPriFileCore" Inputs="$(OutDir)$(TargetName).pri" Outputs="$(OutDir)$(TargetName).dll;$(OutDir)$(TargetName).winmd;$(OutDir)Microsoft.UI.winmd" Condition="Exists('$(OutDir)$(TargetName).dll') And $(BuildingWithBuildExe) != 'true'">
     <Message Text="Touching '$(OutDir)$(TargetName).dll' because pri file changed to work around DevDiv bug https://devdiv.visualstudio.com/DevDiv/_workitems?id=297204" />

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildProjectDirectory)\..\..\mux.controls.props" Condition="Exists('$(MSBuildProjectDirectory)\..\..\mux.controls.props') And $(BuildingWithBuildExe) != 'true'" />
+  <Import Project="$(MSBuildProjectDirectory)\..\..\mux.controls.props" Condition="Exists('$(MSBuildProjectDirectory)\..\..\mux.controls.props')" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\environment.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\ProjectConfigurations.props" />
   <PropertyGroup Label="Globals">
@@ -26,10 +26,6 @@
     <!-- XBF is no longer embedded to improve F5 times but we need it embedded for the Nuget package PRI file, turn it on for release builds -->
     <DisableEmbeddedXbf Condition="'$(Configuration)'=='Release'">false</DisableEmbeddedXbf>
     <AppxBundlePlatforms>x86|x64|arm|arm64</AppxBundlePlatforms>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Use64BitLinker)' == 'true' AND '$(BuildingWithBuildExe)' == 'true'">
-    <OacrLinkTool>$(OSBuildToolsRoot)\vc\HostX64\$(BuildArchName)\link.exe</OacrLinkTool>
-    <LinkToolPath>$(OSBuildToolsRoot)\vc\HostX64\$(BuildArchName)</LinkToolPath>
   </PropertyGroup>
   <!-- <PropertyGroup Condition="'$(Use64BitLinker)' == 'true' AND '$(BuildingWithBuildExe)' != 'true'">
       <LinkToolPath>$(OSBuildToolsRoot)\vc\HostX64\$(BuildArchName)</LinkToolPath>
@@ -84,7 +80,7 @@
     <Import Project="..\Telemetry\Telemetry.vcxitems" Label="Shared" />
     <Import Project="..\ParallaxView\ParallaxView.vcxitems" Label="Shared" />
     <Import Project="..\Scroller\Scroller.vcxitems" Label="Shared" />
-    <Import Project="..\ScrollViewer\ScrollViewer.vcxitems" Label="Shared" Condition="$(BuildingWithBuildExe) != 'true' And $(BuildLeanMuxForTheStoreApp) != 'true'" />
+    <Import Project="..\ScrollViewer\ScrollViewer.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
     <Import Project="..\Lights\Lights.vcxitems" Label="Shared" />
     <Import Project="..\Repeater\Repeater.vcxitems" Label="Shared" />
     <Import Project="..\SwipeControl\SwipeControl.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
@@ -96,16 +92,16 @@
     <Import Project="..\DropDownButton\DropDownButton.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
     <Import Project="..\RadioButtons\RadioButtons.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
     <!-- IconSource is implemented in Windows.UI.Xaml.dll in the OS repo, so we don't want to include it on that side. -->
-    <Import Project="..\IconSource\IconSource.vcxitems" Label="Shared" Condition="$(BuildingWithBuildExe) != 'true'" />
+    <Import Project="..\IconSource\IconSource.vcxitems" Label="Shared" />
     <!-- These two depend on the type InteractionBase, which is behind the Velocity feature Feature_Xaml2018 in the OS repo.
          We can't compile them without attaching the same feature annotation, and MIDL doesn't let us attach feature attributes
          to non-public types.  So for now we'll just exclude these from the OS repo. -->
-    <Import Project="..\Interactions\ButtonInteraction\ButtonInteraction.vcxitems" Label="Shared" Condition="$(BuildingWithBuildExe) != 'true' And $(UseInternalSDK) == 'true'" />
-    <Import Project="..\Interactions\SliderInteraction\SliderInteraction.vcxitems" Label="Shared" Condition="$(BuildingWithBuildExe) != 'true' And $(UseInternalSDK) == 'true'" />
+    <Import Project="..\Interactions\ButtonInteraction\ButtonInteraction.vcxitems" Label="Shared" Condition="$(UseInternalSDK) == 'true'" />
+    <Import Project="..\Interactions\SliderInteraction\SliderInteraction.vcxitems" Label="Shared" Condition="$(UseInternalSDK) == 'true'" />
     <Import Project="..\MenuFlyout\MenuFlyout.vcxitems" Label="Shared" />
     <Import Project="..\TeachingTip\TeachingTip.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
     <Import Project="..\RadioMenuFlyoutItem\RadioMenuFlyoutItem.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
-    <Import Project="..\AnimatedVisualPlayer\AnimatedVisualPlayer.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true' and $(BuildingWithBuildExe) != 'true' And $(UseInsiderSDK) == 'true'" />
+    <Import Project="..\AnimatedVisualPlayer\AnimatedVisualPlayer.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true' and $(UseInsiderSDK) == 'true'" />
   </ImportGroup>
   <ItemGroup>
     <SharedPage Include="@(Page)" />
@@ -134,7 +130,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Condition="$(BuildingWithBuildExe) != 'true'">
+  <PropertyGroup>
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
   </PropertyGroup>
@@ -158,7 +154,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
-    <Midl Condition="$(BuildingWithBuildExe) != 'true'">
+    <Midl>
       <MetadataFileName>$(OutDir)Unmerged\%(Filename)_Unmerged.winmd</MetadataFileName>
       <AdditionalOptions>/no_stamp /no_settings_comment /nomidl %(AdditionalOptions)</AdditionalOptions>
       <!-- TODO: Remove Configuration==Debug from these once this is fixed: Bug 17488419: MIDL "import winmd" behavior doesn't carry through parameter names of methods on implemented interfaces -->
@@ -179,9 +175,9 @@
     <Link>
       <ModuleDefinitionFile>Microsoft.UI.Xaml.def</ModuleDefinitionFile>
       <GenerateDebugInformation Condition="'$(Configuration)'=='Debug'">$(GenerateDebugInformation)</GenerateDebugInformation>
-      <AdditionalDependencies Condition="$(BuildingWithBuildExe) != 'true'">dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <!-- Microsoft.UI.winmd will contain the definition of both public, preview and private types. -->
-      <WindowsMetadataFile Condition="$(BuildingWithBuildExe) != 'true'">$(OutDir)\Microsoft.UI.winmd</WindowsMetadataFile>
+      <WindowsMetadataFile>$(OutDir)\Microsoft.UI.winmd</WindowsMetadataFile>
       <GenerateMapFile>true</GenerateMapFile>
       <LinkTimeCodeGeneration Condition="'$(Configuration)'=='Release'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
@@ -193,7 +189,7 @@
         $(MSBuildProjectDirectory)\..\Generated;
         $(OutDir);
       </AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="$(BuildingWithBuildExe) != 'true'">
+      <AdditionalIncludeDirectories>
         $(IntermediateOutputPath)\CppWinRT\Platform;
         $(IntermediateOutputPath)\CppWinRT\Component;
         $(IntermediateOutputPath)\CppWinRT\Component\Automation\Peers;
@@ -208,18 +204,18 @@
         $(MiniWindowsSDKIncludePath);
       </AdditionalIncludeDirectories>
       <AdditionalOptions>/std:c++17 /bigobj %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="$(BuildingWithBuildExe) != 'true'">/Wv:18 /Zm1000 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Wv:18 /Zm1000 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions>%(AdditionalOptions) /await</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <EnablePREfast Condition="'$(Configuration)'=='Release' And $(BuildingWithBuildExe) != 'true'">true</EnablePREfast>
+      <EnablePREfast Condition="'$(Configuration)'=='Release'">true</EnablePREfast>
       <ShowIncludes>false</ShowIncludes>
       <!-- Disable RTTI to keep binary size down (adds about 50% to release dll size) -->
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <ControlFlowGuard Condition="'$(Configuration)'=='Release'">Guard</ControlFlowGuard>
       <StringPooling Condition="'$(Configuration)'=='Release'">true</StringPooling>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='Debug'">DEBUG;DBG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="$(BuildingWithBuildExe) != 'true'">DISABLE_WINRT_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DISABLE_WINRT_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">MinSpace</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MinSpace</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MinSpace</Optimization>
@@ -243,7 +239,7 @@
     <ClInclude Include="..\inc\tracker_ref.h" />
     <ClInclude Include="..\inc\TypeHelper.h" />
     <ClInclude Include="..\inc\CollectionHelper.h" />
-    <ClInclude Include="MUXControlsFactory.h" Condition="$(BuildingWithBuildExe) != 'true'" />
+    <ClInclude Include="MUXControlsFactory.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="XamlControlsResources.h" />
@@ -254,7 +250,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CommandingHelpers.cpp" />
-    <ClCompile Include="MUXControlsFactory.cpp" Condition="$(BuildingWithBuildExe) != 'true'" />
+    <ClCompile Include="MUXControlsFactory.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="DoubleUtil.cpp" />
     <ClCompile Include="DownlevelHelper.cpp" />
@@ -269,7 +265,7 @@
     <ClCompile Include="XamlMetadataProvider.cpp" />
     <ClCompile Include="$(OutDir)XamlMetadataProviderGenerated.cpp" />
     <ClCompile Include="XamlType.cpp" />
-    <None Include="$(OutDir)XamlMetadataProviderWindowsCodeGen.cs" Condition="$(BuildingWithBuildExe) != 'true'" />
+    <None Include="$(OutDir)XamlMetadataProviderWindowsCodeGen.cs" />
     <None Include="WinRtType.tt" />
   </ItemGroup>
   <ItemGroup>
@@ -277,7 +273,7 @@
     <None Include="Microsoft.UI.Xaml.rc" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup Condition="$(BuildingWithBuildExe) != 'true'">
+  <ItemGroup>
     <Page Include="$(OutDir)Generic.xaml">
       <SubType>Designer</SubType>
       <ThemeResource>true</ThemeResource>
@@ -367,10 +363,10 @@
     <Page Include="@(PageRequiringCustomCompilation)" />
     <CompactPage Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml" />
   </ItemGroup>
-  <ItemGroup Condition="$(BuildingWithBuildExe) != 'true'">
+  <ItemGroup>
     <Midl Include="..\..\idl\Microsoft.UI.Xaml.idl" />
   </ItemGroup>
-  <ItemGroup Condition="$(BuildingWithBuildExe) != 'true'">
+  <ItemGroup>
     <None Include="XamlMetadataProviderGenerated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>$(OutDir)XamlMetadataProviderGenerated.cpp</LastGenOutput>
@@ -385,14 +381,14 @@
   </ItemGroup>
   <ItemGroup>
     <!-- This natvis support is not ready for prime time 
-    <Natvis Include="$(IntermediateOutputPath)CppWinRT\Platform\winrt\cppwinrt.natvis" Condition="$(BuildingWithBuildExe) != 'true'">
+    <Natvis Include="$(IntermediateOutputPath)CppWinRT\Platform\winrt\cppwinrt.natvis">
     </Natvis>
-    <Natvis Include="$(IntermediateOutputPath)CppWinRT\Component\winrt\Microsoft.UI.Xaml.natvis" Condition="$(BuildingWithBuildExe) != 'true'">
+    <Natvis Include="$(IntermediateOutputPath)CppWinRT\Component\winrt\Microsoft.UI.Xaml.natvis">
     </Natvis>
     -->
   </ItemGroup>
   <Import Project="$(CppTargetsFilePath)" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TextTemplating\Microsoft.TextTemplating.targets" Condition="$(BuildingWithBuildExe) != 'true'" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TextTemplating\Microsoft.TextTemplating.targets" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\CustomInlineTasks.targets" />
   <!-- We make it so that devs just include the en-us version of their string resources in the project. This is because
        we only want people editing the en-us version (it's the only file that's input to the localization process) and
@@ -464,11 +460,11 @@
       <NineteenH1ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '19H1' And '%(Type)' == 'ThemeResources'" />
     </ItemGroup>
   </Target>
-  <PropertyGroup Condition="$(BuildingWithBuildExe) != 'true'">
+  <PropertyGroup>
     <GenerateXamlFileBeforeTargets>BeforeBuildGenerateSources;CompileXaml;Prep_ComputeProcessXamlFiles;CompilePageRequiringCustomCompilation</GenerateXamlFileBeforeTargets>
   </PropertyGroup>
  
-  <Target Name="GenerateGenericResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
+  <Target Name="GenerateGenericResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" 
     Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage);@(NineteenH1StylePage)" 
     Outputs="$(OutDir)Generic.xaml;$(OutDir)rs1_generic.xaml;$(OutDir)rs2_generic.xaml;$(OutDir)rs3_generic.xaml;$(OutDir)rs4_generic.xaml;$(OutDir)rs5_generic.xaml;$(OutDir)19h1_generic.xaml;">
       <Message Text="Generating generic resources XAML file " />
@@ -485,15 +481,22 @@
         <Output TaskParameter="ValueSetByTask" PropertyName="GenericXamlFileNeedsCompilation" />	
       </CreateProperty>	  
   </Target>
-  <Target Name="GenerateThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
+  <Target Name="GenerateThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" 
     Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage)" 
     Outputs="$(OutDir)rs1_themeresources.xaml;$(OutDir)rs2_themeresources.xaml;$(OutDir)rs3_themeresources.xaml;$(OutDir)rs4_themeresources.xaml;$(OutDir)rs5_themeresources.xaml;$(OutDir)19h1_themeresources.xaml;">
       <Message Text="Generating theme resources XAML file " />
       <BatchMergeXaml RS1Pages="@(RS1ThemeResourcePage)" RS2Pages="@(RS2ThemeResourcePage)"  RS3Pages="@(RS3ThemeResourcePage)" 
                       RS4Pages="@(RS4ThemeResourcePage)" RS5Pages="@(RS5ThemeResourcePage)"  N19H1Pages="@(NineteenH1ThemeResourcePage)" 
                       PostfixForGeneratedFile="themeresources" OutputDirectory="$(OutDir)" />
-
-  <Target Name="GenerateCompactThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Condition="$(BuildingWithBuildExe) != 'true'" 
+     <!-- NB: We have to use CreateProperty here instead of PropertyGroup.	
+      PropertyGroup values are always evaluated even when their enclosing target is skipped,	
+      whereas CreateProperty has the TaskParameter ValueSetByTask that can be used	
+      to only set a property if the target actually runs. -->	
+      <CreateProperty Value="True">	
+        <Output TaskParameter="ValueSetByTask" PropertyName="ThemeResourceFileNeedsCompilation" />	
+      </CreateProperty>	
+  </Target>
+  <Target Name="GenerateCompactThemeResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" 
     Inputs="@(RS1ThemeResourcePage);@(RS2ThemeResourcePage);@(RS3ThemeResourcePage);@(RS4ThemeResourcePage);@(RS5ThemeResourcePage);@(NineteenH1ThemeResourcePage);@(CompactPage)" 
     Outputs="$(OutDir)rs1_compact_themeresources.xaml;$(OutDir)rs2_compact_themeresources.xaml;$(OutDir)rs3_compact_themeresources.xaml;$(OutDir)rs4_compact_themeresources.xaml;$(OutDir)rs5_compact_themeresources.xaml;$(OutDir)19h1_compact_themeresources.xaml;">
       <Message Text="Generating theme resources XAML file " />
@@ -505,17 +508,16 @@
       whereas CreateProperty has the TaskParameter ValueSetByTask that can be used	
       to only set a property if the target actually runs. -->	
       <CreateProperty Value="True">	
-        <Output TaskParameter="ValueSetByTask" PropertyName="ThemeResourceFileNeedsCompilation" />	
+        <Output TaskParameter="ValueSetByTask" PropertyName="CompactThemeResourceFileNeedsCompilation" />	
       </CreateProperty>	
   </Target>
-  </Target>
-  <Target Name="RemovePageRequiringCustomCompilation" AfterTargets="BeforeBuildGenerateSources" BeforeTargets="MarkupCompilePass2" Condition="'@(PageRequiringCustomCompilation)' != '' And $(BuildingWithBuildExe) != 'true'">
+  <Target Name="RemovePageRequiringCustomCompilation" AfterTargets="BeforeBuildGenerateSources" BeforeTargets="MarkupCompilePass2" Condition="'@(PageRequiringCustomCompilation)' != ''">
     <Message Text="RemovePageRequiringCustomCompilation" />
     <ItemGroup>
       <Page Remove="@(PageRequiringCustomCompilation)" />
     </ItemGroup>
   </Target>
-  <Target Name="AddPageRequiringCustomCompilation" BeforeTargets="CompilePageRequiringCustomCompilation" AfterTargets="MarkupCompilePass2" Condition="'@(PageRequiringCustomCompilation)' != '' And $(BuildingWithBuildExe) != 'true'">
+  <Target Name="AddPageRequiringCustomCompilation" BeforeTargets="CompilePageRequiringCustomCompilation" AfterTargets="MarkupCompilePass2" Condition="'@(PageRequiringCustomCompilation)' != ''">
     <Message Text="AddPageRequiringCustomCompilation" />
     <ItemGroup>
       <Page Include="@(PageRequiringCustomCompilation)" />
@@ -524,7 +526,7 @@
   <!-- The CompilePageRequiringCustomCompilation contents are mostly copied from the
        definition of the MarkupCompilePass2 target from Microsoft.Windows.UI.Xaml.Common.targets.
        We use it to run the same XAML compilation functionality, except against a different SDK. -->
-  <Target Name="CompilePageRequiringCustomCompilation" AfterTargets="MarkupCompilePass2" DependsOnTargets="$(MarkupCompilePass2DependsOn)" Condition="$(BuildingWithBuildExe) != 'true'">
+  <Target Name="CompilePageRequiringCustomCompilation" AfterTargets="MarkupCompilePass2" DependsOnTargets="$(MarkupCompilePass2DependsOn)" >
     <PropertyGroup>
       <WarningLevel>$(PrevWarningLevel)</WarningLevel>
       <WarningLevel Condition="'$(WarningLevel)' == '' and '$(ExplicitResetWarningSuppression)' == 'true'">1</WarningLevel>
@@ -557,11 +559,11 @@
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_themeresources.xbf'))" />
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_themeresources.xbf'))" />
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_themeresources' And ('$(ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_compact_themeresources' And ('$(RS2ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_compact_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_compact_themeresources' And ('$(RS3ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_compact_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_compact_themeresources' And ('$(RS4ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_compact_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_compact_themeresources' And ('$(RS5ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_compact_themeresources.xbf'))" />
-      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_compact_themeresources' And ('$(NineteenH1ThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_compact_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs2_compact_themeresources' And ('$(CompactThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs2_compact_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs3_compact_themeresources' And ('$(CompactThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs3_compact_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs4_compact_themeresources' And ('$(CompactThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs4_compact_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == 'rs5_compact_themeresources' And ('$(CompactThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\rs5_compact_themeresources.xbf'))" />
+      <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '19h1_compact_themeresources' And ('$(CompactThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(IntDir)\Generated Files\Themes\19h1_compact_themeresources.xbf'))" />
     </ItemGroup>
     <Message Condition="'@(PageToBeCompiled)' != ''" Text="CustomCompile with min version %(PageToBeCompiled.MinSDKVersionRequired) for Pages: @(PageToBeCompiled)" />
     <CompileXaml Condition="'@(PageToBeCompiled)' != ''" LanguageSourceExtension="$(DefaultLanguageSourceExtension)" Language="$(Language)" RootNamespace="$(RootNamespace)" XamlPages="@(PageToBeCompiled)" XamlApplications="@(ApplicationDefinition)" SdkXamlPages="@(SdkXamlItems)" PriIndexName="$(PriIndexName)" ProjectName="$(XamlProjectName)" IsPass1="False" DisableXbfGeneration="False" CodeGenerationControlFlags="$(XamlCodeGenerationControlFlags)" ClIncludeFiles="@(ClInclude)" CIncludeDirectories="$(XamlCppIncludeDirectories)" LocalAssembly="$(LocalAssembly)" ProjectPath="$(MSBuildProjectFullPath)" OutputPath="$(XamlGeneratedOutputPath)" OutputType="$(OutputType)" ReferenceAssemblyPaths="@(ReferenceAssemblyPaths)" ReferenceAssemblies="@(XamlReferencesToCompile)" ForceSharedStateShutdown="False" CompileMode="RealBuildPass2" XAMLFingerprint="$(XAMLFingerprint)" FingerprintIgnorePaths="$(XAMLFingerprintIgnorePaths)" VCInstallDir="$(VCInstallDir)" WindowsSdkPath="$(WindowsSdkPath)" GenXbf32Path="$(GenXbfPath)" SavedStateFile="$(XamlSavedStateFilePath)" RootsLog="$(XamlRootsLog)" SuppressWarnings="$(SuppressXamlWarnings)" XamlResourceMapName="$(XamlResourceMapName)" XamlComponentResourceLocation="$(XamlComponentResourceLocation)" TargetPlatformMinVersion="%(PageToBeCompiled.MinSDKVersionRequired)" PlatformXmlDir="$(PlatformXmlDir)">
@@ -593,7 +595,7 @@
       </ClCompile>
     </ItemGroup>
   </Target>
-  <Target Name="mdmerge" AfterTargets="Midl" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="@(Midl -> '%(MetadataFileName)')" Outputs="$(OutDir)Microsoft.UI.winmd;$(OutDir)\sdk\Microsoft.UI.Xaml.winmd;$(IntermediateOutputPath)CppWinRT\Platform\winrt\base.h;$(IntermediateOutputPath)CppWinRT\Component\winrt\Microsoft.UI.Xaml.Controls.h">
+  <Target Name="mdmerge" AfterTargets="Midl" Inputs="@(Midl -> '%(MetadataFileName)')" Outputs="$(OutDir)Microsoft.UI.winmd;$(OutDir)\sdk\Microsoft.UI.Xaml.winmd;$(IntermediateOutputPath)CppWinRT\Platform\winrt\base.h;$(IntermediateOutputPath)CppWinRT\Component\winrt\Microsoft.UI.Xaml.Controls.h">
     <PropertyGroup>
       <MdMergeExe>"$(WindowsSdkDir)bin\$(WindowsTargetPlatformVersion)\$(PreferredToolArchitecture)\mdmerge.exe"</MdMergeExe>
       <!-- using an older version of cpp winrt to avoid compiler issues -->
@@ -657,14 +659,14 @@
       <FileWrites Include="$(OutDir)Microsoft.UI.Composition.winmd" />
     </ItemGroup>
   </Target>
-  <Target Name="CreateReferenceWinmds" AfterTargets="mdmerge" BeforeTargets="XamlMetadataCodeGenMUX" Condition="$(BuildingWithBuildExe) != 'true'">
+  <Target Name="CreateReferenceWinmds" AfterTargets="mdmerge" BeforeTargets="XamlMetadataCodeGenMUX">
     <ItemGroup>
       <T4ParameterValues Include="ReferenceWinmds">
         <Value>@(ProjectionWinMD);@(ComponentWinMD)</Value>
       </T4ParameterValues>
     </ItemGroup>
   </Target>
-  <Target Name="XamlMetadataCodeGenMUX" AfterTargets="CreateReferenceWinmds" BeforeTargets="ClCompile" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="$(MetadataWinmdPaths);XamlMetadataProviderGenerated.tt;CommonHelpers.tt;WinRtType.tt" Outputs="$(OutDir)XamlMetadataProviderGenerated.cpp">
+  <Target Name="XamlMetadataCodeGenMUX" AfterTargets="CreateReferenceWinmds" BeforeTargets="ClCompile" Inputs="$(MetadataWinmdPaths);XamlMetadataProviderGenerated.tt;CommonHelpers.tt;WinRtType.tt" Outputs="$(OutDir)XamlMetadataProviderGenerated.cpp">
     <!-- Run XamlMetadataProviderGenerated.tt t4 template to generate XamlMetadataProviderGenerated.cpp from the winmd file -->
     <CallTarget Targets="TransformAll" />
     <ItemGroup>
@@ -676,16 +678,16 @@
       <Output TaskParameter="Include" ItemName="DependencyPropertyCodeGenOutputs" />
     </CreateItem>
   </Target>
-  <Target Name="RunDependencyPropertyCodeGen" AfterTargets="CreateReferenceWinmds" BeforeTargets="ClCompile" Condition="$(BuildingWithBuildExe) != 'true'" Inputs="$(OutDir)Microsoft.UI.winmd" Outputs="@(DependencyPropertyCodeGenOutputs);$(MSBuildProjectDirectory)\..\Generated\AcrylicBrush.properties.cpp">
+  <Target Name="RunDependencyPropertyCodeGen" AfterTargets="CreateReferenceWinmds" BeforeTargets="ClCompile" Inputs="$(OutDir)Microsoft.UI.winmd" Outputs="@(DependencyPropertyCodeGenOutputs);$(MSBuildProjectDirectory)\..\Generated\AcrylicBrush.properties.cpp">
     <DependencyPropertyCodeGen WinMDInput="$(OutDir)Microsoft.UI.winmd" References="@(ProjectionWinMD)" OutputDirectory="$(MSBuildProjectDirectory)\..\Generated" />
   </Target>
-  <Target Name="WorkAroundFastUpToDateCheckBug" AfterTargets="_GenerateProjectPriFileCore" Inputs="$(OutDir)$(TargetName).pri" Outputs="$(OutDir)$(TargetName).dll;$(OutDir)$(TargetName).winmd;$(OutDir)Microsoft.UI.winmd" Condition="Exists('$(OutDir)$(TargetName).dll') And $(BuildingWithBuildExe) != 'true'">
+  <Target Name="WorkAroundFastUpToDateCheckBug" AfterTargets="_GenerateProjectPriFileCore" Inputs="$(OutDir)$(TargetName).pri" Outputs="$(OutDir)$(TargetName).dll;$(OutDir)$(TargetName).winmd;$(OutDir)Microsoft.UI.winmd" Condition="Exists('$(OutDir)$(TargetName).dll')">
     <Message Text="Touching '$(OutDir)$(TargetName).dll' because pri file changed to work around DevDiv bug https://devdiv.visualstudio.com/DevDiv/_workitems?id=297204" />
     <Touch Files="$(OutDir)$(TargetName).dll" />
     <Touch Files="$(OutDir)$(TargetName).winmd" />
     <Touch Files="$(OutDir)Microsoft.UI.winmd" />
   </Target>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild" Condition="$(BuildingWithBuildExe) != 'true'">
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
@@ -693,7 +695,7 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Gsl.0.1.2.1\build\native\Microsoft.Gsl.targets'))" />
     <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets'))" />
   </Target>
-  <Target Name="RunBinSkim" AfterTargets="AfterBuild" Condition="'$(Configuration)'=='Release' And $(BuildingWithBuildExe) != 'true'">
+  <Target Name="RunBinSkim" AfterTargets="AfterBuild" Condition="'$(Configuration)'=='Release'">
     <PropertyGroup>
       <BinSkimCommand>..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe analyze "$(TargetPath)"</BinSkimCommand>
     </PropertyGroup>
@@ -703,7 +705,7 @@
     </Exec>
     <Error Text="BinSkim task failed." Condition="'$(ExitCode)'=='0'" />
   </Target>
-  <Target Name="CheckCompatibility" BeforeTargets="PrepareForBuild" Condition="'$(Configuration)'=='Release' And $(BuildingWithBuildExe) != 'true'">
+  <Target Name="CheckCompatibility" BeforeTargets="PrepareForBuild" Condition="'$(Configuration)'=='Release'">
     <Message Text="Running CheckCompatibility to ensure that no known incompatibilities between the WinUI and Windows depots have been introduced." />
     <RunPowershellScript Path="$(ScriptPath)CheckCompatibility.ps1" />
   </Target>
@@ -711,7 +713,7 @@
        since we need to re-link Microsoft.UI.Xaml.dll for code coverage.
        We can't get it from any environment variable, so let's write it to a text file as a workaround.
        We'll also output the MSVC tools directory for the same reason. -->
-  <Target Name="AfterBuild" Condition="$(BuildingWithBuildExe) != 'true' And (!Exists('$(OutDir)IntermediateDirectoryLocation.txt') Or !Exists('$(OutDir)VCToolsInstallDirectoryLocation.txt'))">
+  <Target Name="AfterBuild" Condition="(!Exists('$(OutDir)IntermediateDirectoryLocation.txt') Or !Exists('$(OutDir)VCToolsInstallDirectoryLocation.txt'))">
     <WriteLinesToFile File="$(OutDir)IntermediateDirectoryLocation.txt" Lines="$(IntermediateOutputPath)" Overwrite="true" Encoding="Ascii" />
     <WriteLinesToFile File="$(OutDir)VCToolsInstallDirectoryLocation.txt" Lines="$(VCToolsInstallDir)" Overwrite="true" Encoding="Ascii" />
     <ItemGroup>


### PR DESCRIPTION
Fix #487.
Also remove "$(BuildingWithBuildExe) == 'true'" stuff from Microsoft.UI.Xaml.vcxproj.
My old PR break this functionality.
All per os version Flags are combined to only two: GenericXamlFileNeedsCompilation and ThemeResourceFileNeedsCompilation.

~10s would be spent on CompilePageRequiringCustomCompilation when any xaml page is changed.

