### PR TITLE
Update release build definition to pass access token through to code signing

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -79,6 +79,8 @@ jobs:
 
   - ${{if parameters.signConfig }}:
     - task: PkgESCodeSign@10
+      env:
+        SYSTEM_ACCESSTOKEN: $(system.accesstoken)
       displayName: CodeSign
       inputs:
         signConfigXml: ${{ parameters.signConfig }}

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -95,6 +95,8 @@ jobs:
 
   - task: PkgESCodeSign@10
     displayName: CodeSign
+    env:
+      SYSTEM_ACCESSTOKEN: $(system.accesstoken)
     inputs:
       signConfigXml: '$(Build.SourcesDirectory)\build\SignConfig.xml'
       inPathRoot: '$(Build.ArtifactStagingDirectory)\drop'


### PR DESCRIPTION
Code signing started failing because PackageES changed how the signing task works. Now need to pass the auth token through to the task manually.