### PR TITLE
Allow multiple projects references the MUX and projects theirselves have reference relatationship

### DIFF
--- a/build/FrameworkPackage/CustomizedPriConfig/pri.resfiles
+++ b/build/FrameworkPackage/CustomizedPriConfig/pri.resfiles
@@ -1,0 +1,1 @@
+Microsoft.UI.Xaml\DensityStyles\Compact.xaml

--- a/build/FrameworkPackage/CustomizedPriConfig/priconfig.xml
+++ b/build/FrameworkPackage/CustomizedPriConfig/priconfig.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<resources targetOsVersion="10.0.0" majorVersion="1">
+  <index root="\" startIndexAt="pri.resfiles">
+    <default>
+      <qualifier name="Language" value="en-US" />
+      <qualifier name="Contrast" value="standard" />
+      <qualifier name="Scale" value="200" />
+      <qualifier name="HomeRegion" value="001" />
+      <qualifier name="TargetSize" value="256" />
+      <qualifier name="LayoutDirection" value="LTR" />
+      <qualifier name="DXFeatureLevel" value="DX9" />
+      <qualifier name="Configuration" value="" />
+      <qualifier name="AlternateForm" value="" />
+      <qualifier name="Platform" value="UAP" />
+    </default>
+    <indexer-config type="resfiles" qualifierDelimiter="."/>
+    <indexer-config type="PRI"/>
+  </index>
+</resources>

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -228,9 +228,9 @@ $compactxaml =
 "@
 Set-Content -Value $compactxaml $DensityStylesDir\Compact.xaml
 
-# generate CustomizedPri
+# generate CustomizedPri, the file name should be $inputBaseFileName.pri, otherwise vs will not pick it up.
 $priConfigPath = [IO.Path]::GetFullPath("$CustomizedPriDir\priconfig.xml")
-$priOutputPath = [IO.Path]::GetFullPath("$CustomizedPriDir\CustomizedPri.pri")
+$priOutputPath = [IO.Path]::GetFullPath("$CustomizedPriDir\$inputBaseFileName.pri")
 
 $makepriNew = "`"" + (Join-Path $WindowsSdkBinDir "makepri.exe") + "`" new /pr $CustomizedPriDir /cf $priConfigPath /of $priOutputPath /in $inputBaseFileName /o"
 Write-Host $makepriNew

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -120,13 +120,5 @@
       <SubType>Designer</SubType>
       <Link>Microsoft.UI.Xaml\Themes\generic.xaml</Link>
     </Page>
-  </ItemGroup>
-  
-  <!-- Make this URI works in framework package "ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" -->
-  <ItemGroup>
-    <Page Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml">
-      <SubType>Designer</SubType>
-      <Link>Microsoft.UI.Xaml\DensityStyles\Compact.xaml</Link>
-    </Page>
-  </ItemGroup>
+  </ItemGroup>  
 </Project>

--- a/build/NuSpecs/MUXControls.nuspec
+++ b/build/NuSpecs/MUXControls.nuspec
@@ -33,7 +33,5 @@
 
     <!-- This is here for C++ based projects, see http://nugetdocsbeta.azurewebsites.net/ndocs/guides/create-uwp-packages -->
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-Native.targets"/>
-
-    <file target="build\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Compact.xaml"/>
   </files>
 </package>

--- a/build/NuSpecs/MUXControls.nuspec
+++ b/build/NuSpecs/MUXControls.nuspec
@@ -33,5 +33,7 @@
 
     <!-- This is here for C++ based projects, see http://nugetdocsbeta.azurewebsites.net/ndocs/guides/create-uwp-packages -->
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-Native.targets"/>
+
+    <file target="build\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Compact.xaml"/>
   </files>
 </package>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -23,6 +23,7 @@
     <file target="lib\uap10.0\Design" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\Microsoft.UI.Xaml.Design\Microsoft.UI.Xaml.design.dll"/>
 
     <file target="lib\uap10.0\Microsoft.UI.Xaml\Themes" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\Microsoft.UI.Xaml\Generic.xaml"/>
+    <file target="lib\uap10.0" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\CustomizedPri\CustomizedPri.pri"/>
 
     <file target="tools" src="$TOOLSDIR$\**\*.*"/>
 
@@ -33,6 +34,5 @@
     <file target="build\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-FrameworkPackage.targets"/>
     <file target="build\rs1_themes\generic.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\rs1_themes_generic.xaml"/>
-    <file target="build\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Compact.xaml"/>
   </files>
 </package>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -23,7 +23,8 @@
     <file target="lib\uap10.0\Design" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\Microsoft.UI.Xaml.Design\Microsoft.UI.Xaml.design.dll"/>
 
     <file target="lib\uap10.0\Microsoft.UI.Xaml\Themes" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\Microsoft.UI.Xaml\Generic.xaml"/>
-    <file target="lib\uap10.0" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\CustomizedPri\CustomizedPri.pri"/>
+    <file target="lib\uap10.0" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\CustomizedPri\Microsoft.UI.Xaml.pri"/>
+    <file target="lib\uap10.0\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Microsoft.UI.Xaml\DensityStyles\Compact.xaml"/>
 
     <file target="tools" src="$TOOLSDIR$\**\*.*"/>
 

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -24,7 +24,7 @@
 
     <file target="lib\uap10.0\Microsoft.UI.Xaml\Themes" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\Microsoft.UI.Xaml\Generic.xaml"/>
     <file target="lib\uap10.0" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\CustomizedPri\Microsoft.UI.Xaml.pri"/>
-    <file target="lib\uap10.0\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Microsoft.UI.Xaml\DensityStyles\Compact.xaml"/>
+    <file target="lib\uap10.0\Microsoft.UI.Xaml\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Microsoft.UI.Xaml\DensityStyles\Compact.xaml"/>
 
     <file target="tools" src="$TOOLSDIR$\**\*.*"/>
 


### PR DESCRIPTION
Fix #599

To support compact, I injected a to the project for framework package. It introduced problem in _ComputeAppxPackagePayload if more than two projects are references the microsoft.ui.xaml and the two projects have reference relationship too.
For example, we have two projects: C# xUnit project and C# project:
C# xUnit project reference MUX nuget, it copied Compact.xaml to obj and compiled it.
C# project reference MUX nuget, it copied Compact.xaml again.
C# xUnit project reference C# project.
When compile C# xUnit project, _ComputeAppxPackagePayload aggregate Compact.xaml from both project in target _ComputeAppxPackagePayload, and task RemoveDuplicates detects this conflicts.

I have another implementation which removed Page from the .target and replaced it with .pri.