### PR TITLE
Add release x86 to NuGet test

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -9,6 +9,9 @@ parameters:
     Debug_x86:
       buildPlatform: 'x86'
       buildConfiguration: 'Debug'
+    Release_x86:
+      buildPlatform: 'x86'
+      buildConfiguration: 'Release'
     Debug_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'Debug'


### PR DESCRIPTION
We didn't build release x86 for nuget test, but trying to test that flavor in Helix. Helix skips the test if dll doesn't exist so we never noticed. The new test detection script caught it.