### PR TITLE
Correct CornerRadius handling of various controls

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -288,7 +288,8 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             Grid.ColumnSpan="3"
-                            Grid.RowSpan="1" />
+                            Grid.RowSpan="1"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>
                         <ContentPresenter x:Name="HeaderContentPresenter"
                             x:DeferLoadStrategy="Lazy"
                             Visibility="Collapsed"
@@ -396,7 +397,8 @@
                             Canvas.ZIndex="0"
                             Margin="0"
                             DesiredCandidateWindowAlignment="BottomEdge"
-                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}" />
+                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>
 
                         <Popup x:Name="SuggestionsPopup">
                             <Border x:Name="SuggestionsContainer">

--- a/dev/CheckBox/CheckBox.vcxitems
+++ b/dev/CheckBox/CheckBox.vcxitems
@@ -17,6 +17,7 @@
     <Page Include="$(MSBuildThisFileDirectory)CheckBox_themeresources.xaml">
       <Version>RS1</Version>
       <Type>ThemeResources</Type>
+      <UseNonstandardCondtionalXAML>true</UseNonstandardCondtionalXAML>
     </Page>
   </ItemGroup>
 </Project>

--- a/dev/CheckBox/CheckBox_themeresources.xaml
+++ b/dev/CheckBox/CheckBox_themeresources.xaml
@@ -1,5 +1,6 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -296,7 +297,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}" >
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}" >
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CombinedStates">
@@ -650,8 +651,8 @@
                                 UseLayoutRounding="False"
                                 Height="20"
                                 Width="20"
-                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <FontIcon x:Name="CheckGlyph"
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 Glyph="&#xE001;"

--- a/dev/CheckBox/CheckBox_themeresources.xaml
+++ b/dev/CheckBox/CheckBox_themeresources.xaml
@@ -649,7 +649,9 @@
                                 StrokeThickness="{ThemeResource CheckBoxBorderThemeThickness}"
                                 UseLayoutRounding="False"
                                 Height="20"
-                                Width="20" />
+                                Width="20"
+                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <FontIcon x:Name="CheckGlyph"
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 Glyph="&#xE001;"

--- a/dev/ColorPicker/ColorPicker.vcxitems
+++ b/dev/ColorPicker/ColorPicker.vcxitems
@@ -41,6 +41,7 @@
     <Page Include="$(MSBuildThisFileDirectory)ColorPicker.xaml">
       <Version>RS1</Version>
       <Type>DefaultStyle</Type>
+      <UseNonstandardCondtionalXAML>true</UseNonstandardCondtionalXAML>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)ColorPicker_themeresources.xaml">
       <Version>RS1</Version>
@@ -49,6 +50,7 @@
     <Page Include="$(MSBuildThisFileDirectory)ColorSpectrum.xaml">
       <Version>RS1</Version>
       <Type>DefaultStyle</Type>
+      <UseNonstandardCondtionalXAML>true</UseNonstandardCondtionalXAML>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -88,8 +88,8 @@
                                                             <RowDefinition Height="18"/>
                                                         </Grid.RowDefinitions>
                                                         <Rectangle x:Name="HorizontalTrackRect" Grid.ColumnSpan="3" Fill="Transparent" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Opacity="0"
-                                                            RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                                            RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                                            contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                                            contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                                         <Rectangle x:Name="HorizontalDecreaseRect" Fill="Transparent" Grid.Row="1" Opacity="0" />
                                                         <Thumb x:Name="HorizontalThumb" AutomationProperties.AccessibilityView="Raw" Grid.Column="1" DataContext="{TemplateBinding Value}" Height="{ThemeResource SliderHorizontalThumbHeight}" Grid.Row="0" Grid.RowSpan="3" Style="{StaticResource SliderThumbStyle}" Width="{ThemeResource SliderHorizontalThumbWidth}">
                                                             <ToolTipService.ToolTip>
@@ -251,7 +251,7 @@
                                     MaxValue="{TemplateBinding MaxValue}"
                                     Shape="{TemplateBinding ColorSpectrumShape}"
                                     Components="{TemplateBinding ColorSpectrumComponents}"
-                                    CornerRadius="{TemplateBinding CornerRadius}"/>
+                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>
                                 <Grid x:Name="ColorPreviewRectangleGrid" Grid.Column="1" Grid.Row="0" Width="44" Margin="12,0,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition />
@@ -262,27 +262,27 @@
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <Rectangle VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2"
-                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
+                                        contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                         <Rectangle.Fill>
                                             <ImageBrush x:Name="ColorPreviewRectangleCheckeredBackgroundImageBrush" />
                                         </Rectangle.Fill>
                                     </Rectangle>
                                     <Rectangle x:Name="ColorPreviewRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2"
-                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                        contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                     <Rectangle x:Name="PreviousColorRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.Row="1" Visibility="Collapsed"
-                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                        contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                     <Rectangle x:Name="BorderRectangle" Style="{StaticResource ColorPickerBorderStyle}" Grid.RowSpan="2" Grid.ColumnSpan="2"
-                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                        contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 </Grid>
                             </Grid>
                             <Grid Margin="0,12,0,0" x:Name="ThirdDimensionSliderGrid">
                                 <Rectangle Height="11" VerticalAlignment="Center"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                     <Rectangle.Fill>
                                         <LinearGradientBrush x:Name="ThirdDimensionSliderGradientBrush" />
                                     </Rectangle.Fill>
@@ -291,15 +291,15 @@
                             </Grid>
                             <Grid Margin="0,12,0,0" x:Name="AlphaSliderGrid">
                                 <Rectangle Height="11" VerticalAlignment="Center"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                     <Rectangle.Fill>
                                         <ImageBrush x:Name="AlphaSliderCheckeredBackgroundImageBrush" />
                                     </Rectangle.Fill>
                                 </Rectangle>
                                 <Rectangle x:Name="AlphaSliderBackgroundRectangle" Height="11" VerticalAlignment="Center"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                     <Rectangle.Fill>
                                         <LinearGradientBrush x:Name="AlphaSliderGradientBrush" />
                                     </Rectangle.Fill>

--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -3,7 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
     <Style TargetType="controls:ColorPicker" >
         <Setter Property="MaxWidth" Value="392" />
         <Setter Property="MinWidth" Value="312" />
@@ -25,7 +26,7 @@
                                                         <Setter Property="Template">
                                                             <Setter.Value>
                                                                 <ControlTemplate TargetType="Thumb">
-                                                                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="4"/>
+                                                                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" contract7Present:CornerRadius="{ThemeResource SliderThumbCornerRadius}" />
                                                                 </ControlTemplate>
                                                             </Setter.Value>
                                                         </Setter>
@@ -86,9 +87,11 @@
                                                             <RowDefinition Height="Auto"/>
                                                             <RowDefinition Height="18"/>
                                                         </Grid.RowDefinitions>
-                                                        <Rectangle x:Name="HorizontalTrackRect" Grid.ColumnSpan="3" Fill="Transparent" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Opacity="0" />
+                                                        <Rectangle x:Name="HorizontalTrackRect" Grid.ColumnSpan="3" Fill="Transparent" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Opacity="0"
+                                                            RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                                            RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                                         <Rectangle x:Name="HorizontalDecreaseRect" Fill="Transparent" Grid.Row="1" Opacity="0" />
-                                                        <Thumb x:Name="HorizontalThumb" AutomationProperties.AccessibilityView="Raw" Grid.Column="1" DataContext="{TemplateBinding Value}" Height="24" Grid.Row="0" Grid.RowSpan="3" Style="{StaticResource SliderThumbStyle}" Width="8">
+                                                        <Thumb x:Name="HorizontalThumb" AutomationProperties.AccessibilityView="Raw" Grid.Column="1" DataContext="{TemplateBinding Value}" Height="{ThemeResource SliderHorizontalThumbHeight}" Grid.Row="0" Grid.RowSpan="3" Style="{StaticResource SliderThumbStyle}" Width="{ThemeResource SliderHorizontalThumbWidth}">
                                                             <ToolTipService.ToolTip>
                                                                 <ToolTip x:Name="ToolTip" VerticalOffset="20" />
                                                             </ToolTipService.ToolTip>
@@ -247,7 +250,8 @@
                                     MinValue="{TemplateBinding MinValue}"
                                     MaxValue="{TemplateBinding MaxValue}"
                                     Shape="{TemplateBinding ColorSpectrumShape}"
