### PR TITLE
Make TeachingTip a public type

### DIFF
--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -808,6 +808,7 @@ void TeachingTip::OnIsOpenChanged()
         auto [ignored, tipDoesNotFit] = DetermineEffectivePlacement();
         if (tipDoesNotFit)
         {
+            __RP_Marker_ClassMemberById(RuntimeProfiler::ProfId_TeachingTip, RuntimeProfiler::ProfMemberId_TeachingTip_TipDidNotOpenDueToSize);
             RaiseClosingEvent(false);
             auto closedArgs = winrt::make_self<TeachingTipClosedEventArgs>();
             closedArgs->Reason(m_lastCloseReason);

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -770,7 +770,10 @@ void TeachingTip::OnIsOpenChanged()
             auto popup = winrt::Popup();
             m_popupOpenedRevoker = popup.Opened(winrt::auto_revoke, { this, &TeachingTip::OnPopupOpened });
             m_popupClosedRevoker = popup.Closed(winrt::auto_revoke, { this, &TeachingTip::OnPopupClosed });
-            popup.ShouldConstrainToRootBounds(ShouldConstrainToRootBounds());
+            if (SharedHelpers::Is19H1OrHigher())
+            {
+                popup.ShouldConstrainToRootBounds(ShouldConstrainToRootBounds());
+            }
             m_popup.set(popup);
             SetPopupAutomationProperties();
             m_createNewPopupOnOpen = false;
@@ -895,7 +898,12 @@ void TeachingTip::OnShouldConstrainToRootBoundsChanged()
     // ShouldConstrainToRootBounds is a property that can only be set on a popup before it is opened.
     // If we have opened the tip's popup and then this property changes we will need to discard the old popup
     // and replace it with a new popup.  This variable indicates this state.
-    m_createNewPopupOnOpen = true;
+
+    //The underlying popup api is only available on 19h1 plus, if we aren't on that no opt.
+    if (SharedHelpers::Is19H1OrHigher())
+    {
+        m_createNewPopupOnOpen = true;
+    }
 }
 
 void TeachingTip::OnHeroContentPlacementChanged()

--- a/dev/TeachingTip/TeachingTip.idl
+++ b/dev/TeachingTip/TeachingTip.idl
@@ -1,4 +1,4 @@
-﻿[WUXC_VERSION_PREVIEW]
+﻿[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 enum TeachingTipTailVisibility
 {
@@ -7,7 +7,7 @@ enum TeachingTipTailVisibility
     Collapsed,
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 enum TeachingTipCloseReason
 {
@@ -16,7 +16,7 @@ enum TeachingTipCloseReason
     Programmatic,
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 enum TeachingTipPlacementMode
 {
@@ -35,7 +35,7 @@ enum TeachingTipPlacementMode
     RightEdgeAlignedBottom,
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 enum TeachingTipHeroContentPlacementMode
 {
@@ -44,14 +44,14 @@ enum TeachingTipHeroContentPlacementMode
     Bottom,
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 runtimeclass TeachingTipClosedEventArgs
 {
     TeachingTipCloseReason Reason{ get; };
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 runtimeclass TeachingTipClosingEventArgs
 {
@@ -60,7 +60,7 @@ runtimeclass TeachingTipClosingEventArgs
     Windows.Foundation.Deferral GetDeferral();
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass TeachingTipTemplateSettings : Windows.UI.Xaml.DependencyObject
 {
@@ -76,7 +76,7 @@ unsealed runtimeclass TeachingTipTemplateSettings : Windows.UI.Xaml.DependencyOb
     static Windows.UI.Xaml.DependencyProperty IconElementProperty{ get; };
 }
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -50,6 +50,7 @@ namespace RuntimeProfiler
         ProfMemberId_Acrylic_TintLuminosityOpacity_Changed = 0,
         ProfMemberId_TeachingTip_F6AccessKey_FirstInvocation,
         ProfMemberId_TeachingTip_F6AccessKey_SubsequentInvocation,
+        ProfMemberId_TeachingTip_TipDidNotOpenDueToSize,
         ProfMemberId_Size
     } ProfilerMemberId;
 


### PR DESCRIPTION
Make the TeachingTip types public.
Create a telemetry event for when the tip does not open due to size.
Guard against down level use of ShouldConstraintToRootBounds api usage.