### PR TITLE
Fix for text flow issue in first uniform grid item

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -10,7 +10,6 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using Windows.Foundation;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Markup;
@@ -38,7 +37,6 @@ using FlowLayout = Microsoft.UI.Xaml.Controls.FlowLayout;
 using UniformGridLayout = Microsoft.UI.Xaml.Controls.UniformGridLayout;
 using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutContext;
-using LayoutContext = Microsoft.UI.Xaml.Controls.LayoutContext;
 using LayoutPanel = Microsoft.UI.Xaml.Controls.LayoutPanel;
 #endif
 
@@ -207,6 +205,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                                 throw new InvalidOperationException("Unhanlded dimension choice.");
                         }
 
+                        // Need to invalidate measure to kick in bigger size, 
+                        // If the new size is larger, then setting the value does not
+                        // invalidate measure, because the desired size is going to be same.
+                        panel.InvalidateMeasure();
                         Content.UpdateLayout();
 
                         // validate that our dimension's size has propagated to all other buttons
@@ -226,6 +228,49 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                                 case DimensionChoice.Size:
                                     Verify.AreEqual(100, layoutBounds.Width);
                                     Verify.AreEqual(100, layoutBounds.Height);
+                                    break;
+                                default:
+                                    throw new InvalidOperationException("Unhanlded dimension choice.");
+
+                            }
+                        }
+
+                        // Make the first item smaller
+                        switch (dimension)
+                        {
+                            case DimensionChoice.Width:
+                                firstItem.Width = 32;
+                                break;
+                            case DimensionChoice.Height:
+                                firstItem.Height = 32;
+                                break;
+                            case DimensionChoice.Size:
+                                firstItem.Width = 32;
+                                firstItem.Height = 32;
+                                break;
+                            default:
+                                throw new InvalidOperationException("Unhanlded dimension choice.");
+                        }
+
+                        Content.UpdateLayout();
+
+                        // validate that our dimension's size has propagated to all other buttons
+                        for (int i = 0; i < panel.Children.Count; i++)
+                        {
+                            var child = (FrameworkElement)panel.Children.ElementAt(i);
+                            var layoutBounds = LayoutInformation.GetLayoutSlot(child);
+
+                            switch (dimension)
+                            {
+                                case DimensionChoice.Width:
+                                    Verify.AreEqual(32, layoutBounds.Width);
+                                    break;
+                                case DimensionChoice.Height:
+                                    Verify.AreEqual(32, layoutBounds.Height);
+                                    break;
+                                case DimensionChoice.Size:
+                                    Verify.AreEqual(32, layoutBounds.Width);
+                                    Verify.AreEqual(32, layoutBounds.Height);
                                     break;
                                 default:
                                     throw new InvalidOperationException("Unhanlded dimension choice.");

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -105,17 +105,8 @@ void UniformGridLayout::OnItemsChangedCore(
 
 winrt::Size UniformGridLayout::Algorithm_GetMeasureSize(int index, const winrt::Size & availableSize, const winrt::VirtualizingLayoutContext& context)
 {
-    // The first element should always take as much space it wants, all the others should be limited to the size of the first one.
-    // We pass along all the available size so that it has the option to grow/shrink everytime it's resized rather than having a static size from the first time.
-    if (index == 0)
-    {
-        return availableSize;
-    }
-    else
-    {
-        const auto gridState = GetAsGridState(context.LayoutState());
-        return winrt::Size{ static_cast<float>(gridState->EffectiveItemWidth()),static_cast<float>(gridState->EffectiveItemHeight()) };
-    }
+    const auto gridState = GetAsGridState(context.LayoutState());
+    return winrt::Size{ static_cast<float>(gridState->EffectiveItemWidth()),static_cast<float>(gridState->EffectiveItemHeight()) };
 }
 
 winrt::Size UniformGridLayout::Algorithm_GetProvisionalArrangeSize(int /*index*/, const winrt::Size & /*measureSize*/, winrt::Size const& /*desiredSize*/, const winrt::VirtualizingLayoutContext& context)


### PR DESCRIPTION
In uniform grid layout, we measure the first item with available size to figure out the size that all items should get. we never re-measure the first item with the exact size. Although this is reasonable, it causes some issues with text reflow. The fix is to re-measure the first item with the same size used for all items. Not adding a test since this does not really have a difference from the layout's perspective that can be observed. Existing tests cover the layout's behavior which should remain the same.

Fixes #486