### PR TITLE
Scroller layout fix for cases where size is only constrained by MaxWidth/MaxHeight

### DIFF
--- a/dev/Scroller/APITests/ScrollerLayoutTests.cs
+++ b/dev/Scroller/APITests/ScrollerLayoutTests.cs
@@ -245,6 +245,157 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        [TestProperty("Description", "Validates Scroller.ViewportHeight for various layouts.")]
+        public void ViewportHeight()
+        {
+            for (double scrollerContentHeight = 50.0; scrollerContentHeight <= 350.0; scrollerContentHeight += 300.0)
+            {
+                ViewportHeight(
+                    isScrollerParentSizeSet: false,
+                    isScrollerParentMaxSizeSet: false,
+                    scrollerVerticalAlignment: VerticalAlignment.Top,
+                    scrollerContentHeight);
+                ViewportHeight(
+                    isScrollerParentSizeSet: true,
+                    isScrollerParentMaxSizeSet: false,
+                    scrollerVerticalAlignment: VerticalAlignment.Top,
+                    scrollerContentHeight);
+                ViewportHeight(
+                    isScrollerParentSizeSet: false,
+                    isScrollerParentMaxSizeSet: true,
+                    scrollerVerticalAlignment: VerticalAlignment.Top,
+                    scrollerContentHeight);
+
+                ViewportHeight(
+                    isScrollerParentSizeSet: false,
+                    isScrollerParentMaxSizeSet: false,
+                    scrollerVerticalAlignment: VerticalAlignment.Center,
+                    scrollerContentHeight);
+                ViewportHeight(
+                    isScrollerParentSizeSet: true,
+                    isScrollerParentMaxSizeSet: false,
+                    scrollerVerticalAlignment: VerticalAlignment.Center,
+                    scrollerContentHeight);
+                ViewportHeight(
+                    isScrollerParentSizeSet: false,
+                    isScrollerParentMaxSizeSet: true,
+                    scrollerVerticalAlignment: VerticalAlignment.Center,
+                    scrollerContentHeight);
+
+                ViewportHeight(
+                    isScrollerParentSizeSet: false,
+                    isScrollerParentMaxSizeSet: false,
+                    scrollerVerticalAlignment: VerticalAlignment.Stretch,
+                    scrollerContentHeight);
+                ViewportHeight(
+                    isScrollerParentSizeSet: true,
+                    isScrollerParentMaxSizeSet: false,
+                    scrollerVerticalAlignment: VerticalAlignment.Stretch,
+                    scrollerContentHeight);
+                ViewportHeight(
+                    isScrollerParentSizeSet: false,
+                    isScrollerParentMaxSizeSet: true,
+                    scrollerVerticalAlignment: VerticalAlignment.Stretch,
+                    scrollerContentHeight);
+            }
+        }
+
+        private void ViewportHeight(
+            bool isScrollerParentSizeSet,
+            bool isScrollerParentMaxSizeSet,
+            VerticalAlignment scrollerVerticalAlignment,
+            double scrollerContentHeight)
+        {
+            Log.Comment("ViewportHeight test case - isScrollerParentSizeSet: " + isScrollerParentSizeSet + ", isScrollerParentMaxSizeSet: " + isScrollerParentMaxSizeSet +
+                ", scrollerVerticalAlignment: " + scrollerVerticalAlignment + ", scrollerContentHeight: " + scrollerContentHeight);
+
+            Border border = null;
+            Scroller scroller = null;
+            StackPanel stackPanel = null;
+            Rectangle rectangle = null;
+            AutoResetEvent borderLoadedEvent = new AutoResetEvent(false);
+
+            RunOnUIThread.Execute(() =>
+            {
+                rectangle = new Rectangle()
+                {
+                    Width = 30,
+                    Height = scrollerContentHeight
+                };
+
+                stackPanel = new StackPanel()
+                {
+                    BorderThickness = new Thickness(5),
+                    Margin = new Thickness(7),
+                    VerticalAlignment = VerticalAlignment.Top
+                };
+                stackPanel.Children.Add(rectangle);
+
+                scroller = new Scroller()
+                {
+                    Content = stackPanel,
+                    ContentOrientation = ContentOrientation.Vertical,
+                    VerticalAlignment = scrollerVerticalAlignment
+                };
+
+                border = new Border()
+                {
+                    BorderThickness = new Thickness(2),
+                    Margin = new Thickness(3),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Child = scroller
+                };
+                if (isScrollerParentSizeSet)
+                {
+                    border.Width = 300.0;
+                    border.Height = 200.0;
+                }
+                if (isScrollerParentMaxSizeSet)
+                {
+                    border.MaxWidth = 300.0;
+                    border.MaxHeight = 200.0;
+                }
+
+                border.Loaded += (object sender, RoutedEventArgs e) =>
+                {
+                    Log.Comment("Border.Loaded event handler");
+                    borderLoadedEvent.Set();
+                };
+
+                Log.Comment("Setting window content");
+                MUXControlsTestApp.App.TestContentRoot = border;
+            });
+
+            WaitForEvent("Waiting for Border.Loaded event", borderLoadedEvent);
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                double expectedViewportHeight = 
+                    rectangle.Height + stackPanel.BorderThickness.Top + stackPanel.BorderThickness.Bottom +
+                    stackPanel.Margin.Top + stackPanel.Margin.Bottom;
+
+                double borderChildAvailableHeight = border.ActualHeight - border.BorderThickness.Top - border.BorderThickness.Bottom;
+
+                if (expectedViewportHeight > borderChildAvailableHeight || scrollerVerticalAlignment == VerticalAlignment.Stretch)
+                {
+                    expectedViewportHeight = borderChildAvailableHeight;
+                }
+
+                Log.Comment("border.ActualWidth: " + border.ActualWidth + ", border.ActualHeight: " + border.ActualHeight);
+
+                Log.Comment("Checking ViewportWidth - scroller.ViewportWidth: " + scroller.ViewportWidth + 
+                    ", scroller.ActualWidth: " + scroller.ActualWidth);
+                Verify.AreEqual(scroller.ViewportWidth, scroller.ActualWidth);
+
+                Log.Comment("Checking ViewportHeight - expectedViewportHeight: " + expectedViewportHeight + 
+                    ", scroller.ViewportHeight: " + scroller.ViewportHeight + ", scroller.ActualHeight: " + scroller.ActualHeight);
+                Verify.AreEqual(scroller.ViewportHeight, expectedViewportHeight);
+                Verify.AreEqual(scroller.ViewportHeight, scroller.ActualHeight);
+            });
+        }
+
+        [TestMethod]
         [TestProperty("Description", "Uses a StackPanel with Stretch alignment as Scroller.Content to verify it stretched to the size of the Scroller.")]
         public void StretchAlignment()
         {

--- a/dev/Scroller/APITests/ScrollerLayoutTests.cs
+++ b/dev/Scroller/APITests/ScrollerLayoutTests.cs
@@ -306,8 +306,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             VerticalAlignment scrollerVerticalAlignment,
             double scrollerContentHeight)
         {
-            Log.Comment("ViewportHeight test case - isScrollerParentSizeSet: " + isScrollerParentSizeSet + ", isScrollerParentMaxSizeSet: " + isScrollerParentMaxSizeSet +
-                ", scrollerVerticalAlignment: " + scrollerVerticalAlignment + ", scrollerContentHeight: " + scrollerContentHeight);
+            Log.Comment("ViewportHeight test case - isScrollerParentSizeSet: {0}, isScrollerParentMaxSizeSet: {1}, scrollerVerticalAlignment: {2}, scrollerContentHeight: {3}",
+                isScrollerParentSizeSet, isScrollerParentMaxSizeSet, scrollerVerticalAlignment, scrollerContentHeight);
 
             Border border = null;
             Scroller scroller = null;
@@ -382,14 +382,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     expectedViewportHeight = borderChildAvailableHeight;
                 }
 
