### PR TITLE
Make consistency behaviour when clicking on a unselected item or clicking on a selected item

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1324,10 +1324,7 @@ void NavigationView::ChangeSelection(const winrt::IInspectable& prevItem, const 
 
             AnimateSelectionChanged(prevItem, nextActualItem);
 
-            if (IsPaneOpen() && DisplayMode() != winrt::NavigationViewDisplayMode::Expanded)
-            {
-                ClosePane();
-            }
+            ClosePaneIfNeccessaryAfterItemIsClicked();
         }
     }
 }
@@ -1348,6 +1345,8 @@ void NavigationView::OnItemClick(const winrt::IInspectable& /*sender*/, const wi
     if (!m_shouldIgnoreNextSelectionChange && DoesSelectedItemContainContent(clickedItem, itemContainer) && !IsSelectionSuppressed(selectedItem))
     {
         RaiseItemInvoked(selectedItem, false /*isSettings*/, itemContainer);
+
+        ClosePaneIfNeccessaryAfterItemIsClicked();
     }
 }
 
@@ -3226,6 +3225,14 @@ void NavigationView::OnTitleBarMetricsChanged(const winrt::IInspectable& /*sende
 void NavigationView::OnTitleBarIsVisibleChanged(const winrt::CoreApplicationViewTitleBar& /*sender*/, const winrt::IInspectable& /*args*/)
 {
     UpdateTitleBarPadding();
+}
+
+void NavigationView::ClosePaneIfNeccessaryAfterItemIsClicked()
+{
+    if (IsPaneOpen() && DisplayMode() != winrt::NavigationViewDisplayMode::Expanded)
+    {
+        ClosePane();
+    }
 }
 
 bool NavigationView::ShouldIgnoreMeasureOverride()

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -80,6 +80,7 @@ public:
     void CoerceToGreaterThanZero(double& value);
 
 private:
+    void ClosePaneIfNeccessaryAfterItemIsClicked();
     bool ShouldIgnoreMeasureOverride();
     bool NeedTopPaddingForRS5OrHigher(winrt::CoreApplicationViewTitleBar const& coreTitleBar);
     void OnAccessKeyInvoked(winrt::IInspectable const& sender, winrt::AccessKeyInvokedEventArgs const& args);

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -127,6 +127,47 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("NavViewTestSuite", "A")]
+        public void VerifyPaneIsClosedWhenClickingOnSelectedItem()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+            {
+                var displayModeTextBox = new TextBlock(FindElement.ByName("DisplayModeTextBox"));
+                var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+
+                Log.Comment("Test PaneDisplayMode=LeftMinimal");
+                panelDisplayModeComboBox.SelectItemByName("LeftMinimal");
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+
+                Log.Comment("Click on ToggleButton");
+                Button navButton = new Button(FindElement.ById("TogglePaneButton"));
+                navButton.Invoke();
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
+
+                Log.Comment("Select Apps");
+                UIObject appsItem = FindElement.ByName("Apps");
+                appsItem.Click();
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+
+                Log.Comment("Click on ToggleButton");
+                navButton.Invoke();
+                Wait.ForIdle();
+
+                Log.Comment("Click on SelectedItem Apps");
+                appsItem.Click();
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "A")]
         public void PaneDisplayModeLeftLeftCompactLeftMinimalTest()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))


### PR DESCRIPTION
Fix #573 
NavigationView has different logic for clicking on a selected item and click on unselected item.
We try to close the pane when clicking on unselected item which is implemented in ChangeSelection.
When clicked on a selected item, ChangeSelection is not called, but we have special logic in OnItemClick to know about it and raise ItemInvoked event to customer.
This fix would try to close pane for both cases, so I extract the code to ClosePaneIfNeccessaryAfterItemIsClicked, and call it in both ChangeSelection and OnItemClick.
