### PR TITLE
Test case fixes to try to improve test pass reliability

### DIFF
--- a/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
@@ -542,11 +542,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // so we'll use a point 10 pixels from the text box's left edge as a point
                 // known to be within the word's bounding box.
                 Log.Comment("Right-click on the word's location in the text box to get the proofing menu.");
-                InputHelper.RightClick(textBox, 10 - textBox.BoundingRectangle.Width / 2, 0);
+                InputHelper.RightClick(textBox, 10, textBox.BoundingRectangle.Height / 2);
 
-                Log.Comment("Tap on \"ads\" in the proofing menu to fix the spelling error.");
-                var proofingItem = FindElement.ByNameAndClassName("ads", "MenuFlyoutItem");
-                InputHelper.Tap(proofingItem);
+                Log.Comment("Find \"ads\" in the proofing menu to fix the spelling error.");
+                var proofingItem = new MenuItem(FindElement.ByNameAndClassName("ads", "MenuFlyoutItem"));
+                Log.Comment($"Invoke {proofingItem}");
+                proofingItem.Invoke();
 
                 Verify.AreEqual("ads ", textBox.Value);
             }

--- a/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
@@ -547,7 +547,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Find \"ads\" in the proofing menu to fix the spelling error.");
                 var proofingItem = new MenuItem(FindElement.ByNameAndClassName("ads", "MenuFlyoutItem"));
                 Log.Comment($"Invoke {proofingItem}");
-                proofingItem.Invoke();
+                proofingItem.InvokeAndWait();
 
                 Verify.AreEqual("ads ", textBox.Value);
             }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1676,6 +1676,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsTrue(keyTipBounds.IntersectsWith(targetBounds), "KeyTip bounds should be close to target bounds.");
             }
 
+
             // Invoke the AccessKey:
             TextInput.SendText(keyTipText);
             Wait.ForIdle();
@@ -1698,7 +1699,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InvokeNavigationViewAccessKeyAndVerifyKeyTipPlacement("TopNavOverflowButton");
 
                 Log.Comment("Verify overflow menu is opened");
-                Verify.IsTrue(GetTopNavigationItems(TopNavPosition.Overflow).Count > 0);
+                // Flyout doesn't seem raise any UIA WindowOpened/MenuOpened events so just check a few times for the menu to
+                // have opened.
+                TestEnvironment.VerifyAreEqualWithRetry(5,
+                    () => true,
+                    () => GetTopNavigationItems(TopNavPosition.Overflow).Count > 0);
             }
         }
 

--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -857,7 +857,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 dragUIObject.Click();
 
                 Log.Comment("Starting Drag...distance:" + distance);
-                InputHelper.DragDistance(dragUIObject, distance, Direction.South, 4000);
+                InputHelper.DragDistance(dragUIObject, distance, Direction.South);
 
                 TestEnvironment.VerifyAreEqualWithRetry(
                     5,
@@ -2581,7 +2581,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         private void ClickButton(string buttonName)
         {
             var button = new Button(FindElement.ByName(buttonName));
-            button.Invoke();
+            button.InvokeAndWait();
             Wait.ForIdle();
         }
 

--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -853,17 +853,25 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // 5% from the edge of the next item 
                 var distance = (int)(height * 1.45);
 
-                Log.Comment("Starting Drag...distance:" + distance);
-                InputHelper.DragDistance(dragUIObject, distance, Direction.South);
+                Log.Comment("Click on the item to help make the drag more reliable");
+                dragUIObject.Click();
 
-                ClickButton("GetChildrenOrder");
-                Verify.AreEqual("Root | Root.1 | Root.0 | Root.2", ReadResult());
+                Log.Comment("Starting Drag...distance:" + distance);
+                InputHelper.DragDistance(dragUIObject, distance, Direction.South, 4000);
+
+                TestEnvironment.VerifyAreEqualWithRetry(
+                    5,
+                    () => "Root | Root.1 | Root.0 | Root.2",
+                    () => {
+                        ClickButton("GetChildrenOrder");
+                        return ReadResult();
+                    });
 
                 ClickButton("GetItemCount");
                 Verify.AreEqual("4", ReadResult());
 
                 ClickButton("GetItemCommonStates");
-                Verify.AreEqual("Selected Selected Selected Selected", ReadResult().Trim());
+                Verify.AreEqual("Normal Normal Normal Normal", ReadResult().Trim());
             }
         }
 
@@ -1355,10 +1363,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 UIObject dropTarget = FindElement.ByName("DropTarget");
                 Verify.IsNotNull(dropTarget);
 