-                Log.Comment("border.ActualWidth: " + border.ActualWidth + ", border.ActualHeight: " + border.ActualHeight);
-
-                Log.Comment("Checking ViewportWidth - scroller.ViewportWidth: " + scroller.ViewportWidth + 
-                    ", scroller.ActualWidth: " + scroller.ActualWidth);
+                Log.Comment("border.ActualWidth: {0}, border.ActualHeight: {1}",
+                    border.ActualWidth, border.ActualHeight);
+                Log.Comment("Checking ViewportWidth - scroller.ViewportWidth: {0}, scroller.ActualWidth: {1}",
+                    scroller.ViewportWidth, scroller.ActualWidth);
                 Verify.AreEqual(scroller.ViewportWidth, scroller.ActualWidth);
 
-                Log.Comment("Checking ViewportHeight - expectedViewportHeight: " + expectedViewportHeight + 
-                    ", scroller.ViewportHeight: " + scroller.ViewportHeight + ", scroller.ActualHeight: " + scroller.ActualHeight);
+                Log.Comment("Checking ViewportHeight - expectedViewportHeight: {0}, scroller.ViewportHeight: {1}, scroller.ActualHeight: {2}",
+                    expectedViewportHeight, scroller.ViewportHeight, scroller.ActualHeight);
                 Verify.AreEqual(scroller.ViewportHeight, expectedViewportHeight);
                 Verify.AreEqual(scroller.ViewportHeight, scroller.ActualHeight);
             });

