### PR TITLE
Fix layout cycle when an inner repeater needs corrections in non-scrollable direction

### DIFF
--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -346,7 +346,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.UpdateLayout();
                 Verify.AreEqual(1, clearedIndices.Count);
                 Verify.AreEqual(0, clearedIndices[0]);
-                Verify.AreEqual(0, preparedIndices.Count);
+
+                if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
+                {
+                    Verify.AreEqual(0, preparedIndices.Count);
+                }
+                else
+                {
+                    Verify.AreEqual(1, preparedIndices.Count);
+                    Verify.AreEqual(2, preparedIndices[0]);
+                }
+
                 Verify.AreEqual(2, changedIndices.Count);
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(1, 0)));
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(2, 1)));

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -346,8 +346,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.UpdateLayout();
                 Verify.AreEqual(1, clearedIndices.Count);
                 Verify.AreEqual(0, clearedIndices[0]);
-                Verify.AreEqual(1, preparedIndices.Count);
-                Verify.AreEqual(2, preparedIndices[0]);
+                Verify.AreEqual(0, preparedIndices.Count);
                 Verify.AreEqual(2, changedIndices.Count);
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(1, 0)));
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(2, 1)));

--- a/dev/Repeater/FlowLayout.cpp
+++ b/dev/Repeater/FlowLayout.cpp
@@ -8,6 +8,12 @@
 #include "FlowLayoutAlgorithm.h"
 #include "FlowLayoutState.h"
 #include "FlowLayout.h"
+#include "VirtualizingLayoutContext.h"
+
+FlowLayout::FlowLayout()
+{
+    LayoutId(L"FlowLayout");
+}
 
 #pragma region IVirtualizingLayoutOverrides
 
@@ -224,19 +230,19 @@ winrt::Rect FlowLayout::GetExtent(
                     0,
                     std::max(0.0f, static_cast<float>((flowState->SpecialElementDesiredSize().*Minor() + minItemSpacing) * itemsCount - minItemSpacing)),
                     std::max(0.0f, static_cast<float>(averageLineSize - lineSpacing)));
-            REPEATER_TRACE_INFO(L"%ls: \tEstimating extent with no realized elements. \n", LayoutId().data());
+            REPEATER_TRACE_INFO(L"%*s: \tEstimating extent with no realized elements. \n", winrt::get_self<VirtualizingLayoutContext>(context)->Indent(), LayoutId().data());
         }
 
-        REPEATER_TRACE_INFO(L"%ls: \tExtent is {%.0f,%.0f}. Based on average line size {%.0f} and average items per line {%.0f}. \n",
-            LayoutId().data(), extent.Width, extent.Height, averageLineSize, averageItemsPerLine);
+        REPEATER_TRACE_INFO(L"%*s: \tExtent is {%.0f,%.0f}. Based on average line size {%.0f} and average items per line {%.0f}. \n",
+            winrt::get_self<VirtualizingLayoutContext>(context)->Indent(), LayoutId().data(), extent.Width, extent.Height, averageLineSize, averageItemsPerLine);
     }
     else
     {
         MUX_ASSERT(firstRealizedItemIndex == -1);
         MUX_ASSERT(lastRealizedItemIndex == -1);
 
-        REPEATER_TRACE_INFO(L"%ls: \tExtent is {%.0f,%.0f}. ItemCount is 0 \n",
-            LayoutId().data(), extent.Width, extent.Height);
+        REPEATER_TRACE_INFO(L"%*s: \tExtent is {%.0f,%.0f}. ItemCount is 0 \n",
+            winrt::get_self<VirtualizingLayoutContext>(context)->Indent(), LayoutId().data(), extent.Width, extent.Height);
     }
 
     return extent;
