### PR TITLE
Update build pipelines to run on vs2019 agents

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -53,3 +53,4 @@ steps:
       targetType: filePath
       filePath: build\SourceIndexing\IndexPdbs.ps1
       arguments: -SearchDir '${{ parameters.buildOutputDir }}' -SourceRoot '$(Build.SourcesDirectory)' -recursive -Verbose -CommitId $(Build.SourceVersion)
+      errorActionPreference: silentlyContinue

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -52,5 +52,5 @@ steps:
     inputs:
       targetType: filePath
       filePath: build\SourceIndexing\IndexPdbs.ps1
-      arguments: -SearchDir '${{ parameters.buildOutputDir }}' -SourceRoot '$(Build.SourcesDirectory)' -recursive -Verbose -CommitId $(Build.SourceVersion)
+      arguments: -SearchDir '${{ parameters.buildOutputDir }}\$(buildConfiguration)' -SourceRoot '$(Build.SourcesDirectory)' -recursive -Verbose -CommitId $(Build.SourceVersion)
       errorActionPreference: silentlyContinue

--- a/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
@@ -16,7 +16,7 @@ steps:
           if (Test-Path "$rootPath\Microsoft.UI.Xaml")
           {
             $env:BUILDOUTPUT_OVERRIDE = $rootPath
-            & $env:Build_SourcesDirectory\tools\MakeAppxHelper.cmd $platform $config -builddate_yymm $env:BUILDDATE_YYMM -builddate_dd $env:BUILDDATE_DD -subversion $env:BUILDREVISION
+            & $env:Build_SourcesDirectory\tools\MakeAppxHelper.cmd $platform $config -builddate_yymm $env:BUILDDATE_YYMM -builddate_dd $env:BUILDDATE_DD -subversion $env:BUILDREVISION -verbose
             if ($lastexitcode -ne 0) {
                 Write-Host ##vso[task.logissue type=error;] Make AppxHelper $platform $config failed with exit code $lastexitcode
                 Exit 1

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -30,7 +30,7 @@ jobs:
       - ${{ parameters.dependsOn }}
 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   strategy:
     maxParallel: 10
     matrix: ${{ parameters.matrix }}

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -41,7 +41,7 @@ jobs:
     nugetConfigPath: test\MUXControlsReleaseTest\nuget.config
     packageSaveDirectory: $(Build.SourcesDirectory)\packages\muxreleasetest
     artifactDownloadPath: $(Build.SourcesDirectory)\Artifacts
-    currentPackageVersion: 2.1.190218001-prerelease
+    currentPackageVersion: 2.1.190606001
     buildOutputDir: $(Build.SourcesDirectory)\BuildOutput
 
   steps:

--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -7,7 +7,7 @@ jobs:
   condition: succeededOrFailed()
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
 
   steps:

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -22,7 +22,7 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   condition: ${{ parameters.condition }}
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -43,13 +43,14 @@ Copy-IntoNewDirectory FrameworkPackageContents\* $fullOutputPath\PackageContents
 Copy-IntoNewDirectory PriConfig\* $fullOutputPath
 
 $KitsRoot10 = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots" -Name KitsRoot10).KitsRoot10
-# If this path is not found, construct one using Program Files (x86). VS2019 hosted agents seem to have the wrong path populated in the registry.
-if (-not (Test-Path $KitsRoot10))
-{
-    $KitsRoot10 =  "${env:ProgramFiles(x86)}\Windows Kits\10"
-}
-
 $WindowsSdkBinDir = Join-Path $KitsRoot10 "bin\x86"
+# If this path is not found, construct one using Program Files (x86). VS2019 hosted agents seem to have the wrong path populated in the registry.
+if (-not (Test-Path $WindowsSdkBinDir))
+{
+    Write-Host "Not found: $WindowsSdkBinDir"
+    $KitsRoot10 =  "${env:ProgramFiles(x86)}\Windows Kits\10"
+    $WindowsSdkBinDir = Join-Path $KitsRoot10 "bin\x86"
+}
 
 $ActivatableTypes = ""
 

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -43,6 +43,12 @@ Copy-IntoNewDirectory FrameworkPackageContents\* $fullOutputPath\PackageContents
 Copy-IntoNewDirectory PriConfig\* $fullOutputPath
 
 $KitsRoot10 = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots" -Name KitsRoot10).KitsRoot10
+# If this path is not found, construct one using Program Files (x86). VS2019 hosted agents seem to have the wrong path populated in the registry.
+if (-not (Test-Path $KitsRoot10))
+{
+    $KitsRoot10 =  "${env:ProgramFiles(x86)}\Windows Kits\10"
+}
+
 $WindowsSdkBinDir = Join-Path $KitsRoot10 "bin\x86"
 
 $ActivatableTypes = ""

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -75,7 +75,7 @@ function Get-SDK-References-Path
     $sdkVersions = $sdkPropsContent.SelectNodes("//*[contains(local-name(), 'SDKVersion')]") | Sort-Object -Property '#text' -Descending 
     foreach ($version in $sdkVersions)
     {
-        $sdkReferencesPath=$kitsRoot10 + "References\" + $version.'#text'
+        $sdkReferencesPath = Join-Path (Join-Path $kitsRoot10 "References\") ($version.'#text')
         Write-Verbose "Checking $sdkReferencesPath ..."
         if (Test-Path $sdkReferencesPath)
         {
@@ -87,9 +87,13 @@ function Get-SDK-References-Path
 }
 
 $sdkReferencesPath = Get-SDK-References-Path
+$WindowsSdkBinDir = Join-Path $sdkReferencesPath.Replace("References", "bin") "x64"
+Write-Verbose "SdkReferencesPath = $sdkReferencesPath"
+Write-Verbose "WindowsSdkBinDir = $WindowsSdkBinDir"
 $foundationWinmdPath = Get-ChildItem -Recurse $sdkReferencesPath"\Windows.Foundation.FoundationContract" -Filter "Windows.Foundation.FoundationContract.winmd" | Select-Object -ExpandProperty FullName
 $universalWinmdPath = Get-ChildItem -Recurse $sdkReferencesPath"\Windows.Foundation.UniversalApiContract" -Filter "Windows.Foundation.UniversalApiContract.winmd" | Select-Object -ExpandProperty FullName
 $refrenceWinmds = $foundationWinmdPath + ";" + $universalWinmdPath
+Write-Verbose "Calling Get-ActivatableTypes with '$inputBasePath\sdk\$inputBaseFileName.winmd' '$refrenceWinmds'"
 $classes = Get-ActivatableTypes $inputBasePath\sdk\$inputBaseFileName.winmd  $refrenceWinmds  | Sort-Object -Property FullName
 Write-Host $classes.Length Types found.
 @"

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -2,7 +2,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Build
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -2,7 +2,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Build
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -2,7 +2,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: ComponentDetection
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
 
   steps:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -14,7 +14,7 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'') 
   pool:
-    vmImage: 'VS2017-Win2016'
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -117,21 +117,30 @@ jobs:
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
     useReleaseTag: '$(MUXFinalRelease)'
  
-# Build NuGet package tests
+# Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
     buildJobName: 'BuildNugetPkgTests'
     buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop'
-
-# Build framework package tests
+   
+# Framework package tests
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
     buildJobName: 'BuildFrameworkPkgTests'
     buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop\FrameworkPackage'
+
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5
 
 # NuGet package WACK tests 
 - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml

--- a/build/RunHelixTests.yml
+++ b/build/RunHelixTests.yml
@@ -6,7 +6,7 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'') 
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: 'windows-2019'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 4

--- a/build/SourceIndexing/IndexPdbs.ps1
+++ b/build/SourceIndexing/IndexPdbs.ps1
@@ -25,7 +25,7 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 {
     Write-Verbose "Found $file"
 
-    $allFiles = & $srctoolExe -r "$file"
+    $allFiles = & $srctoolExe -r "$file" 2>$null
 
     # If the pdb didn't have enough files then skip it (the srctool output has a blank line even when there's no info
     # so check for less than 2 lines)

--- a/build/SourceIndexing/IndexPdbs.ps1
+++ b/build/SourceIndexing/IndexPdbs.ps1
@@ -25,7 +25,7 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 {
     Write-Verbose "Found $file"
 
-    $allFiles = & $srctoolExe -r "$file" 2>$null
+    $allFiles = (& $srctoolExe -r "$file" 2>&1 | ForEach-Object {$_.ToString()})
 
     # If the pdb didn't have enough files then skip it (the srctool output has a blank line even when there's no info
     # so check for less than 2 lines)

--- a/build/SourceIndexing/IndexPdbs.ps1
+++ b/build/SourceIndexing/IndexPdbs.ps1
@@ -25,7 +25,9 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 {
     Write-Verbose "Found $file"
 
-    $allFiles = (& $srctoolExe -r "$file" 2>&1 | ForEach-Object {$_.ToString()})
+    $ErrorActionPreference = "Continue" # Azure Pipelines defaults to "Stop", continue past errors in this script.
+    
+    $allFiles = & $srctoolExe -r "$file"
 
     # If the pdb didn't have enough files then skip it (the srctool output has a blank line even when there's no info
     # so check for less than 2 lines)

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -17,13 +17,13 @@ Additional reading:
 ## Prerequisites
 #### Visual Studio
 
-Install latest VS2017 (15.9 or later) from here: http://visualstudio.com/downloads
+Install latest VS2019 (16.1 or later) from here: http://visualstudio.com/downloads
 
 #### SDK
 
 While WinUI is designed to work against many versions of Windows, you will need 
 a fairly recent SDK in order to build WinUI. It's required that you install the 
-16299, 17134, 17763 and 18362 SDKs. You can download these via Visual Studio (check 
+17763 and 18362 SDKs. You can download these via Visual Studio (check 
 all the boxes when prompted), or you can manually download them from here: 
 https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk
 
@@ -36,7 +36,7 @@ an Administrator Powershell window:
 
 ## Building the repository
 
-Generally you will want to set your configuration to **Debug**, **x86**, and 
+Generally you will want to set your configuration to **Debug**, **x64**, and 
 select **MUXControlsTestApp** as your startup project in Visual Studio.
 
 ### Creating a NuGet package
@@ -110,7 +110,7 @@ versions you can make use of a Visual Studio subscription [as described here](ht
 ### Automated testing
 
 You can run the test suite from within Visual Studio by using the Test top 
-level menu. For targeting indivual tests you can use [Test Explorer](https://docs.microsoft.com/en-us/visualstudio/test/run-unit-tests-with-test-explorer?view=vs-2017) 
+level menu. For targeting indivual tests you can use [Test Explorer](https://docs.microsoft.com/en-us/visualstudio/test/run-unit-tests-with-test-explorer?view=vs-2019) 
 (found under the Test->Windows sub menu).
 
 This same suite of tests will be run as part of your Pull Request validation 

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -155,7 +155,7 @@
       <Version>6.1.7</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.1.190218001-prerelease</Version>
+      <Version>2.1.190606001</Version>
     </PackageReference>
     <PackageReference Include="MUXCustomBuildTasks">
       <Version>1.0.38</Version>

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
@@ -10,7 +10,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ConvertedPlatformName>$(Platform)</ConvertedPlatformName>
     <ConvertedPlatformName Condition="'$(Platform)' == 'Win32'">x86</ConvertedPlatformName>
@@ -45,37 +45,37 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -196,12 +196,12 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.1.190218001-prerelease\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.1.190218001-prerelease\build\native\Microsoft.UI.Xaml.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
   <Import Project="$(MSBuildProjectDirectory)\..\..\..\CustomInlineTasks.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets')" />
-    <Import Project="..\packages\Microsoft.UI.Xaml.2.1.190218001-prerelease\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.1.190218001-prerelease\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="AfterBuild">
     <RunPowershellScript Path="$(SolutionDir)\tools\ExtractPackageDependencies_ReleaseTest.ps1" Parameters="-sourceFile $(OutDir)\$(AppxPackageName).build.appxrecipe -platform $(ConvertedPlatformName) -outputFile $(AppxPackageTestDir)\$(AppxPackageName).dependencies.txt" FilesWritten="$(AppxPackageTestDir)\$(AppxPackageName).dependencies.txt" />

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/packages.config
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.7" targetFramework="native" />
-  <package id="Microsoft.UI.Xaml" version="2.1.190218001-prerelease" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.1.190606001" targetFramework="native" />
   <package id="MUXCustomBuildTasks" version="1.0.38" targetFramework="native" />
 </packages>


### PR DESCRIPTION
These agents still don't seem to have 18362 installed, but they should soon. When they do that should shave ~5 min off our build times.

Also this gets us on the latest VS compiler which should unblock us to be able to switch to the new exception frame handler support for more binary savings.