-                                    Components="{TemplateBinding ColorSpectrumComponents}"/>
+                                    Components="{TemplateBinding ColorSpectrumComponents}"
+                                    CornerRadius="{TemplateBinding CornerRadius}"/>
                                 <Grid x:Name="ColorPreviewRectangleGrid" Grid.Column="1" Grid.Row="0" Width="44" Margin="12,0,0,0">
                                     <Grid.RowDefinitions>
                                         <RowDefinition />
@@ -257,18 +261,28 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
-                                    <Rectangle VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2">
+                                    <Rectangle VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2"
+                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                         <Rectangle.Fill>
                                             <ImageBrush x:Name="ColorPreviewRectangleCheckeredBackgroundImageBrush" />
                                         </Rectangle.Fill>
                                     </Rectangle>
-                                    <Rectangle x:Name="ColorPreviewRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2" />
-                                    <Rectangle x:Name="PreviousColorRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.Row="1" Visibility="Collapsed" />
-                                    <Rectangle x:Name="BorderRectangle" Style="{StaticResource ColorPickerBorderStyle}" Grid.RowSpan="2" Grid.ColumnSpan="2" />
+                                    <Rectangle x:Name="ColorPreviewRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2"
+                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    <Rectangle x:Name="PreviousColorRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.Row="1" Visibility="Collapsed"
+                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    <Rectangle x:Name="BorderRectangle" Style="{StaticResource ColorPickerBorderStyle}" Grid.RowSpan="2" Grid.ColumnSpan="2"
+                                        RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                        RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 </Grid>
                             </Grid>
                             <Grid Margin="0,12,0,0" x:Name="ThirdDimensionSliderGrid">
-                                <Rectangle Height="11" VerticalAlignment="Center">
+                                <Rectangle Height="11" VerticalAlignment="Center"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                     <Rectangle.Fill>
                                         <LinearGradientBrush x:Name="ThirdDimensionSliderGradientBrush" />
                                     </Rectangle.Fill>
@@ -276,12 +290,16 @@
                                 <primitives:ColorPickerSlider x:Name="ThirdDimensionSlider" Minimum="0" Maximum="100" ColorChannel="Value" Style="{StaticResource ColorPickerSliderStyle}" IsThumbToolTipEnabled="False" />
                             </Grid>
                             <Grid Margin="0,12,0,0" x:Name="AlphaSliderGrid">
-                                <Rectangle Height="11" VerticalAlignment="Center">
+                                <Rectangle Height="11" VerticalAlignment="Center"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                     <Rectangle.Fill>
                                         <ImageBrush x:Name="AlphaSliderCheckeredBackgroundImageBrush" />
                                     </Rectangle.Fill>
                                 </Rectangle>
-                                <Rectangle x:Name="AlphaSliderBackgroundRectangle" Height="11" VerticalAlignment="Center">
+                                <Rectangle x:Name="AlphaSliderBackgroundRectangle" Height="11" VerticalAlignment="Center"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}">
                                     <Rectangle.Fill>
                                         <LinearGradientBrush x:Name="AlphaSliderGradientBrush" />
                                     </Rectangle.Fill>

--- a/dev/ColorPicker/ColorSpectrum.xaml
+++ b/dev/ColorPicker/ColorSpectrum.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
 
     <Style TargetType="primitives:ColorSpectrum" >
@@ -64,11 +65,11 @@
                                 <RectangleGeometry />
                             </Grid.Clip>
                             <Rectangle x:Name="SpectrumRectangle" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <Rectangle x:Name="SpectrumOverlayRectangle" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <Ellipse x:Name="SpectrumEllipse" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Collapsed" Margin="0,0,-1,-1" />
                             <Ellipse x:Name="SpectrumOverlayEllipse" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Collapsed" Margin="0,0,-1,-1" />
                             <Canvas x:Name="InputTarget" Background="Transparent" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Control.IsTemplateFocusTarget="True">
@@ -82,8 +83,8 @@
                                 </Grid>
                             </Canvas>
                             <Rectangle x:Name="RectangleBorder" Style="{StaticResource ColorPickerBorderStyle}" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <Ellipse x:Name="EllipseBorder" Style="{StaticResource ColorPickerBorderStyle}" IsHitTestVisible="False" Visibility="Collapsed" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="-0.5,-0.5,-1.5,-1.5"/>
                         </Grid>
                     </Grid>

