### PR TITLE
Implement TreeViewItemDataAutomationPeer to fix treeviewitem narrator issue

### DIFF
--- a/dev/TreeView/TreeView.vcxitems
+++ b/dev/TreeView/TreeView.vcxitems
@@ -24,6 +24,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TreeViewListAutomationPeer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TreeViewItem.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TreeViewItemAutomationPeer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)TreeViewItemDataAutomationPeer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TreeViewItemInvokedEventArgs.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TreeViewList.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ViewModel.h" />
@@ -43,6 +44,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)TreeViewListAutomationPeer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TreeViewItem.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TreeViewItemAutomationPeer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)TreeViewItemDataAutomationPeer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TreeViewItemInvokedEventArgs.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TreeViewList.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ViewModel.cpp" />

--- a/dev/TreeView/TreeViewAutomationPeers.idl
+++ b/dev/TreeView/TreeViewAutomationPeers.idl
@@ -19,4 +19,11 @@ unsealed runtimeclass TreeViewItemAutomationPeer : Windows.UI.Xaml.Automation.Pe
     [method_name("CreateInstanceWithOwner")] TreeViewItemAutomationPeer(MU_XC_NAMESPACE.TreeViewItem owner);
 }
 
+[WUXC_VERSION_MUXONLY]
+[webhosthidden]
+unsealed runtimeclass TreeViewItemDataAutomationPeer : Windows.UI.Xaml.Automation.Peers.ItemAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
+{
+    [method_name("CreateInstanceWithOwner")] TreeViewItemDataAutomationPeer(MU_XC_NAMESPACE.TreeViewList owner, IInspectable item, Windows.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent);
+}
+
 }

--- a/dev/TreeView/TreeViewAutomationPeers.idl
+++ b/dev/TreeView/TreeViewAutomationPeers.idl
@@ -21,9 +21,9 @@ unsealed runtimeclass TreeViewItemAutomationPeer : Windows.UI.Xaml.Automation.Pe
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
-unsealed runtimeclass TreeViewItemDataAutomationPeer : Windows.UI.Xaml.Automation.Peers.ItemAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
+unsealed runtimeclass TreeViewItemDataAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemDataAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
 {
-    [method_name("CreateInstanceWithOwner")] TreeViewItemDataAutomationPeer(MU_XC_NAMESPACE.TreeViewList owner, IInspectable item, Windows.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent);
+    [method_name("CreateInstanceWithOwner")] TreeViewItemDataAutomationPeer(IInspectable item, Windows.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent);
 }
 
 }

--- a/dev/TreeView/TreeViewAutomationPeers.idl
+++ b/dev/TreeView/TreeViewAutomationPeers.idl
@@ -21,7 +21,7 @@ unsealed runtimeclass TreeViewItemAutomationPeer : Windows.UI.Xaml.Automation.Pe
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
-unsealed runtimeclass TreeViewItemDataAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemDataAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
+unsealed runtimeclass TreeViewItemDataAutomationPeer : Windows.UI.Xaml.Automation.Peers.ItemAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
 {
     [method_name("CreateInstanceWithOwner")] TreeViewItemDataAutomationPeer(IInspectable item, Windows.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent);
 }

--- a/dev/TreeView/TreeViewAutomationPeers.idl
+++ b/dev/TreeView/TreeViewAutomationPeers.idl
@@ -5,7 +5,7 @@
 [webhosthidden]
 [WUXC_INTERFACE_NAME("ITreeViewListAutomationPeer", 71c1b5bc-bb29-4479-a8a8-606be6b823ae)]
 [WUXC_CONSTRUCTOR_NAME("ITreeViewListAutomationPeerFactory", 00f597e2-f811-475a-bfe6-290fe707fa88)]
