### PR TITLE
Enabling tests on OneCore

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -575,6 +575,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AnimatedVisualPlayer_Intera
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AnimatedVisualPlayer_TestUI", "dev\AnimatedVisualPlayer\TestUI\AnimatedVisualPlayer_TestUI.shproj", "{DBEC0BE4-BA3F-41C9-A303-AF98201BE6DC}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "CommonStyles_APITests", "dev\CommonStyles\APITests\CommonStyles_APITests.shproj", "{BA914F48-E924-4FD2-AEE1-264F67DB6C9F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		dev\ParallaxView\TestUI\ParallaxView_TestUI.projitems*{00c52fd5-42fd-33b4-84a0-795c9b5a014d}*SharedItemsImports = 13
@@ -725,6 +727,7 @@ Global
 		dev\TreeView\TestUI\TreeView_TestUI.projitems*{b2c714dd-9c6b-400c-9cef-13a2d48378bd}*SharedItemsImports = 13
 		dev\AnimatedVisualPlayer\AnimatedVisualPlayer.vcxitems*{b39300d2-4510-44ea-aa7b-eda9118f830e}*SharedItemsImports = 9
 		dev\SwipeControl\SwipeControl_APITests\SwipeControl_APITests.projitems*{b75d5d7e-6986-4500-972e-2c10a9b7cc10}*SharedItemsImports = 13
+		dev\CommonStyles\APITests\CommonStyles_ApiTests.projitems*{ba914f48-e924-4fd2-aee1-264f67db6c9f}*SharedItemsImports = 13
 		dev\Interactions\SliderInteraction\InteractionTests\SliderInteraction_InteractionTests.projitems*{bbbb0add-4e05-430c-9ffd-08a299fd1b06}*SharedItemsImports = 13
 		dev\SwipeControl\SwipeControl_TestUI\SwipeControl_TestUI.projitems*{bc75c32b-f63a-4f2d-902c-8142db31a2e7}*SharedItemsImports = 13
 		dev\PullToRefresh\RefreshVisualizer\TestUI\RefreshVisualizer_TestUI.projitems*{bf236ee7-b31d-4150-a777-2b91492a84e2}*SharedItemsImports = 13
@@ -1403,8 +1406,8 @@ Global
 		{D5C2B2A0-50AF-4ACE-939D-17D1ED79FD6F} = {2B730830-19E8-4FB1-BC23-EFDBDACED64B}
 		{2EF860E2-8766-41FC-BDE2-E6B18BB8C206} = {2B730830-19E8-4FB1-BC23-EFDBDACED64B}
 		{FB0D3053-3135-403F-B542-977F3B781673} = {D3327F36-E161-4FED-A0F4-56F2B735827E}
-		{A7F6D6C4-A5A9-43EB-930C-B766417A5E5C} = {5654F115-F01A-495B-91C7-09408ABF14F0}
-		{A25AE312-7C11-4E30-AE35-2E31C744A250} = {5654F115-F01A-495B-91C7-09408ABF14F0}
+		{A7F6D6C4-A5A9-43EB-930C-B766417A5E5C} = {807E57C8-F3E8-4049-AB88-BE3D3285B441}
+		{A25AE312-7C11-4E30-AE35-2E31C744A250} = {807E57C8-F3E8-4049-AB88-BE3D3285B441}
 		{D232C226-CD18-4509-B848-80083AA9892B} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
 		{E770A6D3-7252-4E8A-BD10-FA8524DF8C83} = {D232C226-CD18-4509-B848-80083AA9892B}
 		{833A6892-A079-469A-81C7-54D4CD88029B} = {D232C226-CD18-4509-B848-80083AA9892B}
@@ -1441,6 +1444,7 @@ Global
 		{B39300D2-4510-44EA-AA7B-EDA9118F830E} = {80CCA53D-4A82-4F9F-A825-4FA3718C2AE0}
 		{CBAACCF6-A27D-40B3-980B-ADF51A2EBB89} = {80CCA53D-4A82-4F9F-A825-4FA3718C2AE0}
 		{DBEC0BE4-BA3F-41C9-A303-AF98201BE6DC} = {80CCA53D-4A82-4F9F-A825-4FA3718C2AE0}
+		{BA914F48-E924-4FD2-AEE1-264F67DB6C9F} = {807E57C8-F3E8-4049-AB88-BE3D3285B441}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D93836AB-52D3-4DE2-AE25-23F26F55ECED}

