### PR TITLE
Unblock PR tests: disable RS2 and RS4 test passes.

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -15,7 +15,9 @@ parameters:
     Release_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'release'
-      helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.Client19H1.Open'
+      # temporarily disabling RS2 and RS4 queues to unblock tests.
+      helixTargetQueues: 'Windows.10.Amd64.Client19H1.Open'
+      #helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.Client19H1.Open'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -23,7 +25,9 @@ jobs:
   condition: ${{ parameters.condition }}
   pool:
     vmImage: 'windows-2019'
-  timeoutInMinutes: 120
+  # temporarily increasing timeout to 180
+  timeoutInMinutes: 180
+  #timeoutInMinutes: 120
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
     taefPath: $(Build.SourcesDirectory)\build\Helix\packages\taef.redist.wlk.10.31.180822002\build\Binaries\$(buildPlatform)

--- a/build/Helix/global.json
+++ b/build/Helix/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19258.5"
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19313.7"
   }
 }

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -1,6 +1,8 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Build
+  condition:
+    eq(variables['useBuildOutputFromBuildId'],'') 
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 120


### PR DESCRIPTION
These test passes are currently failing due to an issue in Helix.

This PR also adds 'useBuildOutputFromBuildId' to the PR build to allow testing on previous builds.

Re-enabling these queues is tracked by #871.