### PR TITLE
Update project url to be directly pointing at github

### DIFF
--- a/build/NuSpecs/MUXControls.nuspec
+++ b/build/NuSpecs/MUXControls.nuspec
@@ -11,7 +11,7 @@
     <tags>Windows WinUI UWP XAML Fluent Controls Downlevel Compatibility TreeView ColorPicker NavigationView MenuBar</tags>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="file">license.txt</license>
-    <projectUrl>https://aka.ms/winui</projectUrl>
+    <projectUrl>https://github.com/microsoft/microsoft-ui-xaml</projectUrl>
     <iconUrl>https://aka.ms/winui_icon</iconUrl>
   </metadata>
   <files>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -11,7 +11,7 @@
     <tags>Windows WinUI UWP XAML Fluent Controls Downlevel Compatibility TreeView ColorPicker NavigationView MenuBar</tags>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="file">license.txt</license>
-    <projectUrl>https://aka.ms/winui</projectUrl>
+    <projectUrl>https://github.com/microsoft/microsoft-ui-xaml</projectUrl>
     <iconUrl>https://aka.ms/winui_icon</iconUrl>
   </metadata>
   <files>


### PR DESCRIPTION
GitHub recently added some logic to try to map nuget/npm packages to github projects and track dependencies through repos and packages. Something about this isn't working for WinUI and we *suspect* that it's because our nuget package's project url is pointing at an aka.ms link instead of the github project directly. I'm going to try updating it here to see if this causes GitHub to figure out the linkage for our project going forward.

https://github.com/microsoft/microsoft-ui-xaml/network/dependents is the new page that shows the calculate results, but it's empty for us (compare to https://github.com/microsoft/testfx/network/dependents). 