### PR TITLE
Splitting up test processing from the test job file

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -1,0 +1,31 @@
+parameters:
+  dependsOn: ''
+  rerunPassesRequiredToAvoidFailure: 5
+
+jobs:
+- job: ProcessTestResults
+  condition: succeededOrFailed()
+  dependsOn: ${{ parameters.dependsOn }}
+  pool:
+    vmImage: 'VS2017-Win2016'
+  timeoutInMinutes: 120
+
+  steps:
+  - task: powershell@2
+    displayName: 'UpdateUnreliableTests.ps1'
+    condition: succeededOrFailed()
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    inputs:
+      targetType: filePath
+      filePath: build\Helix\UpdateUnreliableTests.ps1
+      arguments: -RerunPassesRequiredToAvoidFailure '${{ parameters.rerunPassesRequiredToAvoidFailure }}'
+      
+  - task: powershell@2
+    displayName: 'OutputTestResults.ps1'
+    condition: succeededOrFailed()
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    inputs:
+      targetType: filePath
+      filePath: build\Helix\OutputTestResults.ps1

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -132,30 +132,3 @@ jobs:
     inputs:
       PathtoPublish: $(Build.SourcesDirectory)/${{parameters.name}}.$(buildPlatform).$(buildConfiguration).binlog
       artifactName: ${{ parameters.artifactName }}
-      
-- job: Process${{ parameters.name }}TestResults
-  condition: succeededOrFailed()
-  dependsOn: ${{ parameters.name }}
-  pool:
-    vmImage: 'VS2017-Win2016'
-  timeoutInMinutes: 120
-
-  steps:
-  - task: powershell@2
-    displayName: 'UpdateUnreliableTests.ps1'
-    condition: succeededOrFailed()
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    inputs:
-      targetType: filePath
-      filePath: build\Helix\UpdateUnreliableTests.ps1
-      arguments: -RerunPassesRequiredToAvoidFailure '${{ parameters.rerunPassesRequiredToAvoidFailure }}'
-      
-  - task: powershell@2
-    displayName: 'OutputTestResults.ps1'
-    condition: succeededOrFailed()
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    inputs:
-      targetType: filePath
-      filePath: build\Helix\OutputTestResults.ps1

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -56,3 +56,10 @@ jobs:
     runTestJobName: 'RunFrameworkPkgTestsInHelix'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop\FrameworkPackage'
+
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -29,7 +29,12 @@ jobs:
 
 - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
   parameters:
+    name: 'RunTestsInHelix'
     dependsOn: Build
     condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     testSuite: 'DevTestSuite'
+
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn: RunTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5


### PR DESCRIPTION
When I did the initial checkin of the unreliable test processing, I didn't realize that we had some test jobs that ran multiple suites of tests - in those cases, since the test processing is done in the test job file, we ended up needlessly doing it multiple times.  We should split it off into its own job file so we can only do it once at the very end.