### PR TITLE
Fixing two issues with bring into view when using effective viewport

### DIFF
--- a/dev/Repeater/APITests/EffectiveViewportScrollViewerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollViewerTests.cs
@@ -521,7 +521,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             IdleSynchronizer.Wait();
             Verify.IsLessThanOrEqual(1, viewChangedOffsets.Count);
             viewChangedOffsets.Clear();
-            ValidateRealizedRange(repeater, 99, 106);
+            ValidateRealizedRange(repeater, 101, 109);
 
             RunOnUIThread.Execute(() =>
             {

--- a/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
@@ -360,7 +360,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 repeater.ElementPrepared += (sender, args) =>
                 {
-                    Log.Comment("Realized index: " + args.Index + "Wating for index " + waitingForIndex);
+                    Log.Comment($"Realized index: {args.Index} Wating for index {waitingForIndex}");
                     if (args.Index == waitingForIndex)
                     {
                         indexRealized.Set();

--- a/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
@@ -360,6 +360,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 repeater.ElementPrepared += (sender, args) =>
                 {
+                    Log.Comment("Realized index: " + args.Index + "Wating for index " + waitingForIndex);
                     if (args.Index == waitingForIndex)
                     {
                         indexRealized.Set();
@@ -421,6 +422,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             RunOnUIThread.Execute(() =>
             {
                 Log.Comment("Scroll into view item 105 (already realized) w/ animation.");
+                waitingForIndex = 99;
                 repeater.TryGetElement(105).StartBringIntoView(new BringIntoViewOptions
                 {
                     VerticalAlignmentRatio = 0.5,
@@ -433,7 +435,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             IdleSynchronizer.Wait();
             Verify.IsLessThanOrEqual(1, viewChangedOffsets.Count);
             viewChangedOffsets.Clear();
-            ValidateRealizedRange(repeater, 99, 106);
+            ValidateRealizedRange(repeater, 101, 109);
 
             RunOnUIThread.Execute(() =>
             {

--- a/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
@@ -407,7 +407,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             {
                 waitingForIndex = 101;
                 indexRealized.Reset();
-                repeater.GetOrCreateElement(100).StartBringIntoView();
+                repeater.GetOrCreateElement(100).StartBringIntoView(new BringIntoViewOptions {
+                    VerticalAlignmentRatio = 0.0
+                });
                 repeater.UpdateLayout();
             });
 

--- a/dev/Repeater/ViewportManagerDownlevel.h
+++ b/dev/Repeater/ViewportManagerDownlevel.h
@@ -96,7 +96,6 @@ private:
 
     // Event tokens
     winrt::IRepeaterScrollingSurface::PostArrange_revoker m_postArrangeToken;
-    winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering_revoker m_renderingToken;
 
     // Stores information about a parent scrolling surface.
     // We subscribe to...

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.h
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.h
@@ -58,7 +58,8 @@ private:
     void ValidateCacheLength(double cacheLength);
     void RegisterCacheBuildWork();
     void TryInvalidateMeasure();
-    
+    winrt::Rect GetLayoutVisibleWindowDiscardAnchor() const;
+
     winrt::hstring GetLayoutId() const;
 
     ItemsRepeater* m_owner{ nullptr };

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.h
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.h
@@ -61,6 +61,8 @@ private:
     winrt::Rect GetLayoutVisibleWindowDiscardAnchor() const;
 
     winrt::hstring GetLayoutId() const;
+    void OnCompositionTargetRendering(winrt::IInspectable const& sender, winrt::IInspectable const& args);
+    winrt::UIElement GetImmediateChildOfRepeater(winrt::UIElement const& descendant);
 
     ItemsRepeater* m_owner{ nullptr };
 
@@ -87,8 +89,11 @@ private:
     double m_horizontalCacheBufferPerSide{};
     double m_verticalCacheBufferPerSide{};
 
+    bool m_isBringIntoViewInProgress{false};
+
     // Event tokens
     winrt::FrameworkElement::EffectiveViewportChanged_revoker m_effectiveViewportChangedRevoker{};
 
     winrt::FrameworkElement::LayoutUpdated_revoker m_layoutUpdatedRevoker{};
+    winrt::Windows::UI::Xaml::Media::CompositionTarget::Rendering_revoker m_renderingToken{};
 };


### PR DESCRIPTION
(1) We force the element to be anchor when GetOrCreateElement is called but never clear it which causes the window to get stuck.
(2) Once we make a specific element as anchor for bring into view, repeater locks onto that element and keeps suggesting it as the anchor to layout - however the anchor provider is free to pick another anchor and start tracking that which can be trouble. I'm fixing that using the UIElement property to mark just the anchor as a candidate and mark the rest as not so that the scroll anchor provider will not pick a random element when we are trying to bring an element into view. Fixed a couple of tests as well which look like were looking for the incorrect indices.

Fixes #484