--- a/dev/Scroller/APITests/ScrollerLayoutTests.cs
+++ b/dev/Scroller/APITests/ScrollerLayoutTests.cs
@@ -306,8 +306,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             VerticalAlignment scrollerVerticalAlignment,
             double scrollerContentHeight)
         {
-            Log.Comment("ViewportHeight test case - isScrollerParentSizeSet: {0}, isScrollerParentMaxSizeSet: {1}, scrollerVerticalAlignment: {2}, scrollerContentHeight: {3}",
-                isScrollerParentSizeSet, isScrollerParentMaxSizeSet, scrollerVerticalAlignment, scrollerContentHeight);
+            Log.Comment($"ViewportHeight test case - isScrollerParentSizeSet: {isScrollerParentSizeSet}, isScrollerParentMaxSizeSet: {isScrollerParentMaxSizeSet}, scrollerVerticalAlignment: {scrollerVerticalAlignment}, scrollerContentHeight: {scrollerContentHeight}");
 
             Border border = null;
             Scroller scroller = null;
@@ -382,14 +381,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     expectedViewportHeight = borderChildAvailableHeight;
                 }
 
-                Log.Comment("border.ActualWidth: {0}, border.ActualHeight: {1}",
-                    border.ActualWidth, border.ActualHeight);
-                Log.Comment("Checking ViewportWidth - scroller.ViewportWidth: {0}, scroller.ActualWidth: {1}",
-                    scroller.ViewportWidth, scroller.ActualWidth);
+                Log.Comment($"border.ActualWidth: {border.ActualWidth}, border.ActualHeight: {border.ActualHeight}");
+                Log.Comment($"Checking ViewportWidth - scroller.ViewportWidth: {scroller.ViewportWidth}, scroller.ActualWidth: {scroller.ActualWidth}");
                 Verify.AreEqual(scroller.ViewportWidth, scroller.ActualWidth);
 
-                Log.Comment("Checking ViewportHeight - expectedViewportHeight: {0}, scroller.ViewportHeight: {1}, scroller.ActualHeight: {2}",
-                    expectedViewportHeight, scroller.ViewportHeight, scroller.ActualHeight);
+                Log.Comment($"Checking ViewportHeight - expectedViewportHeight: {expectedViewportHeight}, scroller.ViewportHeight: {scroller.ViewportHeight}, scroller.ActualHeight: {scroller.ActualHeight}");
                 Verify.AreEqual(scroller.ViewportHeight, expectedViewportHeight);
                 Verify.AreEqual(scroller.ViewportHeight, scroller.ActualHeight);
             });

--- a/dev/Scroller/Scroller.cpp
+++ b/dev/Scroller/Scroller.cpp
@@ -663,11 +663,20 @@ winrt::Size Scroller::ArrangeOverride(winrt::Size const& finalSize)
 
     const winrt::UIElement content = Content();
     winrt::Rect finalContentRect{};
+
+    // Possible cases:
+    // 1. m_availableSize is infinite, the Scroller is not constrained and takes its Content DesiredSize.
+    //    viewport thus is finalSize.
+    // 2. m_availableSize > finalSize, the Scroller is constrained and its Content is smaller than the available size.
+    //    No matter the Scroller's alignment, it does not grow larger than finalSize. viewport is finalSize again.
+    // 3. m_availableSize <= finalSize, the Scroller is constrained and its Content is larger than or equal to
+    //    the available size. viewport is the smaller & constrained m_availableSize.
     winrt::Size viewport =
     {
-        isinf(m_availableSize.Width) ? finalSize.Width : m_availableSize.Width,
-        isinf(m_availableSize.Height) ? finalSize.Height : m_availableSize.Height,
+        std::min(finalSize.Width, m_availableSize.Width),
+        std::min(finalSize.Height, m_availableSize.Height)
     };
+
     double newUnzoomedExtentWidth = 0.0;
     double newUnzoomedExtentHeight = 0.0;
 

