### PR TITLE
Change project to merge all <Midl/> items together

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_MUXONLY]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 interface IAnimatedVisual
     requires Windows.Foundation.IClosable
@@ -87,4 +90,6 @@ unsealed runtimeclass AnimatedVisualPlayer
     static Windows.UI.Xaml.DependencyProperty PlaybackRateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty SourceProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty StretchProperty{ get; };
+}
+
 }

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.vcxitems
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.vcxitems
@@ -21,7 +21,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerAutomationPeer.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayer.idl" />
-    <None Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)AnimatedVisualPlayerAutomationPeer.idl" />
   </ItemGroup>
 </Project>

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayerAutomationPeer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayerAutomationPeer.idl
@@ -1,6 +1,11 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass AnimatedVisualPlayerAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     AnimatedVisualPlayerAutomationPeer(MU_XC_NAMESPACE.AnimatedVisualPlayer owner);
+}
+
 }

--- a/dev/ColorPicker/ColorPicker.idl
+++ b/dev/ColorPicker/ColorPicker.idl
@@ -1,8 +1,11 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
-[WUXC_INTERFACE_NAME("IColorPicker", 6232e371-5c64-43cb-8b35-7f82dde36740)]
-[WUXC_STATIC_NAME("IColorPickerStatics", 67ca9be7-1574-451a-b6df-fe57d9d07b46)]
-[WUXC_CONSTRUCTOR_NAME("IColorPickerFactory", abae07ff-aecf-481d-9204-201c3894cd1b)]
+[WUXC_INTERFACE_NAME("IColorPicker", 6232e371 - 5c64 - 43cb - 8b35 - 7f82dde36740)]
+[WUXC_STATIC_NAME("IColorPickerStatics", 67ca9be7 - 1574 - 451a - b6df - fe57d9d07b46)]
+[WUXC_CONSTRUCTOR_NAME("IColorPickerFactory", abae07ff - aecf - 481d - 9204 - 201c3894cd1b)]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass ColorPicker : Windows.UI.Xaml.Controls.Control
@@ -65,4 +68,6 @@ unsealed runtimeclass ColorPicker : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty MaxValueProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ColorSpectrumShapeProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ColorSpectrumComponentsProperty { get; };
+}
+
 }

--- a/dev/ColorPicker/ColorPicker.idl
+++ b/dev/ColorPicker/ColorPicker.idl
@@ -3,9 +3,9 @@
 
 [WUXC_VERSION_RS3]
 [webhosthidden]
-[WUXC_INTERFACE_NAME("IColorPicker", 6232e371 - 5c64 - 43cb - 8b35 - 7f82dde36740)]
-[WUXC_STATIC_NAME("IColorPickerStatics", 67ca9be7 - 1574 - 451a - b6df - fe57d9d07b46)]
-[WUXC_CONSTRUCTOR_NAME("IColorPickerFactory", abae07ff - aecf - 481d - 9204 - 201c3894cd1b)]
+[WUXC_INTERFACE_NAME("IColorPicker", 6232e371-5c64-43cb-8b35-7f82dde36740)]
+[WUXC_STATIC_NAME("IColorPickerStatics", 67ca9be7-1574-451a-b6df-fe57d9d07b46)]
+[WUXC_CONSTRUCTOR_NAME("IColorPickerFactory", abae07ff-aecf-481d-9204-201c3894cd1b)]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass ColorPicker : Windows.UI.Xaml.Controls.Control

--- a/dev/ColorPicker/ColorPicker.vcxitems
+++ b/dev/ColorPicker/ColorPicker.vcxitems
@@ -52,13 +52,13 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Common.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ColorPicker.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ColorPickerSlider.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ColorPickerSliderAutomationPeer.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ColorSpectrum.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ColorSpectrumAutomationPeer.idl" />
-    <None Include="$(MSBuildThisFileDirectory)SpectrumBrush.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)Common.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ColorPicker.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ColorPickerSlider.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ColorPickerSliderAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ColorSpectrum.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ColorSpectrumAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)SpectrumBrush.idl" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />

--- a/dev/ColorPicker/ColorPickerSlider.idl
+++ b/dev/ColorPicker/ColorPickerSlider.idl
@@ -1,3 +1,6 @@
+namespace MU_XCP_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IColorPickerSlider", 94394d83-e0df-4c5f-bbcd-8155f4020440)]
@@ -11,4 +14,6 @@ unsealed runtimeclass ColorPickerSlider : Windows.UI.Xaml.Controls.Slider
     MU_XC_NAMESPACE.ColorPickerHsvChannel ColorChannel { get; set; };
 
     static Windows.UI.Xaml.DependencyProperty ColorChannelProperty { get; };
+}
+
 }

--- a/dev/ColorPicker/ColorPickerSliderAutomationPeer.idl
+++ b/dev/ColorPicker/ColorPickerSliderAutomationPeer.idl
@@ -1,3 +1,6 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IColorPickerSliderAutomationPeer", a514215a-7293-4577-924c-47d4e0bf9b90)]
@@ -5,4 +8,6 @@
 unsealed runtimeclass ColorPickerSliderAutomationPeer : Windows.UI.Xaml.Automation.Peers.SliderAutomationPeer
 {
     [method_name("CreateInstanceWithOwner")] ColorPickerSliderAutomationPeer(MU_XCP_NAMESPACE.ColorPickerSlider owner);
+}
+
 }

--- a/dev/ColorPicker/ColorSpectrum.idl
+++ b/dev/ColorPicker/ColorSpectrum.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XCP_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IColorSpectrum", ce46f271-f509-4f98-8288-e4942fb385df)]
 [WUXC_STATIC_NAME("IColorSpectrumStatics", 906bee7c-2cee-4e90-968b-f0a5bd691b4a)]
@@ -41,4 +44,6 @@ unsealed runtimeclass ColorSpectrum : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty MaxValueProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ShapeProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ComponentsProperty { get; };
+}
+
 }

--- a/dev/ColorPicker/ColorSpectrumAutomationPeer.idl
+++ b/dev/ColorPicker/ColorSpectrumAutomationPeer.idl
@@ -1,3 +1,6 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IColorSpectrumAutomationPeer", 15d5ba03-010d-4ff7-9087-f4dd09f831b7)]
@@ -5,4 +8,6 @@
 unsealed runtimeclass ColorSpectrumAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     [method_name("CreateInstanceWithOwner")] ColorSpectrumAutomationPeer(MU_XCP_NAMESPACE.ColorSpectrum owner);
+}
+
 }

--- a/dev/ColorPicker/Common.idl
+++ b/dev/ColorPicker/Common.idl
@@ -1,3 +1,6 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 enum ColorSpectrumShape
@@ -35,4 +38,6 @@ runtimeclass ColorChangedEventArgs
 {
     Windows.UI.Color OldColor { get; };
     Windows.UI.Color NewColor { get; };
+}
+
 }

--- a/dev/ColorPicker/SpectrumBrush.idl
+++ b/dev/ColorPicker/SpectrumBrush.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_INTERNAL]
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
+[WUXC_VERSION_INTERNAL]
 [webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
@@ -14,4 +17,6 @@ runtimeclass SpectrumBrush : Windows.UI.Xaml.Media.XamlCompositionBrushBase
     static Windows.UI.Xaml.DependencyProperty MinSurfaceProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MaxSurfaceProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MaxSurfaceOpacityProperty { get; };
+}
+
 }

--- a/dev/CommandBarFlyout/CommandBarFlyout.idl
+++ b/dev/CommandBarFlyout/CommandBarFlyout.idl
@@ -1,3 +1,6 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_RS5]
 [webhosthidden]
 [contentproperty("PrimaryCommands")]
@@ -15,3 +18,5 @@ unsealed runtimeclass TextCommandBarFlyout : CommandBarFlyout
 {
     TextCommandBarFlyout();
 };
+
+}

--- a/dev/CommandBarFlyout/CommandBarFlyout.vcxitems
+++ b/dev/CommandBarFlyout/CommandBarFlyout.vcxitems
@@ -38,12 +38,12 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)CommandBarFlyout.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)CommandBarFlyout.idl" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)CommandBarFlyoutCommandBar.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)CommandBarFlyoutCommandBar.idl" />
   </ItemGroup>
 </Project>

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.idl
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.idl
@@ -1,3 +1,6 @@
+namespace MU_XCP_NAMESPACE
+{
+
 [WUXC_VERSION_RS5]
 [webhosthidden]
 [MUX_PROPERTY_NEEDS_DP_FIELD]
@@ -35,3 +38,5 @@ unsealed runtimeclass CommandBarFlyoutCommandBar : Windows.UI.Xaml.Controls.Comm
     [MUX_PROPERTY_NEEDS_DP_FIELD]
     CommandBarFlyoutCommandBarTemplateSettings FlyoutTemplateSettings { get; };
 };
+
+}

--- a/dev/DropDownButton/DropDownButton.idl
+++ b/dev/DropDownButton/DropDownButton.idl
@@ -1,6 +1,11 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_RS5]
 [webhosthidden]
 unsealed runtimeclass DropDownButton : Windows.UI.Xaml.Controls.Button
 {
     DropDownButton();
+}
+
 }

