### PR TITLE
Fix test execution in the release pipelines

### DIFF
--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -117,21 +117,30 @@ jobs:
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
     useReleaseTag: '$(MUXFinalRelease)'
  
-# Build NuGet package tests
+# Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
     buildJobName: 'BuildNugetPkgTests'
     buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop'
-
-# Build framework package tests
+   
+# Framework package tests
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
     buildJobName: 'BuildFrameworkPkgTests'
     buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop\FrameworkPackage'
+
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5
 
 # NuGet package WACK tests 
 - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml


### PR DESCRIPTION
Test execution in the release pipeline broke with some recent helix yml file refactoring. This just copies the part from the CI pipeline to release. We can look into refactoring this to a common yml file in the future.