### PR TITLE
Add RaisePropertyChanged for ToggleState call to ToggleSplitButton

### DIFF
--- a/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -227,7 +227,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("Unchecked", toggleStateOnClickTextBlock.DocumentText);
 
                 Log.Comment("Click primary button to check button");
-                ClickPrimaryButton(splitButton);
+                using (var toggleStateWaiter = new PropertyChangedEventWaiter(splitButton, Scope.Element, UIProperty.Get("Toggle.ToggleState")))
+                {
+                    ClickPrimaryButton(splitButton);
+                    Verify.IsTrue(toggleStateWaiter.TryWait(TimeSpan.FromSeconds(1)), "Waiting for the Toggle.ToggleState event should succeed");
+                }
 
                 Verify.AreEqual("Checked", toggleStateTextBlock.DocumentText);
                 Verify.AreEqual("Checked", toggleStateOnClickTextBlock.DocumentText);

--- a/dev/SplitButton/ToggleSplitButton.cpp
+++ b/dev/SplitButton/ToggleSplitButton.cpp
@@ -42,6 +42,13 @@ void ToggleSplitButton::OnIsCheckedChanged()
     {
         auto eventArgs = winrt::make_self<ToggleSplitButtonIsCheckedChangedEventArgs>();
         m_isCheckedChangedEventSource(*this, *eventArgs);
+
+        if (auto peer = winrt::FrameworkElementAutomationPeer::FromElement(*this))
+        {
+            auto newValue = IsChecked() ? winrt::ToggleState::On : winrt::ToggleState::Off;
+            auto oldValue = (newValue == winrt::ToggleState::On) ? winrt::ToggleState::Off : winrt::ToggleState::On;
+            peer.RaisePropertyChangedEvent(winrt::TogglePatternIdentifiers::ToggleStateProperty(), box_value(oldValue), box_value(newValue));
+        }
     }
 
     UpdateVisualStates();


### PR DESCRIPTION
Narrator is not announcing toggle state changes on ToggleSplitButton because it's not raising the UIA event. Add it here and add a test.