### PR TITLE
Update ItemsSource when TreeViewNode changes

### DIFF
--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -705,7 +705,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(Key.Down, ModifierKey.Alt | ModifierKey.Shift);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0", ReadResult());
 
                 InputHelper.Tap(ItemRoot);
 
@@ -713,7 +713,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(Key.Up, ModifierKey.Alt | ModifierKey.Shift);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0", ReadResult());
 
                 InputHelper.Tap(ItemRoot);
 
@@ -723,7 +723,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(Key.Down, ModifierKey.Alt | ModifierKey.Shift);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0", ReadResult());
 
                 InputHelper.Tap(ItemRoot);
 
@@ -733,7 +733,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("4", ReadResult());
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.2 | Root.0", ReadResult());
             }
         }
 
@@ -796,7 +796,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("3", ReadResult());
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2", ReadResult());
             }
         }
 
@@ -857,7 +857,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.DragDistance(dragUIObject, distance, Direction.South);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2", ReadResult());
 
                 ClickButton("GetItemCount");
                 Verify.AreEqual("4", ReadResult());
@@ -1015,7 +1015,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("2", ReadResult());
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.2 | Root.0 | Root.1 | ", ReadResult());
+                Verify.AreEqual("Root | Root.2 | Root.0 | Root.1", ReadResult());
             }
         }
 
@@ -1084,7 +1084,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.DragDistance(dragUIObject, distance, Direction.South);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.2 | Root.0 | Root.1 | ", ReadResult());
+                Verify.AreEqual("Root | Root.2 | Root.0 | Root.1", ReadResult());
 
                 ClickButton("GetItemCount");
                 Verify.AreEqual("4", ReadResult());
@@ -1149,7 +1149,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.DragDistance(dragUIObject, distance, Direction.South);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2", ReadResult());
 
                 ClickButton("GetItemCount");
                 Verify.AreEqual("4", ReadResult());
@@ -1231,7 +1231,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.DragDistance(dragUIObject, distance, Direction.South);
 
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.1.1 | Root.0 | Root.0.0 | Root.1.0 | Root.1.2 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.1.1 | Root.0 | Root.0.0 | Root.1.0 | Root.1.2 | Root.2", ReadResult());
                 Wait.ForIdle();
 
                 ClickButton("GetItemCount");
@@ -2173,7 +2173,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 ClickButton("LabelItems");
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2", ReadResult());
 
                 ClickButton("DisableItemReorder");
 
@@ -2191,7 +2191,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 ClickButton("GetChildrenOrder");
                 // Verify nodes are still in the same order
-                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2", ReadResult());
 
                 Log.Comment("Verify cannot drag onto a node");
                 // Drag Root.0 onto Root.1
@@ -2200,7 +2200,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 ClickButton("GetChildrenOrder");
                 // Verify nodes are still in the same order
-                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2", ReadResult());
             }
         }
 
@@ -2229,7 +2229,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 ClickButton("LabelItems");
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.0 | Root.1 | Root.2", ReadResult());
 
                 ClickButton("DisableClickToExpand");
 
@@ -2240,7 +2240,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.Tap(root0);
                 KeyboardHelper.PressKey(Key.Down, ModifierKey.Alt | ModifierKey.Shift);
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2", ReadResult());
 
                 ClickButton("DisableItemReorder");
 
@@ -2248,7 +2248,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.Tap(root0);
                 KeyboardHelper.PressKey(Key.Down, ModifierKey.Alt | ModifierKey.Shift);
                 ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2 | ", ReadResult());
+                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2", ReadResult());
             }
         }
 

--- a/dev/TreeView/TestUI/TreeViewPage.xaml.cs
+++ b/dev/TreeView/TestUI/TreeViewPage.xaml.cs
@@ -285,7 +285,7 @@ namespace MUXControlsTestApp
                 }
                 else
                 {
-                    Results.Text = "ItemsSourceOrder: " + itemsSourceOrder + "; TreeViewNodeOrder: " + treeViewNodeOrder;
+                    Results.Text = $"ItemsSourceOrder: {itemsSourceOrder}; TreeViewNodeOrder: {treeViewNodeOrder}";
                 }
             }
             else