--- a/dev/AnimatedVisualPlayer/InteractionTests/AnimatedVisualPlayerTests.cs
+++ b/dev/AnimatedVisualPlayer/InteractionTests/AnimatedVisualPlayerTests.cs
@@ -43,7 +43,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/AnimatedVisualPlayer/InteractionTests/AnimatedVisualPlayerTests.cs
+++ b/dev/AnimatedVisualPlayer/InteractionTests/AnimatedVisualPlayerTests.cs
@@ -42,8 +42,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
-        [TestProperty("DEPControlsTestSuite", "SuiteB")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
+        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
+++ b/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
@@ -461,7 +461,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -43,7 +43,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
@@ -39,7 +39,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/CommonManaged/PlatformConfiguration.cs
+++ b/dev/CommonManaged/PlatformConfiguration.cs
@@ -14,7 +14,8 @@ namespace Common
     public enum DeviceType
     {
         Desktop,
-        Phone
+        Phone,
+        OneCore
     }
 
     public enum OSVersion : ushort
@@ -64,6 +65,10 @@ namespace Common
                 return true;
             }
             else if (type == DeviceType.Phone && deviceFamily == "Windows.Mobile")
+            {
+                return true;
+            }
+            else if (type == DeviceType.OneCore && deviceFamily != "Windows.Desktop" && deviceFamily != "Windows.Mobile")
             {
                 return true;
             }

