### PR TITLE
Fix NuGet test in release pipeline

### DIFF
--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -121,7 +121,7 @@ jobs:
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
     dependsOn: CreateNugetPackage
-    useNupkgFromArtifacts: true
+    pkgArtifactPath: '$(artifactDownloadPath)\drop'
     matrix: 
       Debug_x86:
         buildPlatform: 'x86'


### PR DESCRIPTION
MUX-Release.yml is still using the old template parameter, update it to the latest.