--- a/dev/TreeView/TestUI/TreeViewPage.xaml.cs
+++ b/dev/TreeView/TestUI/TreeViewPage.xaml.cs
@@ -234,13 +234,16 @@ namespace MUXControlsTestApp
             while (pendingNodes.Count > 0)
             {
                 var currentNode = pendingNodes.Pop();
-                var children = currentNode.Children;
-                var size = children.Count;
+                var size = currentNode.Children.Count;
                 for (int i = 0; i < size; i++)
                 {
                     pendingNodes.Push(currentNode.Children[size - 1 - i]);
                 }
-                sb.Append(GetNodeContent(currentNode) + " | ");
+                if (sb.Length > 0)
+                {
+                    sb.Append(" | ");
+                }
+                sb.Append(GetNodeContent(currentNode));
             }
 
             return sb.ToString();
@@ -254,13 +257,16 @@ namespace MUXControlsTestApp
             while (pendingItems.Count > 0)
             {
                 var currentItem = pendingItems.Pop();
-                var children = currentItem.Children;
-                var size = children.Count;
+                var size = currentItem.Children.Count;
                 for (int i = 0; i < size; i++)
                 {
                     pendingItems.Push(currentItem.Children[size - 1 - i]);
                 }
-                sb.Append(currentItem.Content + " | ");
+                if (sb.Length > 0)
+                {
+                    sb.Append(" | ");
+                }
+                sb.Append(currentItem.Content);
             }
 
             return sb.ToString();
@@ -273,7 +279,7 @@ namespace MUXControlsTestApp
                 var itemsSourceOrder = GetItemsSourceOrder();
                 var treeViewNodeOrder = GetRootNodeChildrenOrder(ContentModeTestTreeView);
                 // Make sure ItemsSource and TreeViewNode orders are in sync
-                if(itemsSourceOrder == treeViewNodeOrder)
+                if (itemsSourceOrder == treeViewNodeOrder)
                 {
                     Results.Text = itemsSourceOrder;
                 }

--- a/dev/TreeView/TestUI/TreeViewPage.xaml.cs
+++ b/dev/TreeView/TestUI/TreeViewPage.xaml.cs
@@ -226,7 +226,7 @@ namespace MUXControlsTestApp
             return node.Content.ToString();
         }
 
-        private void GetRootNodeChildrenOrder(TreeView tree)
+        private String GetRootNodeChildrenOrder(TreeView tree)
         {
             StringBuilder sb = new StringBuilder();
             Stack<TreeViewNode> pendingNodes = new Stack<TreeViewNode>();
@@ -243,18 +243,48 @@ namespace MUXControlsTestApp
                 sb.Append(GetNodeContent(currentNode) + " | ");
             }
 
-            Results.Text = sb.ToString();
+            return sb.ToString();
+        }
+
+        private String GetItemsSourceOrder()
+        {
+            StringBuilder sb = new StringBuilder();
+            Stack<TreeViewItemSource> pendingItems = new Stack<TreeViewItemSource>();
+            pendingItems.Push(TestTreeViewItemsSource[0]);
+            while (pendingItems.Count > 0)
+            {
+                var currentItem = pendingItems.Pop();
+                var children = currentItem.Children;
+                var size = children.Count;
+                for (int i = 0; i < size; i++)
+                {
+                    pendingItems.Push(currentItem.Children[size - 1 - i]);
+                }
+                sb.Append(currentItem.Content + " | ");
+            }
+
+            return sb.ToString();
         }
 
         private void GetChildrenOrder_Click(object sender, RoutedEventArgs e)
         {
             if(IsInContentMode())
             {
-                GetRootNodeChildrenOrder(ContentModeTestTreeView);
+                var itemsSourceOrder = GetItemsSourceOrder();
+                var treeViewNodeOrder = GetRootNodeChildrenOrder(ContentModeTestTreeView);
+                // Make sure ItemsSource and TreeViewNode orders are in sync
+                if(itemsSourceOrder == treeViewNodeOrder)
+                {
+                    Results.Text = itemsSourceOrder;
+                }
+                else
+                {
+                    Results.Text = "ItemsSourceOrder: " + itemsSourceOrder + "; TreeViewNodeOrder: " + treeViewNodeOrder;
+                }
             }
             else
             {
-                GetRootNodeChildrenOrder(TestTreeView);
+                Results.Text = GetRootNodeChildrenOrder(TestTreeView);
             }
         }
 