--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -59,6 +59,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     public class CommonStylesVisualTreeTestSamples
     {
         [TestMethod]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")] // The default theme is different on OneCore, leading to a test failure.
         public void VerifyVisualTreeForAppBarAndAppBarToggleButton()
         {
             if (!PlatformConfiguration.IsOsVersion(OSVersion.Redstone5))
@@ -127,6 +128,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")] // The default theme is different on OneCore, leading to a test failure.
         public void VerifyVisualTreeExampleWithCustomerFilter()
         {
             if (!PlatformConfiguration.IsOsVersion(OSVersion.Redstone5))
@@ -144,6 +146,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")] // The default theme is different on OneCore, leading to a test failure.
         public void VerifyVisualTreeExampleWithCustomerPropertyValueTranslator()
         {
             if (!PlatformConfiguration.IsOsVersion(OSVersion.Redstone5))

--- a/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
+++ b/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
+++ b/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
@@ -37,7 +37,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/DropDownButton/InteractionTests/DropDownButtonTests.cs
+++ b/dev/DropDownButton/InteractionTests/DropDownButtonTests.cs
@@ -123,7 +123,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/DropDownButton/InteractionTests/DropDownButtonTests.cs
+++ b/dev/DropDownButton/InteractionTests/DropDownButtonTests.cs
@@ -122,7 +122,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/Interactions/ButtonInteraction/InteractionTests/ButtonInteractionTests.cs
+++ b/dev/Interactions/ButtonInteraction/InteractionTests/ButtonInteractionTests.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/Interactions/SliderInteraction/InteractionTests/SliderInteractionTests.cs
+++ b/dev/Interactions/SliderInteraction/InteractionTests/SliderInteractionTests.cs
@@ -54,7 +54,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/LayoutPanel/APITests/LayoutPanelTests.cs
+++ b/dev/LayoutPanel/APITests/LayoutPanelTests.cs
@@ -46,7 +46,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
         [ClassInitialize]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
         public static void ClassInitialize(TestContext context) { }
 
         [TestInitialize]

--- a/dev/Materials/Acrylic/InteractionTests/AcrylicBrushTests.cs
+++ b/dev/Materials/Acrylic/InteractionTests/AcrylicBrushTests.cs
@@ -52,7 +52,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         [TestProperty("MUXControlsTestEnabledForPhone", "True")]
         public static void ClassInitialize(TestContext testContext)
@@ -150,7 +150,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
 
         [TestMethod]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void HideAndShowWindow()
         {
             if (!OnRS2OrGreater()) { return; }

--- a/dev/Materials/Acrylic/InteractionTests/AcrylicBrushTests.cs
+++ b/dev/Materials/Acrylic/InteractionTests/AcrylicBrushTests.cs
@@ -53,7 +53,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         [TestProperty("MUXControlsTestEnabledForPhone", "True")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
+++ b/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         [TestProperty("MUXControlsTestEnabledForPhone", "True")]
         public static void ClassInitialize(TestContext testContext)

--- a/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
+++ b/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
@@ -43,7 +43,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         [TestProperty("MUXControlsTestEnabledForPhone", "True")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
+++ b/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
+++ b/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
@@ -39,7 +39,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         [TestProperty("MUXControlsTestEnabledForPhone", "True")]
         [TestProperty("NavViewTestSuite", "A")]

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -54,7 +54,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         [TestProperty("MUXControlsTestEnabledForPhone", "True")]
         [TestProperty("NavViewTestSuite", "A")]
         public static void ClassInitialize(TestContext testContext)

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewXamlIslandsTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewXamlIslandsTests.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext, TestType.WPFXAMLIsland); 

--- a/dev/ParallaxView/InteractionTests/ParallaxViewTests.cs
+++ b/dev/ParallaxView/InteractionTests/ParallaxViewTests.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MinVersion", "RS1")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/PersonPicture/InteractionTests/PersonPictureTests.cs
+++ b/dev/PersonPicture/InteractionTests/PersonPictureTests.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/PullToRefresh/RefreshContainer/InteractionTests/RefreshContainerTests.cs
+++ b/dev/PullToRefresh/RefreshContainer/InteractionTests/RefreshContainerTests.cs
@@ -37,7 +37,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -40,7 +40,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
+++ b/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
+++ b/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
@@ -39,7 +39,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/RatingControl/InteractionTests/RatingControlTests.cs
+++ b/dev/RatingControl/InteractionTests/RatingControlTests.cs
@@ -46,7 +46,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/ScrollViewer/InteractionTests/ScrollViewerTestsWithInputHelper.cs
+++ b/dev/ScrollViewer/InteractionTests/ScrollViewerTestsWithInputHelper.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/Scroller/InteractionTests/ScrollerTestsWithAutomationPeer.cs
+++ b/dev/Scroller/InteractionTests/ScrollerTestsWithAutomationPeer.cs
@@ -37,7 +37,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/Scroller/InteractionTests/ScrollerTestsWithInputHelper.cs
+++ b/dev/Scroller/InteractionTests/ScrollerTestsWithInputHelper.cs
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -39,7 +39,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
+++ b/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
@@ -50,7 +50,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
+++ b/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/TeachingTip/APITests/TeachingTipTests.cs
+++ b/dev/TeachingTip/APITests/TeachingTipTests.cs
@@ -33,6 +33,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     public class TeachingTipTests
     {
         [TestMethod]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")] // TeachingTip doesn't appear to show up correctly in OneCore.
         public void TeachingTipBackgroundTest()
         {
             var loadedEvent = new AutoResetEvent(false);

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -42,7 +42,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -37,7 +37,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("TreeViewTestSuite", "A")]
         public static void ClassInitialize(TestContext testContext)
         {
@@ -124,7 +124,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         // [TestMethod]
         // [TestProperty("TreeViewTestSuite", "A")]
-        // [TestProperty("Platform", "Desktop")]
+        // [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         // BUG: Multiple unreliable TreeView tests #131
         public void ExpandCollapseTest_NodeMode()
         {
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void ExpandCollapseTest_ContentMode()
         {
            ExpandCollapseTest(isContentMode:true);
@@ -198,7 +198,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void ExpandCollapseViaAutomationTest_NodeMode()
         {
             ExpandCollapseViaAutomationTest();
@@ -206,7 +206,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void ExpandCollapseViaAutomationTest_ContentMode()
         {
             ExpandCollapseViaAutomationTest(isContentMode:true);
@@ -238,7 +238,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewItemClickTest_NodeMode()
         {
             TreeViewItemClickTest();
@@ -246,7 +246,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewItemClickTest_ContentMode()
         {
             TreeViewItemClickTest(isContentMode:true);
@@ -254,7 +254,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void FlyoutTreeViewItemClickTest()
         {
             using (var setup = new TestSetupHelper("TreeView Tests"))
@@ -289,7 +289,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         // Regression test for bug 15801893
         public void FlyoutTreeViewItemTabTest()
         {
@@ -414,7 +414,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         //[TestMethod]
         //[TestProperty("TreeViewTestSuite", "A")]
-        //[TestProperty("Platform", "Desktop")]
+        //[TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         // BUG: Multiple unreliable TreeView tests #131
         public void TreeViewKeyDownLeftToRightTest_NodeMode()
         {
@@ -423,7 +423,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         // [TestMethod]
         // [TestProperty("TreeViewTestSuite", "A")]
-        // [TestProperty("Platform", "Desktop")]
+        // [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         // BUG: Multiple unreliable TreeView tests #131
         public void TreeViewKeyDownLeftToRightTest_ContentMode()
         {
@@ -549,7 +549,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewSelectedItemTest_NodeMode()
         {
             TreeViewSelectedItemTest();
@@ -557,7 +557,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewSelectedItemTest_ContentMode()
         {
             TreeViewSelectedItemTest(isContentMode:true);
@@ -595,7 +595,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewSwappingNodesTest_NodeMode()
         {
             TreeViewSwappingNodesTest();
@@ -603,7 +603,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewSwappingNodesTest_ContentMode()
         {
             TreeViewSwappingNodesTest(isContentMode:true);
@@ -651,7 +651,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewExpandingEventTest_NodeMode()
         {
             TreeViewExpandingEventTest();
@@ -659,7 +659,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewExpandingEventTest_ContentMode()
         {
             TreeViewExpandingEventTest(isContentMode:true);
@@ -739,7 +739,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewKeyboardReorderTest_NodeMode()
         {
             TreeViewKeyboardReorderTest();
@@ -747,7 +747,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewKeyboardReorderTest_ContentMode()
         {
             TreeViewKeyboardReorderTest(isContentMode:true);
@@ -947,7 +947,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewCollectionChangesEffectSelectedNodesTest_NodeMode()
         {
             TreeViewCollectionChangesEffectSelectedNodesTest();
@@ -955,7 +955,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "A")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewCollectionChangesEffectSelectedNodesTest_ContentMode()
         {
             TreeViewCollectionChangesEffectSelectedNodesTest(isContentMode:true);
@@ -1596,7 +1596,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewMultiSelectKeyboardingTest_NodeMode()
         {
             TreeViewMultiSelectKeyboardingTest();
@@ -1604,7 +1604,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewMultiSelectKeyboardingTest_ContentMode()
         {
             TreeViewMultiSelectKeyboardingTest(isContentMode:true);
@@ -1661,7 +1661,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewMultiSelectItemTest_NodeMode()
         {
             TreeViewMultiSelectItemTest();
@@ -1669,7 +1669,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewMultiSelectItemTest_ContentMode()
         {
             TreeViewMultiSelectItemTest(isContentMode:true);
@@ -1858,7 +1858,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewItemUIATest_NodeMode()
         {
             TreeViewItemUIATest();
@@ -1866,7 +1866,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewItemUIATest_ContentMode()
         {
             TreeViewItemUIATest(isContentMode:true);
@@ -1909,7 +1909,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void ValidateExpandingRaisedOnItemHavingUnrealizedChildren_NodeMode()
         {
             ValidateExpandingRaisedOnItemHavingUnrealizedChildren();
@@ -1917,7 +1917,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void ValidateExpandingRaisedOnItemHavingUnrealizedChildren_ContentMode()
         {
             ValidateExpandingRaisedOnItemHavingUnrealizedChildren(isContentMode:true);
@@ -2553,7 +2553,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TreeViewTestSuite", "B")]
-        [TestProperty("Platform", "Desktop")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         public void TreeViewNodeInMarkupTest()
         {
             using (var setup = new TestSetupHelper(new[] { "TreeView Tests", "TreeViewNodeInMarkupTestPage" }))

--- a/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
+++ b/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
@@ -67,7 +67,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
-        [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {
             TestEnvironment.Initialize(testContext);

--- a/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
+++ b/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
@@ -66,7 +66,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [ClassInitialize]
         [TestProperty("RunAs", "User")]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
         [TestProperty("MUXControlsTestSuite", "SuiteB")]
         public static void ClassInitialize(TestContext testContext)
         {

--- a/test/MUXControls.Test/Infra/TestEnvironment.cs
+++ b/test/MUXControls.Test/Infra/TestEnvironment.cs
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
         [TestProperty("MUXControlsTestEnabledForPhone", "False")]
         public static void AssemblyInitialize(TestContext testContext)
         {
-            if (PlatformConfiguration.IsDevice(DeviceType.Desktop))
+            if (!PlatformConfiguration.IsDevice(DeviceType.OneCore))
             {
                 // We need to make the process DPI aware so it properly handles scale factors other than 100%.
                 // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 only existed RS2 and up, so we'll fall back to

--- a/test/MUXControls.Test/Infra/TestEnvironment.cs
+++ b/test/MUXControls.Test/Infra/TestEnvironment.cs
@@ -107,15 +107,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
         [TestProperty("MUXControlsTestEnabledForPhone", "False")]
         public static void AssemblyInitialize(TestContext testContext)
         {
-            // We need to make the process DPI aware so it properly handles scale factors other than 100%.
-            // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 only existed RS2 and up, so we'll fall back to
-            // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE below RS2.
-            if (SetProcessDpiAwarenessContext(
-                PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone2) ?
-                    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 :
-                    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE) < 0)
+            if (PlatformConfiguration.IsDevice(DeviceType.Desktop))
             {
-                throw new Exception("Failed to set process DPI awareness context!  Error = " + Marshal.GetLastWin32Error());
+                // We need to make the process DPI aware so it properly handles scale factors other than 100%.
+                // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 only existed RS2 and up, so we'll fall back to
+                // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE below RS2.
+                if (SetProcessDpiAwarenessContext(
+                    PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone2) ?
+                        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 :
+                        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE) < 0)
+                {
+                    throw new Exception("Failed to set process DPI awareness context!  Error = " + Marshal.GetLastWin32Error());
+                }
             }
 
 #if USING_TAEF

--- a/test/MUXControls.Test/Infra/TestEnvironment.cs
+++ b/test/MUXControls.Test/Infra/TestEnvironment.cs
@@ -101,8 +101,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 #endif
         [TestProperty("RunFixtureAs:Assembly", "ElevatedUserOrSystem")]
         [TestProperty("Hosting:Mode", "UAP")]
-        // Default value for test metadata used to group tests 
-        [TestProperty("MUXControlsTestSuite", "SuiteA")]
         // Default value for tests is to not run on phone. Test Classes or Test Methods can override
         [TestProperty("MUXControlsTestEnabledForPhone", "False")]
         public static void AssemblyInitialize(TestContext testContext)

--- a/test/MUXControlsTestApp/App.xaml.cs
+++ b/test/MUXControlsTestApp/App.xaml.cs
@@ -53,6 +53,9 @@ namespace MUXControlsTestApp
 
             // Instantiate this very early to exercise MaterialHelper's ability to be instantiated before XAML has a dispatcher.
             MaterialHelperTestApi.IgnoreAreEffectsFast = true;
+
+            // OneCore has no splash screen, so we'll ignore the splash-screen requirement there.
+            _isSplashScreenDismissed = PlatformConfiguration.IsDevice(DeviceType.OneCore);
         }
 
         public Frame RootFrame

--- a/test/MUXControlsTestApp/TAEF/Package.Razzle.appxmanifest
+++ b/test/MUXControlsTestApp/TAEF/Package.Razzle.appxmanifest
@@ -7,6 +7,7 @@
     <DisplayName>MUXControlsTestApp</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
+    <uap:SupportedUsers>multiple</uap:SupportedUsers>
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10586.0" MaxVersionTested="10.0.20000.0" />

--- a/test/MUXControlsTestApp/TAEF/Package.VS.appxmanifest
+++ b/test/MUXControlsTestApp/TAEF/Package.VS.appxmanifest
@@ -6,6 +6,7 @@
     <DisplayName>MUXControlsTestApp</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
+    <uap:SupportedUsers>multiple</uap:SupportedUsers>
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10586.0" MaxVersionTested="10.0.20000.0" />

--- a/test/MUXControlsTestApp/ThemeResourcesTests.cs
+++ b/test/MUXControlsTestApp/ThemeResourcesTests.cs
@@ -42,7 +42,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     {
         [ClassInitialize]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
         public static void Setup(TestContext context) { }
 
         [TestMethod]

--- a/test/MUXControlsTestApp/WaitForDebugger.cs
+++ b/test/MUXControlsTestApp/WaitForDebugger.cs
@@ -23,26 +23,33 @@ namespace MUXControlsTestApp
     {
         [AssemblyInitialize]
         [TestProperty("Classification", "Integration")]
-        [TestProperty("Platform", "Any")]
         public static void AssemblyInitialize(TestContext testContext)
         {
+            try
+            {
 #if USING_TAEF
-            if (testContext.Properties.Contains("WaitForDebugger") || testContext.Properties.Contains("WaitForAppDebugger"))
+                if (testContext.Properties.Contains("WaitForDebugger") || testContext.Properties.Contains("WaitForAppDebugger"))
 #else
             if (testContext.Properties.ContainsKey("WaitForDebugger") || testContext.Properties.ContainsKey("WaitForAppDebugger"))
 #endif
-            {
-                var processId = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
-                var waitEvent = new AutoResetEvent(false);
-
-                while (!System.Diagnostics.Debugger.IsAttached)
                 {
-                    Log.Comment(string.Format("Waiting for a debugger to attach (processId = {0})...", processId));
-                    Windows.System.Threading.ThreadPoolTimer.CreateTimer((timer) => { waitEvent.Set(); }, TimeSpan.FromSeconds(1));
-                    waitEvent.WaitOne();
-                }
+                    var processId = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
+                    var waitEvent = new AutoResetEvent(false);
 
-                System.Diagnostics.Debugger.Break();
+                    while (!System.Diagnostics.Debugger.IsAttached)
+                    {
+                        Log.Comment(string.Format("Waiting for a debugger to attach (processId = {0})...", processId));
+                        Windows.System.Threading.ThreadPoolTimer.CreateTimer((timer) => { waitEvent.Set(); }, TimeSpan.FromSeconds(1));
+                        waitEvent.WaitOne();
+                    }
+
+                    System.Diagnostics.Debugger.Break();
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error("Oh noes: " + e.ToString());
+                throw;
             }
         }
     }

--- a/test/MUXControlsTestApp/WaitForDebugger.cs
+++ b/test/MUXControlsTestApp/WaitForDebugger.cs
@@ -25,31 +25,23 @@ namespace MUXControlsTestApp
         [TestProperty("Classification", "Integration")]
         public static void AssemblyInitialize(TestContext testContext)
         {
-            try
-            {
 #if USING_TAEF
-                if (testContext.Properties.Contains("WaitForDebugger") || testContext.Properties.Contains("WaitForAppDebugger"))
+            if (testContext.Properties.Contains("WaitForDebugger") || testContext.Properties.Contains("WaitForAppDebugger"))
 #else
             if (testContext.Properties.ContainsKey("WaitForDebugger") || testContext.Properties.ContainsKey("WaitForAppDebugger"))
 #endif
-                {
-                    var processId = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
-                    var waitEvent = new AutoResetEvent(false);
-
-                    while (!System.Diagnostics.Debugger.IsAttached)
-                    {
-                        Log.Comment(string.Format("Waiting for a debugger to attach (processId = {0})...", processId));
-                        Windows.System.Threading.ThreadPoolTimer.CreateTimer((timer) => { waitEvent.Set(); }, TimeSpan.FromSeconds(1));
-                        waitEvent.WaitOne();
-                    }
-
-                    System.Diagnostics.Debugger.Break();
-                }
-            }
-            catch (Exception e)
             {
-                Log.Error("Oh noes: " + e.ToString());
-                throw;
+                var processId = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
+                var waitEvent = new AutoResetEvent(false);
+
+                while (!System.Diagnostics.Debugger.IsAttached)
+                {
+                    Log.Comment(string.Format("Waiting for a debugger to attach (processId = {0})...", processId));
+                    Windows.System.Threading.ThreadPoolTimer.CreateTimer((timer) => { waitEvent.Set(); }, TimeSpan.FromSeconds(1));
+                    waitEvent.WaitOne();
+                }
+
+                System.Diagnostics.Debugger.Break();
             }
         }
     }


### PR DESCRIPTION
These are changes required for us to run our tests on OneCore.  The changes can be summarized as follows:

- We should not be using the Platform test property, as that's deprecated, and any test annotated with that property will not run on OneCore.  Instead, we should use TestPass:IncludeOnlyOn to restrict to specific platforms.
- Interaction tests currently have an issue where they can't retrieve the correct UIA root.  For now, only API tests will run on OneCore.
- SetProcessDpiAwarenessContext is not implemented on OneCore, so I've changed things not to call it there.
- OneCore also does not have splash screens, so I've changed things so we don't wait for the splash screen to be dismissed there.
- Finally, OneCore requires test apps to be multi-user applications when run without a logged-in user, so I changed our test app accordingly.