### PR TITLE
make sure all items in flow layout get the entire line size.

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -1202,6 +1202,45 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             }
         }
 
+        [TestMethod]
+        public void VerifyItemsGetFullSpaceInMajorDirectionWhenSmallerThanLineSize()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var layoutPanel = (LayoutPanel)XamlReader.Load(
+                    @"<controls:LayoutPanel Width='800'  
+                        xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                        xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                        <controls:LayoutPanel.Layout>
+                            <controls:FlowLayout  />
+                        </controls:LayoutPanel.Layout>
+                        <Border Width='300' Height='300' />
+                        <Border Width='350' Height='150' />
+                        <Border Width='300' Height='300' />
+                        <Border Width='350' Height='250' />
+                    </controls:LayoutPanel>");
+
+                Content = layoutPanel;
+                layoutPanel.UpdateLayout();
+
+                var expected = new List<Rect>() 
+                {
+                    new Rect(0, 0, 300, 300),
+                    new Rect(300, 0, 350, 300),
+                    new Rect(0, 300, 300, 300),
+                    new Rect(300, 300, 350, 300),
+                    new Rect(0, 600, 200, 250)
+                };
+
+                for (int i = 0; i < layoutPanel.Children.Count; i++)
+                {
+                    var child = (FrameworkElement)layoutPanel.Children[i];
+                    var actualRect = LayoutInformation.GetLayoutSlot(child);
+                    Verify.AreEqual(expected[i], actualRect);
+                }
+            });
+        }
+
         #region Private Helpers
 
         private enum LayoutChoice

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -572,7 +572,7 @@ void FlowLayoutAlgorithm::ArrangeVirtualizingLayout(
             if (currentBounds.*MajorStart() != currentLineOffset)
             {
                 spaceAtLineEnd = finalSize.*Minor() - previousElementBounds.*MinorStart() - previousElementBounds.*MinorSize();
-                PerformLineAlignment(i - countInLine, countInLine, spaceAtLineStart, spaceAtLineEnd, lineAlignment, layoutId);
+                PerformLineAlignment(i - countInLine, countInLine, spaceAtLineStart, spaceAtLineEnd, currentLineSize, lineAlignment, layoutId);
                 spaceAtLineStart = currentBounds.*MinorStart();
                 countInLine = 0;
                 currentLineOffset = currentBounds.*MajorStart();
@@ -589,7 +589,7 @@ void FlowLayoutAlgorithm::ArrangeVirtualizingLayout(
         if (countInLine > 0)
         {
             float spaceAtEnd = finalSize.*Minor() - previousElementBounds.*MinorStart() - previousElementBounds.*MinorSize();
-            PerformLineAlignment(realizedElementCount - countInLine, countInLine, spaceAtLineStart, spaceAtEnd, lineAlignment, layoutId);
+            PerformLineAlignment(realizedElementCount - countInLine, countInLine, spaceAtLineStart, spaceAtEnd, currentLineSize, lineAlignment, layoutId);
         }
     }
 }
@@ -601,12 +601,14 @@ void FlowLayoutAlgorithm::PerformLineAlignment(
     int countInLine,
     float spaceAtLineStart,
     float spaceAtLineEnd,
+    float lineSize,
     FlowLayoutAlgorithm::LineAlignment lineAlignment,
     const wstring_view& layoutId)
 {
     for (int rangeIndex = lineStartIndex; rangeIndex < lineStartIndex + countInLine; ++rangeIndex)
     {
         auto bounds = m_elementManager.GetLayoutBoundsForRealizedIndex(rangeIndex);
+        bounds.*MajorSize() = lineSize;
 
         if (!m_scrollOrientationSameAsFlow)
         {

--- a/dev/Repeater/FlowLayoutAlgorithm.h
+++ b/dev/Repeater/FlowLayoutAlgorithm.h
@@ -104,6 +104,7 @@ private:
         int countInLine,
         float spaceAtLineStart,
         float spaceAtLineEnd,
+        float lineSize,
         FlowLayoutAlgorithm::LineAlignment lineAlignment,
         const wstring_view& layoutId);
 #pragma endregion


### PR DESCRIPTION
Make sure that all items in flow layout get arranged with the full line size so they can align themselves within that space.

Fixes #646