### PR TITLE
Forward FlowDirection from TeachingTip to content

### DIFF
--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -494,6 +494,7 @@
                                       AutomationProperties.LandmarkType="Custom"
                                       Background="{TemplateBinding Background}"
                                       BorderBrush="{TemplateBinding BorderBrush}"
+                                      FlowDirection="{TemplateBinding FlowDirection}"
                                       Grid.Row="1"
                                       Grid.Column="1"
                                       Grid.ColumnSpan="3"

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml
@@ -350,6 +350,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -511,6 +512,9 @@
                 <CheckBox Grid.Row="44" Grid.Column="1" Checked="OnTipShadowChecked" Unchecked="OnTipShadowUnchecked" IsChecked="True"/>
                 <TextBlock Grid.Row="45" Foreground="Red" Text="Tail Elevation" VerticalAlignment="Center"/>
                 <Slider Grid.Row="46" Grid.ColumnSpan="2" Minimum="0" Maximum="100" ValueChanged="TailElevationSliderChanged" Value="0"/>
+
+                <TextBlock Grid.Row="47" Foreground="Red" Text="Is Page RTL" VerticalAlignment="Center"/>
+                <CheckBox Grid.Row="47" Grid.Column="1" IsChecked="{x:Bind IsPageRTL, Mode=TwoWay}"/>
             </Grid>
         </ScrollViewer>
 

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
@@ -16,6 +16,7 @@ using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI.Xaml.Automation;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 
 #if !BUILD_WINDOWS
@@ -39,12 +40,9 @@ namespace MUXControlsTestApp
     public sealed partial class TeachingTipPage : TestPage, INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
-        private void NotifyPropertyChanged(string propertyName)
+        private void NotifyPropertyChanged([CallerMemberName]string propertyName = null)
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         Deferral deferral;
@@ -881,17 +879,14 @@ namespace MUXControlsTestApp
 
         public bool IsPageRTL
         {
-            get
-            {
-                return FlowDirection == FlowDirection.RightToLeft;
-            }
+            get => FlowDirection == FlowDirection.RightToLeft;
             set
             {
                 FlowDirection newFlowDirection = value ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
                 if (FlowDirection != newFlowDirection)
                 {
                     FlowDirection = newFlowDirection;
-                    NotifyPropertyChanged(nameof(IsPageRTL));
+                    NotifyPropertyChanged();
                 }
             }
         }

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
@@ -15,6 +15,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI.Xaml.Automation;
+using System.ComponentModel;
 
 
 #if !BUILD_WINDOWS
@@ -35,8 +36,17 @@ namespace MUXControlsTestApp
         VisualTree = 0,
         Resources = 1
     }
-    public sealed partial class TeachingTipPage : TestPage
+    public sealed partial class TeachingTipPage : TestPage, INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void NotifyPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
         Deferral deferral;
         DispatcherTimer timer;
         DispatcherTimer showTimer;
@@ -867,6 +877,23 @@ namespace MUXControlsTestApp
                 current = VisualTreeHelper.GetParent(current);
             }
             return (FrameworkElement)current;
+        }
+
+        public bool IsPageRTL
+        {
+            get
+            {
+                return FlowDirection == FlowDirection.RightToLeft;
+            }
+            set
+            {
+                FlowDirection newFlowDirection = value ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+                if (FlowDirection != newFlowDirection)
+                {
+                    FlowDirection = newFlowDirection;
+                    NotifyPropertyChanged(nameof(IsPageRTL));
+                }
+            }
         }
     }
 }

--- a/test/MUXControlsTestApp/MainPage.xaml
+++ b/test/MUXControlsTestApp/MainPage.xaml
@@ -20,8 +20,6 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="0">
-            <TextBlock Text="Languages:"/>
-            <ComboBox x:Name="LanguageChooser" AutomationProperties.AutomationId="LanguageChooser" VerticalAlignment="Center" Margin="0,0,0,5" SelectionChanged="LanguageChooser_SelectionChanged"/>
         </StackPanel>
         <ScrollViewer Grid.Row="1" HorizontalAlignment="Center" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
             <ItemsControl ItemsSource="{x:Bind Tests}">