-unsealed runtimeclass TreeViewListAutomationPeer : Windows.UI.Xaml.Automation.Peers.SelectorAutomationPeer
+unsealed runtimeclass TreeViewListAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewAutomationPeer
 {
     [method_name("CreateInstanceWithOwner")] TreeViewListAutomationPeer(MU_XC_NAMESPACE.TreeViewList owner);
 }
@@ -23,7 +23,7 @@ unsealed runtimeclass TreeViewItemAutomationPeer : Windows.UI.Xaml.Automation.Pe
 [webhosthidden]
 unsealed runtimeclass TreeViewItemDataAutomationPeer : Windows.UI.Xaml.Automation.Peers.ItemAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
 {
-    [method_name("CreateInstanceWithOwner")] TreeViewItemDataAutomationPeer(IInspectable item, Windows.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer parent);
+    [method_name("CreateInstanceWithOwner")] TreeViewItemDataAutomationPeer(IInspectable item, MU_XAP_NAMESPACE.TreeViewListAutomationPeer parent);
 }
 
 }

--- a/dev/TreeView/TreeViewItemDataAutomationPeer.cpp
+++ b/dev/TreeView/TreeViewItemDataAutomationPeer.cpp
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "TreeView.h"
+#include "TreeViewItem.h"
+#include "TreeViewItemDataAutomationPeer.h"
+#include <UIAutomationCore.h>
+#include <UIAutomationCoreApi.h>
+
+CppWinRTActivatableClassWithBasicFactory(TreeViewItemDataAutomationPeer);
+
+TreeViewItemDataAutomationPeer::TreeViewItemDataAutomationPeer(winrt::TreeViewList owner, winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent) :
+    ReferenceTracker(item, parent)
+{
+}
+
+// IExpandCollapseProvider 
+winrt::ExpandCollapseState TreeViewItemDataAutomationPeer::ExpandCollapseState()
+{
+    if (auto peer = GetTreeViewItemAutomationPeer())
+    {
+        return peer.ExpandCollapseState();
+    }
+    throw winrt::hresult_error(UIA_E_ELEMENTNOTENABLED);
+}
+
+void TreeViewItemDataAutomationPeer::Collapse()
+{
+    if (auto peer = GetTreeViewItemAutomationPeer())
+    {
+        return peer.Collapse();
+    }
+    throw winrt::hresult_error(UIA_E_ELEMENTNOTENABLED);
+}
+
+void TreeViewItemDataAutomationPeer::Expand()
+{
+    if (auto peer = GetTreeViewItemAutomationPeer())
+    {
+        return peer.Expand();
+    }
+    throw winrt::hresult_error(UIA_E_ELEMENTNOTENABLED);
+}
+
+// IAutomationPeerOverrides
+winrt::IInspectable TreeViewItemDataAutomationPeer::GetPatternCore(winrt::PatternInterface const& patternInterface)
+{
+    if (patternInterface == winrt::PatternInterface::ExpandCollapse)
+    {
+        return *this;
+    }
+
+    return __super::GetPatternCore(patternInterface);
+}
+
+winrt::TreeViewItemAutomationPeer TreeViewItemDataAutomationPeer::GetTreeViewItemAutomationPeer()
+{
+    // ItemsAutomationPeer hold ItemsControlAutomationPeer and Item properties.
+    // ItemsControlAutomationPeer -> ItemsControl by ItemsControlAutomationPeer.Owner -> ItemsControl Look up Item to get TreeViewItem -> Get TreeViewItemAutomationPeer 
+    if (auto itemsControlAutomationPeer = ItemsControlAutomationPeer())
+    {
+        if (auto itemsControl = itemsControlAutomationPeer.Owner().try_as<winrt::ItemsControl>())
+        {
+            if (auto item = itemsControl.ContainerFromItem(Item()).try_as<winrt::UIElement>())
+            {
+                if (auto treeViewItemAutomationPeer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(item).try_as<winrt::TreeViewItemAutomationPeer>())
+                {
+                    return treeViewItemAutomationPeer;
+                }
+            }
+        }
+    }
+    throw winrt::hresult_error(UIA_E_ELEMENTNOTENABLED);
+}

