### PR TITLE
MUXFinalRelease packages should not have -prerelease tag

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -8,6 +8,7 @@ parameters:
   primaryBuildArch: x86
   buildFlavor: Release
   signConfig: ''
+  releasePackage: 'false'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -37,6 +38,7 @@ jobs:
       echo parameters.publishPath '${{ parameters.publishPath }}'
       echo buildrevision=$(buildrevision)
       echo builddate=$(builddate)
+      echo releasePackage=${{ parameters.releasePackage }}
     displayName: 'CreateNugetPackage: Display parameters'
 
   - task: DownloadBuildArtifacts@0 
@@ -60,19 +62,20 @@ jobs:
         sourceFolder: '$(Build.SourcesDirectory)\Artifacts\drop'
         Contents: '**\Microsoft.UI.Xaml*.appx'
 
-  - task: powershell@2
-    displayName: 'build-nupkg.ps1'
-    inputs:
-      targetType: filePath
-      filePath: build\NuSpecs\build-nupkg.ps1
-      arguments: > 
-        -BuildOutput '$(Build.SourcesDirectory)\Artifacts\drop' 
-        -OutputDir '${{ parameters.nupkgdir }}' 
-        -prereleaseversion prerelease 
-        -DateOverride '$(builddate)'
-        -Subversion '$(buildrevision)' 
-        -BuildArch ${{ parameters.primaryBuildArch }}
+  - powershell: |
+      $prereleaseTag = "prerelease"
+      if ("${{ parameters.releasePackage}}" -eq [bool]::TrueString) { $prereleaseTag = "" }
+
+      & "$env:Build_SourcesDirectory\build\NuSpecs\build-nupkg.ps1" `
+        -BuildOutput '$(Build.SourcesDirectory)\Artifacts\drop' `
+        -OutputDir '${{ parameters.nupkgdir }}' `
+        -prereleaseversion "$prereleaseTag" `
+        -DateOverride '$(builddate)' `
+        -Subversion '$(buildrevision)' `
+        -BuildArch ${{ parameters.primaryBuildArch }} `
         -BuildFlavor ${{ parameters.buildFlavor }}
+
+    displayName: 'build-nupkg.ps1'
 
   - ${{if parameters.signConfig }}:
     - task: PkgESCodeSign@10

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -8,7 +8,7 @@ parameters:
   primaryBuildArch: x86
   buildFlavor: Release
   signConfig: ''
-  releasePackage: 'false'
+  useReleaseTag: 'false'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -38,7 +38,7 @@ jobs:
       echo parameters.publishPath '${{ parameters.publishPath }}'
       echo buildrevision=$(buildrevision)
       echo builddate=$(builddate)
-      echo releasePackage=${{ parameters.releasePackage }}
+      echo useReleaseTag=${{ parameters.useReleaseTag }}
     displayName: 'CreateNugetPackage: Display parameters'
 
   - task: DownloadBuildArtifacts@0 
@@ -64,7 +64,7 @@ jobs:
 
   - powershell: |
       $prereleaseTag = "prerelease"
-      if ("${{ parameters.releasePackage}}" -eq [bool]::TrueString) { $prereleaseTag = "" }
+      if ("${{ parameters.useReleaseTag}}" -eq [bool]::TrueString) { $prereleaseTag = "" }
 
       & "$env:Build_SourcesDirectory\build\NuSpecs\build-nupkg.ps1" `
         -BuildOutput '$(Build.SourcesDirectory)\Artifacts\drop' `

--- a/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
@@ -11,9 +11,9 @@ steps:
         {
           $rootPath = "${{ parameters.buildOutputDir }}\$config\$platform"
           Write-Host ""
-          Write-Host "Checking for $rootPath"
+          Write-Host "Checking for $rootPath\Microsoft.UI.Xaml"
           Write-Host ""
-          if (Test-Path $rootPath)
+          if (Test-Path "$rootPath\Microsoft.UI.Xaml")
           {
             $env:BUILDOUTPUT_OVERRIDE = $rootPath
             & $env:Build_SourcesDirectory\tools\MakeAppxHelper.cmd $platform $config -builddate_yymm $env:BUILDDATE_YYMM -builddate_dd $env:BUILDDATE_DD -subversion $env:BUILDREVISION

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -113,6 +113,7 @@ jobs:
     jobName: CreateNugetPackage
     dependsOn: SignBinariesAndPublishSymbols
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
+    releasePackage: '$(MUXFinalRelease)'
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -113,7 +113,7 @@ jobs:
     jobName: CreateNugetPackage
     dependsOn: SignBinariesAndPublishSymbols
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
-    releasePackage: '$(MUXFinalRelease)'
+    useReleaseTag: '$(MUXFinalRelease)'
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml


### PR DESCRIPTION
Another bit of logic that didn't get ported over to the yaml pipeline. 