### PR TITLE
when using non virtualized layout with ItemsRepeater, don't track the viewport and keep running layout

### DIFF
--- a/dev/Repeater/APITests/Common/Mocks/MockNonVirtualizingLayout.cs
+++ b/dev/Repeater/APITests/Common/Mocks/MockNonVirtualizingLayout.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks
+{
+    class MockNonVirtualizingLayout : NonVirtualizingLayout
+    {
+        public Func<Size, NonVirtualizingLayoutContext, Size> MeasureLayoutFunc { get; set; }
+        public Func<Size, NonVirtualizingLayoutContext, Size> ArrangeLayoutFunc { get; set; }
+
+        public new void InvalidateMeasure()
+        {
+            base.InvalidateMeasure();
+        }
+
+        protected override Size MeasureOverride(NonVirtualizingLayoutContext context, Size availableSize)
+        {
+            return MeasureLayoutFunc != null ? MeasureLayoutFunc(availableSize, context) : default(Size);
+        }
+
+        protected override Size ArrangeOverride(NonVirtualizingLayoutContext context, Size finalSize)
+        {
+            return ArrangeLayoutFunc != null ? ArrangeLayoutFunc(finalSize, context) : default(Size);
+        }
+    }
+}

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -173,7 +173,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 arrangeCount = 0;
 
                 // once we switch to a virtualizing layout we should 
-                // get atleast two passes to update the viewport.
+                // get at least two passes to update the viewport.
                 repeater.Layout = new MockVirtualizingLayout() {
                     MeasureLayoutFunc = (size, context) =>
                     {

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -172,7 +172,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 measureCount = 0;
                 arrangeCount = 0;
 
-                // once we switch to a virtualizing layout we should 
+                // Once we switch to a virtualizing layout we should 
                 // get at least two passes to update the viewport.
                 repeater.Layout = new MockVirtualizingLayout() {
                     MeasureLayoutFunc = (size, context) =>

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -129,6 +129,71 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        [TestMethod]
+        public void ValidateNonVirtualLayoutDoesNotGetMeasuredForViewportChanges()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                int measureCount = 0;
+                int arrangeCount = 0;
+                var repeater = new ItemsRepeater();
+
+                // with a non virtualizing layout, repeater will just
+                // run layout once. 
+                repeater.Layout = new MockNonVirtualizingLayout() 
+                {
+                    MeasureLayoutFunc = (size, context) =>
+                    {
+                        measureCount++;
+                        return new Size(100, 800);
+                    },
+                    ArrangeLayoutFunc = (size, context) =>
+                    {
+                        arrangeCount++;
+                        return new Size(100, 800);
+                    }
+                };
+
+                repeater.ItemsSource = Enumerable.Range(0, 10);
+                repeater.ItemTemplate = (DataTemplate)XamlReader.Load(
+                    @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                         <Button Content='{Binding}' Height='100' />
+                    </DataTemplate>");
+
+                Content = new ScrollViewer() 
+                {
+                    Content = repeater
+                };
+                Content.UpdateLayout();
+
+                Verify.AreEqual(1, measureCount);
+                Verify.AreEqual(1, arrangeCount);
+
+                measureCount = 0;
+                arrangeCount = 0;
+
+                // once we switch to a virtualizing layout we should 
+                // get atleast two passes to update the viewport.
+                repeater.Layout = new MockVirtualizingLayout() {
+                    MeasureLayoutFunc = (size, context) =>
+                    {
+                        measureCount++;
+                        return new Size(100, 800);
+                    },
+                    ArrangeLayoutFunc = (size, context) =>
+                    {
+                        arrangeCount++;
+                        return new Size(100, 800);
+                    }
+                };
+
+                Content.UpdateLayout();
+
+                Verify.IsGreaterThan(measureCount, 1);
+                Verify.IsGreaterThan(arrangeCount, 1);
+            });
+        }
+
         private ItemsRepeaterScrollHost CreateAndInitializeRepeater(
            object itemsSource,
            VirtualizingLayout layout,

--- a/dev/Repeater/APITests/Repeater_APITests.projitems
+++ b/dev/Repeater/APITests/Repeater_APITests.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Common\ElementAnimatorDerived.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\LayoutExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\FlowLayoutDerived.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockNonVirtualizingLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\NamedGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\NonVirtualStackLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\OrientationBasedMeasures.cs" />

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -347,15 +347,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.AreEqual(1, clearedIndices.Count);
                 Verify.AreEqual(0, clearedIndices[0]);
 
-                if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-                {
-                    Verify.AreEqual(0, preparedIndices.Count);
-                }
-                else
-                {
-                    Verify.AreEqual(1, preparedIndices.Count);
-                    Verify.AreEqual(2, preparedIndices[0]);
-                }
+                Verify.AreEqual(1, preparedIndices.Count);
+                Verify.AreEqual(2, preparedIndices[0]);
 
                 Verify.AreEqual(2, changedIndices.Count);
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(1, 0)));

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -347,6 +347,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.AreEqual(1, clearedIndices.Count);
                 Verify.AreEqual(0, clearedIndices[0]);
 
