### PR TITLE
NavView Hamburger btn and header overlap on launch in minimal mode

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1441,7 +1441,9 @@ NavigationViewVisualStateDisplayMode NavigationView::GetVisualStateDisplayMode(c
     // In minimal mode, when the NavView is closed, the HeaderContent doesn't have
     // its own dedicated space, and must 'share' the top of the NavView with the 
     // pane toggle button ('hamburger' button) and the back button.
-    if (ShouldShowBackButton())
+    auto visibility = IsBackButtonVisible();
+    auto backButtonVisible = (visibility == winrt::NavigationViewBackButtonVisible::Visible || (visibility == winrt::NavigationViewBackButtonVisible::Auto && !SharedHelpers::IsOnXbox()));
+    if (backButtonVisible)
     {
         return NavigationViewVisualStateDisplayMode::MinimalWithBackButton;
     }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1441,9 +1441,7 @@ NavigationViewVisualStateDisplayMode NavigationView::GetVisualStateDisplayMode(c
     // In minimal mode, when the NavView is closed, the HeaderContent doesn't have
     // its own dedicated space, and must 'share' the top of the NavView with the 
     // pane toggle button ('hamburger' button) and the back button.
-    auto visibility = IsBackButtonVisible();
-    auto backButtonVisible = (visibility == winrt::NavigationViewBackButtonVisible::Visible || (visibility == winrt::NavigationViewBackButtonVisible::Auto && !SharedHelpers::IsOnXbox()));
-    if (backButtonVisible)
+    if (ShouldShowBackButton())
     {
         return NavigationViewVisualStateDisplayMode::MinimalWithBackButton;
     }
@@ -2588,6 +2586,7 @@ void NavigationView::OnPropertyChanged(const winrt::DependencyPropertyChangedEve
     if (property == s_IsPaneOpenProperty)
     {
         OnIsPaneOpenChanged();
+        UpdateVisualStateForDisplayModeGroup(DisplayMode());
     }
     else if (property == s_CompactModeThresholdWidthProperty ||
         property == s_ExpandedModeThresholdWidthProperty)

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3810,14 +3810,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Navigation Minimal Test" }))
             {
                 Log.Comment("Click on ToggleButton");
-                Button navButton = new Button(FindElement.ById("TogglePaneButton"));
-                navButton.Invoke();
-                Wait.ForIdle();
+                FindElement.ById<Button>("TogglePaneButton").InvokeAndWait();
 
                 Log.Comment("Get NavView Active VisualStates");
-                var getNavViewActiveVisualStatesButton = new Button(FindElement.ByName("GetNavViewActiveVisualStates"));
-                getNavViewActiveVisualStatesButton.Invoke();
-                Wait.ForIdle();
+                FindElement.ByName<Button>("GetNavViewActiveVisualStates").InvokeAndWait();
 
                 const string visualStateName = "MinimalWithBackButton";
                 var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3803,6 +3803,28 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("NavViewTestSuite", "D")]
+        public void EnsureDisplayModeGroupUpdatesOnPaneClosedToMinimalWithBackButton()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Navigation Minimal Test" }))
+            {
+                Log.Comment("Click on ToggleButton");
+                Button navButton = new Button(FindElement.ById("TogglePaneButton"));
+                navButton.Invoke();
+                Wait.ForIdle();
+
+                Log.Comment("Get NavView Active VisualStates");
+                var getNavViewActiveVisualStatesButton = new Button(FindElement.ByName("GetNavViewActiveVisualStates"));
+                getNavViewActiveVisualStatesButton.Invoke();
+                Wait.ForIdle();
+
+                const string visualStateName = "MinimalWithBackButton";
+                var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
+                Verify.IsTrue(result.GetText().Contains(visualStateName), "Active VisualStates should not include " + visualStateName);
+            }
+        }
+
         // Test for issue 450 https://github.com/Microsoft/microsoft-ui-xaml/issues/450
         [TestMethod]
         [TestProperty("NavViewTestSuite", "D")]

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3817,7 +3817,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 const string visualStateName = "MinimalWithBackButton";
                 var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
-                Verify.IsTrue(result.GetText().Contains(visualStateName), "Active VisualStates should not include " + visualStateName);
+                Verify.IsTrue(result.GetText().Contains(visualStateName), "Active VisualStates should include " + visualStateName);
             }
         }
 

--- a/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml
@@ -24,6 +24,7 @@
             <Button x:Name="NavigateToTopNavPage" AutomationProperties.Name="Top Nav Test" Margin="2" HorizontalAlignment="Stretch">Top Nav Test</Button>
             <Button x:Name="NavigateToAnimationPage" AutomationProperties.Name="Navigation Animation Test" Margin="2" HorizontalAlignment="Stretch">Navigation Animation Test</Button>
             <Button x:Name="NavigateToIsPaneOpenPage" AutomationProperties.Name="Navigation IsPaneOpen Test" Margin="2" HorizontalAlignment="Stretch">Navigation IsPaneOpen Test</Button>
+            <Button x:Name="NavigateToMinimalPage" AutomationProperties.Name="Navigation Minimal Test" Margin="2" HorizontalAlignment="Stretch">Navigation Minimal Test</Button>
         </StackPanel>
     </Grid>
 </local:TestPage>

--- a/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml.cs
@@ -32,6 +32,7 @@ namespace MUXControlsTestApp
             NavigateToTopNavPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewTopNavStorePage), 0); };
             NavigateToAnimationPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewAnimationPage), 0); };
             NavigateToIsPaneOpenPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewIsPaneOpenPage), 0); };
