### PR TITLE
Consolidating WinUI-Public-MUX-PR and WinUI-Public-Tests

### DIFF
--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -10,6 +10,9 @@ jobs:
       Debug_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Debug'
+      Release_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Release'
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
@@ -21,8 +24,14 @@ jobs:
 
   steps:
   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-  
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+
+- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    dependsOn: Build
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    testSuite: 'DevTestSuite'
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
@@ -43,3 +52,8 @@ jobs:
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
+
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn: RunTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5


### PR DESCRIPTION
Now that we're handling unreliable tests as separate from actual test failures, we can finally merge these two jobs into a single job and have only a single job as a PR gate.  The only differences between these two jobs is that the latter also builds x86 release, and that the latter runs tests, so I've added those two steps to the former job.  Once this is checked in, then we can disable and delete the latter job, as it'll be fully redundant.