--- a/dev/TreeView/TreeView.cpp
+++ b/dev/TreeView/TreeView.cpp
@@ -232,7 +232,7 @@ void TreeView::OnItemsAdded(int index, int count)
         auto item = m_itemsDataSource.GetAt(i);
         auto node = winrt::make_self<TreeViewNode>();
         node->Content(item);
-        winrt::get_self<TreeViewNodeVector>(RootNodes())->InsertAtCore(index, *node);
+        winrt::get_self<TreeViewNodeVector>(RootNodes())->InsertAt(index, *node, false);
     }
 }
 
@@ -240,7 +240,7 @@ void TreeView::OnItemsRemoved(int index, int count)
 {
     for (int i = 0; i < count; i++)
     {
-        winrt::get_self<TreeViewNodeVector>(RootNodes())->RemoveAtCore(index);
+        winrt::get_self<TreeViewNodeVector>(RootNodes())->RemoveAt(index, false);
     }
 }
 
@@ -254,7 +254,7 @@ void TreeView::SyncRootNodesWithItemsSource()
     }
 
     auto children = winrt::get_self<TreeViewNodeVector>(RootNodes());
-    children->ClearCore();
+    children->Clear();
 
     if (m_itemsDataSource)
     {
@@ -265,7 +265,7 @@ void TreeView::SyncRootNodesWithItemsSource()
             auto node = winrt::make_self<TreeViewNode>();
             node->IsContentMode(true);
             node->Content(item);
-            children->AppendCore(*node);
+            children->Append(*node, false);
         }
     }
 }

--- a/dev/TreeView/TreeView.cpp
+++ b/dev/TreeView/TreeView.cpp
@@ -254,7 +254,7 @@ void TreeView::SyncRootNodesWithItemsSource()
     }
 
     auto children = winrt::get_self<TreeViewNodeVector>(RootNodes());
-    children->Clear();
+    children->Clear(false /* updateItemsSource */);
 
     if (m_itemsDataSource)
     {

--- a/dev/TreeView/TreeView.cpp
+++ b/dev/TreeView/TreeView.cpp
@@ -232,7 +232,7 @@ void TreeView::OnItemsAdded(int index, int count)
         auto item = m_itemsDataSource.GetAt(i);
         auto node = winrt::make_self<TreeViewNode>();
         node->Content(item);
-        winrt::get_self<TreeViewNodeVector>(RootNodes())->InsertAt(index, *node, false);
+        winrt::get_self<TreeViewNodeVector>(RootNodes())->InsertAt(index, *node, false /* updateItemsSource */);
     }
 }
 
@@ -240,7 +240,7 @@ void TreeView::OnItemsRemoved(int index, int count)
 {
     for (int i = 0; i < count; i++)
     {
-        winrt::get_self<TreeViewNodeVector>(RootNodes())->RemoveAt(index, false);
+        winrt::get_self<TreeViewNodeVector>(RootNodes())->RemoveAt(index, false /* updateItemsSource */);
     }
 }
 
@@ -265,7 +265,7 @@ void TreeView::SyncRootNodesWithItemsSource()
             auto node = winrt::make_self<TreeViewNode>();
             node->IsContentMode(true);
             node->Content(item);
-            children->Append(*node, false);
+            children->Append(*node, false /* updateItemsSource */);
         }
     }
 }

--- a/dev/TreeView/TreeViewItem.cpp
+++ b/dev/TreeView/TreeViewItem.cpp
@@ -87,7 +87,7 @@ void TreeViewItem::OnDrop(winrt::DragEventArgs const& e)
                         if (treeViewList->IsFlatIndexValid(nodeIndex))
                         {
                             treeViewList->RemoveNodeFromParent(node);
-                            winrt::get_self<TreeViewNodeVector>(droppedOnNode.Children())->AppendCore(node);
+                            winrt::get_self<TreeViewNodeVector>(droppedOnNode.Children())->Append(node);
                         }
                     }
 
