### PR TITLE
Stop installing SDK in Nuget creation job

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -49,9 +49,6 @@ jobs:
   - template: MUX-InstallNuget-Steps.yml
 
   - ${{if parameters.signConfig }}:
-    # Install SDK since the custom appx generation needs to resolve winmd types from it.
-    - template: MUX-InstallWindowsSDK-Steps.yml
-
     # Re-create framework packages because we made them in the build step against unsigned binaries.
     - template: MUX-MakeFrameworkPackages-Steps.yml
 

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -62,7 +62,7 @@ Write-Verbose "Copying $inputBasePath\Themes"
 Copy-IntoNewDirectory -IfExists $inputBasePath\Themes $fullOutputPath\PackageContents\Microsoft.UI.Xaml
 
 [xml]$sdkPropsContent = Get-Content $PSScriptRoot\..\..\sdkversion.props
-$highestSdkVersion = $sdkPropsContent.GetElementsByTagName("*").'#text' -match "10." | Sort-Object | Select-Object -Last 1
+$highestSdkVersion = ($sdkPropsContent.SelectNodes("//*[contains(local-name(), 'SDKVersion')]") | Where-Object { -not $_.ToString().Contains("Insider")} | Select-Object -Last 1).'#text'
 $sdkReferencesPath=$kitsRoot10 + "References\" + $highestSdkVersion;    
 $foundationWinmdPath = Get-ChildItem -Recurse $sdkReferencesPath"\Windows.Foundation.FoundationContract" -Filter "Windows.Foundation.FoundationContract.winmd" | Select-Object -ExpandProperty FullName
 $universalWinmdPath = Get-ChildItem -Recurse $sdkReferencesPath"\Windows.Foundation.UniversalApiContract" -Filter "Windows.Foundation.UniversalApiContract.winmd" | Select-Object -ExpandProperty FullName


### PR DESCRIPTION
PackageES folks complained that we were installing the insider SDK on shared agents. I was doing this out of convenience but we don't actually need the insider SDK to do the framework package job (17763 is good enough), so I'm just pulling out the latest non-insider SDK version and using that instead.