### PR TITLE
Adding dev tests to MUX-CI.yml

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -33,6 +33,13 @@ jobs:
   
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
+- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    dependsOn: Build
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    testSuite: 'DevTestSuite'
+
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
   parameters:
@@ -60,6 +67,7 @@ jobs:
 - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
   parameters:
     dependsOn:
+    - RunTestsInHelix
     - RunNugetPkgTestsInHelix
     - RunFrameworkPkgTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5


### PR DESCRIPTION
This will make MUX-CI.yml a superset of MUX-PR.yml, and will allow us to remove RunHelixTests.yml once it goes in.