### PR TITLE
Fixing a spacing issue that is tied to orientation

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -136,16 +136,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         canvas.Children.Add(panel);
                         Content = canvas;
                         Content.UpdateLayout();
-                        int minItemSpacing = 0;
-                        int lineSpacing = 0;
-                        ValidateGridLayoutChildrenLayoutBounds(om, (i) => panel.Children[i], itemMinorSize, itemMajorSize, minItemSpacing, lineSpacing, panel.Children.Count, panel.DesiredSize);
+                        int minRowSpacing = 0;
+                        int minColumnSpacing = 0;
+                        ValidateGridLayoutChildrenLayoutBounds(om, (i) => panel.Children[i], itemMinorSize, itemMajorSize, minRowSpacing, minColumnSpacing, panel.Children.Count, panel.DesiredSize);
 
-                        minItemSpacing = 5;
-                        lineSpacing = 10;
-                        ((UniformGridLayout)panel.Layout).MinRowSpacing = lineSpacing ;
-                        ((UniformGridLayout)panel.Layout).MinColumnSpacing = minItemSpacing;
+                        minRowSpacing = 5;
+                        minColumnSpacing = 10;
+                        ((UniformGridLayout)panel.Layout).MinRowSpacing = minRowSpacing;
+                        ((UniformGridLayout)panel.Layout).MinColumnSpacing = minColumnSpacing;
                         Content.UpdateLayout();
-                        ValidateGridLayoutChildrenLayoutBounds(om, (i) => panel.Children[i], itemMinorSize, itemMajorSize, minItemSpacing, lineSpacing, panel.Children.Count, panel.DesiredSize);
+                        ValidateGridLayoutChildrenLayoutBounds(om, (i) => panel.Children[i], itemMinorSize, itemMajorSize, minRowSpacing, minColumnSpacing, panel.Children.Count, panel.DesiredSize);
                     }
                 }
             });
@@ -1245,13 +1245,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             Func<int, UIElement> elementAtIndexFunc,
             double itemMinorSize,
             double itemMajorSize,