+                if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
+                {
+                    Verify.AreEqual(0, preparedIndices.Count);
+                }
+                else
+                {
+                    Verify.AreEqual(1, preparedIndices.Count);
+                    Verify.AreEqual(2, preparedIndices[0]);
+                }
+
                 Verify.AreEqual(2, changedIndices.Count);
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(1, 0)));
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(2, 1)));

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -347,9 +347,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.AreEqual(1, clearedIndices.Count);
                 Verify.AreEqual(0, clearedIndices[0]);
 
-                Verify.AreEqual(1, preparedIndices.Count);
-                Verify.AreEqual(2, preparedIndices[0]);
-
                 Verify.AreEqual(2, changedIndices.Count);
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(1, 0)));
                 Verify.IsTrue(changedIndices.Contains(new KeyValuePair<int, int>(2, 1)));

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -609,7 +609,8 @@ void ItemsRepeater::OnLayoutChanged(const winrt::Layout& oldValue, const winrt::
         m_arrangeInvalidated = newValue.ArrangeInvalidated(winrt::auto_revoke, { this, &ItemsRepeater::InvalidateArrangeForLayout });
     }
 
-    m_viewportManager->OnLayoutChanged();
+    bool isVirtualizingLayout = newValue != nullptr && newValue.try_as<winrt::VirtualizingLayout>() != nullptr;
+    m_viewportManager->OnLayoutChanged(isVirtualizingLayout);
     InvalidateMeasure();
 }
 

--- a/dev/Repeater/ViewportManager.h
+++ b/dev/Repeater/ViewportManager.h
@@ -17,7 +17,7 @@ public:
     virtual void SetLayoutExtent(winrt::Rect extent) = 0;
     virtual winrt::Point GetOrigin() const = 0;
 
-    virtual void OnLayoutChanged() = 0;
+    virtual void OnLayoutChanged(bool isVirtualizing) = 0;
     virtual void OnElementPrepared(const winrt::UIElement& element) = 0;
     virtual void OnElementCleared(const winrt::UIElement& element) = 0;
     virtual void OnOwnerMeasuring() = 0;

--- a/dev/Repeater/ViewportManagerDownlevel.cpp
+++ b/dev/Repeater/ViewportManagerDownlevel.cpp
@@ -149,11 +149,7 @@ void ViewportManagerDownLevel::OnLayoutChanged(bool isVirtualizing)
     m_managingViewportDisabled = !isVirtualizing;
     m_layoutExtent = {};
     m_expectedViewportShift = {};
-
-    if (!m_managingViewportDisabled)
-    {
-        ResetCacheBuffer();
-    }
+    ResetCacheBuffer();
 }
 
 void ViewportManagerDownLevel::OnElementCleared(const winrt::UIElement& element)

--- a/dev/Repeater/ViewportManagerDownlevel.h
+++ b/dev/Repeater/ViewportManagerDownlevel.h
@@ -30,7 +30,7 @@ public:
     void SetLayoutExtent(winrt::Rect extent) override;
     winrt::Point GetOrigin() const override{ return winrt::Point(m_layoutExtent.X, m_layoutExtent.Y); }
 
-    void OnLayoutChanged() override;
+    void OnLayoutChanged(bool isVirtualizing) override;
     void OnElementPrepared(const winrt::UIElement& element) override {}
     void OnElementCleared(const winrt::UIElement& element) override;
     void OnOwnerMeasuring() override {};
@@ -93,6 +93,11 @@ private:
     double m_maximumVerticalCacheLength{ 2.0 };
     double m_horizontalCacheBufferPerSide{};
     double m_verticalCacheBufferPerSide{};