--- a/dev/DropDownButton/DropDownButton.vcxitems
+++ b/dev/DropDownButton/DropDownButton.vcxitems
@@ -32,7 +32,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)DropDownButton.idl" />
-    <None Include="$(MSBuildThisFileDirectory)DropDownButtonAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)DropDownButton.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)DropDownButtonAutomationPeer.idl" />
   </ItemGroup>
 </Project>

--- a/dev/DropDownButton/DropDownButtonAutomationPeer.idl
+++ b/dev/DropDownButton/DropDownButtonAutomationPeer.idl
@@ -1,7 +1,12 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_RS5]
 [webhosthidden]
 unsealed runtimeclass DropDownButtonAutomationPeer : Windows.UI.Xaml.Automation.Peers.ButtonAutomationPeer,
 Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
 {
     DropDownButtonAutomationPeer(MU_XC_NAMESPACE.DropDownButton owner);
+}
+
 }

--- a/dev/Effects/microsoft.ui.composition.effects.idl
+++ b/dev/Effects/microsoft.ui.composition.effects.idl
@@ -1,18 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
-// TODO: Remove !defined(DEBUG) after this is fixed: BUG 17488419: MIDL "import winmd" behavior doesn't carry through parameter names of methods on implemented interfaces
-// Because of it in RELEASE builds we use the old IDL includes, but in debug we still use importwinmd behavior to get faster VS builds
-#if defined(BUILD_WINDOWS) || !defined(DEBUG)
-import "oaidl.idl";
-import "Inspectable.idl";
-
-import "Windows.Foundation.idl";
-import "Windows.Foundation.Numerics.idl";
-import "Windows.Graphics.Effects.idl";
-import "Windows.UI.idl";
-import "Windows.UI.Composition.idl";
-#endif
-
 #ifndef BUILD_WINDOWS
 #define MUXCONTROLS_VERSION_PARAM 1.0
 #define MUXCONTROLS_VERSION_ATTRIBUTE version(MUXCONTROLS_VERSION_PARAM)

--- a/dev/IconSource/IconSource.idl
+++ b/dev/IconSource/IconSource.idl
@@ -1,3 +1,6 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IIconSource", 92ec8d55-45eb-47a4-863c-91b224044f9b)]
@@ -85,4 +88,6 @@ unsealed runtimeclass PathIconSource : IconSource
     Windows.UI.Xaml.Media.Geometry Data { get; set; };
 
     static Windows.UI.Xaml.DependencyProperty DataProperty { get; };
+}
+
 }

--- a/dev/IconSource/IconSource.vcxitems
+++ b/dev/IconSource/IconSource.vcxitems
@@ -33,6 +33,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)SymbolIconSource.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)IconSource.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)IconSource.idl" />
   </ItemGroup>
 </Project>

--- a/dev/Interactions/ButtonInteraction/ButtonInteraction.idl
+++ b/dev/Interactions/ButtonInteraction/ButtonInteraction.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 enum ButtonInteractionInvokeMode
 {
@@ -30,4 +33,6 @@ Windows.UI.Xaml.Data.INotifyPropertyChanged
     Boolean IsHovering { get; };
     Boolean IsPressing { get; };
     event Windows.Foundation.TypedEventHandler<ButtonInteraction, ButtonInteractionInvokedEventArgs> Invoked;
+}
+
 }

--- a/dev/Interactions/ButtonInteraction/ButtonInteraction.vcxitems
+++ b/dev/Interactions/ButtonInteraction/ButtonInteraction.vcxitems
@@ -15,7 +15,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)ButtonInteraction.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ButtonInteraction.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)ButtonInteraction.cpp" />

--- a/dev/Interactions/SliderInteraction/SliderInteraction.idl
+++ b/dev/Interactions/SliderInteraction/SliderInteraction.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass SliderInteraction : 
 #ifdef USE_INTERNAL_SDK
@@ -16,4 +19,6 @@ Windows.UI.Xaml.Data.INotifyPropertyChanged
     Double Position { get; };
     Double SmallChange { get; set; };
     Double LargeChange { get; set; };
+}
+
 }

--- a/dev/Interactions/SliderInteraction/SliderInteraction.vcxitems
+++ b/dev/Interactions/SliderInteraction/SliderInteraction.vcxitems
@@ -15,7 +15,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)SliderInteraction.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)SliderInteraction.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)SliderInteraction.cpp" />

--- a/dev/LayoutPanel/LayoutPanel.idl
+++ b/dev/LayoutPanel/LayoutPanel.idl
@@ -1,3 +1,6 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass LayoutPanel : Windows.UI.Xaml.Controls.Panel
@@ -18,4 +21,6 @@ unsealed runtimeclass LayoutPanel : Windows.UI.Xaml.Controls.Panel
 
     Windows.UI.Xaml.CornerRadius CornerRadius{ get; set; };
     static Windows.UI.Xaml.DependencyProperty CornerRadiusProperty{ get; };
+}
+
 }

--- a/dev/LayoutPanel/LayoutPanel.vcxitems
+++ b/dev/LayoutPanel/LayoutPanel.vcxitems
@@ -22,6 +22,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)LayoutPanelLayoutContext.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)LayoutPanel.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)LayoutPanel.idl" />
   </ItemGroup>
 </Project>

--- a/dev/Lights/Lights.vcxitems
+++ b/dev/Lights/Lights.vcxitems
@@ -39,12 +39,12 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)XamlAmbientLight.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RevealBorderLight.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RevealHoverLight.idl" />
-    <None Include="$(MSBuildThisFileDirectory)XamlAmbientLight.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RevealBorderLight.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RevealHoverLight.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)XamlAmbientLight.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)MaterialHelperTestApi.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RevealTestApi.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)MaterialHelperTestApi.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RevealTestApi.idl" />
   </ItemGroup>
 </Project>

--- a/dev/Lights/MaterialHelperTestApi.idl
+++ b/dev/Lights/MaterialHelperTestApi.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 [default_interface]
@@ -7,4 +10,6 @@ runtimeclass MaterialHelperTestApi : Windows.UI.Xaml.DependencyObject
 
     static Boolean SimulateDisabledByPolicy { get; set; };
     static Boolean IgnoreAreEffectsFast { get; set; };
+}
+
 }

--- a/dev/Lights/RevealBorderLight.idl
+++ b/dev/Lights/RevealBorderLight.idl
@@ -1,6 +1,11 @@
+namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 unsealed runtimeclass RevealBorderLight : Windows.UI.Xaml.Media.XamlLight
 {
     RevealBorderLight();
+}
+
 }

--- a/dev/Lights/RevealHoverLight.idl
+++ b/dev/Lights/RevealHoverLight.idl
@@ -1,6 +1,11 @@
+namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 unsealed runtimeclass RevealHoverLight : Windows.UI.Xaml.Media.XamlLight
 {
     RevealHoverLight();
+}
+
 }

--- a/dev/Lights/RevealTestApi.idl
+++ b/dev/Lights/RevealTestApi.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_INTERNAL]
+﻿namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
+[WUXC_VERSION_INTERNAL]
 [webhosthidden]
 runtimeclass RevealTestApi : Windows.UI.Xaml.DependencyObject
 {
@@ -22,4 +25,6 @@ runtimeclass RevealTestApi : Windows.UI.Xaml.DependencyObject
     Boolean HoverLight_ShouldBeOn(RevealHoverLight value);
     Boolean HoverLight_IsPressed(RevealHoverLight value);
     Boolean HoverLight_IsPointerOver(RevealHoverLight value);
+}
+
 }

--- a/dev/Lights/XamlAmbientLight.idl
+++ b/dev/Lights/XamlAmbientLight.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 unsealed runtimeclass XamlAmbientLight : Windows.UI.Xaml.Media.XamlLight
@@ -13,4 +16,6 @@ unsealed runtimeclass XamlAmbientLight : Windows.UI.Xaml.Media.XamlLight
     static Windows.UI.Xaml.DependencyProperty IsTargetProperty { get; };
     static void SetIsTarget(Windows.UI.Xaml.DependencyObject object, Boolean value);
     static Boolean GetIsTarget(Windows.UI.Xaml.DependencyObject object);
+}
+
 }

--- a/dev/Materials/Acrylic/AcrylicBrush.idl
+++ b/dev/Materials/Acrylic/AcrylicBrush.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XM_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 enum AcrylicBackgroundSource
 {
@@ -49,4 +52,6 @@ unsealed runtimeclass AcrylicBrush : Windows.UI.Xaml.Media.XamlCompositionBrushB
     {
         static Windows.UI.Xaml.DependencyProperty TintLuminosityOpacityProperty { get; };
     }
+}
+
 }

--- a/dev/Materials/Acrylic/AcrylicBrush.vcxitems
+++ b/dev/Materials/Acrylic/AcrylicBrush.vcxitems
@@ -25,10 +25,10 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)AcrylicTestApi.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)AcrylicBrush.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)AcrylicBrush.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)AcrylicTestApi.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)AcrylicTestApi.idl" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="$(MSBuildThisFileDirectory)Assets\NoiseAsset_256X256_PNG.png" />