+                Log.Comment($"Dragging from {dragUIObject} to {dropTarget}");
                 InputHelper.DragToTarget(dragUIObject, dropTarget);
 
-                var droppedItem = new TextBlock(FindElement.ByName("DropTargetTextBlock")).DocumentText;
-                Verify.AreEqual("Root.2", droppedItem);
+                TestEnvironment.VerifyAreEqualWithRetry(
+                    5,
+                    () => "Root.2",
+                    () => new TextBlock(FindElement.ByName("DropTargetTextBlock")).DocumentText,
+                    () => {
+                        // The drag&drop operation may not have worked because the input is unreliable, just try again.
+                        InputHelper.DragToTarget(dragUIObject, dropTarget);
+                    });
             }
         }
 

--- a/test/MUXControls.Test/Common/AppsTestExtensions.cs
+++ b/test/MUXControls.Test/Common/AppsTestExtensions.cs
@@ -96,6 +96,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common
             Wait.ForIdle();
         }
 
+        public static void InvokeAndWait(this MenuItem menuItem, TimeSpan? timeout = null)
+        {
+            if (menuItem == null)
+            {
+                Log.Error("Attempted to invoke a null MenuItem! Dumping context...");
+                DumpHelper.DumpFullContext();
+                throw new ArgumentNullException("menuItem");
+            }
+
+            using (var waiter = menuItem.GetInvokedWaiter())
+            {
+                menuItem.Invoke();
+                if (timeout == null)
+                {
+                    waiter.Wait();
+                }
+                else
+                {
+                    waiter.Wait(timeout.Value);
+                }
+            }
+
+            Wait.ForIdle();
+        }
+
         public static void ToggleAndWait(this ToggleButton toggleButton)
         {
             if (toggleButton == null)

--- a/test/MUXControls.Test/Infra/Application.cs
+++ b/test/MUXControls.Test/Infra/Application.cs
@@ -479,6 +479,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 
             if (!File.Exists(appxPath))
             {
+                Log.Comment($".appx not found at '{appxPath}'");
                 // If the AppX doesn't even exist, then we definitely need to package it.
                 appXPackagingNecessary = true;
             }
@@ -486,10 +487,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
             {
                 // Otherwise, we need to package it if any of its contents have been built since the last packaging.
                 DateTime appxWriteTime = File.GetLastWriteTime(appxPath);
+                DateTime exeWriteTime = File.GetLastWriteTime(Path.Combine(testAppDirectory, _packageName + ".exe"));
+                DateTime dllWriteTime = File.GetLastWriteTime(Path.Combine(architectureDirectory, "Microsoft.UI.Xaml", "Microsoft.UI.Xaml.dll"));
 
                 appXPackagingNecessary =
-                    File.GetLastWriteTime(Path.Combine(testAppDirectory, _packageName + ".exe")) > appxWriteTime ||
-                    File.GetLastWriteTime(Path.Combine(architectureDirectory, "Microsoft.UI.Xaml", "Microsoft.UI.Xaml.dll")) > appxWriteTime;
+                    exeWriteTime > appxWriteTime ||
+                    dllWriteTime > appxWriteTime;
+
+                Log.Comment($"AppX packaging necessary: {appXPackagingNecessary} (appxWriteTime = {appxWriteTime}, exeWriteTime = {exeWriteTime}, dllWriteTime = {dllWriteTime})");
             }
 
             // Only package the AppX or install the app if we need to - otherwise, we'll get unnecessary console windows showing up

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -4,6 +4,11 @@
   <PropertyGroup>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
+    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
+    <AppxBundle>Never</AppxBundle>
+    <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
+    <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
   </PropertyGroup>
   <!-- We need to define NuGet references using this newer style for running tests locally in VS to work.
        However, for some reason, specifially in lab builds, using the below to resolve NuGet references


### PR DESCRIPTION
Some changes to a few test cases to try to improve their reliability. 
* TextCommandBarFlyout: proofing test was using tap to click on the menu which might have been racing with the show animation. Switched to Invoke.
* TreeView tests with drag&drop were having issues. I tried a couple different fixes here and whichever one seems more reliable I'll apply in more places -- either retry logic to see if it's just a race on the TextBlock getting updated on the drop event being async or to see if the drag itself just isn't happening, retrying the drag operation itself, or trying to tap on the dragged from item first to improve drag reliability.
* Also fixed an issue with the test infrastructure where I noticed that the appx packaging was happening every time for infrastructure tests (the appx properties in the csproj fix that).