### PR TITLE
Disable dhandler for test runs

### DIFF
--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -4,6 +4,10 @@ robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
 
 reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
 
+:: kill dhandler, which is a tool designed to handle unexpected windows appearing. But since our tests are 
+:: expected to show UI we don't want it running.
+taskkill -f -im dhandler.exe
+
 cd scripts
 powershell -ExecutionPolicy Bypass .\InstallTestAppDependencies.ps1
 cd ..


### PR DESCRIPTION
Kill dhandler, which is a tool designed to handle unexpected windows appearing. But since our tests are expected to show UI we don't want it running.