### PR TITLE
Add warnings to pipeline when localization handback is required

### DIFF
--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -19,4 +19,11 @@ jobs:
     inputs:
       filename: '$(Build.SourcesDirectory)\tools\VSTSRunLocWorkflow.cmd'
 
-
+  - powershell: |
+      $changes = & git ls-files -m
+      Write-Host "##vso[task.logissue type=warning;]Localization updates needed"
+      foreach ($change in $changes)
+      {
+        Write-Host "##vso[task.logissue type=warning;]$change"
+      }
+    displayName: checkEditedFiles

--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -21,9 +21,13 @@ jobs:
 
   - powershell: |
       $changes = & git ls-files -m
-      Write-Host "##vso[task.logissue type=warning;]Localization updates needed"
-      foreach ($change in $changes)
+      if ($changes)
       {
-        Write-Host "##vso[task.logissue type=warning;]$change"
+        Write-Host "##vso[task.complete result=SucceededWithIssues;]"
+        Write-Host "##vso[task.logissue type=warning;]Localization updates needed"
+        foreach ($change in $changes)
+        {
+          Write-Host "##vso[task.logissue type=warning;]$change"
+        }
       }
     displayName: checkEditedFiles


### PR DESCRIPTION
The localization handoff pipeline runs once a day but we weren't being notified when hand-back was required. This adds a check to the pipeline to see if any files are checked out at the end of the run, which indicates that there's newly localized files.

If this happens we also set the pipeline status to "partially succeeded" and then I can set up a Azure DevOps email notification when the pipeline completes with that status.