### PR TITLE
Ensure that elements are refreshed when itemssource change when using non virtualizing layout

### DIFF
--- a/dev/Repeater/APITests/Common/CustomItemsSource.cs
+++ b/dev/Repeater/APITests/Common/CustomItemsSource.cs
@@ -39,11 +39,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 
             if (reset)
             {
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
             }
             else
             {
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                     NotifyCollectionChangedAction.Add,
                     oldStartingIndex: -1,
                     oldItemsCount: -1,
@@ -61,11 +61,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 
             if (reset)
             {
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
             }
             else
             {
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                     NotifyCollectionChangedAction.Remove,
                     oldStartingIndex: index,
                     oldItemsCount: count,
@@ -88,11 +88,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 
             if (reset)
             {
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
             }
             else
             {
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                     NotifyCollectionChangedAction.Replace,
                     oldStartingIndex: index,
                     oldItemsCount: oldCount,
@@ -115,14 +115,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 
             // something changed, but i don't want to tell you the 
             // exact changes 
-            OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+            OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
         }
 
         public new void Clear()
         {
             Inner.Clear();
             // something changed, but i don't want to tell you the exact changes 
-            OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+            OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
         }
 
         protected override int GetSizeCore()

--- a/dev/Repeater/APITests/Common/CustomItemsSourceView.cs
+++ b/dev/Repeater/APITests/Common/CustomItemsSourceView.cs
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
             throw new NotImplementedException();
         }
 
-        protected void OnDataSourceChanged(NotifyCollectionChangedEventArgs args)
+        protected void OnItemsSourceChanged(NotifyCollectionChangedEventArgs args)
         {
             CollectionChanged(this, args);
         }

--- a/dev/Repeater/APITests/Common/Mocks/MockItemsSource.cs
+++ b/dev/Repeater/APITests/Common/Mocks/MockItemsSource.cs
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks
                 }
             };
 
-            data.CollectionChanged += (s, e) => mock.OnDataSourceChanged(e);
+            data.CollectionChanged += (s, e) => mock.OnItemsSourceChanged(e);
 
             return mock;
         }
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks
 
             }
 
-            data.VectorChanged += (s, e) => mock.OnDataSourceChanged(e.ConvertToDataSourceChangedEventArgs());
+            data.VectorChanged += (s, e) => mock.OnItemsSourceChanged(e.ConvertToDataSourceChangedEventArgs());
 
             return mock;
         }
@@ -139,9 +139,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks
             _recordedKeyFromIndexCalls.Clear();
         }
 
-        public new void OnDataSourceChanged(NotifyCollectionChangedEventArgs args)
+        public new void OnItemsSourceChanged(NotifyCollectionChangedEventArgs args)
         {
-            base.OnDataSourceChanged(args);
+            base.OnItemsSourceChanged(args);
         }
 
         protected override int GetSizeCore()

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        public void ValidateSwitchignItemsSourceRefreshesElementsVirtualLayout()
+        public void ValidateSwitchingItemsSourceRefreshesElementsVirtualLayout()
         {
             ValidateSwitchingItemsSourceRefreshesElements(isVirtualLayout: true);
         }

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -140,7 +140,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 };
 
                 // By default we use stack layout that is virtualizing.
-                if(!isVirtualLayout)
+                if (!isVirtualLayout)
                 {
                     repeater.Layout = new NonVirtualStackLayout();
                 }

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -12,6 +12,8 @@ using Windows.Foundation.Collections;
 using Windows.UI.Xaml.Controls;
 using Common;
 using System;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -30,7 +32,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #endif
 
     [TestClass]