--- a/dev/Materials/Acrylic/AcrylicTestApi.idl
+++ b/dev/Materials/Acrylic/AcrylicTestApi.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 runtimeclass AcrylicTestApi : Windows.UI.Xaml.DependencyObject
@@ -18,4 +21,6 @@ interface IAcrylicBrushStaticsPrivate
 {
     Windows.UI.Composition.CompositionEffectBrush CreateBackdropAcrylicEffectBrush(Windows.UI.Composition.Compositor compositor, Windows.UI.Color initialTintColor, Windows.UI.Color initialFallbackColor, Boolean willTintColorAlwaysBeOpaque);
     Windows.UI.Composition.CompositionEffectBrush CreateBackdropAcrylicEffectBrushWithLuminosity(Windows.UI.Composition.Compositor compositor, Windows.UI.Color initialTintColor, Windows.UI.Color initialLuminosityColor, Windows.UI.Color initialFallbackColor, Boolean willTintColorAlwaysBeOpaque);
+}
+
 }

--- a/dev/Materials/Reveal/RevealBrush.idl
+++ b/dev/Materials/Reveal/RevealBrush.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XM_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 enum RevealBrushState
 {
@@ -50,4 +53,6 @@ unsealed runtimeclass RevealBorderBrush : RevealBrush
 unsealed runtimeclass RevealBackgroundBrush : RevealBrush
 {
     RevealBackgroundBrush();
+}
+
 }

--- a/dev/Materials/Reveal/RevealBrush.vcxitems
+++ b/dev/Materials/Reveal/RevealBrush.vcxitems
@@ -25,7 +25,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)RevealBrushTestApi.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RevealBrush.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RevealBrush.idl" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)RevealBrush_rs1_themeresources.xaml">
@@ -60,9 +60,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RevealControls.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RevealControls.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RevealBrushTestApi.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RevealBrushTestApi.idl" />
   </ItemGroup>
 </Project>

--- a/dev/Materials/Reveal/RevealBrushTestApi.idl
+++ b/dev/Materials/Reveal/RevealBrushTestApi.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_MEDIA_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 runtimeclass RevealBrushTestApi : Windows.UI.Xaml.DependencyObject
@@ -12,4 +15,6 @@ runtimeclass RevealBrushTestApi : Windows.UI.Xaml.DependencyObject
     Windows.UI.Composition.CompositionBrush CompositionBrush { get; };
     Windows.UI.Composition.CompositionBrush NoiseBrush { get; };
     
+}
+
 }

--- a/dev/Materials/Reveal/RevealControls.idl
+++ b/dev/Materials/Reveal/RevealControls.idl
@@ -1,6 +1,11 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass RevealListViewItemPresenter : Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter
 {
     RevealListViewItemPresenter();
+}
+
 }

--- a/dev/MenuBar/MenuBar.idl
+++ b/dev/MenuBar/MenuBar.idl
@@ -1,3 +1,6 @@
+namespace MU_XC_NAMESPACE
+{
+
 [WUXC_VERSION_RS5]
 [webhosthidden]
 unsealed runtimeclass MenuBarItemFlyout : Windows.UI.Xaml.Controls.MenuFlyout
@@ -29,4 +32,6 @@ unsealed runtimeclass MenuBar : Windows.UI.Xaml.Controls.Control
     Windows.Foundation.Collections.IVector<MenuBarItem> Items { get; };
 
     static Windows.UI.Xaml.DependencyProperty ItemsProperty { get; };
+}
+
 }

--- a/dev/MenuBar/MenuBar.vcxitems
+++ b/dev/MenuBar/MenuBar.vcxitems
@@ -44,9 +44,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)MenuBar.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)MenuBar.idl" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)MenuBarAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)MenuBarAutomationPeer.idl" />
   </ItemGroup>
 </Project>

--- a/dev/MenuBar/MenuBarAutomationPeer.idl
+++ b/dev/MenuBar/MenuBarAutomationPeer.idl
@@ -1,3 +1,6 @@
+namespace MU_XAP_NAMESPACE
+{
+
 /* MenuBarAutomationPeer Content */
 [WUXC_VERSION_RS5]
 [webhosthidden]
@@ -14,4 +17,6 @@ Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,
 Windows.UI.Xaml.Automation.Provider.IInvokeProvider
 {
     MenuBarItemAutomationPeer(MU_XC_NAMESPACE.MenuBarItem owner);
+}
+
 }

--- a/dev/NavigationView/NavigationView.idl
+++ b/dev/NavigationView/NavigationView.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 enum NavigationViewDisplayMode
 {
@@ -324,4 +327,6 @@ unsealed runtimeclass NavigationViewItemSeparator : NavigationViewItemBase
 unsealed runtimeclass NavigationViewItemHeader : NavigationViewItemBase
 {
     NavigationViewItemHeader();
+}
+
 }

--- a/dev/NavigationView/NavigationView.vcxitems
+++ b/dev/NavigationView/NavigationView.vcxitems
@@ -55,8 +55,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TopNavigationViewDataProvider.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)NavigationView.idl" />
-    <None Include="$(MSBuildThisFileDirectory)NavigationViewItemAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)NavigationView.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)NavigationViewItemPresenter.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)NavigationViewItemAutomationPeer.idl" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)NavigationView.xaml">

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.idl
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.idl
@@ -1,3 +1,6 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("INavigationViewItemAutomationPeer", 309847a5-9971-4d8d-a81c-085c7086a1b9)]
@@ -5,4 +8,6 @@
 unsealed runtimeclass NavigationViewItemAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemAutomationPeer
 {
     [method_name("CreateInstanceWithOwner")] NavigationViewItemAutomationPeer(MU_XC_NAMESPACE.NavigationViewItem owner);
+}
+
 }

--- a/dev/NavigationView/NavigationViewItemPresenter.idl
+++ b/dev/NavigationView/NavigationViewItemPresenter.idl
@@ -1,3 +1,6 @@
+namespace MU_XCP_NAMESPACE
+{
+
 [WUXC_VERSION_RS5]
 [webhosthidden]
 unsealed runtimeclass NavigationViewItemPresenter : Windows.UI.Xaml.Controls.ContentControl
@@ -6,4 +9,6 @@ unsealed runtimeclass NavigationViewItemPresenter : Windows.UI.Xaml.Controls.Con
 
     Windows.UI.Xaml.Controls.IconElement Icon { get; set; };
     static Windows.UI.Xaml.DependencyProperty IconProperty { get; };
+}
+
 }

--- a/dev/ParallaxView/ParallaxView.idl
+++ b/dev/ParallaxView/ParallaxView.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 enum ParallaxSourceOffsetKind
 {
@@ -55,4 +58,6 @@ unsealed runtimeclass ParallaxView : Windows.UI.Xaml.FrameworkElement
     static Windows.UI.Xaml.DependencyProperty VerticalSourceStartOffsetProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MaxVerticalShiftRatioProperty { get; };
     static Windows.UI.Xaml.DependencyProperty VerticalShiftProperty { get; };
+}
+
 }

--- a/dev/ParallaxView/ParallaxView.vcxitems
+++ b/dev/ParallaxView/ParallaxView.vcxitems
@@ -15,7 +15,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)ParallaxView.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ParallaxView.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)ParallaxView.h" />

--- a/dev/PersonPicture/PersonPicture.idl
+++ b/dev/PersonPicture/PersonPicture.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IPersonPicture", 6c230b6d-0d75-4059-91bc-7b174d1d7315)]
 [WUXC_STATIC_NAME("IPersonPictureStatics", dbec0982-3c10-4639-9614-aa5b7cdc32ca)]
@@ -42,4 +45,6 @@ runtimeclass PersonPictureTemplateSettings : Windows.UI.Xaml.DependencyObject
 {
     String ActualInitials { get; };
     Windows.UI.Xaml.Media.ImageBrush ActualImageBrush { get; };
+}
+
 }

--- a/dev/PersonPicture/PersonPicture.vcxitems
+++ b/dev/PersonPicture/PersonPicture.vcxitems
@@ -21,8 +21,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)PersonPictureAutomationPeer.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)PersonPicture.idl" />
-    <None Include="$(MSBuildThisFileDirectory)PersonPictureAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)PersonPicture.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)PersonPictureAutomationPeer.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)InitialsGenerator.h" />

--- a/dev/PersonPicture/PersonPictureAutomationPeer.idl
+++ b/dev/PersonPicture/PersonPictureAutomationPeer.idl
@@ -1,3 +1,6 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IPersonPictureAutomationPeer", 27156d4c-a66f-4aaf-8286-4f796d30628c)]
@@ -5,4 +8,6 @@
 unsealed runtimeclass PersonPictureAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     [method_name("CreateInstanceWithOwner")] PersonPictureAutomationPeer(MU_XC_NAMESPACE.PersonPicture owner);
+}
+
 }

