### PR TITLE
Fixing CalendarDatePicker's template

### DIFF
--- a/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
+++ b/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.ThemeDictionaries>
@@ -175,12 +176,12 @@
 
                         </VisualStateManager.VisualStateGroups>
                         <FlyoutBase.AttachedFlyout>
-                            <Flyout Placement="Bottom" ShouldConstrainToRootBounds="False">
+                            <Flyout Placement="Bottom" contract8Present:ShouldConstrainToRootBounds="False">
                                 <Flyout.FlyoutPresenterStyle>
                                     <Style TargetType="FlyoutPresenter">
                                         <Setter Property="Padding" Value="0" />
                                         <Setter Property="BorderThickness" Value="0" />
-                                        <Setter Property="IsDefaultShadowEnabled" Value="True" />
+                                        <contract8Present:Setter Property="IsDefaultShadowEnabled" Value="True" />
                                         <Setter Property="Template">
                                             <Setter.Value>
                                                 <ControlTemplate TargetType="FlyoutPresenter">

--- a/mux.controls.props
+++ b/mux.controls.props
@@ -32,7 +32,9 @@
 
   <PropertyGroup>
     <CSLangVersion>7</CSLangVersion>
-    <MSBuildWarningsAsErrors>WMC0151</MSBuildWarningsAsErrors>
+    
+    <!-- Surface as errors the warnings that a XAML file is using a type defined in a later version of XAML than the min version for which we're compiling. -->
+    <MSBuildWarningsAsErrors>WMC0151;XLS1105</MSBuildWarningsAsErrors>
   </PropertyGroup>
   
   <!-- MUXControls Project-specific Properties -->

--- a/mux.controls.props
+++ b/mux.controls.props
@@ -32,6 +32,7 @@
 
   <PropertyGroup>
     <CSLangVersion>7</CSLangVersion>
+    <MSBuildWarningsAsErrors>WMC0151</MSBuildWarningsAsErrors>
   </PropertyGroup>
   
   <!-- MUXControls Project-specific Properties -->


### PR DESCRIPTION
CalendarDatePicker's default template currently references two properties added in later versions of XAML without using conditional XAML.  This adds conditional XAML to the template in those cases.