@@ -260,8 +266,8 @@ void FlowLayout::OnLineArranged(
     winrt::VirtualizingLayoutContext const& context)
 {
 
-    REPEATER_TRACE_INFO(L"%ls: \tOnLineArranged startIndex:%d Count:%d LineHeight:%d \n",
-        LayoutId().data(), startIndex, countInLine, lineSize);
+    REPEATER_TRACE_INFO(L"%*s: \tOnLineArranged startIndex:%d Count:%d LineHeight:%d \n",
+        winrt::get_self<VirtualizingLayoutContext>(context)->Indent(), LayoutId().data(), startIndex, countInLine, lineSize);
     
     const auto flowState = GetAsFlowState(context.LayoutState());
     flowState->OnLineArranged(startIndex, countInLine, lineSize, context);

--- a/dev/Repeater/FlowLayout.h
+++ b/dev/Repeater/FlowLayout.h
@@ -17,6 +17,8 @@ class FlowLayout :
     public FlowLayoutProperties
 {
 public:
+    FlowLayout();
+
     // Disambiguate EnsureProperties and ClearProperties
     using FlowLayoutProperties::EnsureProperties;
     using FlowLayoutProperties::ClearProperties;

--- a/dev/Repeater/FlowLayoutAlgorithm.h
+++ b/dev/Repeater/FlowLayoutAlgorithm.h
@@ -90,7 +90,7 @@ private:
     bool ShouldContinueFillingUpSpace(
         int index,
         GenerateDirection direction);
-    winrt::Rect EstimateExtent(const winrt::Size& availableSize);
+    winrt::Rect EstimateExtent(const winrt::Size& availableSize, const wstring_view& layoutId);
     void RaiseLineArranged();
 #pragma endregion
 

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -17,6 +17,9 @@
 #include "ItemTemplateWrapper.h"
 #endif
 
+// Change to 'true' to turn on debugging outputs in Output window
+bool RepeaterTrace::s_IsDebugOutputEnabled{ false };
+
 winrt::Point ItemsRepeater::ClearedElementsArrangePosition = winrt::Point(-10000.0f, -10000.0f);
 winrt::Rect ItemsRepeater::InvalidRect = { -1.f, -1.f, -1.f, -1.f };
 

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -442,6 +442,8 @@ void ItemsRepeater::OnElementIndexChanged(const winrt::UIElement& element, int o
     }
 }
 
+// Provides an indentation based on repeater elements in the UI Tree that
+// can be used to make logging a little easier to read.
 int ItemsRepeater::Indent()
 {
     int indent = 1;

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -120,6 +120,8 @@ public:
         return s_VirtualizationInfoProperty;
     }
 
+    int Indent();
+
 private:
     void OnLoaded(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/);
     void OnUnloaded(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/);
@@ -179,5 +181,5 @@ private:
     // UIAffinityQueue cleanup. To avoid that bug, take a strong ref
     winrt::IElementFactory m_itemTemplate{ nullptr };
     winrt::Layout m_layout{ nullptr };
-    winrt::ElementAnimator m_animator{ nullptr }; 
+    winrt::ElementAnimator m_animator{ nullptr };
 };

--- a/dev/Repeater/LayoutContext.h
+++ b/dev/Repeater/LayoutContext.h
@@ -19,4 +19,17 @@ public:
     virtual void LayoutStateCore(winrt::IInspectable const& state);
 #pragma endregion
 
+    int Indent()
+    {
+        return m_indent;
+    }
+
+    void Indent(int value)
+    {
+        m_indent = value;
+    }
+
+private:
+    int m_indent{ 0 };
+
 };

--- a/dev/Repeater/LayoutContext.h
+++ b/dev/Repeater/LayoutContext.h
@@ -19,6 +19,7 @@ public:
     virtual void LayoutStateCore(winrt::IInspectable const& state);
 #pragma endregion
 
+#ifdef _DEBUG
     int Indent()
     {
         return m_indent;
@@ -31,5 +32,10 @@ public:
 
 private:
     int m_indent{ 0 };
-
+#else
+    int Indent()
+    {
+        return 0;
+    }
+#endif
 };

--- a/dev/Repeater/RepeaterTrace.h
+++ b/dev/Repeater/RepeaterTrace.h
@@ -52,6 +52,9 @@ public:
                 TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                 TraceLoggingKeyword(KEYWORD_REPEATER),
                 TraceLoggingWideString(buffer, "Message"));
+#ifdef _DEBUG
+            OutputDebugStringW(buffer);
+#endif
         }
         va_end(args);
     }

--- a/dev/Repeater/RepeaterTrace.h
+++ b/dev/Repeater/RepeaterTrace.h
@@ -24,6 +24,10 @@ if(IsRepeaterTracingEnabled()) \
 { \
     RepeaterTrace::TraceInfo(message, __VA_ARGS__); \
 } \
+else if (RepeaterTrace::s_IsDebugOutputEnabled) \
+{ \
+    RepeaterTrace::TraceInfo(message, __VA_ARGS__); \
+} \
 
 #define REPEATER_TRACE_PERF(info) \
 if(IsRepeaterPerfTracingEnabled()) \
@@ -34,6 +38,7 @@ if(IsRepeaterPerfTracingEnabled()) \
 class RepeaterTrace
 {
 public:
+    static bool s_IsDebugOutputEnabled;
     static void TraceInfo(PCWSTR message, ...) noexcept
     {
         va_list args;
@@ -52,9 +57,12 @@ public:
                 TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                 TraceLoggingKeyword(KEYWORD_REPEATER),
                 TraceLoggingWideString(buffer, "Message"));
-#ifdef _DEBUG
-            OutputDebugStringW(buffer);
-#endif
+
+            if (RepeaterTrace::s_IsDebugOutputEnabled)
+            {
+                OutputDebugStringW(buffer);
+            }
+
         }
         va_end(args);
     }

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -9,12 +9,14 @@
 #include "StackLayoutState.h"
 #include "StackLayout.h"
 #include "RuntimeProfiler.h"