--- a/dev/PullToRefresh/RefreshContainer/RefreshContainer.idl
+++ b/dev/PullToRefresh/RefreshContainer/RefreshContainer.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS4]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS4]
 [webhosthidden]
 enum RefreshPullDirection
 {
@@ -27,4 +30,6 @@ unsealed runtimeclass RefreshContainer : Windows.UI.Xaml.Controls.ContentControl
 
     static Windows.UI.Xaml.DependencyProperty VisualizerProperty { get; };
     static Windows.UI.Xaml.DependencyProperty PullDirectionProperty { get; };
+}
+
 }

--- a/dev/PullToRefresh/RefreshContainer/RefreshContainer.vcxitems
+++ b/dev/PullToRefresh/RefreshContainer/RefreshContainer.vcxitems
@@ -22,7 +22,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)RefreshContainer.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RefreshContainer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RefreshContainer.idl" />
   </ItemGroup>
   <ItemGroup Condition="$(BuildLeanMuxForTheStoreApp) != 'true'">
     <Page Include="$(MSBuildThisFileDirectory)RefreshContainer.xaml">
@@ -35,6 +35,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RefreshContainerPrivate.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RefreshContainerPrivate.idl" />
   </ItemGroup>
 </Project>

--- a/dev/PullToRefresh/RefreshContainer/RefreshContainerPrivate.idl
+++ b/dev/PullToRefresh/RefreshContainer/RefreshContainerPrivate.idl
@@ -1,6 +1,12 @@
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+interface IRefreshInfoProviderAdapter;
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 interface IRefreshContainerPrivate
 {
     IRefreshInfoProviderAdapter RefreshInfoProviderAdapter { get; set; };
+}
+
 }

--- a/dev/PullToRefresh/RefreshVisualizer/PullToRefreshHelperTestAPI.idl
+++ b/dev/PullToRefresh/RefreshVisualizer/PullToRefreshHelperTestAPI.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 [default_interface]
@@ -6,4 +9,6 @@ runtimeclass PullToRefreshHelperTestApi
     static MU_XC_NAMESPACE.RefreshInteractionRatioChangedEventArgs CreateRefreshInteractionRatioChangedEventArgsInstance(Double value);
     static MU_XC_NAMESPACE.RefreshStateChangedEventArgs CreateRefreshStateChangedEventArgsInstance(MU_XC_NAMESPACE.RefreshVisualizerState oldValue, MU_XC_NAMESPACE.RefreshVisualizerState newValue);
     static MU_XC_NAMESPACE.RefreshRequestedEventArgs CreateRefreshRequestedEventArgsInstance(Windows.Foundation.Deferral handler);
+}
+
 }

--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.idl
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS4]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS4]
 [webhosthidden]
 enum RefreshVisualizerOrientation
 {
@@ -69,4 +72,6 @@ unsealed runtimeclass RefreshVisualizer : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty OrientationProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ContentProperty { get; };
     static Windows.UI.Xaml.DependencyProperty StateProperty { get; };
+}
+
 }

--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.vcxitems
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.vcxitems
@@ -30,7 +30,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)RefreshVisualizerEventArgs.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RefreshVisualizer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RefreshVisualizer.idl" />
   </ItemGroup>
   <ItemGroup Condition="$(BuildLeanMuxForTheStoreApp) != 'true'">
     <Page Include="$(MSBuildThisFileDirectory)RefreshVisualizer.xaml">
@@ -43,7 +43,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)PullToRefreshHelperTestAPI.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RefreshVisualizerPrivate.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)PullToRefreshHelperTestAPI.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RefreshVisualizerPrivate.idl" />
   </ItemGroup>
 </Project>

--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizerPrivate.idl
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizerPrivate.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 interface IRefreshInfoProvider
@@ -20,4 +23,6 @@ interface IRefreshVisualizerPrivate
 {
     IRefreshInfoProvider InfoProvider { get; set; };
     void SetInternalPullDirection(MU_XC_NAMESPACE.RefreshPullDirection value);
+}
+
 }

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.idl
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
 interface IRefreshInfoProviderAdapter
@@ -22,4 +25,6 @@ runtimeclass ScrollViewerIRefreshInfoProviderAdapter : IRefreshInfoProviderAdapt
     ScrollViewerIRefreshInfoProviderAdapter(MU_XC_NAMESPACE.RefreshPullDirection refreshPullDirection, IAdapterAnimationHandler animationHandler);
 
     IRefreshInfoProvider Adapt(Windows.UI.Xaml.Controls.ScrollViewer adaptee, Windows.Foundation.Size visualizerSize);
+}
+
 }

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.vcxitems
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.vcxitems
@@ -14,7 +14,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)ScrollViewerIRefreshInfoProviderAdapter.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ScrollViewerIRefreshInfoProviderAdapter.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)ScrollViewerIRefreshInfoProviderDefaultAnimationHandler.cpp" />

--- a/dev/RadioButtons/RadioButtons.idl
+++ b/dev/RadioButtons/RadioButtons.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 [contentproperty("Items")]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
@@ -32,3 +35,4 @@ unsealed runtimeclass RadioButtons : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty HeaderProperty{ get; };
 }
 
+}

--- a/dev/RadioButtons/RadioButtons.vcxitems
+++ b/dev/RadioButtons/RadioButtons.vcxitems
@@ -37,8 +37,8 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RadioButtons.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RadioButtonsPrimitives.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RadioButtonsAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RadioButtons.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RadioButtonsPrimitives.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RadioButtonsAutomationPeer.idl" />
   </ItemGroup>
 </Project>

--- a/dev/RadioButtons/RadioButtons.vcxitems.filters
+++ b/dev/RadioButtons/RadioButtons.vcxitems.filters
@@ -14,12 +14,12 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)RadioButtonsListView.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RadioButtons.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RadioButtonsPrimitives.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RadioButtonsAutomationPeer.idl" />
-  </ItemGroup>
-  <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)RadioButtons.xaml" />
     <Page Include="$(MSBuildThisFileDirectory)RadioButtons_themeresources.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="$(MSBuildThisFileDirectory)RadioButtons.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RadioButtonsPrimitives.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RadioButtonsAutomationPeer.idl" />
   </ItemGroup>
 </Project>

--- a/dev/RadioButtons/RadioButtonsAutomationPeer.idl
+++ b/dev/RadioButtons/RadioButtonsAutomationPeer.idl
@@ -1,6 +1,11 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass RadioButtonsListViewItemAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemAutomationPeer
 {
     RadioButtonsListViewItemAutomationPeer(MU_XCP_NAMESPACE.RadioButtonsListViewItem owner);
+}
+
 }

--- a/dev/RadioButtons/RadioButtonsPrimitives.idl
+++ b/dev/RadioButtons/RadioButtonsPrimitives.idl
@@ -1,3 +1,6 @@
+namespace MU_XCP_NAMESPACE
+{
+
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass RadioButtonsListView : Windows.UI.Xaml.Controls.ListView
@@ -11,4 +14,6 @@ unsealed runtimeclass RadioButtonsListView : Windows.UI.Xaml.Controls.ListView
 unsealed runtimeclass RadioButtonsListViewItem : Windows.UI.Xaml.Controls.ListViewItem
 {
     RadioButtonsListViewItem();
+}
+
 }

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.idl
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_MUXONLY]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
@@ -11,4 +14,6 @@ unsealed runtimeclass RadioMenuFlyoutItem : Windows.UI.Xaml.Controls.MenuFlyoutI
 
     static Windows.UI.Xaml.DependencyProperty IsCheckedProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty GroupNameProperty{ get; };
+}
+
 }

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.vcxitems
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.vcxitems
@@ -43,6 +43,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RadioMenuFlyoutItem.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RadioMenuFlyoutItem.idl" />
   </ItemGroup>
 </Project>

--- a/dev/RatingControl/RatingControl.idl
+++ b/dev/RatingControl/RatingControl.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS3]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IRatingItemInfo", 9ccbe6a2-591e-47a0-a318-6a1f7947da2d)]
 [WUXC_CONSTRUCTOR_NAME("IRatingItemInfoFactory", b0fd43d6-cfec-43c8-9ac5-0b0d5e25d862)]
@@ -89,4 +92,6 @@ unsealed runtimeclass RatingControl : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty PlaceholderValueProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ItemInfoProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ValueProperty { get; };
+}
+
 }

--- a/dev/RatingControl/RatingControl.vcxitems
+++ b/dev/RatingControl/RatingControl.vcxitems
@@ -44,8 +44,8 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)RatingControl.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RatingControlAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RatingControl.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RatingControlAutomationPeer.idl" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw">

--- a/dev/RatingControl/RatingControlAutomationPeer.idl
+++ b/dev/RatingControl/RatingControlAutomationPeer.idl
@@ -1,3 +1,6 @@
+﻿namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_RS3]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("IRatingControlAutomationPeer", 3d14349a-9963-4a47-823c-f457cb3209d5)]
@@ -5,4 +8,6 @@
 unsealed runtimeclass RatingControlAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     [method_name("CreateInstanceWithOwner")] RatingControlAutomationPeer(MU_XC_NAMESPACE.RatingControl owner);
