### PR TITLE
Use latest available sdk version when making framework package

### DIFF
--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -65,14 +65,14 @@ Copy-IntoNewDirectory -IfExists $inputBasePath\Themes $fullOutputPath\PackageCon
 function Get-SDK-References-Path
 {
     [xml]$sdkPropsContent = Get-Content $PSScriptRoot\..\..\sdkversion.props
-    $sdkVersions = $sdkPropsContent.SelectNodes("//*[contains(local-name(), 'SDKVersion')]")
-    for ($i=$sdkVersions.Count-1; $i -ge 0; $i--)
+    $sdkVersions = $sdkPropsContent.SelectNodes("//*[contains(local-name(), 'SDKVersion')]") | Sort-Object -Property '#text' -Descending 
+    foreach ($version in $sdkVersions)
     {
-        $sdkReferencesPath=$kitsRoot10 + "References\" + $sdkVersions[$i].'#text'
-        Write-Host Checking $sdkReferencesPath ...
+        $sdkReferencesPath=$kitsRoot10 + "References\" + $version.'#text'
+        Write-Verbose "Checking $sdkReferencesPath ..."
         if (Test-Path $sdkReferencesPath)
         {
-            Write-Host Found $sdkReferencesPath
+            Write-Verbose "Found $sdkReferencesPath"
             return $sdkReferencesPath
         }
     }

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -123,9 +123,9 @@ jobs:
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop'
     matrix: 
-      Debug_x86:
+      Release_x86:
         buildPlatform: 'x86'
-        buildConfiguration: 'Debug'
+        buildConfiguration: 'Release'
       Debug_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Debug'


### PR DESCRIPTION
We've been using the latest insider sdk version number when building framework packages. Package ES pool doesn't have the latest 19h1 sdk installed yet which causes the release pipeline to fail at making framework package step.

Updated the script to search for the latest installed sdk version instead of always using the newest insider version.