-            double minItemSpacing,
-            double lineSpacing,
+            double minRowSpacing,
+            double minColumnSpacing,
             int childCount,
             Size desiredSize)
         {
             var expectedRect = om.MinorMajorRect(0, 0, itemMinorSize, itemMajorSize);
             double extentMajor = 0;
+            var minItemSpacing = om.ScrollOrientation == ScrollOrientation.Vertical ? minColumnSpacing : minRowSpacing;
+            var lineSpacing = om.ScrollOrientation == ScrollOrientation.Vertical ? minRowSpacing : minColumnSpacing;
+
             for (int i = 0; i < childCount; i++)
             {
                 var child = (FrameworkElement)elementAtIndexFunc(i);
@@ -1384,8 +1387,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         break;
 
                     case LayoutChoice.Grid:
-
-                        layout = new UniformGridLayout() { MinItemWidth = itemSize, MinItemHeight = itemSize, MinRowSpacing = lineSpacing };
+                        var minRowSpacing = om.ScrollOrientation == ScrollOrientation.Vertical ? lineSpacing : 0;
+                        var minColumnSpacing = om.ScrollOrientation == ScrollOrientation.Horizontal ? lineSpacing : 0;
+                        layout = new UniformGridLayout() { MinItemWidth = itemSize, MinItemHeight = itemSize, MinRowSpacing = minRowSpacing, MinColumnSpacing = minColumnSpacing };
                         break;
 
                     case LayoutChoice.Flow:

--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -140,10 +140,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         int lineSpacing = 0;
                         ValidateGridLayoutChildrenLayoutBounds(om, (i) => panel.Children[i], itemMinorSize, itemMajorSize, minItemSpacing, lineSpacing, panel.Children.Count, panel.DesiredSize);
 
-                        minItemSpacing = 10;
+                        minItemSpacing = 5;
                         lineSpacing = 10;
-                        ((UniformGridLayout)panel.Layout).MinRowSpacing = minItemSpacing;
-                        ((UniformGridLayout)panel.Layout).MinColumnSpacing = lineSpacing;
+                        ((UniformGridLayout)panel.Layout).MinRowSpacing = lineSpacing ;
+                        ((UniformGridLayout)panel.Layout).MinColumnSpacing = minItemSpacing;
                         Content.UpdateLayout();
                         ValidateGridLayoutChildrenLayoutBounds(om, (i) => panel.Children[i], itemMinorSize, itemMajorSize, minItemSpacing, lineSpacing, panel.Children.Count, panel.DesiredSize);
                     }
@@ -1385,7 +1385,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                     case LayoutChoice.Grid:
 
-                        layout = new UniformGridLayout() { MinItemWidth = itemSize, MinItemHeight = itemSize, MinColumnSpacing = lineSpacing };
+                        layout = new UniformGridLayout() { MinItemWidth = itemSize, MinItemHeight = itemSize, MinRowSpacing = lineSpacing };
                         break;
 
                     case LayoutChoice.Flow:

--- a/dev/Repeater/UniformGridLayout.h
+++ b/dev/Repeater/UniformGridLayout.h
@@ -95,15 +95,13 @@ private:
 
     double LineSpacing()
     {
-        // ScrollOrientation is inverse of UniformGridLayout.Orientation
-        return ScrollOrientation() == ScrollOrientation::Horizontal ? m_minColumnSpacing : m_minRowSpacing;
+        return Orientation() == winrt::Orientation::Horizontal ? m_minRowSpacing: m_minColumnSpacing;
 
     }
 
     double MinItemSpacing()
     {
-        // ScrollOrientation is inverse of UniformGridLayout.Orientation
-        return ScrollOrientation() == ScrollOrientation::Horizontal ? m_minRowSpacing : m_minColumnSpacing;
+        return Orientation() == winrt::Orientation::Horizontal ? m_minColumnSpacing: m_minRowSpacing;
     }
 
     // Fields

--- a/dev/Repeater/UniformGridLayout.h
+++ b/dev/Repeater/UniformGridLayout.h
@@ -95,12 +95,15 @@ private:
 
     double LineSpacing()
     {
-        return ScrollOrientation() == ScrollOrientation::Vertical ? m_minColumnSpacing : m_minRowSpacing;
+        // ScrollOrientation is inverse of UniformGridLayout.Orientation
+        return ScrollOrientation() == ScrollOrientation::Horizontal ? m_minColumnSpacing : m_minRowSpacing;
+
     }
 
     double MinItemSpacing()
     {
-        return ScrollOrientation() == ScrollOrientation::Vertical ? m_minRowSpacing : m_minColumnSpacing;
+        // ScrollOrientation is inverse of UniformGridLayout.Orientation
+        return ScrollOrientation() == ScrollOrientation::Horizontal ? m_minRowSpacing : m_minColumnSpacing;
     }
 
     // Fields

--- a/dev/Repeater/UniformGridLayoutState.cpp
+++ b/dev/Repeater/UniformGridLayoutState.cpp
@@ -82,7 +82,7 @@ void UniformGridLayoutState::SetSize(
     m_effectiveItemHeight = (std::isnan(LayoutItemHeight) ? UIElement.DesiredSize().Height : LayoutItemHeight);
 
     auto availableSizeMinor = orientation == winrt::Orientation::Horizontal ? availableSize.Width : availableSize.Height;
-    auto minorItemSpacing = orientation == winrt::Orientation::Horizontal ? minRowSpacing : minColumnSpacing;
+    auto minorItemSpacing = orientation == winrt::Orientation::Vertical ? minRowSpacing : minColumnSpacing;
 
     auto itemSizeMinor = orientation == winrt::Orientation::Horizontal ? m_effectiveItemWidth : m_effectiveItemHeight;
     itemSizeMinor += minorItemSpacing;


### PR DESCRIPTION
A bit of confusion caused some unexpected behavior with the spacing properties. The MinRow and MinColumn spacing is supposed to be row and column spacing based on the orientation set on the layout. There is also a scroll orientation which is usually opposite of the orientation set on the layout. A bug caused the meaning of row/column to be flipped based on the orientation. 

Fixes #626