--- a/dev/ColorPicker/ColorSpectrum.xaml
+++ b/dev/ColorPicker/ColorSpectrum.xaml
@@ -63,8 +63,12 @@
                             <Grid.Clip>
                                 <RectangleGeometry />
                             </Grid.Clip>
-                            <Rectangle x:Name="SpectrumRectangle" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
-                            <Rectangle x:Name="SpectrumOverlayRectangle" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+                            <Rectangle x:Name="SpectrumRectangle" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                            <Rectangle x:Name="SpectrumOverlayRectangle" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <Ellipse x:Name="SpectrumEllipse" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Collapsed" Margin="0,0,-1,-1" />
                             <Ellipse x:Name="SpectrumOverlayEllipse" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Visibility="Collapsed" Margin="0,0,-1,-1" />
                             <Canvas x:Name="InputTarget" Background="Transparent" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Control.IsTemplateFocusTarget="True">
@@ -77,7 +81,9 @@
                                     </Ellipse>
                                 </Grid>
                             </Canvas>
-                            <Rectangle x:Name="RectangleBorder" Style="{StaticResource ColorPickerBorderStyle}" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+                            <Rectangle x:Name="RectangleBorder" Style="{StaticResource ColorPickerBorderStyle}" IsHitTestVisible="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                             <Ellipse x:Name="EllipseBorder" Style="{StaticResource ColorPickerBorderStyle}" IsHitTestVisible="False" Visibility="Collapsed" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="-0.5,-0.5,-1.5,-1.5"/>
                         </Grid>
                     </Grid>

--- a/dev/CommonStyles/TestUI/CornerRadiusPage.xaml
+++ b/dev/CommonStyles/TestUI/CornerRadiusPage.xaml
@@ -6,6 +6,8 @@
     xmlns:local="using:MUXControlsTestApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -237,6 +239,30 @@
                     </Button.ContextFlyout>
                 </Button>
             </Grid>
+            <Grid Grid.Row="12" Style="{StaticResource RightColumn}">
+                <Button Content="Click me">
+                    <Button.Flyout>
+                        <Flyout>
+                            <Flyout.FlyoutPresenterStyle>
+                                <Style TargetType="FlyoutPresenter">
+                                    <Setter Property="CornerRadius" Value="6"/>
+                                </Style>
+                            </Flyout.FlyoutPresenterStyle>
+                            <TextBlock Text="Hello World"/>
+                        </Flyout>
+                    </Button.Flyout>
+                    <Button.ContextFlyout>
+                        <Flyout>
+                            <Flyout.FlyoutPresenterStyle>
+                                <Style TargetType="FlyoutPresenter">
+                                    <Setter Property="CornerRadius" Value="6"/>
+                                </Style>
+                            </Flyout.FlyoutPresenterStyle>
+                            <TextBlock Text="Hello World" MinHeight="300" MinWidth="300"/>
+                        </Flyout>
+                    </Button.ContextFlyout>
+                </Button>
+            </Grid>
 
             <TextBlock Grid.Row="13" Text="MenuFlyout" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Row="13" Style="{StaticResource LeftColumn}">
@@ -257,6 +283,48 @@
                     </Button.Flyout>
                     <Button.ContextFlyout>
                         <MenuFlyout>
