### PR TITLE
Exclude compact.xbf from package if it belongs to other project

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -92,6 +92,7 @@
     
   <PropertyGroup>
     <XamlWinmdName>Microsoft.UI.Xaml.winmd</XamlWinmdName>
+    <XamlCompactXbfName>Microsoft.UI.Xaml\DensityStyles\Compact.xbf</XamlCompactXbfName>
   </PropertyGroup>
   <Target Name="_FixWinmdCopyLocal" AfterTargets="ResolveNuGetPackageAssets">
     <ItemGroup>
@@ -113,6 +114,15 @@
     </ItemGroup>
   </Target>
 
+  <!-- Workaround for https://github.com/Microsoft/microsoft-ui-xaml/issues/599. Exclude Compact.xbf which is not in this project -->
+  <Target Name="_FixXamlCompactXbfPackaging" BeforeTargets="_ComputeAppxPackagePayload">
+    <ItemGroup>
+      <XamlCompactXbfPackagingOutput Include="@(PackagingOutputs)" Condition="'%(PackagingOutputs.TargetPath)' == '$(XamlCompactXbfName)' and '%(PackagingOutputs.ProjectName)' != '$(MSBuildProjectName)'" />
+    </ItemGroup>
+    <ItemGroup Condition="'@(XamlCompactXbfPackagingOutput)' != ''">
+      <PackagingOutputs Remove="@(XamlCompactXbfPackagingOutput)" />
+    </ItemGroup>
+  </Target>
 
   <!-- Workaround for apps that need RS1 support, include this only if min version is RS1 -->
   <ItemGroup Condition="($([System.Version]::Parse('$(TargetPlatformMinVersion)').Build) &lt; 15063) And '$(DisableMicrosoftUIXamlRS1ThemesWorkaround)'==''">

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -212,6 +212,11 @@ void TeachingTip::CreateLightDismissIndicatorPopup()
     if (!m_lightDismissIndicatorPopup)
     {
         auto popup = winrt::Popup();
+        // Set XamlRoot on the popup to handle XamlIsland/AppWindow scenarios.
+        if (winrt::IUIElement10 uiElement10 = *this)
+        {
+            popup.XamlRoot(uiElement10.XamlRoot());
+        }
         // A Popup needs contents to open, so set a child that doesn't do anything.
         auto grid = winrt::Grid();
         popup.Child(grid);
@@ -790,6 +795,12 @@ void TeachingTip::OnIsOpenChanged()
         if (!m_popup || m_createNewPopupOnOpen)
         {
             auto popup = winrt::Popup();
+            // Set XamlRoot on the popup to handle XamlIsland/AppWindow scenarios.
+            if (winrt::IUIElement10 uiElement10 = *this)
+            {
+                popup.XamlRoot(uiElement10.XamlRoot());
+            }
+
             m_popupOpenedRevoker = popup.Opened(winrt::auto_revoke, { this, &TeachingTip::OnPopupOpened });
             m_popupClosedRevoker = popup.Closed(winrt::auto_revoke, { this, &TeachingTip::OnPopupClosed });
             if (auto&& popup3 = popup.try_as<winrt::Controls::Primitives::IPopup3>())

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTests.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTests.cs
@@ -45,5 +45,16 @@ namespace MUXControls.ReleaseTest
                 Verify.AreEqual(textBlock.DocumentText, "Loaded");
             }
         }
+
+        [TestMethod]
+        public void CompactDictionaryTest()
+        {
+            using (var setup = new TestSetupHelper("CompactDictionary Tests"))
+            {
+                var textBlock = new TextBlock(FindElement.ByName("CompactTextBox"));
+                Verify.IsNotNull(textBlock);
+                Verify.AreEqual(textBlock.BoundingRectangle.Height, 24);
+            }
+        }
     }
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -104,6 +104,9 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TestPages\CompactDictionaryTestPage.xaml.cs">
+      <DependentUpon>CompactDictionaryTestPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="TestPages\PullToRefreshTestPage.xaml.cs">
       <DependentUpon>PullToRefreshTestPage.xaml</DependentUpon>
     </Compile>
@@ -134,6 +137,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="TestPages\CompactDictionaryTestPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="TestPages\PullToRefreshTestPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestInventory.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestInventory.cs
@@ -12,7 +12,8 @@ namespace NugetPackageTestApp
         {
             Tests = new List<TestDeclaration>
             {
-                new TestDeclaration("PullToRefresh Tests", typeof(PullToRefreshTestPage))
+                new TestDeclaration("PullToRefresh Tests", typeof(PullToRefreshTestPage)),
+                new TestDeclaration("CompactDictionary Tests", typeof(CompactDictionaryTestPage))
             };
         }
 

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/CompactDictionaryTestPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/CompactDictionaryTestPage.xaml
@@ -1,0 +1,20 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<utils:TestPage
+    x:Class="NugetPackageTestApp.CompactDictionaryTestPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:NugetPackageTestApp"
+    xmlns:utils="using:MUXControlsTestApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.Resources>
+            <ResourceDictionary Source="ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" />
+        </Grid.Resources>
+
+        <TextBox Text="" AutomationProperties.Name="CompactTextBox"/>
+    </Grid>
+</utils:TestPage>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/CompactDictionaryTestPage.xaml.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/CompactDictionaryTestPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MUXControlsTestApp;
+
+namespace NugetPackageTestApp
+{
+    public sealed partial class CompactDictionaryTestPage : TestPage
+    {
+        public CompactDictionaryTestPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Fix #599
To support compact, I injected a to the project for framework package. It introduced problem in _ComputeAppxPackagePayload if more than two projects are references the microsoft.ui.xaml and the two projects have reference relationship too.
For example, we have two projects: C# xUnit project and C# project:
C# xUnit project reference MUX nuget, it copied Compact.xaml to obj and compiled it.
C# project reference MUX nuget, it copied Compact.xaml again.
C# xUnit project reference C# project.
When compile C# xUnit project, _ComputeAppxPackagePayload aggregate Compact.xaml from both project in target _ComputeAppxPackagePayload, and task RemoveDuplicates detects this conflicts.

This just exclude the compact.xbf from packaging if it's matching with the MSBuildProjectName