### PR TITLE
Fix a Teaching Tip Crash in unpackaged apps

### DIFF
--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1123,17 +1123,22 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
 
     if (auto const teachingTipPeer = winrt::FrameworkElementAutomationPeer::FromElement(*this).try_as<winrt::TeachingTipAutomationPeer>())
     {
-        auto const appName = []()
+        auto const notificationString = [this]()
         {
-            if (auto&& package = winrt::ApplicationModel::Package::Current())
+            auto const appName = []()
             {
-                return package.DisplayName();
-            }
-            return winrt::hstring{};
-        }();
+                try
+                {
+                    if (auto&& package = winrt::ApplicationModel::Package::Current())
+                    {
+                        return package.DisplayName();
+                    }
+                }
+                catch (...) {}
 
-        auto const notificationString = [this, appName]()
-        {
+                return winrt::hstring{};
+            }();
+
             if (!appName.empty())
             {
                 return StringUtil::FormatString(


### PR DESCRIPTION
Move Package::Current() to a try block. Fixes #742 