+                            <MenuFlyoutItem Text="Share" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE72D;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem Text="Copy" Icon="Copy" />
+                            <MenuFlyoutItem Text="Delete" Icon="Delete" />
+                            <MenuFlyoutSeparator />
+                            <MenuFlyoutItem Text="Rename" />
+                            <MenuFlyoutItem Text="Select" />
+                        </MenuFlyout>
+                    </Button.ContextFlyout>
+                </Button>
+            </Grid>
+            <Grid Grid.Row="13" Style="{StaticResource RightColumn}">
+                <Button Content="Click me">
+                    <Button.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyout.MenuFlyoutPresenterStyle>
+                                <Style TargetType="MenuFlyoutPresenter">
+                                    <Setter Property="CornerRadius" Value="6"/>
+                                </Style>
+                            </MenuFlyout.MenuFlyoutPresenterStyle>
+                            <MenuFlyoutItem Text="Share" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE72D;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem Text="Copy" Icon="Copy" />
+                            <MenuFlyoutItem Text="Delete" Icon="Delete" />
+                            <MenuFlyoutSeparator />
+                            <MenuFlyoutItem Text="Rename" />
+                            <MenuFlyoutItem Text="Select" />
+                        </MenuFlyout>
+                    </Button.Flyout>
+                    <Button.ContextFlyout>
+                        <MenuFlyout>
+                            <MenuFlyout.MenuFlyoutPresenterStyle>
+                                <Style TargetType="MenuFlyoutPresenter">
+                                    <Setter Property="CornerRadius" Value="6"/>
+                                </Style>
+                            </MenuFlyout.MenuFlyoutPresenterStyle>
                             <MenuFlyoutItem Text="Share" >
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE72D;" />
@@ -317,26 +385,50 @@
             </Grid>
 
             <TextBlock Grid.Row="21" Text="Slider" Style="{StaticResource SideHeader}"/>
-            <Grid Grid.Row="21" Style="{StaticResource LeftColumn}" MinWidth="50">
+            <Grid Grid.Row="21" Style="{StaticResource LeftColumn}" MinWidth="200">
                 <Slider Orientation="Horizontal"/>
             </Grid>
-            <Grid Grid.Row="21" Style="{StaticResource RightColumn}" MinWidth="50">
+            <Grid Grid.Row="21" Style="{StaticResource RightColumn}" MinWidth="200">
+                <Grid.Resources>
+                    <!-- Rounding slider thumb until that becomes the default -->
+                    <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+                </Grid.Resources>
                 <Slider Orientation="Horizontal" CornerRadius="6"/>
             </Grid>
 
             <TextBlock Grid.Row="22" Text="Slider" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Row="22" Style="{StaticResource LeftColumn}">
-                <Slider Orientation="Horizontal" TickFrequency="1" Width="100" TickPlacement="Outside"/>
+                <Slider Orientation="Horizontal" TickFrequency="1" Width="200" TickPlacement="Outside"/>
             </Grid>
             <Grid Grid.Row="22" Style="{StaticResource RightColumn}">
-                <Slider Orientation="Horizontal" TickFrequency="1" Width="100" TickPlacement="Outside" CornerRadius="6"/>
+                <Grid.Resources>
+                    <!-- Rounding slider thumb until that becomes the default -->
+                    <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+                </Grid.Resources>
+                <Slider Orientation="Horizontal" TickFrequency="1" Width="200" TickPlacement="Outside" CornerRadius="6"/>
             </Grid>
 
             <TextBlock Grid.Row="23" Text="" Style="{StaticResource SideHeader}"/>
-            <Grid Grid.Row="23" Style="{StaticResource LeftColumn}" MinHeight="50">
+            <Grid Grid.Row="23" Style="{StaticResource LeftColumn}" MinHeight="100">
                 <Slider Orientation="Vertical"/>
             </Grid>
-            <Grid Grid.Row="23" Style="{StaticResource RightColumn}" MinHeight="50">
+            <Grid Grid.Row="23" Style="{StaticResource RightColumn}" MinHeight="100">
+                <Grid.Resources>
+                    <!-- Rounding slider thumb until that becomes the default -->
+                    <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+                </Grid.Resources>
                 <Slider Orientation="Vertical" CornerRadius="6"/>
             </Grid>
 
@@ -345,20 +437,31 @@
                 <Slider Orientation="Vertical" TickFrequency="1" Height="100" TickPlacement="Outside"/>
             </Grid>
             <Grid Grid.Row="24" Style="{StaticResource RightColumn}">
+                <Grid.Resources>
+                    <!-- Rounding slider thumb until that becomes the default -->
+                    <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+                </Grid.Resources>
                 <Slider Orientation="Vertical" TickFrequency="1" Height="100" TickPlacement="Outside" CornerRadius="6"/>
             </Grid>
 
             <TextBlock Grid.Row="31" Text="ProgressBar" Style="{StaticResource SideHeader}"/>
