### PR TITLE
F6 while focus is in the tip should return focus

### DIFF
--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -554,6 +554,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     SetCloseButtonContent(CloseButtonContentOptions.ShortText);
                     OpenTeachingTip();
                     CloseOpenAndCloseWithJustKeyboardViaF6();
+                    OpenTeachingTip();
+                    UseF6ToReturnToTestPageToCloseTip();
+                    SetCloseButtonContent(CloseButtonContentOptions.NoText);
                 }
             }
         }
@@ -566,6 +569,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             KeyboardHelper.PressKey(Key.Enter);
             WaitForTipOpened();
             KeyboardHelper.PressKey(Key.F6);
+            KeyboardHelper.PressKey(Key.Enter);
+            WaitForTipClosed();
+        }
+        private void UseF6ToReturnToTestPageToCloseTip()
+        {
+            KeyboardHelper.PressKey(Key.F6);
+            KeyboardHelper.PressKey(Key.Tab);
+            KeyboardHelper.PressKey(Key.F6);
+            KeyboardHelper.PressKey(Key.Tab);
             KeyboardHelper.PressKey(Key.Enter);
             WaitForTipClosed();
         }

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -542,22 +542,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             using (var setup = new TestSetupHelper("TeachingTip Tests"))
             {
-                elements = new TeachingTipTestPageElements();
-                foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
-                {
-                    SetTeachingTipLocation(location);
-
-                    ScrollTargetIntoView();
-                    ScrollBy(10);
-                    OpenTeachingTip();
-                    CloseOpenAndCloseWithJustKeyboardViaF6();
-                    SetCloseButtonContent(CloseButtonContentOptions.ShortText);
-                    OpenTeachingTip();
-                    CloseOpenAndCloseWithJustKeyboardViaF6();
-                    OpenTeachingTip();
-                    UseF6ToReturnToTestPageToCloseTip();
-                    SetCloseButtonContent(CloseButtonContentOptions.NoText);
-                }
+                ScrollTargetIntoView();
+                ScrollBy(10);
+                OpenTeachingTip();
+                CloseOpenAndCloseWithJustKeyboardViaF6();
+                SetCloseButtonContent(CloseButtonContentOptions.ShortText);
+                OpenTeachingTip();
+                CloseOpenAndCloseWithJustKeyboardViaF6();
+                OpenTeachingTip();
+                UseF6ToReturnToTestPageToCloseTip();
+                SetCloseButtonContent(CloseButtonContentOptions.NoText);
             }
         }
 

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -958,8 +958,12 @@ void TeachingTip::OnHeroContentPlacementChanged()
 
 void TeachingTip::OnF6AcceleratorKeyClicked(const winrt::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args)
 {
-    if (args.VirtualKey() == winrt::VirtualKey::F6 && args.EventType() == winrt::CoreAcceleratorKeyEventType::KeyDown)
+    if (!args.Handled() &&
+        IsOpen() &&
+        args.VirtualKey() == winrt::VirtualKey::F6 &&
+        (args.EventType() == winrt::CoreAcceleratorKeyEventType::KeyDown || args.EventType() == winrt::CoreAcceleratorKeyEventType::SystemKeyDown))
     {
+        args.Handled(true);
         //  Logging usage telemetry
         if (m_hasF6BeenInvoked)
         {

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -963,7 +963,32 @@ void TeachingTip::OnF6AcceleratorKeyClicked(const winrt::CoreDispatcher&, const 
 
 void TeachingTip::OnCloseButtonGettingFocusFromF6(const winrt::IInspectable&, const winrt::GettingFocusEventArgs& args)
 {
-    m_previouslyFocusedElement.set(args.OldFocusedElement().try_as<winrt::Control>());
+    auto const focusFromContent = [this, args]()
+    {
+        auto parent = winrt::VisualTreeHelper::GetParent(args.OldFocusedElement());
+        while (parent)
+        {
+            if (auto parentAsPopup = parent.try_as<winrt::Popup>())
+            {
+                if (parentAsPopup == m_popup.get())
+                {
+                        return true;
+                }
+            }
+            parent = winrt::VisualTreeHelper::GetParent(parent);
+        }
+        return false;
+    }();
+
+    if (focusFromContent)
+    {
+        m_previouslyFocusedElement.get().Focus(winrt::FocusState::Keyboard);
+    }
+    else
+    {
+        m_previouslyFocusedElement.set(args.OldFocusedElement().try_as<winrt::Control>());
+    }
+
     m_closeButtonGettingFocusFromF6Revoker.revoke();
 }
 


### PR DESCRIPTION
The tip tracks which element had focus when F6 is hit the first time, when F6 is pressed from within the tip should be returned to that element.