### PR TITLE
Fix TreeViewNodeVector::Clear

### DIFF
--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -426,9 +426,12 @@ void TreeViewNodeVector::Clear(bool updateItemsSource)
 
         inner->Clear();
 
-        if (auto itemsSource = GetWritableParentItemsSource())
+        if (updateItemsSource)
         {
-            itemsSource.Clear();
+            if (auto itemsSource = GetWritableParentItemsSource())
+            {
+                itemsSource.Clear();
+            }
         }
     }
 }


### PR DESCRIPTION
Clear function should check `updateItemsSource` parameter first before it actually clears the ItemsSource, this is causing `ValidateMultiSelectDragDropRootsAndNonRoots_ContentMode` test to fail.