### PR TITLE
Fix CI break

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -74,7 +74,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: build\Helix\PrepareHelixPayload.ps1
-      arguments: -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)'
+      arguments: -Platform '$(buildPlatform)' -Configuration '$(buildConfiguration)' -ArtifactName '${{ parameters.artifactName }}'
       
   - task: CmdLine@1
     displayName: 'Display Helix payload contents'


### PR DESCRIPTION
Fix for #749. Lost the `ArtifactName` parameter when resolving merge conflicts. Adding it back.