--- a/dev/TreeView/TreeViewItemDataAutomationPeer.cpp
+++ b/dev/TreeView/TreeViewItemDataAutomationPeer.cpp
@@ -11,7 +11,7 @@
 
 CppWinRTActivatableClassWithBasicFactory(TreeViewItemDataAutomationPeer);
 
-TreeViewItemDataAutomationPeer::TreeViewItemDataAutomationPeer(winrt::TreeViewList owner, winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent) :
+TreeViewItemDataAutomationPeer::TreeViewItemDataAutomationPeer(winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent) :
     ReferenceTracker(item, parent)
 {
 }

--- a/dev/TreeView/TreeViewItemDataAutomationPeer.cpp
+++ b/dev/TreeView/TreeViewItemDataAutomationPeer.cpp
@@ -11,7 +11,7 @@
 
 CppWinRTActivatableClassWithBasicFactory(TreeViewItemDataAutomationPeer);
 
-TreeViewItemDataAutomationPeer::TreeViewItemDataAutomationPeer(winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent) :
+TreeViewItemDataAutomationPeer::TreeViewItemDataAutomationPeer(winrt::IInspectable const& item, winrt::TreeViewListAutomationPeer const& parent) :
     ReferenceTracker(item, parent)
 {
 }

--- a/dev/TreeView/TreeViewItemDataAutomationPeer.h
+++ b/dev/TreeView/TreeViewItemDataAutomationPeer.h
@@ -10,7 +10,7 @@ class TreeViewItemDataAutomationPeer :
         winrt::implementation::TreeViewItemDataAutomationPeerT>
 {
 public:
-    TreeViewItemDataAutomationPeer(winrt::TreeViewList owner, winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent);
+    TreeViewItemDataAutomationPeer(winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent);
 
     // IExpandCollapseProvider
     winrt::ExpandCollapseState ExpandCollapseState();

--- a/dev/TreeView/TreeViewItemDataAutomationPeer.h
+++ b/dev/TreeView/TreeViewItemDataAutomationPeer.h
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "TreeViewItemDataAutomationPeer.g.h"
+
+class TreeViewItemDataAutomationPeer :
+    public ReferenceTracker<TreeViewItemDataAutomationPeer,
+        winrt::implementation::TreeViewItemDataAutomationPeerT>
+{
+public:
+    TreeViewItemDataAutomationPeer(winrt::TreeViewList owner, winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent);
+
+    // IExpandCollapseProvider
+    winrt::ExpandCollapseState ExpandCollapseState();
+    void Collapse();
+    void Expand();
+
+    // IAutomationPeerOverrides
+    winrt::IInspectable GetPatternCore(winrt::PatternInterface const& patternInterface);
+
+private:
+    winrt::TreeViewItemAutomationPeer GetTreeViewItemAutomationPeer();
+};
+

--- a/dev/TreeView/TreeViewItemDataAutomationPeer.h
+++ b/dev/TreeView/TreeViewItemDataAutomationPeer.h
@@ -10,7 +10,7 @@ class TreeViewItemDataAutomationPeer :
         winrt::implementation::TreeViewItemDataAutomationPeerT>
 {
 public:
-    TreeViewItemDataAutomationPeer(winrt::IInspectable const& item, winrt::ItemsControlAutomationPeer const& parent);
+    TreeViewItemDataAutomationPeer(winrt::IInspectable const& item, winrt::TreeViewListAutomationPeer const& parent);
 
     // IExpandCollapseProvider
     winrt::ExpandCollapseState ExpandCollapseState();

--- a/dev/TreeView/TreeViewListAutomationPeer.cpp
+++ b/dev/TreeView/TreeViewListAutomationPeer.cpp
@@ -5,6 +5,7 @@
 #include "common.h"
 #include "TreeViewList.h"
 #include "TreeViewListAutomationPeer.h"
+#include "TreeViewItemDataAutomationPeer.h"
 
 CppWinRTActivatableClassWithBasicFactory(TreeViewListAutomationPeer);
 
@@ -16,7 +17,7 @@ TreeViewListAutomationPeer::TreeViewListAutomationPeer(winrt::TreeViewList const
 //IItemsControlAutomationPeerOverrides2
 winrt::ItemAutomationPeer TreeViewListAutomationPeer::OnCreateItemAutomationPeer(winrt::IInspectable const& item)
 {
-    winrt::ItemAutomationPeer itemPeer{ item, *this };
+    winrt::TreeViewItemDataAutomationPeer itemPeer{ nullptr, item, *this };
     return itemPeer;
 }
 

--- a/dev/TreeView/TreeViewListAutomationPeer.cpp
+++ b/dev/TreeView/TreeViewListAutomationPeer.cpp
@@ -17,7 +17,7 @@ TreeViewListAutomationPeer::TreeViewListAutomationPeer(winrt::TreeViewList const
 //IItemsControlAutomationPeerOverrides2
 winrt::ItemAutomationPeer TreeViewListAutomationPeer::OnCreateItemAutomationPeer(winrt::IInspectable const& item)
 {
-    winrt::TreeViewItemDataAutomationPeer itemPeer{ nullptr, item, *this };
+    winrt::TreeViewItemDataAutomationPeer itemPeer{ item, *this };
     return itemPeer;
 }
 

--- a/dev/inc/CppWinRTIncludes.h
+++ b/dev/inc/CppWinRTIncludes.h
@@ -366,6 +366,7 @@ namespace winrt
     using ItemAutomationPeer = winrt::Windows::UI::Xaml::Automation::Peers::ItemAutomationPeer;
     using ListViewItemAutomationPeer = winrt::Windows::UI::Xaml::Automation::Peers::ListViewItemAutomationPeer;
     using PatternInterface = winrt::Windows::UI::Xaml::Automation::Peers::PatternInterface;
+    using ItemsControlAutomationPeer = winrt::Windows::UI::Xaml::Automation::Peers::ItemsControlAutomationPeer;
     using SelectorAutomationPeer = winrt::Windows::UI::Xaml::Automation::Peers::SelectorAutomationPeer;
     using SliderAutomationPeer = winrt::Windows::UI::Xaml::Automation::Peers::SliderAutomationPeer;
 


### PR DESCRIPTION
TreeViewItem is a subclass of ListViewItem.
We have wrong implementation for ExpandCollapseProvider for TreeViewItem. It should be in TreeViewItemDataAutomationPeer other than TreeViewItemAutomationPeer. Otherwise when a TreeView item is collapsed, then expanded, we may have a different TreeViewItem container for the same data, and it finally cause wrong TreeViewItemAutomaitonPeer is called from narrator.

There are two AutomationPeers for a ListViewItem, ListViewAutomationPeer and ListViewItemDataAutomationPeer. ListViewItemDataAutomationPeer is the source of true for the data, and IExpandCollapseProvider should be based on ListViewItemDataAutomationPeer.

This fix just delegate ExpandCollapseProvider functions to TreeViewItemAutomationPeer since TreeViewItemAutomationPeer already implemented ExpandCollapseProvider API.

Old implementation has fixed 1:1 mapping like this:
TreeViewItem <-> TreeViewItemAutomationPeer <-> ExpandCollapseProvider 

In the new implementation, ExpandCollapseProvider <->TreeViewItemDataAutomationPeer, so it doesn't have fixed mapping to  TreeViewItemAutomationPeer, but  an indirect mapping.
Here is the logic: ExpandCollapseProvider -> TreeViewItemDataAutomationPeer ->ItemsControlAutomationPeer -> ItemsControl by ItemsControlAutomationPeer.Owner -> ItemsControl Look up Item to get TreeViewItem -> Get TreeViewItemAutomationPeer  