-            <Grid Grid.Row="31" Style="{StaticResource LeftColumn}" MinWidth="50">
+            <Grid Grid.Row="31" Style="{StaticResource LeftColumn}" MinWidth="100">
                 <ProgressBar Minimum="0" Maximum="100" Value="50"/>
             </Grid>
-            <Grid Grid.Row="31" Style="{StaticResource RightColumn}" MinWidth="50">
+            <Grid Grid.Row="31" Style="{StaticResource RightColumn}" MinWidth="100">
                 <ProgressBar Minimum="0" Maximum="100" Value="50" CornerRadius="6"/>
             </Grid>
 
             <TextBlock Grid.Row="32" Text="TextBlock" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Row="32" Style="{StaticResource LeftColumn}">
                 <TextBlock Text="Hello World"/>
+            </Grid>
+            <Grid Grid.Row="32" Style="{StaticResource RightColumn}">
+                <TextBlock>N/A</TextBlock>
             </Grid>
 
             <TextBlock Grid.Row="33" Text="RichTextBlock" Style="{StaticResource SideHeader}"/>
@@ -368,6 +471,9 @@
                         Hello World
                     </Paragraph>
                 </RichTextBlock>
+            </Grid>
+            <Grid Grid.Row="33" Style="{StaticResource RightColumn}">
+                <TextBlock>N/A</TextBlock>
             </Grid>
 
             <TextBlock Grid.Row="34" Text="CheckBox" Style="{StaticResource SideHeader}"/>
@@ -408,6 +514,21 @@
             </Grid>
             <Grid Grid.Row="38" Style="{StaticResource RightColumn}">
                 <RichEditBox CornerRadius="6"/>
+            </Grid>
+            <TextBlock Grid.Row="39" Text="FlipView" Style="{StaticResource SideHeader}"/>
+            <Grid Grid.Row="39" Style="{StaticResource LeftColumn}" Width="200" Height="200">
+                <FlipView>
+                    <Grid Background="Red"/>
+                    <Grid Background="Green"/>
+                    <Grid Background="Blue"/>
+                </FlipView>
+            </Grid>
+            <Grid Grid.Row="39" Style="{StaticResource RightColumn}" Width="200" Height="200">
+                <FlipView CornerRadius="6">
+                    <Grid Background="Red"/>
+                    <Grid Background="Green"/>
+                    <Grid Background="Blue"/>
+                </FlipView>
             </Grid>
 
             <TextBlock Grid.Row="40" Text="RadioButton" Style="{StaticResource SideHeader}"/>
@@ -462,6 +583,44 @@
                 <HyperlinkButton Content="Hello World" CornerRadius="6"/>
             </Grid>
 
+            <TextBlock Grid.Row="45" Text="DropDownButton" Style="{StaticResource SideHeader}"/>
+            <Grid Grid.Row="45" Style="{StaticResource LeftColumn}">
+                <controls:DropDownButton Content="Hello World"/>
+            </Grid>
+            <Grid Grid.Row="45" Style="{StaticResource RightColumn}">
+                <controls:DropDownButton Content="Hello World" CornerRadius="6"/>
+            </Grid>
+            <TextBlock Grid.Row="46" Text="SplitButton" Style="{StaticResource SideHeader}"/>
+            <Grid Grid.Row="46" Style="{StaticResource LeftColumn}">
+                <controls:SplitButton Content="Hello World"/>
+            </Grid>
+            <Grid Grid.Row="46" Style="{StaticResource RightColumn}">
+                <controls:SplitButton Content="Hello World" CornerRadius="6"/>
+            </Grid>
+            <TextBlock Grid.Row="47" Text="ColorPicker" Style="{StaticResource SideHeader}"/>
+            <Grid Grid.Row="47" Style="{StaticResource LeftColumn}">
+                <controls:ColorPicker IsAlphaEnabled="True"/>
+            </Grid>
+            <Grid Grid.Row="47" Style="{StaticResource RightColumn}">
+                <Grid.Resources>
+                    <Style TargetType="ComboBox">
+                        <Setter Property="CornerRadius" Value="6"/>
+                    </Style>
+                    <Style TargetType="TextBox">
+                        <Setter Property="CornerRadius" Value="6"/>
+                    </Style>
+                    <Style TargetType="primitives:ColorPickerSlider">
+                        <Setter Property="CornerRadius" Value="6"/>
+                    </Style>
+                    <!-- Rounding slider thumb until that becomes the default -->
+                    <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
+                    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+                </Grid.Resources>
+                <controls:ColorPicker IsAlphaEnabled="True" CornerRadius="6"/>
+            </Grid>
             <TextBlock Grid.Row="48" Text="ListView" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Row="48" Style="{StaticResource LeftColumn}">
                 <ListView SelectionMode="Multiple">

