### PR TITLE
avoid reading index property on args during reset.

### DIFF
--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -249,7 +249,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 {
                     get
                     {
-                        if(CollectionChange == CollectionChange.Reset)
+                        if (CollectionChange == CollectionChange.Reset)
                         {
                             // C++/CX observable collection fails if accessing index 
                             // when the args is for a Reset, so emulating that behavior here.

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml.Controls;
 using Common;
+using System;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -242,7 +243,27 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             private class WinRTVectorChangedEventArgs : IVectorChangedEventArgs
             {
                 public CollectionChange CollectionChange { get; private set; }
-                public uint Index { get; private set; }
+
+                private uint _index;
+                public uint Index
+                {
+                    get
+                    {
+                        if(CollectionChange == CollectionChange.Reset)
+                        {
+                            // C++/CX observable collection fails if accessing index 
+                            // when the args is for a Reset, so emulating that behavior here.
+                            throw new InvalidOperationException();
+                        }
+
+                        return _index;
+                    }
+
+                    private set
+                    {
+                        _index = value;
+                    }
+                }
 
                 public WinRTVectorChangedEventArgs(CollectionChange change, int index)
                 {

--- a/dev/Repeater/InspectingDataSource.cpp
+++ b/dev/Repeater/InspectingDataSource.cpp
@@ -195,7 +195,6 @@ void InspectingDataSource::OnVectorChanged(
     // Also note that we do not access the data - we just add nullptr. We just 
     // need the count.
 
-    const auto index = static_cast<int>(e.Index());
     winrt::NotifyCollectionChangedAction action{};
     int oldStartingIndex = -1;
     int newStartingIndex = -1;
@@ -207,18 +206,18 @@ void InspectingDataSource::OnVectorChanged(
     {
     case winrt::Collections::CollectionChange::ItemInserted:
         action = winrt::NotifyCollectionChangedAction::Add;
-        newStartingIndex = index;
+        newStartingIndex = static_cast<int>(e.Index());
         newItems.Append(nullptr);
         break;
     case winrt::Collections::CollectionChange::ItemRemoved:
         action = winrt::NotifyCollectionChangedAction::Remove;
-        oldStartingIndex = index;
+        oldStartingIndex = static_cast<int>(e.Index());
         oldItems.Append(nullptr);
         break;
     case winrt::Collections::CollectionChange::ItemChanged:
         action = winrt::NotifyCollectionChangedAction::Replace;
-        oldStartingIndex = index;
-        newStartingIndex = index;
+        oldStartingIndex = static_cast<int>(e.Index());
+        newStartingIndex = oldStartingIndex;
         newItems.Append(nullptr);
         oldItems.Append(nullptr);
         break;


### PR DESCRIPTION
C++/CX observable vector throws if you try to read the index property during a reset event. So avoid reading the property. 

Fixes #607