-    public class InspectingDataSourceTests
+    public class InspectingDataSourceTests: TestsBase
     {
         [TestMethod]
         public void CanCreateFromIBindableIterable()
@@ -111,6 +113,61 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.AreEqual(true, dataSource.HasKeyIndexMapping);
                 Verify.AreEqual(5, dataSource.IndexFromKey("5"));
                 Verify.AreEqual("5", dataSource.KeyFromIndex(5));
+            });
+        }
+
+        [TestMethod]
+        public void ValidateSwitchignItemsSourceRefreshesElementsNonVirtualLayout()
+        {
+            ValidateSwitchingItemsSourceRefreshesElements(isVirtualLayout: false);
+        }
+
+        [TestMethod]
+        public void ValidateSwitchignItemsSourceRefreshesElementsVirtualLayout()
+        {
+            ValidateSwitchingItemsSourceRefreshesElements(isVirtualLayout: true);
+        }
+
+        public void ValidateSwitchingItemsSourceRefreshesElements(bool isVirtualLayout)
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                ItemsRepeater repeater = null;
+                const int numItems = 10;
+
+                repeater = new ItemsRepeater() {
+                    ItemsSource = Enumerable.Range(0, numItems),
+                };
+
+                // By default we use stack layout that is virtualizing.
+                if(!isVirtualLayout)
+                {
+                    repeater.Layout = new NonVirtualStackLayout();
+                }
+
+                Content = new ItemsRepeaterScrollHost() {
+                    Width = 400,
+                    Height = 400,
+                    ScrollViewer = new Windows.UI.Xaml.Controls.ScrollViewer() {
+                        Content = repeater
+                    }
+                };
+
+                Content.UpdateLayout();
+                for (int i = 0; i < numItems; i++)
+                {
+                    var element = (TextBlock)repeater.TryGetElement(i);
+                    Verify.AreEqual(i.ToString(), element.Text);
+                }
+
+                repeater.ItemsSource = Enumerable.Range(20, numItems);
+                Content.UpdateLayout();
+
+                for (int i = 0; i < numItems; i++)
+                {
+                    var element = (TextBlock)repeater.TryGetElement(i);
+                    Verify.AreEqual((i + 20).ToString(), element.Text);
+                }
             });
         }
 

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        public void ValidateSwitchignItemsSourceRefreshesElementsNonVirtualLayout()
+        public void ValidateSwitchingItemsSourceRefreshesElementsNonVirtualLayout()
         {
             ValidateSwitchingItemsSourceRefreshesElements(isVirtualLayout: false);
         }

--- a/dev/Repeater/AnimationManager.cpp
+++ b/dev/Repeater/AnimationManager.cpp
@@ -38,7 +38,7 @@ void AnimationManager::OnLayoutChanging()
     m_hasRecordedLayoutTransitions = true;
 }
 