@@ -104,10 +104,10 @@ void TreeViewItem::OnDrop(winrt::DragEventArgs const& e)
 
                     if (droppedNode != droppedOnNode)
                     {
-                        winrt::get_self<TreeViewNodeVector>(droppedNode.Parent().Children())->RemoveAtCore(removeIndex);
+                        winrt::get_self<TreeViewNodeVector>(droppedNode.Parent().Children())->RemoveAt(removeIndex);
 
                         // Append the dragged dropped item as a child of the node it was dropped onto
-                        winrt::get_self<TreeViewNodeVector>(droppedOnNode.Children())->AppendCore(droppedNode);
+                        winrt::get_self<TreeViewNodeVector>(droppedOnNode.Children())->Append(droppedNode);
 
                         // If not set to true then the Reorder code of listview will override what is being done here.
                         args.Handled(true);
@@ -558,8 +558,8 @@ void TreeViewItem::ReorderItems(const winrt::ListView& listControl, const winrt:
 
     auto parentNode = targetNode.Parent();
     auto children = winrt::get_self<TreeViewNodeVector>(parentNode.Children());
-    children->RemoveAtCore(childIndex);
-    children->InsertAtCore(childIndex + positionModifier, targetNode);
+    children->RemoveAt(childIndex);
+    children->InsertAt(childIndex + positionModifier, targetNode);
     listControl.UpdateLayout();
 
     auto treeView = AncestorTreeView();

--- a/dev/TreeView/TreeViewList.cpp
+++ b/dev/TreeView/TreeViewList.cpp
@@ -120,9 +120,9 @@ void TreeViewList::OnDrop(winrt::DragEventArgs const& e)
     {
         if (m_draggedTreeViewNode && IsIndexValid(m_emptySlotIndex))
         {
-
             // Get the node at which we will insert
             winrt::TreeViewNode insertAtNode = NodeAtFlatIndex(m_emptySlotIndex);
+
             if (IsMutiSelectWithSelectedItems())
             {
                 // Multiselect drag and drop. In the selected items, find all the selected subtrees 
@@ -133,61 +133,12 @@ void TreeViewList::OnDrop(winrt::DragEventArgs const& e)
                 // Loop through in reverse order because we are inserting above the previous item to get the order correct.
                 for (int i = static_cast<int>(selectedRootNodes.size()) - 1; i >= 0; --i)
                 {
-                    auto node = selectedRootNodes[i];
-                    int nodeFlatIndex = FlatIndex(node);
-                    if (IsFlatIndexValid(nodeFlatIndex))
-                    {
-                        RemoveNodeFromParent(node);
-
-                        int insertOffset = (((int)nodeFlatIndex) < m_emptySlotIndex) ? 1 : 0;
-                        int insertNodeIndexInParent = IndexInParent(insertAtNode);
-                        // if the insertAtNode is a parent that is expanded
-                        // insert as the first child
-                        if (insertAtNode.IsExpanded() && insertOffset == 1)
-                        {
-                            winrt::get_self<TreeViewNodeVector>(insertAtNode.Children())->InsertAtCore(0, node);
-                        }
-                        else
-                        {
-                            // Add the item to the new parent (parent of the insertAtNode)
-                            winrt::get_self<TreeViewNodeVector>(insertAtNode.Parent().Children())->InsertAtCore(insertNodeIndexInParent + insertOffset, node);
-                        }
-                    }
+                    MoveNodeInto(selectedRootNodes[i], insertAtNode);
                 }
             }
             else
             {
-                winrt::TreeViewNode draggedNode = m_draggedTreeViewNode.get();
-                if (insertAtNode != draggedNode)
-                {
-                    uint32_t relativeIndex = 0;
-                    unsigned int draggedIndex;
-
-                    winrt::TreeViewNode tvi = m_draggedTreeViewNode.get();
-                    auto returnBool = ListViewModel()->IndexOfNode(tvi, draggedIndex);
-                    const int insertOffset = (((int)draggedIndex) < m_emptySlotIndex) ? 1 : 0;
-
-                    {
-                        // Remove the item from its current parent
-                        auto children = winrt::get_self<TreeViewNodeVector>(draggedNode.Parent().Children());
-                        children->IndexOf(draggedNode, relativeIndex);
-                        children->RemoveAtCore(relativeIndex);
-                    }
-
-                    // if the insertAtNode is a parent that is expanded
-                    // insert as the first child
-                    if (insertAtNode.IsExpanded() && insertOffset == 1)
-                    {
-                        winrt::get_self<TreeViewNodeVector>(insertAtNode.Children())->InsertAtCore(0, draggedNode);
-                    }
-                    else
-                    {
-                        // Add the item to the new parent (parent of the insertAtNode)
-                        auto children = winrt::get_self<TreeViewNodeVector>(insertAtNode.Parent().Children());
-                        children->IndexOf(insertAtNode, relativeIndex);
-                        children->InsertAtCore(relativeIndex + insertOffset, draggedNode);
-                    }
-                }
+                MoveNodeInto(m_draggedTreeViewNode.get(), insertAtNode);
             }
 
             UpdateDropTargetDropEffect(false, false, nullptr);
@@ -196,6 +147,30 @@ void TreeViewList::OnDrop(winrt::DragEventArgs const& e)
     }
 
     __super::OnDrop(e);
+}
+
+void TreeViewList::MoveNodeInto(winrt::TreeViewNode const& node, winrt::TreeViewNode const& insertAtNode)
+{
+    int nodeFlatIndex = FlatIndex(node);
+    if (insertAtNode != node && IsFlatIndexValid(nodeFlatIndex))
+    {
+        RemoveNodeFromParent(node);
+
+        int insertOffset = nodeFlatIndex < m_emptySlotIndex ? 1 : 0;
+        // if the insertAtNode is a parent that is expanded
+        // insert as the first child
+        if (insertAtNode.IsExpanded() && insertOffset == 1)
+        {
+            winrt::get_self<TreeViewNodeVector>(insertAtNode.Children())->InsertAt(0, node);
+        }
+        else
+        {
+            // Add the item to the new parent (parent of the insertAtNode)
+            auto children = winrt::get_self<TreeViewNodeVector>(insertAtNode.Parent().Children());
+            int insertNodeIndexInParent = IndexInParent(insertAtNode);
+            children->InsertAt(insertNodeIndexInParent + insertOffset, node);
+        }
+    }
 }
 
 void TreeViewList::OnDragOver(winrt::DragEventArgs const& args)
@@ -568,7 +543,7 @@ unsigned int TreeViewList::RemoveNodeFromParent(const winrt::TreeViewNode& node)
     auto children = winrt::get_self<TreeViewNodeVector>(node.Parent().Children());
     if (children->IndexOf(node, indexInParent))
     {
-        children->RemoveAtCore(indexInParent);
+        children->RemoveAt(indexInParent);
     }
 
     return indexInParent;

--- a/dev/TreeView/TreeViewList.h
+++ b/dev/TreeView/TreeViewList.h
@@ -58,6 +58,7 @@ private:
     unsigned int IndexInParent(const winrt::TreeViewNode& node);
     winrt::TreeViewNode NodeAtFlatIndex(int index) const;
     winrt::TreeViewNode GetRootOfSelection(const winrt::TreeViewNode& node) const;
+    void MoveNodeInto(winrt::TreeViewNode const& node, winrt::TreeViewNode const& insertAtNode);
 
     tracker_ref<winrt::TreeViewItem> m_draggedOverItem{ this };
     winrt::hstring m_dropTargetDropEffectString;

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -229,7 +229,7 @@ void TreeViewNode::OnItemsRemoved(int index, int count)
 void TreeViewNode::SyncChildrenNodesWithItemsSource()
 {
     auto children = winrt::get_self<TreeViewNodeVector>(Children());
-    children->Clear();
+    children->Clear(false /* updateItemsSource */);
 
     if (m_itemsDataSource)
     {
@@ -386,14 +386,14 @@ void TreeViewNodeVector::RemoveAtEnd(bool updateItemsSource)
     RemoveAt(updateItemsSource);
 }
 
-void TreeViewNodeVector::ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values)
+void TreeViewNodeVector::ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values, bool updateItemsSource)
 {
     auto inner = GetVectorInnerImpl();
 
     auto count = inner->Size();
     if (count > 0)
     {
-        Clear();
+        Clear(updateItemsSource);
 
         auto itemsSource = GetWritableParentItemsSource();
         // Set parent on new elements
@@ -411,7 +411,7 @@ void TreeViewNodeVector::ReplaceAll(winrt::array_view<winrt::TreeViewNode const>
     }
 }
 
-void TreeViewNodeVector::Clear()
+void TreeViewNodeVector::Clear(bool updateItemsSource)
 {
     auto inner = GetVectorInnerImpl();
     auto count = inner->Size();

--- a/dev/TreeView/TreeViewNode.h
+++ b/dev/TreeView/TreeViewNode.h
@@ -107,21 +107,14 @@ public:
     TreeViewNodeVector(unsigned int capacity);
 
     void SetParent(winrt::TreeViewNode value);
-    void AppendCore(winrt::TreeViewNode const& item);
-    void InsertAtCore(unsigned int index, winrt::TreeViewNode const& item);
-    void SetAtCore(unsigned int index, winrt::TreeViewNode const& item);   
-    void RemoveAtCore(unsigned int index);
-    void RemoveAtEndCore();
-    void ReplaceAllCore(winrt::array_view<winrt::TreeViewNode const> values);
-    void ClearCore(); 
 
-    void Append(winrt::TreeViewNode const& item);   
-    void InsertAt(unsigned int index, winrt::TreeViewNode const& item);
-    void SetAt(unsigned int index, winrt::TreeViewNode const& item);   
-    void RemoveAt(unsigned int index);    
-    void RemoveAtEnd();
+    void Append(winrt::TreeViewNode const& item, bool updateItemsSource = true);   
+    void InsertAt(unsigned int index, winrt::TreeViewNode const& item, bool updateItemsSource = true);
+    void SetAt(unsigned int index, winrt::TreeViewNode const& item, bool updateItemsSource = true);   
+    void RemoveAt(unsigned int index, bool updateItemsSource = true);
+    void RemoveAtEnd(bool updateItemsSource = true);
     void ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values);    
     void Clear();
+    winrt::IBindableVector GetParentItemsSource();
+    TreeViewNode* Parent();
 };
-
-void throwIllegalMethodCallException();

--- a/dev/TreeView/TreeViewNode.h
+++ b/dev/TreeView/TreeViewNode.h
@@ -115,6 +115,6 @@ public:
     void SetAt(unsigned int index, winrt::TreeViewNode const& item, bool updateItemsSource = true);   
     void RemoveAt(unsigned int index, bool updateItemsSource = true);
     void RemoveAtEnd(bool updateItemsSource = true);
-    void ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values);    
-    void Clear();
+    void ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values, bool updateItemsSource = true);    
+    void Clear(bool updateItemsSource = true);
 };