@@ -47,6 +45,19 @@
         <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Center">
             <Button Content="Magic Scale Change" Click="Button_Click"/>
             <CheckBox x:Name="LongAnimationsDisabled" AutomationProperties.AutomationId="LongAnimationsDisabled" Content="Long Animations Disabled" Checked="LongAnimationsDisabled_Checked" Unchecked="LongAnimationsDisabled_Unchecked" Margin="10,0,0,0"/>
+
+            <ComboBox
+                x:Name="LanguageChooser"
+                Header="Languages"
+                AutomationProperties.AutomationId="LanguageChooser"
+                VerticalAlignment="Center"
+                SelectionChanged="LanguageChooser_SelectionChanged"/>
+            <ComboBox
+                x:Name="FlowDirectionChooser"
+                Header="FlowDirection"
+                AutomationProperties.AutomationId="FlowDirectionChooser"
+                VerticalAlignment="Center"
+                SelectionChanged="FlowDirectionChooser_SelectionChanged"/>
 
         </StackPanel>
     </Grid>

--- a/test/MUXControlsTestApp/MainPage.xaml.cs
+++ b/test/MUXControlsTestApp/MainPage.xaml.cs
@@ -108,6 +108,11 @@ namespace MUXControlsTestApp
             "zh-TW"
         };
 
+        public List<FlowDirection> FlowDirections
+        {
+            get;
+        } = new List<FlowDirection>() { FlowDirection.LeftToRight, FlowDirection.RightToLeft };
+
         public MainPage()
         {
             this.InitializeComponent();
@@ -122,6 +127,13 @@ namespace MUXControlsTestApp
                 AutomationProperties.SetAutomationId(item, locale);
             }
 
+            foreach (var flowDirection in FlowDirections)
+            {
+                var item = new ComboBoxItem { Content = flowDirection.ToString(), Tag = flowDirection };
+                FlowDirectionChooser.Items.Add(item);
+                AutomationProperties.SetAutomationId(item, flowDirection.ToString());
+            }
+
             // This setting is persisted across multiple openings of an app, so we always want to initialize it to en-US
             // in case the app crashed while in a different language or otherwise was not able to set it back.
             MUXControlsTestApp.App.LanguageOverride = "en-US";
@@ -129,6 +141,7 @@ namespace MUXControlsTestApp
             // We'll additionally make sure that the combo box begins on the right element to reflect the current value.
             LanguageChooser.SelectedIndex = locales.IndexOf("en-US");
             LongAnimationsDisabled.IsChecked = MUXControlsTestApp.App.DisableLongAnimations;
+            FlowDirectionChooser.SelectedIndex = FlowDirections.IndexOf(GetRootFlowDirection());
 
             // App remembers ExtendViewIntoTitleBar and the value persists true if test case aborted and didn't change it back
             // Always set it to false when app restarted
@@ -210,6 +223,20 @@ namespace MUXControlsTestApp
         private void LongAnimationsDisabled_Unchecked(object sender, RoutedEventArgs e)
         {
             MUXControlsTestApp.App.DisableLongAnimations = false;
+        }
+
+        private void FlowDirectionChooser_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            FrameworkElement root = Window.Current.Content as FrameworkElement;
+            if (root != null)
+            {
+                root.FlowDirection = (FlowDirection)((ComboBoxItem)FlowDirectionChooser.SelectedItem).Tag;
+            }
+        }
+
+        private FlowDirection GetRootFlowDirection()
+        {
+            return (Window.Current.Content as FrameworkElement)?.FlowDirection ?? FlowDirection.LeftToRight;
         }
     }
 }


### PR DESCRIPTION
This is not as complete a fix as Stephen was looking into, but I wanted to unblock the scenario for 2.1. 

With this change the content now flows correctly and the tip is positioned correctly but the "Left" and "Right" placements are always interpreted as if the app was LeftToRight. Since the tip appears (albeit not always at the requested placement), this seems better than nothing for now.