### PR TITLE
NuGet package fix for support of win32 projects

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-Native.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Native.targets
@@ -5,7 +5,7 @@
     <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
     <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
+  <ItemGroup>
     <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.UI.Xaml.winmd">
       <Implementation>Microsoft.UI.Xaml.dll</Implementation>
     </Reference>


### PR DESCRIPTION
Removing Condition="'$(TargetPlatformIdentifier)' == 'UAP'" for Issue #294 and Proposal #494, for Win32 projects support.

Without this change, attempting to compile repro project
\UWPCompositionDemos\HelloVectors\HelloVectors_win32_cpp\HelloVectors_win32_cpp.vcxproj
from https://github.com/clarkezone/UWPCompositionDemos/tree/vectors would result in the WinUI nuget not being found, even though it was properly installed.

That error went away when using the experimental nuget build https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=11145 instead.

Fixes #294, fixes #494