--- a/dev/TreeView/TreeViewNode.h
+++ b/dev/TreeView/TreeViewNode.h
@@ -106,7 +106,9 @@ public:
     TreeViewNodeVector();
     TreeViewNodeVector(unsigned int capacity);
 
+    TreeViewNode* Parent();
     void SetParent(winrt::TreeViewNode value);
+    winrt::IBindableVector GetWritableParentItemsSource();
 
     void Append(winrt::TreeViewNode const& item, bool updateItemsSource = true);   
     void InsertAt(unsigned int index, winrt::TreeViewNode const& item, bool updateItemsSource = true);
@@ -115,6 +117,4 @@ public:
     void RemoveAtEnd(bool updateItemsSource = true);
     void ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values);    
     void Clear();
-    winrt::IBindableVector GetParentItemsSource();
-    TreeViewNode* Parent();
 };


### PR DESCRIPTION
Fixes #556 

TreeView currently doesn't update ItemsSource when the underlying TreeViewNode structure changes. In content mode (when using databinding in TreeView), we deny all the external TreeViewNode updates by throwing an exception. Some internal fucntions (InsertAtCore, RemoveAtCore, etc) were created so we can update TreeViewNode states internally (for drag&drop) without triggering exceptions. But those inernal updates only changes TreeViewNode, which makes ItemsSource and TreeViewNode out of sync.

This change makes TreeView update ItemsSource when TreeViewNode changes. The exception and special internal functions are removed since TreeViewNode changes will be reflected to ItemsSource correctly, there's no need to deny external node changes now.

There are bunch of existing drag&drop tests that covers this 'TreeViewNode change triggers ItemsSource change' scenario. Updated GetChildrenOrder function to make sure we compare both TreeViewNode and ItemsSource orders for content mode tests.