### PR TITLE
refresh items when item template changes

### DIFF
--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -283,7 +283,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 Content = CreateAndInitializeRepeater
                 (
-                   itemsSource: Enumerable.Range(0, numItems).Select(i => string.Format("{0}", i)),
+                   itemsSource: Enumerable.Range(0, numItems).Select(i => i.ToString()),
                    elementFactory: dataTemplate,
                    layout: new StackLayout(),
                    repeater: ref repeater
@@ -456,17 +456,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             var dataTemplate1 = (DataTemplate)XamlReader.Load(
                      @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
                             <TextBlock Text='{Binding}' />
-                        </DataTemplate>");
+                       </DataTemplate>");
 
             var dataTemplate2 = (DataTemplate)XamlReader.Load(
                     @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
                             <Button Content='{Binding}' />
-                        </DataTemplate>");
+                      </DataTemplate>");
             ItemsRepeater repeater = null;
             const int numItems = 10;
             Content = CreateAndInitializeRepeater
             (
-               itemsSource: Enumerable.Range(0, numItems).Select(i => string.Format("{0}", i)),
+               itemsSource: Enumerable.Range(0, numItems).Select(i => i.ToString()),
                elementFactory: dataTemplate1,
                layout: layout,
                repeater: ref repeater

--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -12,6 +12,7 @@ using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common;
 using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks;
+using Microsoft.UI.Xaml.Controls;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -38,7 +39,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #endif
 
     [TestClass]
-    public class ElementFactoryTests : TestsBase
+    public class ItemTemplateTests : TestsBase
     {
         [TestMethod]
         public void ValidateRecycling()
@@ -432,9 +433,68 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        [TestMethod]
+        public void ValidateTemplateSwitchingRefreshesElementsVirtualizingLayout()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                ValidateTemplateSwitchingRefreshesElements(new StackLayout());
+            });
+        }
+
+        [TestMethod]
+        public void ValidateTemplateSwitchingRefreshesElementsNonVirtualizingLayout()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                ValidateTemplateSwitchingRefreshesElements(new NonVirtualStackLayout());
+            });
+        }
+
+        public void ValidateTemplateSwitchingRefreshesElements(Layout layout)
+        {
+            var dataTemplate1 = (DataTemplate)XamlReader.Load(
+                     @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                            <TextBlock Text='{Binding}' />
+                        </DataTemplate>");
+
+            var dataTemplate2 = (DataTemplate)XamlReader.Load(
+                    @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                            <Button Content='{Binding}' />
+                        </DataTemplate>");
+            ItemsRepeater repeater = null;
+            const int numItems = 10;
+            Content = CreateAndInitializeRepeater
+            (
+               itemsSource: Enumerable.Range(0, numItems).Select(i => string.Format("{0}", i)),
+               elementFactory: dataTemplate1,
+               layout: layout,
+               repeater: ref repeater
+            );
+
+            Content.UpdateLayout();
+            Verify.AreEqual(numItems, VisualTreeHelper.GetChildrenCount(repeater));
+            for (int i = 0; i < numItems; i++)
+            {
+                var element = (TextBlock)repeater.TryGetElement(i);
+                Verify.AreEqual(i.ToString(), element.Text);
+            }
+
+            repeater.ItemTemplate = dataTemplate2;
+            Content.UpdateLayout();
+
+            // The old elements have been recycled but still parented under this repeater.
+            Verify.AreEqual(numItems * 2, VisualTreeHelper.GetChildrenCount(repeater));
+            for (int i = 0; i < numItems; i++)
+            {
+                var element = (Button)repeater.TryGetElement(i);
+                Verify.AreEqual(i.ToString(), element.Content);
+            }
+        }
+
         private ItemsRepeaterScrollHost CreateAndInitializeRepeater(
             object itemsSource,
-            VirtualizingLayout layout,
+            Layout layout,
             object elementFactory,
             ref ItemsRepeater repeater)
         {
@@ -453,7 +513,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             {
                 Width = 400,
                 Height = 400,
-                ScrollViewer = new ScrollViewer()
+                ScrollViewer = new Windows.UI.Xaml.Controls.ScrollViewer()
                 {
                     Content = repeater
                 }

--- a/dev/Repeater/APITests/Repeater_APITests.projitems
+++ b/dev/Repeater/APITests/Repeater_APITests.projitems
@@ -41,7 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RepeaterFocusTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RepeaterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SelectionModelTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)ElementFactoryTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ItemTemplateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewManagerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewportTests.cs" />
   </ItemGroup>

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -536,7 +536,7 @@ void ItemsRepeater::OnItemTemplateChanged(const winrt::IElementFactory& oldValue
     }
 
     // Since the ItemTemplate has changed, we need to re-evaluate all the items that
-    // have already been created and are now in the tree. The easist way to do that
+    // have already been created and are now in the tree. The easiest way to do that
     // would be to do a reset.. Note that this has to be done before we change the template
     // so that the cleared elements go back into the old template.
     if (auto layout = Layout())


### PR DESCRIPTION
When the item template changes, we should refresh all the items so that they get the new template.