+}
+
 }

--- a/dev/Repeater/ItemsRepeater.idl
+++ b/dev/Repeater/ItemsRepeater.idl
@@ -1,4 +1,7 @@
-﻿runtimeclass ItemsSourceView;
+﻿namespace MU_XC_NAMESPACE
+{
+
+runtimeclass ItemsSourceView;
 runtimeclass ItemsRepeater;
 runtimeclass ElementFactory;
 runtimeclass LayoutContext;
@@ -614,4 +617,6 @@ unsealed runtimeclass SelectionModel : Windows.UI.Xaml.Data.INotifyPropertyChang
     void ClearSelection();
 
     protected void OnPropertyChanged(String propertyName);
+}
+
 }

--- a/dev/Repeater/Repeater.vcxitems
+++ b/dev/Repeater/Repeater.vcxitems
@@ -14,9 +14,9 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)ItemsRepeater.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RepeaterAutomationPeer.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RepeaterPrivate.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ItemsRepeater.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RepeaterAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RepeaterPrivate.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)AnimationManager.h" />

--- a/dev/Repeater/RepeaterAutomationPeer.idl
+++ b/dev/Repeater/RepeaterAutomationPeer.idl
@@ -1,6 +1,11 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass RepeaterAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     RepeaterAutomationPeer(MU_XC_NAMESPACE.ItemsRepeater owner);
+}
+
 }

--- a/dev/Repeater/RepeaterPrivate.idl
+++ b/dev/Repeater/RepeaterPrivate.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 interface IRepeaterScrollingSurface;
 
 [WUXC_VERSION_INTERNAL]
@@ -25,4 +28,6 @@ interface IRepeaterScrollingSurface
     void RegisterAnchorCandidate(Windows.UI.Xaml.UIElement element);
     void UnregisterAnchorCandidate(Windows.UI.Xaml.UIElement element);
     Windows.Foundation.Rect GetRelativeViewport(Windows.UI.Xaml.UIElement child);
+}
+
 }

--- a/dev/ScrollViewer/ScrollViewer.idl
+++ b/dev/ScrollViewer/ScrollViewer.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 enum ScrollBarVisibility
 {
@@ -159,4 +162,6 @@ unsealed runtimeclass ScrollViewer : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty MaxZoomFactorProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HorizontalAnchorRatioProperty { get; };
     static Windows.UI.Xaml.DependencyProperty VerticalAnchorRatioProperty { get; };
+}
+
 }

--- a/dev/ScrollViewer/ScrollViewer.vcxitems
+++ b/dev/ScrollViewer/ScrollViewer.vcxitems
@@ -39,6 +39,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)ScrollViewer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ScrollViewer.idl" />
   </ItemGroup>
 </Project>

--- a/dev/Scroller/Scroller.idl
+++ b/dev/Scroller/Scroller.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 struct ScrollInfo 
 { 
@@ -180,4 +183,6 @@ runtimeclass ScrollerAnchorRequestedEventArgs
 {
     Windows.Foundation.Collections.IVector<Windows.UI.Xaml.UIElement> AnchorCandidates { get; };
     Windows.UI.Xaml.UIElement AnchorElement { get; set; };
+}
+
 }

--- a/dev/Scroller/Scroller.vcxitems
+++ b/dev/Scroller/Scroller.vcxitems
@@ -15,9 +15,9 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Scroller.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ScrollerPrimitives.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ScrollerAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)Scroller.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ScrollerPrimitives.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ScrollerAutomationPeer.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)InteractionTrackerAsyncOperation.h" />

--- a/dev/Scroller/ScrollerAutomationPeer.idl
+++ b/dev/Scroller/ScrollerAutomationPeer.idl
@@ -1,6 +1,11 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_XAP_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass ScrollerAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     ScrollerAutomationPeer(MU_XCP_NAMESPACE.Scroller owner);
+}
+
 }

--- a/dev/Scroller/ScrollerPrimitives.idl
+++ b/dev/Scroller/ScrollerPrimitives.idl
@@ -1,4 +1,7 @@
-﻿#ifdef ApplicableRangeType
+﻿namespace MU_XCP_NAMESPACE
+{
+
+#ifdef ApplicableRangeType
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
 enum SnapPointApplicableRangeType
@@ -347,4 +350,6 @@ unsealed runtimeclass Scroller : Windows.UI.Xaml.FrameworkElement
     static Windows.UI.Xaml.DependencyProperty MaxZoomFactorProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HorizontalAnchorRatioProperty { get; };
     static Windows.UI.Xaml.DependencyProperty VerticalAnchorRatioProperty { get; };
+}
+
 }

--- a/dev/SplitButton/SplitButton.idl
+++ b/dev/SplitButton/SplitButton.idl
@@ -1,4 +1,8 @@
-﻿[WUXC_VERSION_RS5]
+﻿namespace MU_XC_NAMESPACE
+{
+
+
+[WUXC_VERSION_RS5]
 [webhosthidden]
 [default_interface]
 runtimeclass SplitButtonClickEventArgs
@@ -44,4 +48,6 @@ unsealed runtimeclass ToggleSplitButton : SplitButton
     Boolean IsChecked{ get; set; };
 
     event Windows.Foundation.TypedEventHandler<ToggleSplitButton, ToggleSplitButtonIsCheckedChangedEventArgs> IsCheckedChanged;
+}
+
 }

--- a/dev/SplitButton/SplitButton.vcxitems
+++ b/dev/SplitButton/SplitButton.vcxitems
@@ -47,9 +47,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)SplitButton.idl" />
-    <None Include="$(MSBuildThisFileDirectory)SplitButtonAutomationPeer.idl" />
-    <None Include="$(MSBuildThisFileDirectory)SplitButtonTestApi.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)SplitButton.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)SplitButtonAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)SplitButtonTestApi.idl" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />

--- a/dev/SplitButton/SplitButtonAutomationPeer.idl
+++ b/dev/SplitButton/SplitButtonAutomationPeer.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS5]
+﻿namespace MU_XAP_NAMESPACE
+{
+
+[WUXC_VERSION_RS5]
 [webhosthidden]
 unsealed runtimeclass SplitButtonAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,
 Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,
@@ -14,4 +17,6 @@ Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,
 Windows.UI.Xaml.Automation.Provider.IToggleProvider
 {
     ToggleSplitButtonAutomationPeer(MU_XC_NAMESPACE.ToggleSplitButton owner);
+}
+
 }

--- a/dev/SplitButton/SplitButtonTestApi.idl
+++ b/dev/SplitButton/SplitButtonTestApi.idl
@@ -1,7 +1,12 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [default_interface]
 [webhosthidden]
 runtimeclass SplitButtonTestApi
 {
     static Boolean SimulateTouch{ get; set; };
+}
+
 }

--- a/dev/SwipeControl/SwipeControl.idl
+++ b/dev/SwipeControl/SwipeControl.idl
@@ -1,4 +1,7 @@
-﻿runtimeclass SwipeItems;
+﻿namespace MU_XC_NAMESPACE
+{
+
+runtimeclass SwipeItems;
 runtimeclass SwipeControl;
 runtimeclass SwipeItemInvokedEventArgs;
 runtimeclass SwipeItem;
@@ -96,4 +99,6 @@ unsealed runtimeclass SwipeItem : Windows.UI.Xaml.DependencyObject
     static Windows.UI.Xaml.DependencyProperty CommandProperty { get; };
     static Windows.UI.Xaml.DependencyProperty CommandParameterProperty { get; };
     static Windows.UI.Xaml.DependencyProperty BehaviorOnInvokedProperty { get; };
+}
+
 }

--- a/dev/SwipeControl/SwipeControl.vcxitems
+++ b/dev/SwipeControl/SwipeControl.vcxitems
@@ -45,6 +45,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)SwipeControl.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)SwipeControl.idl" />
   </ItemGroup>
 </Project>

--- a/dev/TeachingTip/TeachingTip.idl
+++ b/dev/TeachingTip/TeachingTip.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 enum TeachingTipTailVisibility
 {
@@ -154,4 +157,6 @@ unsealed runtimeclass TeachingTip : Windows.UI.Xaml.Controls.ContentControl
     static Windows.UI.Xaml.DependencyProperty IconSourceProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty TemplateSettingsProperty{ get; };
+}
+
 }

--- a/dev/TeachingTip/TeachingTip.vcxitems
+++ b/dev/TeachingTip/TeachingTip.vcxitems
@@ -49,8 +49,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipTemplateSettings.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)TeachingTip.idl" />
-    <None Include="$(MSBuildThisFileDirectory)TeachingTipAutomationPeer.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)TeachingTip.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)TeachingTipAutomationPeer.idl" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />

