### PR TITLE
Fix test cleanup failures

### DIFF
--- a/test/MUXControlsTestApp/Utilities/TestHelpers.cs
+++ b/test/MUXControlsTestApp/Utilities/TestHelpers.cs
@@ -129,7 +129,7 @@ namespace MUXControlsTestApp.Utilities
                 if (rootElement != null
                 // In MUXControlsTestApp.App.TestContentRoot setter, we set the content to MainPage if value is null.
                 // Therefore UnloadedEvent will never be triggered if rootElement type is MainPage, no need to add event here.
-                && rootElement.GetType() != typeof(MainPage))
+                && !(rootElement is MainPage))
                 {
                     rootElement.Unloaded += (sender, args) => unloadedEvent.Set();
                 }

--- a/test/MUXControlsTestApp/Utilities/TestHelpers.cs
+++ b/test/MUXControlsTestApp/Utilities/TestHelpers.cs
@@ -126,7 +126,10 @@ namespace MUXControlsTestApp.Utilities
             {
                 FrameworkElement rootElement = MUXControlsTestApp.App.TestContentRoot as FrameworkElement;
 
-                if (rootElement != null)
+                if (rootElement != null
+                // In MUXControlsTestApp.App.TestContentRoot setter, we set the content to MainPage if value is null.
+                // Therefore UnloadedEvent will never be triggered if rootElement type is MainPage, no need to add event here.
+                && rootElement.GetType() != typeof(MainPage))
                 {
                     rootElement.Unloaded += (sender, args) => unloadedEvent.Set();
                 }


### PR DESCRIPTION
CommandBarFlyoutTests.VerifyFlyoutDefaultPropertyValues and ScrollViewerTests.VerifyDefaultPropertyValues hang waiting for the Unloaded event.

https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=11864&view=ms.vss-test-web.build-test-results-tab

Updated ClearVisualTreeRoot to fix the issue, more details in code comment.