-void AnimationManager::OnDataSourceChanged(const winrt::IInspectable&, const winrt::NotifyCollectionChangedEventArgs& args)
+void AnimationManager::OnItemsSourceChanged(const winrt::IInspectable&, const winrt::NotifyCollectionChangedEventArgs& args)
 {
     switch (args.Action())
     {

--- a/dev/Repeater/AnimationManager.h
+++ b/dev/Repeater/AnimationManager.h
@@ -14,7 +14,7 @@ public:
 
     void OnAnimatorChanged(const winrt::ElementAnimator& newAnimator);
     void OnLayoutChanging();
-    void OnDataSourceChanged(const winrt::IInspectable& source, const winrt::NotifyCollectionChangedEventArgs& args);
+    void OnItemsSourceChanged(const winrt::IInspectable& source, const winrt::NotifyCollectionChangedEventArgs& args);
     void OnElementPrepared(const winrt::UIElement& element);
     bool ClearElement(const winrt::UIElement& element);
     void OnElementBoundsChanged(const winrt::UIElement& element, winrt::Rect oldBounds, winrt::Rect newBounds);

--- a/dev/Repeater/FlowLayout.cpp
+++ b/dev/Repeater/FlowLayout.cpp
@@ -80,7 +80,7 @@ void FlowLayout::OnItemsChangedCore(
     winrt::IInspectable const& source,
     winrt::NotifyCollectionChangedEventArgs const& args)
 {
-    GetFlowAlgorithm(context).OnDataSourceChanged(source, args, context);
+    GetFlowAlgorithm(context).OnItemsSourceChanged(source, args, context);
     // Always invalidate layout to keep the view accurate.
     InvalidateLayout();
 }

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -115,7 +115,7 @@ void FlowLayoutAlgorithm::MakeAnchor(
     }
 }
 
-void FlowLayoutAlgorithm::OnDataSourceChanged(
+void FlowLayoutAlgorithm::OnItemsSourceChanged(
     const winrt::IInspectable& source,
     winrt::NotifyCollectionChangedEventArgs const& args,
     const winrt::IVirtualizingLayoutContext& /*context*/)

--- a/dev/Repeater/FlowLayoutAlgorithm.h
+++ b/dev/Repeater/FlowLayoutAlgorithm.h
@@ -46,7 +46,7 @@ public:
         const winrt::VirtualizingLayoutContext& context,
         FlowLayoutAlgorithm::LineAlignment lineAlignment,
         const wstring_view& layoutId);
-    void OnDataSourceChanged(
+    void OnItemsSourceChanged(
         const winrt::IInspectable& source,
         winrt::NotifyCollectionChangedEventArgs const& args,
         const winrt::IVirtualizingLayoutContext& context);

--- a/dev/Repeater/InspectingDataSource.cpp
+++ b/dev/Repeater/InspectingDataSource.cpp
@@ -182,7 +182,7 @@ void InspectingDataSource::OnCollectionChanged(
     const winrt::IInspectable& /*sender*/,
     const winrt::NotifyCollectionChangedEventArgs& e)
 {
-    OnDataSourceChanged(e);
+    OnItemsSourceChanged(e);
 }
 
 void InspectingDataSource::OnVectorChanged(
@@ -229,7 +229,7 @@ void InspectingDataSource::OnVectorChanged(
         break;
     }
 
-    OnDataSourceChanged(
+    OnItemsSourceChanged(
         winrt::NotifyCollectionChangedEventArgs(
             action,
             newItems,

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -695,7 +695,7 @@ void ItemsRepeater::OnItemsSourceViewChanged(const winrt::IInspectable& sender, 
     m_processingItemsSourceChange.set(args);
     auto processingChange = gsl::finally([this]()
     {
-            m_processingItemsSourceChange.set(nullptr);
+        m_processingItemsSourceChange.set(nullptr);
     });
 
     m_animationManager.OnItemsSourceChanged(sender, args);

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -527,10 +527,8 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
         {
             // Walk through all the elements and make sure they are cleared for
             // non-virtualizing layouts.
-            auto children = Children();
-            for (unsigned i = 0u; i < children.Size(); ++i)
+            for (const auto& element: Children())
             {
-                auto element = children.GetAt(i);
                 if (GetVirtualizationInfo(element)->IsRealized())
                 {
                     ClearElementImpl(element);
@@ -707,8 +705,9 @@ void ItemsRepeater::OnItemsSourceViewChanged(const winrt::IInspectable& sender, 
         {
             virtualLayout.OnItemsChangedCore(GetLayoutContext(), sender, args);
         }
-        else if (auto nonVirtualLayout = layout.as<winrt::NonVirtualizingLayout>())
+        else
         {
+            // NonVirtualizingLayout
             InvalidateMeasure();
         }
     }

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -136,7 +136,7 @@ private:
     void InvalidateArrangeForLayout(winrt::Layout const& sender, winrt::IInspectable const& args);
 
     winrt::VirtualizingLayoutContext GetLayoutContext();
-    bool IsProcessingCollectionChange() const { return m_processingDataSourceChange != nullptr; }
+    bool IsProcessingCollectionChange() const { return m_processingItemsSourceChange != nullptr; }
 
     winrt::IIterable<winrt::DependencyObject> CreateChildrenInTabFocusOrderIterable();
 
@@ -152,8 +152,8 @@ private:
 
     tracker_ref<winrt::VirtualizingLayoutContext> m_layoutContext{ this };
     tracker_ref<winrt::IInspectable> m_layoutState{ this };
-    // Value is different from null only while we are on the OnDataSourceChanged call stack.
-    tracker_ref<winrt::NotifyCollectionChangedEventArgs> m_processingDataSourceChange{ this };
+    // Value is different from null only while we are on the OnItemsSourceChanged call stack.
+    tracker_ref<winrt::NotifyCollectionChangedEventArgs> m_processingItemsSourceChange{ this };
 
     winrt::Size m_lastAvailableSize{};
     bool m_isLayoutInProgress{ false };

--- a/dev/Repeater/ItemsSourceView.cpp
+++ b/dev/Repeater/ItemsSourceView.cpp
@@ -55,7 +55,7 @@ void ItemsSourceView::CollectionChanged(winrt::event_token const& token)
 
 #pragma region IDataSourceProtected
 
-void ItemsSourceView::OnDataSourceChanged(winrt::NotifyCollectionChangedEventArgs const& args)
+void ItemsSourceView::OnItemsSourceChanged(winrt::NotifyCollectionChangedEventArgs const& args)
 {
     m_cachedSize = GetSizeCore();
     m_collectionChangedEventSource(*this, args);

--- a/dev/Repeater/ItemsSourceView.h
+++ b/dev/Repeater/ItemsSourceView.h
@@ -23,7 +23,7 @@ public:
 #pragma endregion
 
 #pragma region Consume API for internal use only.
-    void OnDataSourceChanged(winrt::NotifyCollectionChangedEventArgs const& args);
+    void OnItemsSourceChanged(winrt::NotifyCollectionChangedEventArgs const& args);
 
     virtual int32_t GetSizeCore();
     virtual winrt::IInspectable GetAtCore(int index);

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -88,7 +88,7 @@ void StackLayout::OnItemsChangedCore(
     winrt::IInspectable const& source,
     winrt::NotifyCollectionChangedEventArgs const& args)
 {
-    GetFlowAlgorithm(context).OnDataSourceChanged(source, args, context);
+    GetFlowAlgorithm(context).OnItemsSourceChanged(source, args, context);
     // Always invalidate layout to keep the view accurate.
     InvalidateLayout();
 }

--- a/dev/Repeater/TestUI/Samples/CircleLayoutDemo/CircleLayoutSamplePage.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/CircleLayoutDemo/CircleLayoutSamplePage.xaml.cs
@@ -152,7 +152,7 @@ namespace MUXControlsTestApp.Samples
 
         private void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            OnDataSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnItemsSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
     }
 

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml.cs
@@ -95,11 +95,11 @@ namespace MUXControlsTestApp.Samples
 
                 if (reset)
                 {
-                    OnDataSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                    OnItemsSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
                 }
                 else
                 {
-                    OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                    OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                         NotifyCollectionChangedAction.Add,
                         oldStartingIndex: -1,
                         oldItemsCount: 0,
@@ -117,11 +117,11 @@ namespace MUXControlsTestApp.Samples
 
                 if (reset)
                 {
-                    OnDataSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                    OnItemsSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
                 }
                 else
                 {
-                    OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                    OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                         NotifyCollectionChangedAction.Remove,
                         oldStartingIndex: index,
                         oldItemsCount: count,
@@ -144,11 +144,11 @@ namespace MUXControlsTestApp.Samples
 
                 if (reset)
                 {
-                    OnDataSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                    OnItemsSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
                 }
                 else
                 {
-                    OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                    OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                         NotifyCollectionChangedAction.Replace,
                         oldStartingIndex: index,
                         oldItemsCount: oldCount,
@@ -171,7 +171,7 @@ namespace MUXControlsTestApp.Samples
 
                 // something changed, but i dont want to tell you the 
                 // exact changes 
-                OnDataSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                OnItemsSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
             }
         }
     }

--- a/dev/Repeater/TestUI/Samples/DelegatingItemsSource.cs
+++ b/dev/Repeater/TestUI/Samples/DelegatingItemsSource.cs
@@ -55,7 +55,7 @@ namespace MUXControlsTestApp.Samples
                 e.NewStartingIndex,
                 e.NewItems == null ? -1 : e.NewItems.Count);
 
-            OnDataSourceChanged(args);
+            OnItemsSourceChanged(args);
         }
     }
 }

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -94,7 +94,7 @@ void UniformGridLayout::OnItemsChangedCore(
     winrt::IInspectable const& source,
     winrt::NotifyCollectionChangedEventArgs const& args)
 {
-    GetFlowAlgorithm(context).OnDataSourceChanged(source, args, context);
+    GetFlowAlgorithm(context).OnItemsSourceChanged(source, args, context);
     // Always invalidate layout to keep the view accurate.
     InvalidateLayout();
 

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -305,7 +305,7 @@ void ViewManager::UpdatePin(const winrt::UIElement& element, bool addPin)
     }
 }
 
-void ViewManager::OnDataSourceChanged(const winrt::IInspectable&, const winrt::NotifyCollectionChangedEventArgs& args)
+void ViewManager::OnItemsSourceChanged(const winrt::IInspectable&, const winrt::NotifyCollectionChangedEventArgs& args)
 {
     // Note: For items that have been removed, the index will not be touched. It will hold
     // the old index before it was removed. It is not valid anymore.

--- a/dev/Repeater/ViewManager.h
+++ b/dev/Repeater/ViewManager.h
@@ -24,7 +24,7 @@ public:
     void PrunePinnedElements();
     void UpdatePin(const winrt::UIElement& element, bool addPin);
 
-    void OnDataSourceChanged(const winrt::IInspectable& source, const winrt::NotifyCollectionChangedEventArgs& args);
+    void OnItemsSourceChanged(const winrt::IInspectable& source, const winrt::NotifyCollectionChangedEventArgs& args);
     void OnLayoutChanging();
     void OnOwnerArranged();
 

--- a/dev/Scroller/APITests/ScrollerAnchoringTests.cs
+++ b/dev/Scroller/APITests/ScrollerAnchoringTests.cs
@@ -963,7 +963,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Inner.Insert(index + i, string.Format("ItemI #{0}", Inner.Count));
                 }
 
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                     NotifyCollectionChangedAction.Add,
                     oldStartingIndex: -1,
                     oldItemsCount: 0,
@@ -978,7 +978,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Inner.RemoveAt(index);
                 }
 
-                OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                     NotifyCollectionChangedAction.Remove,
                     oldStartingIndex: index,
                     oldItemsCount: count,

--- a/dev/Scroller/TestUI/ScrollerRepeaterAnchoringPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerRepeaterAnchoringPage.xaml.cs
@@ -788,11 +788,11 @@ namespace MUXControlsTestApp
 
                     if (reset)
                     {
-                        OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                        OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
                     }
                     else
                     {
-                        OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                        OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                             NotifyCollectionChangedAction.Add,
                             oldStartingIndex: -1,
                             oldItemsCount: 0,
@@ -820,11 +820,11 @@ namespace MUXControlsTestApp
 
                     if (reset)
                     {
-                        OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                        OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
                     }
                     else
                     {
-                        OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                        OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                             NotifyCollectionChangedAction.Remove,
                             oldStartingIndex: index,
                             oldItemsCount: count,
@@ -869,11 +869,11 @@ namespace MUXControlsTestApp
 
                     if (reset)
                     {
-                        OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                        OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
                     }
                     else
                     {
-                        OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                        OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                             NotifyCollectionChangedAction.Replace,
                             oldStartingIndex: index,
                             oldItemsCount: oldCount,
@@ -905,7 +905,7 @@ namespace MUXControlsTestApp
                         Inner.Insert(to, value);
                     }
 
-                    OnDataSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+                    OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
When using a non virtualizing layout, we should refresh all the elements when the items source changes. This was causing some weirdness especially in nested cases where the items source is set when recycling across groups. Also updating data source which is the old name for ItemsSource.