--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
@@ -102,6 +102,12 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -274,17 +280,51 @@
                 </Border>
                 <Button x:Name="btnGetExtentHeight" Content="G" Margin="1" Grid.Row="22" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetExtentHeight_Click"/>
 
-                <TextBlock Text="Width:" Grid.Row="23" Grid.Column="0" VerticalAlignment="Center"/>
-                <TextBox x:Name="txtWidth" Grid.Row="23" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-                <Button x:Name="btnGetWidth" Content="G" Margin="1" Grid.Row="23" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetWidth_Click"/>
-                <Button x:Name="btnSetWidth" Content="S" Margin="1" Grid.Row="23" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetWidth_Click"/>
-                <Button x:Name="btnQueueWidth" Content="Q" Margin="1" Grid.Row="23" Grid.Column="4" VerticalAlignment="Center" Click="BtnQueueWidth_Click"/>
+                <TextBlock Text="ViewportWidth:" Grid.Row="23" Grid.Column="0" VerticalAlignment="Center"/>
+                <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="23" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <TextBlock x:Name="tblViewportWidth" VerticalAlignment="Center" Margin="2"/>
+                </Border>
+                <Button x:Name="btnGetViewportWidth" Content="G" Margin="1" Grid.Row="23" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetViewportWidth_Click"/>
 
-                <TextBlock Text="Height:" Grid.Row="24" Grid.Column="0" VerticalAlignment="Center"/>
-                <TextBox x:Name="txtHeight" Grid.Row="24" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-                <Button x:Name="btnGetHeight" Content="G" Margin="1" Grid.Row="24" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHeight_Click"/>
-                <Button x:Name="btnSetHeight" Content="S" Margin="1" Grid.Row="24" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHeight_Click"/>
-                <Button x:Name="btnQueueHeight" Content="Q" Margin="1" Grid.Row="24" Grid.Column="4" VerticalAlignment="Center" Click="BtnQueueHeight_Click"/>
+                <TextBlock Text="ViewportHeight:" Grid.Row="24" Grid.Column="0" VerticalAlignment="Center"/>
+                <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="24" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <TextBlock x:Name="tblViewportHeight" VerticalAlignment="Center" Margin="2"/>
+                </Border>
+                <Button x:Name="btnGetViewportHeight" Content="G" Margin="1" Grid.Row="24" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetViewportHeight_Click"/>
+
+                <TextBlock Text="Width:" Grid.Row="25" Grid.Column="0" VerticalAlignment="Center"/>
+                <TextBox x:Name="txtWidth" Grid.Row="25" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Button x:Name="btnGetWidth" Content="G" Margin="1" Grid.Row="25" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetWidth_Click"/>
+                <Button x:Name="btnSetWidth" Content="S" Margin="1" Grid.Row="25" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetWidth_Click"/>
+                <Button x:Name="btnQueueWidth" Content="Q" Margin="1" Grid.Row="25" Grid.Column="4" VerticalAlignment="Center" Click="BtnQueueWidth_Click"/>
+
+                <TextBlock Text="Height:" Grid.Row="26" Grid.Column="0" VerticalAlignment="Center"/>
+                <TextBox x:Name="txtHeight" Grid.Row="26" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Button x:Name="btnGetHeight" Content="G" Margin="1" Grid.Row="26" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHeight_Click"/>
+                <Button x:Name="btnSetHeight" Content="S" Margin="1" Grid.Row="26" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHeight_Click"/>
+                <Button x:Name="btnQueueHeight" Content="Q" Margin="1" Grid.Row="26" Grid.Column="4" VerticalAlignment="Center" Click="BtnQueueHeight_Click"/>
+
+                <TextBlock Text="MaxWidth:" Grid.Row="27" Grid.Column="0" VerticalAlignment="Center"/>
+                <TextBox x:Name="txtMaxWidth" Grid.Row="27" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Button x:Name="btnGetMaxWidth" Content="G" Margin="1" Grid.Row="27" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetMaxWidth_Click"/>
+                <Button x:Name="btnSetMaxWidth" Content="S" Margin="1" Grid.Row="27" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetMaxWidth_Click"/>
+
+                <TextBlock Text="MaxHeight:" Grid.Row="28" Grid.Column="0" VerticalAlignment="Center"/>
+                <TextBox x:Name="txtMaxHeight" Grid.Row="28" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+                <Button x:Name="btnGetMaxHeight" Content="G" Margin="1" Grid.Row="28" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetMaxHeight_Click"/>
+                <Button x:Name="btnSetMaxHeight" Content="S" Margin="1" Grid.Row="28" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetMaxHeight_Click"/>
+
+                <TextBlock Text="ActualWidth:" Grid.Row="29" Grid.Column="0" VerticalAlignment="Center"/>
+                <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="29" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <TextBlock x:Name="tblActualWidth" VerticalAlignment="Center" Margin="2"/>
+                </Border>
+                <Button x:Name="btnGetActualWidth" Content="G" Margin="1" Grid.Row="29" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetActualWidth_Click"/>
+
+                <TextBlock Text="ActualHeight:" Grid.Row="30" Grid.Column="0" VerticalAlignment="Center"/>
+                <Border BorderThickness="1" BorderBrush="DarkGray" Grid.Row="30" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <TextBlock x:Name="tblActualHeight" VerticalAlignment="Center" Margin="2"/>
+                </Border>
+                <Button x:Name="btnGetActualHeight" Content="G" Margin="1" Grid.Row="30" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetActualHeight_Click"/>
             </Grid>
         </ScrollViewer>
 

