### PR TITLE
Fixing the CI build by ensuring a unique job name

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -132,7 +132,7 @@ jobs:
       PathtoPublish: $(Build.SourcesDirectory)/${{parameters.name}}.$(buildPlatform).$(buildConfiguration).binlog
       artifactName: 'drop'
       
-- job: ProcessTestResults
+- job: Process${{ parameters.name }}TestResults
   condition: succeededOrFailed()
   dependsOn: ${{ parameters.name }}
   pool:


### PR DESCRIPTION
My [most recent commit](https://github.com/microsoft/microsoft-ui-xaml/commit/a5acee716318c2b365b5d161bafbbc1d9b93c375) broke the CI build because the CI build has two different instances of the RunHelixTests job, each with a different name, but the sub-job I added does not use the different name, so Azure DevOps complained that two different jobs with the same name were detected.  This fixes things by adding the original job name to the sub-job to differentiate it.