--- a/dev/DatePicker/DatePicker_themeresources.xaml
+++ b/dev/DatePicker/DatePicker_themeresources.xaml
@@ -215,7 +215,8 @@
                                                     Foreground="{TemplateBinding Foreground}"
                                                     HorizontalContentAlignment="Stretch"
                                                     VerticalContentAlignment="Stretch"
-                                                    AutomationProperties.AccessibilityView="Raw" />
+                                                    AutomationProperties.AccessibilityView="Raw"
+                                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -285,7 +286,8 @@
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Stretch"
                             VerticalAlignment="Top"
-                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}">
+                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}">
                             <Grid x:Name="FlyoutButtonContentGrid">
 
                                 <Grid.ColumnDefinitions>

--- a/dev/Slider/Slider_themeresources.xaml
+++ b/dev/Slider/Slider_themeresources.xaml
@@ -372,11 +372,11 @@
                                     Height="{ThemeResource SliderTrackThemeHeight}"
                                     Grid.Row="1"
                                     Grid.ColumnSpan="3"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <Rectangle x:Name="HorizontalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Row="1"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <TickBar x:Name="TopTickBar"
                                     Visibility="Collapsed"
                                     Fill="{ThemeResource SliderTickBarFill}"
@@ -428,14 +428,14 @@
                                     Width="{ThemeResource SliderTrackThemeHeight}"
                                     Grid.Column="1"
                                     Grid.RowSpan="3"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <Rectangle x:Name="VerticalDecreaseRect"
                                     Fill="{TemplateBinding Foreground}"
                                     Grid.Column="1"
                                     Grid.Row="2"
-                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <TickBar x:Name="LeftTickBar"
                                     Visibility="Collapsed"
                                     Fill="{ThemeResource SliderTickBarFill}"

--- a/dev/Slider/Slider_themeresources.xaml
+++ b/dev/Slider/Slider_themeresources.xaml
@@ -166,6 +166,11 @@
     <x:Double x:Key="SliderPostContentMargin">15</x:Double>
     <x:Double x:Key="SliderHorizontalHeight">32</x:Double>
     <x:Double x:Key="SliderVerticalWidth">32</x:Double>
+    <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
+    <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
+    <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
+    <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
+    <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
     
     <Style TargetType="Slider">
         <Setter Property="Background" Value="{ThemeResource SliderTrackFill}" />
@@ -192,7 +197,7 @@
                                                 Background="{TemplateBinding Background}"
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                                contract7Present:CornerRadius="4" />
+                                                contract7Present:CornerRadius="{ThemeResource SliderThumbCornerRadius}" />
                                         </ControlTemplate>
                                     </Setter.Value>
                                 </Setter>
@@ -366,8 +371,12 @@
                                     Fill="{TemplateBinding Background}"
                                     Height="{ThemeResource SliderTrackThemeHeight}"
                                     Grid.Row="1"
-                                    Grid.ColumnSpan="3" />
-                                <Rectangle x:Name="HorizontalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Row="1" />
+                                    Grid.ColumnSpan="3"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                <Rectangle x:Name="HorizontalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Row="1"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <TickBar x:Name="TopTickBar"
                                     Visibility="Collapsed"
                                     Fill="{ThemeResource SliderTickBarFill}"
@@ -392,8 +401,8 @@
                                 <Thumb x:Name="HorizontalThumb"
                                     Style="{StaticResource SliderThumbStyle}"
                                     DataContext="{TemplateBinding Value}"
-                                    Height="24"
-                                    Width="8"
+                                    Height="{ThemeResource SliderHorizontalThumbHeight}"
+                                    Width="{ThemeResource SliderHorizontalThumbWidth}"
                                     Grid.Row="0"
                                     Grid.RowSpan="3"
                                     Grid.Column="1"