+            NavigateToMinimalPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewMinimalPage), 0); };
         }
 
     }

--- a/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
@@ -1,0 +1,26 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="MUXControlsTestApp.NavigationViewMinimalPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
+                                    IsBackEnabled="True" Header="TESTAPP HEADER" PaneDisplayMode="LeftMinimal">
+            <muxcontrols:NavigationView.MenuItems>
+                <muxcontrols:NavigationViewItem x:Name="HomeItem" Content="Home" Icon="Home"/>
+                <muxcontrols:NavigationViewItem x:Name="AppsItem" Content="Apps" Icon="Shop" />
+            </muxcontrols:NavigationView.MenuItems>
+            <StackPanel Margin="0,0,0,0">
+                <TextBlock x:Name="NavViewActiveVisualStatesResult" AutomationProperties.Name="NavViewActiveVisualStatesResult"/>
+                <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>
+            </StackPanel>
+        </muxcontrols:NavigationView>
+    </Grid>
+</local:TestPage>

--- a/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
@@ -9,14 +9,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-
+<!-- This page contains a NavigationView control that is in LeftMinimal mode on initial load -->
     <Grid>
         <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
                                     IsBackEnabled="True" Header="Minimal Test Page" PaneDisplayMode="LeftMinimal">
-            <muxcontrols:NavigationView.MenuItems>
-                <muxcontrols:NavigationViewItem x:Name="HomeItem" Content="Home" Icon="Home"/>
-                <muxcontrols:NavigationViewItem x:Name="AppsItem" Content="Apps" Icon="Shop" />
-            </muxcontrols:NavigationView.MenuItems>
             <StackPanel>
                 <TextBlock x:Name="NavViewActiveVisualStatesResult" AutomationProperties.Name="NavViewActiveVisualStatesResult"/>
                 <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>

--- a/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
@@ -12,12 +12,12 @@
 
     <Grid>
         <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
-                                    IsBackEnabled="True" Header="TESTAPP HEADER" PaneDisplayMode="LeftMinimal">
+                                    IsBackEnabled="True" Header="Minimal Test Page" PaneDisplayMode="LeftMinimal">
             <muxcontrols:NavigationView.MenuItems>
                 <muxcontrols:NavigationViewItem x:Name="HomeItem" Content="Home" Icon="Home"/>
                 <muxcontrols:NavigationViewItem x:Name="AppsItem" Content="Apps" Icon="Shop" />
             </muxcontrols:NavigationView.MenuItems>
-            <StackPanel Margin="0,0,0,0">
+            <StackPanel>
                 <TextBlock x:Name="NavViewActiveVisualStatesResult" AutomationProperties.Name="NavViewActiveVisualStatesResult"/>
                 <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>
             </StackPanel>

--- a/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using Windows.UI.Xaml;
+
+namespace MUXControlsTestApp
+{
+    public sealed partial class NavigationViewMinimalPage : TestPage
+    {
+        public NavigationViewMinimalPage()
+        {
+            this.InitializeComponent();
+        }
+
+        private void GetNavViewActiveVisualStates_Click(object sender, RoutedEventArgs e)
+        {
+            var visualstates = Utilities.VisualStateHelper.GetCurrentVisualStateName(NavView);
+            NavViewActiveVisualStatesResult.Text = string.Join(",", visualstates);
+        }
+    }
+}

--- a/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
+++ b/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
@@ -88,7 +88,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)NavigationViewIsPaneOpenPage.xaml.cs">
       <DependentUpon>NavigationViewIsPaneOpenPage.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)NavigationViewMinimalPage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NavigationViewMinimalPage.xaml.cs">
+     <DependentUpon>NavigationViewMinimalPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)NavigationViewStretchPage.xaml.cs">
       <DependentUpon>NavigationViewStretchPage.xaml</DependentUpon>
     </Compile>
@@ -121,11 +123,6 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)NavigationViewTopNavStorePage.xaml.cs">
       <DependentUpon>NavigationViewTopNavStorePage.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="D:\microsoft-ui-xaml\dev\NavigationView\TestUI\NavigationViewMinimalPage.xaml.cs">
-      <DependentUpon>NavigationViewMinimalPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
+++ b/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
@@ -26,6 +26,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)NavigationViewMinimalPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)NavigationViewStretchPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -84,6 +88,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)NavigationViewIsPaneOpenPage.xaml.cs">
       <DependentUpon>NavigationViewIsPaneOpenPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)NavigationViewMinimalPage.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NavigationViewStretchPage.xaml.cs">
       <DependentUpon>NavigationViewStretchPage.xaml</DependentUpon>
     </Compile>
@@ -116,6 +121,11 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)NavigationViewTopNavStorePage.xaml.cs">
       <DependentUpon>NavigationViewTopNavStorePage.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="D:\microsoft-ui-xaml\dev\NavigationView\TestUI\NavigationViewMinimalPage.xaml.cs">
+      <DependentUpon>NavigationViewMinimalPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Issue #274 

Fixed issue with DisplayModeGroup not being properly updated in the scenario when navview is first loaded in minimal mode. Due to the pane being open by default, the DisplayModeGroup visual state is not in the proper state it needs to be in when the pane is closed.

I created a new navigation view test page in order to recreate the scenario where NavigationView gets first loaded in minimal mode.