--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml.cs
@@ -1266,6 +1266,16 @@ namespace MUXControlsTestApp
             tblExtentHeight.Text = scroller.ExtentHeight.ToString();
         }
 
+        private void BtnGetViewportWidth_Click(object sender, RoutedEventArgs e)
+        {
+            tblViewportWidth.Text = scroller.ViewportWidth.ToString();
+        }
+
+        private void BtnGetViewportHeight_Click(object sender, RoutedEventArgs e)
+        {
+            tblViewportHeight.Text = scroller.ViewportHeight.ToString();
+        }
+
         private void BtnGetWidth_Click(object sender, RoutedEventArgs e)
         {
             txtWidth.Text = scroller.Width.ToString();
@@ -1291,6 +1301,24 @@ namespace MUXControlsTestApp
                 double value = Convert.ToDouble(txtWidth.Text);
                 lstQueuedOperations.Add(new QueuedOperation(QueuedOperationType.SetWidth, value));
                 AppendAsyncEventMessage("Queued SetWidth " + value);
+            }
+            catch (Exception ex)
+            {
+                txtExceptionReport.Text = ex.ToString();
+                lstScrollerEvents.Items.Add(ex.ToString());
+            }
+        }
+
+        private void BtnGetMaxWidth_Click(object sender, RoutedEventArgs e)
+        {
+            txtMaxWidth.Text = scroller.MaxWidth.ToString();
+        }
+
+        private void BtnSetMaxWidth_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                scroller.MaxWidth = Convert.ToDouble(txtMaxWidth.Text);
             }
             catch (Exception ex)
             {
@@ -1330,6 +1358,34 @@ namespace MUXControlsTestApp
                 txtExceptionReport.Text = ex.ToString();
                 lstScrollerEvents.Items.Add(ex.ToString());
             }
+        }
+
+        private void BtnGetMaxHeight_Click(object sender, RoutedEventArgs e)
+        {
+            txtMaxHeight.Text = scroller.MaxHeight.ToString();
+        }
+
+        private void BtnSetMaxHeight_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                scroller.MaxHeight = Convert.ToDouble(txtMaxHeight.Text);
+            }
+            catch (Exception ex)
+            {
+                txtExceptionReport.Text = ex.ToString();
+                lstScrollerEvents.Items.Add(ex.ToString());
+            }
+        }
+
+        private void BtnGetActualWidth_Click(object sender, RoutedEventArgs e)
+        {
+            tblActualWidth.Text = scroller.ActualWidth.ToString();
+        }
+
+        private void BtnGetActualHeight_Click(object sender, RoutedEventArgs e)
+        {
+            tblActualHeight.Text = scroller.ActualHeight.ToString();
         }
 
         private void BtnClearScrollerEvents_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Fixes #551 'Scroller is arranged incorrectly'.

The Scroller picked an incorrect ViewportHeight when it was limited in height by its parent's MaxHeight. 
The available height given to it in Scroller::MeasureOverride is MaxHeight. A small Scroller.Content results in a DesiredSize smaller than MaxHeight and in Scroller::ArrangeOverride the finalSize is thus smaller than MaxHeight, The ViewportHeight in that case should be the smaller finalSize.Height.   The bug was that it picked the larger MaxHeight.  In fact, in all cases the ViewportHeight should be smaller value between finalSize.Height and the available height.  The same rule applies to the width.

Added ability to test more layouts in MUXControlsTestApp and added new unit test.