--- a/dev/TeachingTip/TeachingTipAutomationPeer.idl
+++ b/dev/TeachingTip/TeachingTipAutomationPeer.idl
@@ -1,7 +1,7 @@
-namespace MU_XAP_NAMESPACE
+﻿namespace MU_XAP_NAMESPACE
 {
 
-﻿[WUXC_VERSION_MUXONLY]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass TeachingTipAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {

--- a/dev/TeachingTip/TeachingTipAutomationPeer.idl
+++ b/dev/TeachingTip/TeachingTipAutomationPeer.idl
@@ -1,6 +1,11 @@
+namespace MU_XAP_NAMESPACE
+{
+
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
 unsealed runtimeclass TeachingTipAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     TeachingTipAutomationPeer(MU_XC_NAMESPACE.TeachingTip owner);
+}
+
 }

--- a/dev/TestHooks/MUXControlsTestHooks.idl
+++ b/dev/TestHooks/MUXControlsTestHooks.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 runtimeclass MUXControlsTestHooksLoggingMessageEventArgs
@@ -15,4 +18,6 @@ runtimeclass MUXControlsTestHooks
     static void SetLoggingLevelForType(String type, Boolean isLoggingInfoLevel, Boolean isLoggingVerboseLevel);
     static void SetLoggingLevelForInstance(Object sender, Boolean isLoggingInfoLevel, Boolean isLoggingVerboseLevel);
     static event Windows.Foundation.TypedEventHandler<Object, MUXControlsTestHooksLoggingMessageEventArgs> LoggingMessage;
+}
+
 }

--- a/dev/TestHooks/RepeaterTestHooks.idl
+++ b/dev/TestHooks/RepeaterTestHooks.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [webhosthidden]
 [default_interface]
@@ -11,4 +14,6 @@ runtimeclass RepeaterTestHooks
 
     static String GetLayoutId(Object layout);
     static void SetLayoutId(Object layout, String id);
+}
+
 }

--- a/dev/TestHooks/ScrollViewerTestHooks.idl
+++ b/dev/TestHooks/ScrollViewerTestHooks.idl
@@ -1,7 +1,12 @@
-﻿[WUXC_VERSION_INTERNAL]
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
+[WUXC_VERSION_INTERNAL]
 [default_interface]
 [webhosthidden]
 runtimeclass ScrollViewerTestHooks
 {
     static MU_XCP_NAMESPACE.Scroller GetScrollerPart(MU_XC_NAMESPACE.ScrollViewer scrollViewer);
+}
+
 }

--- a/dev/TestHooks/ScrollerTestHooks.idl
+++ b/dev/TestHooks/ScrollerTestHooks.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_INTERNAL]
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
+[WUXC_VERSION_INTERNAL]
 [webhosthidden]
 enum ScrollerViewChangeResult
 {
@@ -54,4 +57,6 @@ runtimeclass ScrollerTestHooks
     static event Windows.Foundation.TypedEventHandler<MU_XCP_NAMESPACE.Scroller, ScrollerTestHooksInteractionSourcesChangedEventArgs> InteractionSourcesChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XCP_NAMESPACE.Scroller, Object> ContentLayoutOffsetXChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XCP_NAMESPACE.Scroller, Object> ContentLayoutOffsetYChanged;
+}
+
 }

--- a/dev/TestHooks/SwipeTestHooks.idl
+++ b/dev/TestHooks/SwipeTestHooks.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [default_interface]
 [webhosthidden]
@@ -9,4 +12,6 @@ runtimeclass SwipeTestHooks
     static event Windows.Foundation.TypedEventHandler<Object, Object> LastInteractedWithSwipeControlChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.SwipeControl, Object> OpenedStatusChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.SwipeControl, Object> IdleStatusChanged;
+}
+
 }

--- a/dev/TestHooks/TeachingTipTestHooks.idl
+++ b/dev/TestHooks/TeachingTipTestHooks.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_INTERNAL]
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
+[WUXC_VERSION_INTERNAL]
 [default_interface]
 [webhosthidden]
 runtimeclass TeachingTipTestHooks
@@ -28,4 +31,6 @@ runtimeclass TeachingTipTestHooks
     static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.TeachingTip, Object> OffsetChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.TeachingTip, Object> EffectivePlacementChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.TeachingTip, Object> EffectiveHeroContentPlacementChanged;
+}
+
 }

--- a/dev/TestHooks/TestHooks.vcxitems
+++ b/dev/TestHooks/TestHooks.vcxitems
@@ -46,11 +46,11 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipTestHooks.h" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)MUXControlsTestHooks.idl" />
-    <None Include="$(MSBuildThisFileDirectory)RepeaterTestHooks.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ScrollerTestHooks.idl" />
-    <None Include="$(MSBuildThisFileDirectory)ScrollViewerTestHooks.idl" Condition="$(BuildingWithBuildExe) != 'true'" />
-    <None Include="$(MSBuildThisFileDirectory)SwipeTestHooks.idl" />
-    <None Include="$(MSBuildThisFileDirectory)TeachingTipTestHooks.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)MUXControlsTestHooks.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)RepeaterTestHooks.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ScrollerTestHooks.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)ScrollViewerTestHooks.idl" Condition="$(BuildingWithBuildExe) != 'true'" />
+    <Midl Include="$(MSBuildThisFileDirectory)SwipeTestHooks.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)TeachingTipTestHooks.idl" />
   </ItemGroup>
 </Project>

--- a/dev/TreeView/TreeView.idl
+++ b/dev/TreeView/TreeView.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS4]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_RS4]
 [webhosthidden]
 enum TreeViewSelectionMode
 {
@@ -214,4 +217,6 @@ unsealed runtimeclass TreeViewItem : Windows.UI.Xaml.Controls.ListViewItem
         static Windows.UI.Xaml.DependencyProperty HasUnrealizedChildrenProperty{ get; };
         static Windows.UI.Xaml.DependencyProperty ItemsSourceProperty{ get; };
     }
+}
+
 }

--- a/dev/TreeView/TreeView.vcxitems
+++ b/dev/TreeView/TreeView.vcxitems
@@ -48,8 +48,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ViewModel.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)TreeView.idl" />
-    <None Include="$(MSBuildThisFileDirectory)TreeViewAutomationPeers.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)TreeView.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)TreeViewAutomationPeers.idl" />
   </ItemGroup>
   <ItemGroup Condition="$(BuildLeanMuxForTheStoreApp) != 'true'">
     <Page Include="$(MSBuildThisFileDirectory)TreeView.xaml">

--- a/dev/TreeView/TreeViewAutomationPeers.idl
+++ b/dev/TreeView/TreeViewAutomationPeers.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_RS4]
+﻿namespace MU_XAP_NAMESPACE
+{
+
+[WUXC_VERSION_RS4]
 [webhosthidden]
 [WUXC_INTERFACE_NAME("ITreeViewListAutomationPeer", 71c1b5bc-bb29-4479-a8a8-606be6b823ae)]
 [WUXC_CONSTRUCTOR_NAME("ITreeViewListAutomationPeerFactory", 00f597e2-f811-475a-bfe6-290fe707fa88)]
@@ -14,4 +17,6 @@ unsealed runtimeclass TreeViewListAutomationPeer : Windows.UI.Xaml.Automation.Pe
 unsealed runtimeclass TreeViewItemAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemAutomationPeer, Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider
 {
     [method_name("CreateInstanceWithOwner")] TreeViewItemAutomationPeer(MU_XC_NAMESPACE.TreeViewItem owner);
+}
+
 }

--- a/dev/TwoPaneView/DisplayRegionHelperTestApi.idl
+++ b/dev/TwoPaneView/DisplayRegionHelperTestApi.idl
@@ -1,3 +1,6 @@
+namespace MU_PRIVATE_CONTROLS_NAMESPACE
+{
+
 [WUXC_VERSION_INTERNAL]
 [default_interface]
 [webhosthidden]
@@ -5,4 +8,6 @@ runtimeclass DisplayRegionHelperTestApi
 {
     static Boolean SimulateDisplayRegions { get; set; };
     static MU_XC_NAMESPACE.TwoPaneViewMode SimulateMode { get; set; };
+}
+
 }

--- a/dev/TwoPaneView/TwoPaneView.idl
+++ b/dev/TwoPaneView/TwoPaneView.idl
@@ -1,4 +1,7 @@
-﻿[WUXC_VERSION_19H1]
+﻿namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_19H1]
 [webhosthidden]
 enum TwoPaneViewPriority
 {
@@ -72,4 +75,6 @@ unsealed runtimeclass TwoPaneView : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty TallModeConfigurationProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MinWideModeWidthProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MinTallModeHeightProperty { get; };
+}
+
 }

--- a/dev/TwoPaneView/TwoPaneView.vcxitems
+++ b/dev/TwoPaneView/TwoPaneView.vcxitems
@@ -15,7 +15,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)TwoPaneView.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)TwoPaneView.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)DisplayRegionHelper.h" />
@@ -41,6 +41,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)DisplayRegionHelperTestApi.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)DisplayRegionHelperTestApi.idl" />
   </ItemGroup>
 </Project>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -160,11 +160,10 @@
     <Midl>
       <MetadataFileName>$(OutDir)Unmerged\%(Filename)_Unmerged.winmd</MetadataFileName>
       <AdditionalOptions>/no_stamp /no_settings_comment /nomidl %(AdditionalOptions)</AdditionalOptions>