+
+    // For non-virtualizing layouts, we do not need to keep
+    // updating viewports and invalidating measure often. So when
+    // a non virtualizing layout is used, we stop doing all that work.
+    bool m_managingViewportDisabled{ false };
 
     // Event tokens
     winrt::IRepeaterScrollingSurface::PostArrange_revoker m_postArrangeToken;

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -245,24 +245,25 @@ void ViewportManagerWithPlatformFeatures::OnOwnerArranged()
 
 void ViewportManagerWithPlatformFeatures::OnLayoutUpdated(winrt::IInspectable const& sender, winrt::IInspectable const& args)
 {
-	if (!m_managingViewportDisabled)
-	{
-		// We were expecting a viewport shift but we never got one and we are not going to in this
-		// layout pass. We likely will never get this shift, so lets assume that we are never going to get it and
-		// adjust our expected shift to track that. One case where this can happen is when there is no scrollviewer
-		// that can scroll in the direction where the shift is expected.
-		if (m_pendingViewportShift.X != 0 || m_pendingViewportShift.Y != 0)
-		{
-			REPEATER_TRACE_INFO(L"%ls: \tLayout Updated with pending shift %.0f %.0f- invalidating measure \n",
-				GetLayoutId().data(),
-				m_pendingViewportShift.X,
-				m_pendingViewportShift.Y);
-
-			TryInvalidateMeasure();
-		}
-	}
-
     m_layoutUpdatedRevoker.revoke();
+    if (m_managingViewportDisabled)
+    {
+        return;
+    }
+
+    // We were expecting a viewport shift but we never got one and we are not going to in this
+    // layout pass. We likely will never get this shift, so lets assume that we are never going to get it and
+    // adjust our expected shift to track that. One case where this can happen is when there is no scrollviewer
+    // that can scroll in the direction where the shift is expected.
+    if (m_pendingViewportShift.X != 0 || m_pendingViewportShift.Y != 0)
+    {
+        REPEATER_TRACE_INFO(L"%ls: \tLayout Updated with pending shift %.0f %.0f- invalidating measure \n",
+            GetLayoutId().data(),
+            m_pendingViewportShift.X,
+            m_pendingViewportShift.Y);
+
+        TryInvalidateMeasure();
+    }
 }
 
 void ViewportManagerWithPlatformFeatures::OnMakeAnchor(const winrt::UIElement& anchor, const bool isAnchorOutsideRealizedRange)

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -413,7 +413,7 @@ void ViewportManagerWithPlatformFeatures::EnsureScroller()
             // a scroller, let's do it now.
             UpdateViewport(winrt::Rect{});
         }
-        else if(!m_managingViewportDisabled)
+        else if (!m_managingViewportDisabled)
         {
             m_effectiveViewportChangedRevoker = m_owner->EffectiveViewportChanged(winrt::auto_revoke, { this, &ViewportManagerWithPlatformFeatures::OnEffectiveViewportChanged });
         }

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -178,7 +178,7 @@ void ViewportManagerWithPlatformFeatures::OnLayoutChanged(bool isVirtualizing)
     {
         m_effectiveViewportChangedRevoker.revoke();
     }
-    else if(!m_effectiveViewportChangedRevoker)
+    else if (!m_effectiveViewportChangedRevoker)
     {
         m_effectiveViewportChangedRevoker = m_owner->EffectiveViewportChanged(winrt::auto_revoke, { this, &ViewportManagerWithPlatformFeatures::OnEffectiveViewportChanged });
     }

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -262,6 +262,12 @@ void ViewportManagerWithPlatformFeatures::OnLayoutUpdated(winrt::IInspectable co
             m_pendingViewportShift.X,
             m_pendingViewportShift.Y);
 
+        // Assume this is never going to come.
+        m_unshiftableShift.X += m_pendingViewportShift.X;
+        m_unshiftableShift.Y += m_pendingViewportShift.Y;
+        m_pendingViewportShift = {};
+        m_expectedViewportShift = {};
+
         TryInvalidateMeasure();
     }
 }

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.h
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.h
@@ -32,7 +32,7 @@ public:
     void SetLayoutExtent(winrt::Rect extent) override;
     winrt::Point GetOrigin() const override { return winrt::Point(m_layoutExtent.X, m_layoutExtent.Y); }
 
-    void OnLayoutChanged() override;
+    void OnLayoutChanged(bool isVirtualizing) override;
     void OnElementPrepared(const winrt::UIElement& element) override;
     void OnElementCleared(const winrt::UIElement& element) override;
     void OnOwnerMeasuring() override;
@@ -96,6 +96,10 @@ private:
     double m_verticalCacheBufferPerSide{};
 
     bool m_isBringIntoViewInProgress{false};
+    // For non-virtualizing layouts, we do not need to keep
+    // updating viewports and invalidating measure often. So when
+    // a non virtualizing layout is used, we stop doing all that work.
+    bool m_managingViewportDisabled{ false };
 
     // Event tokens
     winrt::FrameworkElement::EffectiveViewportChanged_revoker m_effectiveViewportChangedRevoker{};


### PR DESCRIPTION
The layout does not even have a way to get to the viewport anyway, so there is no use tracking the viewport and calling measure/arrange unnecessarily. This should improve the perf when using a non-virtualizing layouts with repeater drastically especially when scrolling.

Fixes #570