@@ -418,11 +427,15 @@
                                     Fill="{TemplateBinding Background}"
                                     Width="{ThemeResource SliderTrackThemeHeight}"
                                     Grid.Column="1"
-                                    Grid.RowSpan="3" />
+                                    Grid.RowSpan="3"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <Rectangle x:Name="VerticalDecreaseRect"
                                     Fill="{TemplateBinding Foreground}"
                                     Grid.Column="1"
-                                    Grid.Row="2" />
+                                    Grid.Row="2"
+                                    RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                    RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
                                 <TickBar x:Name="LeftTickBar"
                                     Visibility="Collapsed"
                                     Fill="{ThemeResource SliderTickBarFill}"
@@ -447,8 +460,8 @@
                                 <Thumb x:Name="VerticalThumb"
                                     Style="{StaticResource SliderThumbStyle}"
                                     DataContext="{TemplateBinding Value}"
-                                    Width="24"
-                                    Height="8"
+                                    Width="{ThemeResource SliderVerticalThumbWidth}"
+                                    Height="{ThemeResource SliderVerticalThumbHeight}"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Grid.ColumnSpan="3"

--- a/dev/TimePicker/TimePicker_themeresources.xaml
+++ b/dev/TimePicker/TimePicker_themeresources.xaml
@@ -212,7 +212,8 @@
                                                     Foreground="{TemplateBinding Foreground}"
                                                     HorizontalContentAlignment="Stretch"
                                                     VerticalContentAlignment="Stretch"
-                                                    AutomationProperties.AccessibilityView="Raw" />
+                                                    AutomationProperties.AccessibilityView="Raw"
+                                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>
                                             </Grid>
                                         </ControlTemplate>
                                     </Setter.Value>
@@ -282,7 +283,8 @@
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Stretch"
                             VerticalAlignment="Top"
-                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}">
+                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}">
                             <Grid x:Name="FlyoutButtonContentGrid">
 
                                 <Grid.ColumnDefinitions>

--- a/dev/ToolTip/ToolTip_rs1_themeresources.xaml
+++ b/dev/ToolTip/ToolTip_rs1_themeresources.xaml
@@ -1,5 +1,8 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All Rights Reserved. -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:maps="using:Windows.UI.Xaml.Controls.Maps">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <x:Double x:Key="ToolTipContentThemeFontSize">12</x:Double>
@@ -47,7 +50,16 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
-                    <ContentPresenter x:Name="LayoutRoot" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" MaxWidth="320" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Padding="{TemplateBinding Padding}" TextWrapping="Wrap">
+                    <ContentPresenter x:Name="LayoutRoot"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        MaxWidth="320" Content="{TemplateBinding Content}"
+                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        Padding="{TemplateBinding Padding}"
+                        TextWrapping="Wrap"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="OpenStates">
                                 <VisualState x:Name="Closed">

--- a/dev/ToolTip/ToolTip_rs5_themeresources.xaml
+++ b/dev/ToolTip/ToolTip_rs5_themeresources.xaml
@@ -1,6 +1,8 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All Rights Reserved. -->
-<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:maps="using:Windows.UI.Xaml.Controls.Maps" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <StaticResource x:Key="ToolTipBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
@@ -29,7 +31,18 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
-                    <ContentPresenter x:Name="LayoutRoot" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" BackgroundSizing="OuterBorderEdge" BorderBrush="{TemplateBinding BorderBrush}" MaxWidth="320" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Padding="{TemplateBinding Padding}" TextWrapping="Wrap">
+                    <ContentPresenter x:Name="LayoutRoot"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        BackgroundSizing="OuterBorderEdge"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        MaxWidth="320"
+                        Content="{TemplateBinding Content}"
+                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        Padding="{TemplateBinding Padding}"
+                        TextWrapping="Wrap"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="OpenStates">


### PR DESCRIPTION
Part of feature #659 

Apply CornerRadius to:
- AutoSuggestBox
- CheckBox
- ColorPicker
- DatePicker
- Slider
- TimePicker
- ToolTip

New resources for controlling Slider thumb:
- SliderThumbCornerRadius
- SliderHorizontalThumbWidth
- SliderHorizontalThumbHeight
- SliderVerticalThumbWidth
- SliderVerticalThumbHeight

Add some missing controls (mostly WinUI ones) to CornerRadiusPage