-      <!-- TODO: Remove Configuration==Debug from these once this is fixed: Bug 17488419: MIDL "import winmd" behavior doesn't carry through parameter names of methods on implemented interfaces -->
-      <AdditionalOptions Condition="'$(Configuration)'=='Debug'">%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd"</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)'=='Debug'">%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Networking.Connectivity.WwanContract\2.0.0.0\Windows.Networking.Connectivity.WwanContract.winmd"</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)'=='Debug' And $(UseInsiderSDK) == 'true'">%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.UniversalApiContract\8.0.0.0\Windows.Foundation.UniversalApiContract.winmd"</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)'=='Debug' And $(UseInsiderSDK) != 'true'">%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd"</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd"</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Networking.Connectivity.WwanContract\2.0.0.0\Windows.Networking.Connectivity.WwanContract.winmd"</AdditionalOptions>
+      <AdditionalOptions Condition="$(UseInsiderSDK) == 'true'">%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.UniversalApiContract\8.0.0.0\Windows.Foundation.UniversalApiContract.winmd"</AdditionalOptions>
+      <AdditionalOptions Condition="$(UseInsiderSDK) != 'true'">%(AdditionalOptions) /reference "$(WindowsSDK_MetadataPathVersioned)\Windows.Foundation.UniversalApiContract\7.0.0.0\Windows.Foundation.UniversalApiContract.winmd"</AdditionalOptions>
       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..;$(MSBuildProjectDirectory)\..\..\idl;$(MiniWindowsSDKIncludePath)</AdditionalIncludeDirectories>
       <AdditionalMetadataDirectories Condition="'$(MiniWindowsSDKWinMDPath)'!=''">$(MiniWindowsSDKWinMDPath)</AdditionalMetadataDirectories>
       <OutputDirectory>$(OutDir)</OutputDirectory>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -59,6 +59,9 @@
       <IsPreviewResource>False</IsPreviewResource>
     </PRIResource>
   </ItemDefinitionGroup>
+  <ItemGroup>
+    <Midl Include="..\..\idl\Microsoft.UI.Xaml.idl" />
+  </ItemGroup>
   <ImportGroup Label="Shared">
     <Import Project="..\RatingControl\RatingControl.vcxitems" Label="Shared" Condition="$(BuildLeanMuxForTheStoreApp) != 'true'" />
     <Import Project="..\NavigationView\NavigationView.vcxitems" Label="Shared" />
@@ -366,9 +369,6 @@
     <CompactPage Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <Midl Include="..\..\idl\Microsoft.UI.Xaml.idl" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="XamlMetadataProviderGenerated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>$(OutDir)XamlMetadataProviderGenerated.cpp</LastGenOutput>
@@ -596,6 +596,27 @@
         <CompilerIteration>XamlGenerated</CompilerIteration>
       </ClCompile>
     </ItemGroup>
+  </Target>
+  <PropertyGroup>
+      <ProjectMergedIdl>$(IntermediateOutputPath)\Microsoft.UI.Xaml.idl</ProjectMergedIdl>
+  </PropertyGroup>
+
+  <!-- Merge all idl files into one -->
+  <Target Name="MergeIDLFiles"
+          Inputs="@(Midl)"
+          Outputs="$(ProjectMergedIdl)"
+          BeforeTargets="Midl">
+      <PropertyGroup>
+          <MidlLines>@(Midl->'&#x23;include &lt;%(FullPath)&gt;', '&#x0D;&#x0A;')</MidlLines>
+      </PropertyGroup>
+
+      <WriteLinesToFile File="$(ProjectMergedIdl)" Lines="$(MidlLines)" WriteOnlyWhenDifferent="true" Overwrite="true" />
+      
+      <ItemGroup>
+          <OriginalMidl Include="@(Midl)" />
+          <Midl Remove="@(OriginalMidl)" />
+          <Midl Include="$(ProjectMergedIdl)" />
+      </ItemGroup>
   </Target>
   <Target Name="mdmerge" AfterTargets="Midl" Inputs="@(Midl -> '%(MetadataFileName)')" Outputs="$(OutDir)Microsoft.UI.winmd;$(OutDir)\sdk\Microsoft.UI.Xaml.winmd;$(IntermediateOutputPath)CppWinRT\Platform\winrt\base.h;$(IntermediateOutputPath)CppWinRT\Component\winrt\Microsoft.UI.Xaml.Controls.h">
     <PropertyGroup>

--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -3,83 +3,6 @@
 #define WUXC_VERSION_RS5_CONTRACT  7
 #define WUXC_VERSION_19H1_CONTRACT 8
 
-#ifdef BUILD_WINDOWS
-
-// USE_INTERNAL_SDK is defined here because the definition 
-// in environment.props is not used in razzle. The BUILD_WINDOWS label 
-// is defined by build.cmd automatically.
-#define USE_INTERNAL_SDK
-
-#define MU_XC_NAMESPACE Windows.UI.Xaml.Controls
-#define MU_XCP_NAMESPACE Windows.UI.Xaml.Controls.Primitives
-#define MU_XM_NAMESPACE Windows.UI.Xaml.Media
-#define MU_XAP_NAMESPACE Windows.UI.Xaml.Automation.Peers
-#define MU_PRIVATE_CONTROLS_NAMESPACE Windows.UI.Xaml.Controls
-#define MU_PRIVATE_MEDIA_NAMESPACE Windows.UI.Xaml.Media
-
-import "oaidl.idl";
-import "contactmanager.idl";
-import "windows.foundation.idl";
-import "windows.system.input.idl";
-import "windows.ui.composition.interactions.idl";
-import "windows.ui.core.corewindow.idl";
-import "windows.ui.input.gesturerecognizer.idl";
-import "windows.ui.input.pointerpoint.idl";
-import "windows.ui.xaml.idl";
-import "windows.ui.xaml-private.idl";
-import "displayproperties.idl";
-
-#include <FeatureStaging-XAML.h>
-
-namespace Windows.UI.Xaml
-{
-    apicontract PrivateApiContract;
-}
-
-namespace Windows.Foundation
-{
-    apicontract UniversalApiContract;
-}
-
-#define WUXC_VERSION_RS3 contract(Windows.Foundation.UniversalApiContract, WUXC_VERSION_RS3_CONTRACT)
-#define WUXC_VERSION_RS4 contract(Windows.Foundation.UniversalApiContract, WUXC_VERSION_RS4_CONTRACT)
-#define WUXC_VERSION_RS5 contract(Windows.Foundation.UniversalApiContract, WUXC_VERSION_RS5_CONTRACT)
-#define WUXC_VERSION_19H1 contract(Windows.Foundation.UniversalApiContract, WUXC_VERSION_19H1_CONTRACT)
-
-// Test internal APIs
-#define WUXC_VERSION_INTERNAL WUXC_VERSION_19H1, feature(Feature_WUXCPreviewTypes)
-// Preview APIs
-#define WUXC_VERSION_PREVIEW WUXC_VERSION_19H1, feature(Feature_WUXCPreviewTypes)
-// Public APIs
-#define WUXC_VERSION_MUXONLY WUXC_VERSION_PREVIEW
-
-#define WUXC_INTERFACE_NAME(name, uuid) interface_name(name, uuid)
-#define WUXC_STATIC_NAME(name, uuid) static_name(name, uuid)
-#define WUXC_CONSTRUCTOR_NAME(name, uuid) constructor_name(name, uuid)
-
-#define MUX_HAS_CUSTOM_FACTORY
-#define MUX_PROPERTY_NEEDS_DP_FIELD
-#define MUX_PROPERTY_CHANGED_CALLBACK(enable) 
-#define MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME(name) 
-#define MUX_DEFAULT_VALUE(value) 
-#define MUX_PROPERTY_TYPE(value) 
-#define MUX_PROPERTY_VALIDATION_CALLBACK(value)
-
-#else
-// TODO: Remove after this is fixed: BUG 17488419: MIDL "import winmd" behavior doesn't carry through parameter names of methods on implemented interfaces
-// Because of it in RELEASE builds we use the old IDL includes, but in debug we still use importwinmd behavior to get faster VS builds
-#ifndef DEBUG
-import "inspectable.idl";
-import "Windows.Foundation.idl";
-import "Windows.UI.idl";
-import "Windows.UI.Xaml.idl";
-import "Windows.UI.Xaml.Controls.idl";
-import "Windows.UI.Xaml.CustomAttributes.idl";
-import "Windows.UI.Xaml.Markup.idl";
-import "Windows.UI.Composition.Effects.idl";
-import "Windows.UI.Composition.Interactions.idl";
-#endif
-
 #define MU_XC_NAMESPACE Microsoft.UI.Xaml.Controls
 #define MU_XCP_NAMESPACE Microsoft.UI.Xaml.Controls.Primitives
 #define MU_XM_NAMESPACE Microsoft.UI.Xaml.Media
@@ -213,9 +136,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
 // Instance method on the owning type that can be used to validate or coerce the value.
 #define MUX_PROPERTY_VALIDATION_CALLBACK(value) muxpropertyvalidationcallback(value)
 