+#include "VirtualizingLayoutContext.h"
 
 #pragma region IFlowLayout
 
 StackLayout::StackLayout()
 {
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_StackLayout);
+    LayoutId(L"StackLayout");
 }
 
 #pragma endregion
@@ -159,7 +161,9 @@ winrt::Rect StackLayout::GetExtent(
         }
         else
         {
-            REPEATER_TRACE_INFO(L"%ls: \tEstimating extent with no realized elements.  \n", LayoutId().data());
+            REPEATER_TRACE_INFO(L"%*s: \tEstimating extent with no realized elements.  \n",
+                winrt::get_self<VirtualizingLayoutContext>(context)->Indent(),
+                LayoutId().data());
         }
     }
     else
@@ -168,7 +172,8 @@ winrt::Rect StackLayout::GetExtent(
         MUX_ASSERT(lastRealizedItemIndex == -1);
     }
 
-    REPEATER_TRACE_INFO(L"%ls: \tExtent is (%.0f,%.0f). Based on average %.0f. \n",
+    REPEATER_TRACE_INFO(L"%*s: \tExtent is (%.0f,%.0f). Based on average %.0f. \n",
+        winrt::get_self<VirtualizingLayoutContext>(context)->Indent(),
         LayoutId().data(), extent.Width, extent.Height, averageElementSize);
     return extent;
 }

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -8,12 +8,14 @@
 #include "UniformGridLayoutState.h"
 #include "UniformGridLayout.h"
 #include "RuntimeProfiler.h"
+#include "VirtualizingLayoutContext.h"
 
 #pragma region IGridLayout
 
 UniformGridLayout::UniformGridLayout()
 {
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_UniformGridLayout);
+    LayoutId(L"UniformGridLayout");
 }
 
 #pragma endregion
@@ -178,14 +180,14 @@ winrt::FlowLayoutAnchorInfo UniformGridLayout::Algorithm_GetAnchorForTargetEleme
 }
 
 winrt::Rect UniformGridLayout::Algorithm_GetExtent(
-    const winrt::Size & availableSize,
-    const winrt::VirtualizingLayoutContext & context,
-    const winrt::UIElement & firstRealized,
+    const winrt::Size& availableSize,
+    const winrt::VirtualizingLayoutContext& context,
+    const winrt::UIElement& firstRealized,
     int firstRealizedItemIndex,
-    const winrt::Rect & firstRealizedLayoutBounds,
-    const winrt::UIElement & lastRealized,
+    const winrt::Rect& firstRealizedLayoutBounds,
+    const winrt::UIElement& lastRealized,
     int lastRealizedItemIndex,
-    const winrt::Rect & lastRealizedLayoutBounds)
+    const winrt::Rect& lastRealizedLayoutBounds)
 {
     UNREFERENCED_PARAMETER(lastRealized);
 
@@ -200,7 +202,7 @@ winrt::Rect UniformGridLayout::Algorithm_GetExtent(
     const float lineSize = GetMajorSizeWithSpacing(context);
 
     if (itemsCount > 0)
-    {        
+    {
         extent.*MinorSize() =
             std::isfinite(availableSizeMinor) ?
             availableSizeMinor :

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -49,13 +49,13 @@ winrt::UIElement ViewManager::GetElement(int index, bool forceCreate, bool suppr
     if (suppressAutoRecycle)
     {
         virtInfo->AutoRecycleCandidate(false);
-        REPEATER_TRACE_INFO(L"GetElement: %d Not AutoRecycleCandidate: \n", virtInfo->Index());
+        REPEATER_TRACE_INFO(L"%* GetElement: %d Not AutoRecycleCandidate: \n", m_owner->Indent(), virtInfo->Index());
     }
     else
     {
         virtInfo->AutoRecycleCandidate(true);
         virtInfo->KeepAlive(true);
-        REPEATER_TRACE_INFO(L"GetElement: %d AutoRecycleCandidate: \n", virtInfo->Index());
+        REPEATER_TRACE_INFO(L"%* GetElement: %d AutoRecycleCandidate: \n", m_owner->Indent(), virtInfo->Index());
     }
 
     return element;

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.h
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.h
@@ -82,6 +82,12 @@ private:
     // Sometimes the scrolling surface cannot service a shift (for example
     // it is already at the top and cannot shift anymore.)
     winrt::Point m_pendingViewportShift{};
+    // Unshiftable shift amount that this view manager can
+    // handle on its own to fake it to the layout as if the shift
+    // actually happened. This can happen in cases where no scrollviewer
+    // in the parent chain can scroll in the shift direction.
+    winrt::Point m_unshiftableShift{};
+
 
     // Realization window cache fields
     double m_maximumHorizontalCacheLength{ 2.0 };


### PR DESCRIPTION
There can be cases where we might need to do correction for stack/flow layouts - however there might not be any scrollviewers in the parent chain that can scroll in that direction. In those cases, we can have repeater fake the correction to keep the layouts happy.

Also making some updates to tracing to make the output indented so it is easier to read.