### PR TITLE
Rationalize local TAEF workflow with AzDO workflow

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -18,6 +18,7 @@ set BUILDALL=
 set BUILDLEANMUXFORTHESTOREAPP=
 set MUXFINAL=
 set PROJECTPATH=
+set BUILDTARGET=
 
 if "%1" == "" goto :usage
 
@@ -96,6 +97,12 @@ if "%1" == "/project" (
     shift
     goto :MoreArguments
 )
+if "%1" == "/target" (
+    set BUILDTARGET=%BUILDTARGET%  -t:%~2
+    shift
+    shift
+    goto :MoreArguments
+)
 if "%1" == "/usevsprerelease" (
     set VSWHEREPARAMS=%VSWHEREPARAMS% -prerelease
     shift
@@ -137,15 +144,18 @@ if "%USEINSIDERSDK%" == "1" ( set EXTRAMSBUILDPARAMS=/p:UseInsiderSDK=true )
 if "%USEINTERNALSDK%" == "1" ( set EXTRAMSBUILDPARAMS=/p:UseInternalSDK=true )
 if "%EMITTELEMETRYEVENTS%" == "1" ( set EXTRAMSBUILDPARAMS=/p:EmitTelemetryEvents=true )
 
+
+if "%BUILDTARGET%" NEQ "" ( set EXTRAMSBUILDPARAMS=%EXTRAMSBUILDPARAMS% %BUILDTARGET% )
+
 if "%PROJECTPATH%" NEQ "" (
-    set MSBuildCommand="%MSBUILDPATH%" %PROJECTPATH% /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /flp:Verbosity=Diagnostic /fl /bl %EXTRAMSBUILDPARAMS% /verbosity:Minimal
+    set MSBuildCommand="%MSBUILDPATH%" %PROJECTPATH% /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /flp:Verbosity=Diagnostic /fl /bl %EXTRAMSBUILDPARAMS% /verbosity:Minimal /p:AppxBundle=Never /p:AppxSymbolPackageEnabled=false 
     echo !MSBuildCommand!
     !MSBuildCommand!
 ) else (
     if "%BUILDALL%" == "" (
         set XES_OUTDIR=%BUILD_BINARIESDIRECTORY%\%BUILDCONFIGURATION%\%BUILDPLATFORM%\
 
-        "%MSBUILDPATH%" .\MUXControls.sln /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /flp:Verbosity=Diagnostic /fl /bl %EXTRAMSBUILDPARAMS% /verbosity:Minimal
+        "%MSBUILDPATH%" .\MUXControls.sln /p:platform="%BUILDPLATFORM%" /p:configuration="%BUILDCONFIGURATION%" /flp:Verbosity=Diagnostic /fl /bl %EXTRAMSBUILDPARAMS% /verbosity:Minimal /p:AppxBundle=Never /p:AppxSymbolPackageEnabled=false 
 
         if "%ERRORLEVEL%" == "0" call .\tools\MakeAppxHelper.cmd %BUILDPLATFORM% %BUILDCONFIGURATION%
     ) else (
@@ -192,6 +202,7 @@ echo        /UseInternalSDK - build using internal SDK
 echo        /EmitTelemetryEvents - build with telemetry events turned on
 echo        /project ^<path^> - builds a specific project
 echo        /usevsprerelease - use the prerelease VS on the machine instead of latest stable
+echo        /target - specify the msbuild target. Specify multiple times to build multiple targets.
 echo.
 
 :end

--- a/CreateTestBinariesDirFromLocalBuild.ps1
+++ b/CreateTestBinariesDirFromLocalBuild.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding()]
+param(
+    [switch]$NoBuild,
+    [switch]$Release,
+    [String]$Flavor = "Debug",
+    [String]$Platform = "x86"
+)
+
+function DoesTaefAppXNeedBuild
+{
+    param(
+        [System.IO.FileSystemInfo]$MuxDllFile,
+        [string]$ProjectName,
+        [string]$Platform,
+        [string]$Flavor
+    )
+
+    $projectFileName = "$($ProjectName).TAEF"
+
+    return DoesAppXNeedBuild -MuxDllFile $MuxDllFile -ProjectName $ProjectName -Platform $Platform -Flavor $Flavor -AppXPath "$projectFileName\AppPackages\$($ProjectName)_Test\$ProjectName.appx" -ExePath "$projectFileName\$ProjectName.exe"
+}
+
+function DoesAppXNeedBuild
+{
+    param(
+        [System.IO.FileSystemInfo]$MuxDllFile,
+        [string]$AppXPath,
+        [string]$ExePath,
+        [string]$ProjectName,
+        [string]$BuildTarget,
+        [string]$Platform,
+        [string]$Flavor
+    )
+
+    $appxFullPath = "$PSScriptRoot\BuildOutput\$Flavor\$Platform\$AppXPath"
+    $testAppxFile = Get-Item $appxFullPath -ErrorAction Ignore
+    $testExeFile = Get-Item "$PSScriptRoot\BuildOutput\$Flavor\$Platform\$ExePath" -ErrorAction Ignore
+
+    if((!$testAppxFile) -or (!$testExeFile) -or ($testExeFile.LastWriteTime -gt $testAppxFile.LastWriteTime) -or ($muxDllFile.LastWriteTime -gt $testAppxFile.LastWriteTime))
+    {
+        if ($testAppxFile)
+        {
+            Write-Host "$testAppxFile LastWriteTime = $($testAppxFile.LastWriteTime)"
+        }
+        else
+        {
+            Write-Host "No appx at $appxFullPath"
+        }
+        if ($testExeFile)
+        {
+            Write-Host "$testExeFile LastWriteTime = $($testExeFile.LastWriteTime)"
+        }
+        Write-Host "$muxDllFile LastWriteTime = $($muxDllFile.LastWriteTime)"
+
+        return $true
+    }
+    else
+    {
+        return $false
+    }
+}
+
+
+# Clean up artifacts and HelixPayload directories:
+$artifactsDropDir = "$PSScriptRoot\Artifacts\drop"
+$helixpayloadDir = "$PSScriptRoot\HelixPayload\$Flavor\$Platform"
+if(Test-Path $artifactsDropDir)
+{
+    Remove-Item $artifactsDropDir -Force -Recurse
+}
+
+if(Test-Path $helixpayloadDir)
+{
+    Remove-Item $helixpayloadDir -Force -Recurse
+}
+
+# Determine if we need to build the test binaries:
+$muxDllFile = Get-Item "$PSScriptRoot\BuildOutput\$Flavor\$Platform\Microsoft.UI.Xaml\Microsoft.UI.Xaml.dll"
+
+$shouldBuild = $false;
+$buildCmd = "";
+if(!$Release)
+{   
+    $shouldBuild = $shouldBuild -Or (DoesTaefAppXNeedBuild -MuxDllFile $muxDllFile -ProjectName "MUXControlsTestApp" -Platform $Platform -Flavor $Flavor)
+    $shouldBuild = $shouldBuild -Or (DoesTaefAppXNeedBuild -MuxDllFile $muxDllFile -ProjectName "IXMPTestApp" -Platform $Platform -Flavor $Flavor)
+    $shouldBuild = $shouldBuild -Or (DoesAppXNeedBuild -MuxDllFile $muxDllFile -ProjectName "MUXControlsTestAppWPFPackage" -Platform $Platform -Flavor $Flavor -AppXPath "MUXControlsTestAppWPFPackage\AppPackages\MUXControlsTestAppWPFPackage_Test\MUXControlsTestAppWPFPackage.appx" -ExePath "MUXControlsTestAppWPF\MUXControlsTestAppWPF.exe" -ProjectPath "MUXControlsTestAppWPFPackage\MUXControlsTestAppWPFPackage.wapproj")
+    if($shouldBuild)
+    {
+        $buildCmd = "$PSScriptRoot\build.cmd $($Platform.ToLower()) $($Flavor.ToLower()) /target test\MUXControlsTestApp\MUXControlsTestApp_TAEF:Publish /target test\IXMPTestApp\IXMPTestApp_TAEF:Publish /target test\MUXControlsTestAppWPF\MUXControlsTestAppWPFPackage:Publish"
+    }
+}
+else
+{
+    $shouldBuild = $shouldBuild -Or (DoesAppXNeedBuild -MuxDllFile $muxDllFile -ProjectName "NugetPackageTestApp" -Platform $Platform -Flavor $Flavor -AppXPath "NugetPackageTestApp\AppPackages\NugetPackageTestApp_Test\NugetPackageTestApp.appx" -ExePath "NugetPackageTestApp\NugetPackageTestApp.exe" -ProjectPath "MUXControlsReleaseTest\NugetPackageTestApp\NugetPackageTestApp.csproj")
+    $shouldBuild = $shouldBuild -Or (DoesAppXNeedBuild -MuxDllFile $muxDllFile -ProjectName "NugetPackageTestAppCX" -Platform $Platform -Flavor $Flavor -AppXPath "NugetPackageTestAppCX\AppPackages\NugetPackageTestAppCX_Test\NugetPackageTestAppCX.appx" -ExePath "NugetPackageTestAppCX\NugetPackageTestAppCX.exe" -ProjectPath "MUXControlsReleaseTest\NugetPackageTestAppCX\NugetPackageTestAppCX.csproj")
+    if($shouldBuild)
+    {
+        $buildCmd = "$PSScriptRoot\build.cmd $($Platform.ToLower()) $($Flavor.ToLower()) /project D:\microsoft-ui-xaml\test\MUXControlsReleaseTest\MUXControlsReleaseTest.sln"
+    }
+}
+
+if($shouldBuild)
+{
+    if(!$NoBuild)
+    {
+        Write-Host $buildCmd
+        Invoke-Expression $buildCmd
+    }
+    else
+    {
+        Write-Warning "Test binaries are out of date, but -NoBuild flag was specified so skipping build"
+    }
+}
+
+
+& .\build\CopyFilesToStagingDir.ps1 -BuildOutputDir "$PSScriptRoot\BuildOutput\" -PublishDir $artifactsDropDir -Platform $Platform -Configuration $Flavor -PublishAppxFiles
+& .\Tools\NugetWrapper.cmd restore build\Helix\packages.config -PackagesDirectory build\Helix\packages
+& .\build\Helix\PrepareHelixPayload.ps1 -Platform $Platform -Configuration $Flavor
+
+Write-Host "Test binaries dir created in $helixpayloadDir"

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -3,7 +3,8 @@ Param(
     [string]$BuildOutputDir,
     [string]$PublishDir,
     [string]$Platform,
-    [string]$Configuration
+    [string]$Configuration,
+    [switch]$PublishAppxFiles=$false
 )
 
 $FullBuildOutput = "$($BuildOutputDir)\$($Configuration)\$($Platform)"
@@ -22,7 +23,7 @@ function PublishFile {
         {
             $ignore = New-Item -ItemType Directory $destinationDir
         }
-        Copy-Item -Force $source $destinationDir
+        Copy-Item -Recurse -Force $source $destinationDir
     }
     else
     {
@@ -38,6 +39,18 @@ PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml.Design\Microsoft.UI.Xam
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\MUXControls.Test.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.ReleaseTest.TAEF\MUXControls.ReleaseTest.dll $FullPublishDir\Test\
 PublishFile -IfExists $FullBuildOutput\FrameworkPackage\*.* $FullPublishDir\FrameworkPackage
+
+if($PublishAppxFiles)
+{
+    $AppxPackagesDir = "$FullPublishDir\AppxPackages"
+
+    PublishFile -IfExists $FullBuildOutput\MUXControlsTestApp.TAEF\AppPackages\MUXControlsTestApp_Test\ $AppxPackagesDir
+    PublishFile -IfExists $FullBuildOutput\IXMPTestApp.TAEF\AppPackages\IXMPTestApp_Test\ $AppxPackagesDir
+    PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppWPFPackage\AppPackages\MUXControlsTestAppWPFPackage_Test\ $AppxPackagesDir
+
+    PublishFile -IfExists $FullBuildOutput\NugetPackageTestApp\AppPackages\NugetPackageTestApp_Test\ $AppxPackagesDir
+    PublishFile -IfExists $FullBuildOutput\NugetPackageTestAppCX\AppPackages\NugetPackageTestAppCX_Test\ $AppxPackagesDir
+}
 
 # Publish pdbs:
 $symbolsOutputDir = "$($FullPublishDir)\Symbols\"


### PR DESCRIPTION
1. Rename RunTest.ps1 to RunTestsOnTShellConnectedDevice.ps1 to more accurately describe it's function.
2. Remove the test file build and copy logic from RunTest.ps1 and move it to CreateTestBinariesDirFromLocalBuild.ps1 which is independently useful.
3. Rationalize the file copy logic with AzDO Pipelines. Instead of having custom logic, just re-use the CopyFilesToStagingDir.ps1 and PrepareHelixPayload.ps1 scripts which are used by the Pipeline. This is probably slightly less efficient since it involves two steps (BuildOutput -> Artifacts\drop -> HelixPayload), but it is worth it to make the local workflow align with the Azure Pipeline workflow.
4. Update the build logic. The runtests.ps1 has logic to determine if the test binaries are out of date. However, this frequently resulted in a full build of MUX.dll occurring even when it was not necessary. This seems to be a result of passing the test project (e.g. MUXControls.Test.TAEF.csproj) to msbuild instead of the .sln. It also invoked msbuild multiple times, which slows things down and causes repeat work. So instead we build the .sln instead of the .proj, but specify the particular targets that we care about.

The main benefit of these changes is that it makes it easier for an IC to investigate a test failure that occurs in Helix (using TAEF) but not when run locally from VS (using VSTest). It is now simple to run CreateTestBinariesDirFromLocalBuild.ps1 and then copy that dir to whatever device is needed and invoke te.exe. It also removes duplicate logic that would be easy to get out of sync.

A next step to build on this would be to have a script that can take a url to an AzDO build and have it pull the binaries from there instead of from a local build to create a HelixPayload directory. That would also be useful, but it is not covered in this change.

Closes #93