-#endif
-
-#ifndef BUILD_WINDOWS
 namespace MU_X_XTI_NAMESPACE
 {
     [WUXC_VERSION_MUXONLY]
@@ -232,48 +152,10 @@ namespace MU_X_XTI_NAMESPACE
         static void Initialize();
     }
 }
-#endif
 
 
 namespace MU_XC_NAMESPACE
 {
-#include <Materials\Reveal\RevealControls.idl>
-#include <NavigationView\NavigationView.idl>
-#include <ParallaxView\ParallaxView.idl>
-#include <Repeater\ItemsRepeater.idl>
-#include <Scroller\Scroller.idl>
-#include <LayoutPanel\LayoutPanel.idl>
-
-#ifndef BUILD_WINDOWS
-#include <IconSource\IconSource.idl>
-#endif
-
-#ifndef BUILD_LEAN_MUX_FOR_THE_STORE_APP
-#ifndef BUILD_WINDOWS
-#include <AnimatedVisualPlayer\AnimatedVisualPlayer.idl>
-#endif
-#include <ColorPicker\Common.idl>
-#include <ColorPicker\ColorPicker.idl>
-#include <CommandBarFlyout\CommandBarFlyout.idl>
-#include <MenuBar\MenuBar.idl>
-#include <PersonPicture\PersonPicture.idl>
-#include <PullToRefresh\RefreshVisualizer\RefreshVisualizer.idl>
-#include <PullToRefresh\RefreshContainer\RefreshContainer.idl>
-#include <RatingControl\RatingControl.idl>
-#include <TwoPaneView\TwoPaneView.idl>
-#include <SwipeControl\SwipeControl.idl>
-#include <TreeView\TreeView.idl>
-#include <SplitButton\SplitButton.idl>
-#include <DropDownButton\DropDownButton.idl>
-#include <RadioButtons\RadioButtons.idl>
-#include <RadioMenuFlyoutItem\RadioMenuFlyoutItem.idl>
-#include <TeachingTip\TeachingTip.idl>
-#ifndef BUILD_WINDOWS
-#include <ScrollViewer\ScrollViewer.idl>
-#endif
-#endif
-
-
     [WUXC_VERSION_MUXONLY]
     [webhosthidden]
     [default_interface]
@@ -292,90 +174,4 @@ namespace MU_XC_NAMESPACE
             static Windows.UI.Xaml.DependencyProperty UseCompactResourcesProperty{ get; };
         }
     }
-}
-
-namespace MU_XCP_NAMESPACE
-{
-#ifndef BUILD_LEAN_MUX_FOR_THE_STORE_APP
-#include <ColorPicker\ColorSpectrum.idl>
-#include <ColorPicker\ColorPickerSlider.idl>
-#include <CommandBarFlyout\CommandBarFlyoutCommandBar.idl>
-#include <RadioButtons\RadioButtonsPrimitives.idl>
-#endif
-#include <NavigationView\NavigationViewItemPresenter.idl>
-#include <Scroller\ScrollerPrimitives.idl>
-}
-
-namespace MU_XM_NAMESPACE
-{
-#include <Materials\Acrylic\AcrylicBrush.idl>
-#include <Materials\Reveal\RevealBrush.idl>
-}
-
-namespace MU_XAP_NAMESPACE
-{
-#include <NavigationView\NavigationViewItemAutomationPeer.idl>
-
-#ifndef BUILD_LEAN_MUX_FOR_THE_STORE_APP
-#ifndef BUILD_WINDOWS
-#include <AnimatedVisualPlayer\AnimatedVisualPlayerAutomationPeer.idl>
-#endif
-#include <TeachingTip\TeachingTipAutomationPeer.idl>
-#include <ColorPicker\ColorSpectrumAutomationPeer.idl>
-#include <ColorPicker\ColorPickerSliderAutomationPeer.idl>
-#include <MenuBar\MenuBarAutomationPeer.idl>
-#include <PersonPicture\PersonPictureAutomationPeer.idl>
-#include <RatingControl\RatingControlAutomationPeer.idl>
-#include <TreeView\TreeViewAutomationPeers.idl>
-#include <RadioButtons\RadioButtonsAutomationPeer.idl>
-#include <Repeater\RepeaterAutomationPeer.idl>
-#include <SplitButton\SplitButtonAutomationPeer.idl>
-#include <DropDownButton\DropDownButtonAutomationPeer.idl>
-#include <Scroller\ScrollerAutomationPeer.idl>
-#endif
-}
-
-// Types in these namespaces end up in a separate WinMD from the public types in the MUXControls repo
-// and therefore are "private" because we don't give Microsoft.UI.Private.WinMD to any customers.
-// However, it is useful for these types to still be in a WinMD so that we can use them from our test app.
-namespace MU_PRIVATE_CONTROLS_NAMESPACE
-{
-// These two depend on the type InteractionBase, which is behind the Velocity feature Feature_Xaml2018 in the OS repo.
-// We can't compile them without attaching the same feature annotation, and MIDL doesn't let us attach feature attributes
-// to non-public types.  So for now we'll just exclude these from the OS repo.
-#ifndef BUILD_WINDOWS
-#include <Interactions\ButtonInteraction\ButtonInteraction.idl>
-#include <Interactions\SliderInteraction\SliderInteraction.idl>
-#endif
-
-#include <Repeater\RepeaterPrivate.idl>
-#include <TestHooks\MUXControlsTestHooks.idl>
-#include <TestHooks\RepeaterTestHooks.idl>
-#include <TestHooks\ScrollerTestHooks.idl>
-
-#ifndef BUILD_LEAN_MUX_FOR_THE_STORE_APP
-#include <TestHooks\SwipeTestHooks.idl>
-#include <ColorPicker\SpectrumBrush.idl>
-#include <PullToRefresh\RefreshVisualizer\RefreshVisualizerPrivate.idl>
-#include <PullToRefresh\ScrollViewerIRefreshInfoProviderAdapter\ScrollViewerIRefreshInfoProviderAdapter.idl>
-#include <PullToRefresh\RefreshContainer\RefreshContainerPrivate.idl>
-#include <PullToRefresh\RefreshVisualizer\PullToRefreshHelperTestAPI.idl>
-#include <TwoPaneView\DisplayRegionHelperTestApi.idl>
-#include <TestHooks\TeachingTipTestHooks.idl>
-#include <SplitButton\SplitButtonTestApi.idl>
-#ifndef BUILD_WINDOWS
-#include <TestHooks\ScrollViewerTestHooks.idl>
-#endif
-#endif
-}
-
-namespace MU_PRIVATE_MEDIA_NAMESPACE
-{
-#include <Lights\RevealBorderLight.idl>
-#include <Lights\RevealHoverLight.idl>
-#include <Lights\RevealTestApi.idl>
-#include <Lights\MaterialHelperTestApi.idl>
-#include <Lights\XamlAmbientLight.idl>
-#include <Materials\Reveal\RevealBrushTestApi.idl>
-#include <Materials\Acrylic\AcrylicTestApi.idl>
 }

--- a/tools/GenerateNewControlProjectFiles/NEWCONTROL.idl
+++ b/tools/GenerateNewControlProjectFiles/NEWCONTROL.idl
@@ -1,4 +1,7 @@
-[WUXC_VERSION_RS5]
+namespace MU_XC_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
 [webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 unsealed runtimeclass NEWCONTROL : Windows.UI.Xaml.Controls.Control
@@ -8,4 +11,6 @@ unsealed runtimeclass NEWCONTROL : Windows.UI.Xaml.Controls.Control
     Object Placeholder{ get; set; };
 
     static Windows.UI.Xaml.DependencyProperty PlaceholderProperty{ get; };
+}
+
 }

--- a/tools/GenerateNewControlProjectFiles/NEWCONTROL.vcxitems
+++ b/tools/GenerateNewControlProjectFiles/NEWCONTROL.vcxitems
@@ -31,6 +31,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)NEWCONTROL.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)NEWCONTROL.idl" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a quality-of-life improvement -- a small step along the path to improving our dev inner loop so that we can have a "mini" solution which includes only the projects/controls that you're actively developing.

This step changes it so that you author `<Midl/>` items as normal in your projects but the MUX vcxproj merges them all together and invokes MIDL.exe just once. This is a change from before where you would add a MIDL item to your project and then have to manually change the file type to "None". You don't need to do that anymore.

Also before you `#include`-d your .idl file manually in Microsoft.UI.Xaml.idl, and you don't need to do that now either. But this also means that you need to explicitly specify the namespace in the IDL. So that's why this change has 100 files changed -- I had to add the namespace to each idl file. There's a nice advantage here that you can now just have 1 idl file in each dev project that includes control, automation peer and test hooks in different namespaces. This didn't work before because of the pattern we had adopted.

The Microsoft.UI.Xaml.idl and Microsoft.UI.Xaml.vcxproj changes are the most interesting, but there are a couple vcxitems changes where a .idl file was missing (since it was manually in the MUX.idl and was accidentally not listed).