### PR TITLE
Test regression fix for ApiTests.RepeaterTests.ViewportTests/EffectiveViewportScrollerTests following Scroller fix

### DIFF
--- a/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
@@ -110,6 +110,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 scroller.ScrollTo(0.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(scrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -119,6 +120,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 scroller.ZoomTo(2.0f, Vector2.Zero, new ZoomOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(zoomCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -197,6 +199,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 verticalScroller.ScrollTo(0.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(verticalScrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -208,6 +211,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 horizontalScroller.ScrollTo(400.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(horizontalScrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {

--- a/dev/Repeater/APITests/ViewportTests.cs
+++ b/dev/Repeater/APITests/ViewportTests.cs
@@ -243,6 +243,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 scroller.ScrollTo(0.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(scrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -255,6 +256,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 scroller.ScrollTo(400.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(scrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -267,6 +269,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     new ZoomOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(zoomCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -340,6 +343,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 verticalScroller.ScrollTo(0.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(verticalScrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {
@@ -351,6 +355,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 horizontalScroller.ScrollTo(400.0, 100.0, new ScrollOptions(AnimationMode.Disabled, SnapPointsMode.Ignore));
             });
             Verify.IsTrue(horizontalScrollCompletedEvent.WaitOne(DefaultWaitTimeInMS));
+            CompositionPropertySpy.SynchronouslyTickUIThread(1);
 
             RunOnUIThread.Execute(() =>
             {


### PR DESCRIPTION
The Scroller check-in from yesterday (#669) fixed the timing of the Scroller.ScrollCompleted and Scroller.ZoomCompleted events. They used to be raised unnecessarily late. This was an old Scroller regression.  The four tests involved here need to wait a single tick for the ItemsRepeater's realization window to be updated after the Scroller.ScrollCompleted and Scroller.ZoomCompleted events (which occur right after the ViewChanged event and the view dependency properties were updated). 
The RepeaterTestHooks.BuildTreeCompleted event could not be used as it was not raised.
