### PR TITLE
Fixing Scroller.Content flicker during rasterization for Issue #541.

### DIFF
--- a/dev/Scroller/APITests/ScrollerViewChangeTests.cs
+++ b/dev/Scroller/APITests/ScrollerViewChangeTests.cs
@@ -21,7 +21,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
-#if !BUILD_WINDOWS
 using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
 using AnimationMode = Microsoft.UI.Xaml.Controls.AnimationMode;
 using SnapPointsMode = Microsoft.UI.Xaml.Controls.SnapPointsMode;
@@ -34,7 +33,6 @@ using ZoomCompletedEventArgs = Microsoft.UI.Xaml.Controls.ZoomCompletedEventArgs
 
 using ScrollerTestHooks = Microsoft.UI.Private.Controls.ScrollerTestHooks;
 using ScrollerViewChangeResult = Microsoft.UI.Private.Controls.ScrollerViewChangeResult;
-#endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -1480,7 +1478,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 {
                     List<ExpressionAnimationStatusChange> expressionAnimationStatusChanges = scrollerTestHooksHelper.GetExpressionAnimationStatusChanges(scroller);
                     ScrollerTestHooksHelper.LogExpressionAnimationStatusChanges(expressionAnimationStatusChanges);
-                    VerifyExpressionAnimationStatusChangesForZoomFactorSuspension(expressionAnimationStatusChanges);
+                    VerifyExpressionAnimationStatusChangesForTranslationAndZoomFactorSuspension(expressionAnimationStatusChanges);
                 });
             }
         }
@@ -1546,7 +1544,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 {
                     List<ExpressionAnimationStatusChange> expressionAnimationStatusChanges = scrollerTestHooksHelper.GetExpressionAnimationStatusChanges(scroller);
                     ScrollerTestHooksHelper.LogExpressionAnimationStatusChanges(expressionAnimationStatusChanges);
-                    VerifyExpressionAnimationStatusChangesForZoomFactorSuspension(expressionAnimationStatusChanges);                    
+                    VerifyExpressionAnimationStatusChangesForTranslationAndZoomFactorSuspension(expressionAnimationStatusChanges);                    
                 });
             }
         }
@@ -1615,7 +1613,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 {
                     List<ExpressionAnimationStatusChange> expressionAnimationStatusChanges = scrollerTestHooksHelper.GetExpressionAnimationStatusChanges(scroller);
                     ScrollerTestHooksHelper.LogExpressionAnimationStatusChanges(expressionAnimationStatusChanges);
-                    VerifyExpressionAnimationStatusChangesForZoomFactorSuspension(expressionAnimationStatusChanges);
+                    VerifyExpressionAnimationStatusChangesForTranslationAndZoomFactorSuspension(expressionAnimationStatusChanges);
                 });
             }
         }
@@ -1888,17 +1886,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
-        private void VerifyExpressionAnimationStatusChangesForZoomFactorSuspension(List<ExpressionAnimationStatusChange> expressionAnimationStatusChanges)
+        private void VerifyExpressionAnimationStatusChangesForTranslationAndZoomFactorSuspension(List<ExpressionAnimationStatusChange> expressionAnimationStatusChanges)
         {
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
             {
-                // Facades are enabled. The zoom factor animation is expected to be interrupted momentarily.
+                // Facades are enabled. The translation and zoom factor animations are expected to be interrupted momentarily.
                 Verify.IsNotNull(expressionAnimationStatusChanges);
-                Verify.AreEqual(expressionAnimationStatusChanges.Count, 2);
+                Verify.AreEqual(expressionAnimationStatusChanges.Count, 4);
+
                 Verify.IsFalse(expressionAnimationStatusChanges[0].IsExpressionAnimationStarted);
-                Verify.AreEqual(expressionAnimationStatusChanges[0].PropertyName, "Scale");
-                Verify.IsTrue(expressionAnimationStatusChanges[1].IsExpressionAnimationStarted);
+                Verify.IsFalse(expressionAnimationStatusChanges[1].IsExpressionAnimationStarted);
+                Verify.IsTrue(expressionAnimationStatusChanges[2].IsExpressionAnimationStarted);
+                Verify.IsTrue(expressionAnimationStatusChanges[3].IsExpressionAnimationStarted);
+
+                Verify.AreEqual(expressionAnimationStatusChanges[0].PropertyName, "Translation");
                 Verify.AreEqual(expressionAnimationStatusChanges[1].PropertyName, "Scale");
+                Verify.AreEqual(expressionAnimationStatusChanges[2].PropertyName, "Translation");
+                Verify.AreEqual(expressionAnimationStatusChanges[3].PropertyName, "Scale");
             }
             else
             {

--- a/dev/Scroller/Scroller.h
+++ b/dev/Scroller/Scroller.h
@@ -368,11 +368,11 @@ private:
         const winrt::UIElement& content);
     void StartTransformExpressionAnimations(
         const winrt::UIElement& content,
-        bool forZoomFactorAnimationInterruption);
+        bool forAnimationsInterruption);
     void StopTransformExpressionAnimations(
         const winrt::UIElement& content,
-        bool forZoomFactorAnimationInterruption);
-    bool StartZoomFactorExpressionAnimation();
+        bool forAnimationsInterruption);
+    bool StartZoomFactorExpressionAnimation(bool interruptCountdown = false);
     void StopZoomFactorExpressionAnimation();
     void StartExpressionAnimationSourcesAnimations();
     void StartScrollControllerExpressionAnimationSourcesAnimations(

--- a/dev/Scroller/Scroller.h
+++ b/dev/Scroller/Scroller.h
@@ -75,10 +75,9 @@ public:
     static constexpr int s_zoomFactorChangeMinMs{ 50 };
     static constexpr int s_zoomFactorChangeMaxMs{ 1000 };
 
-    // Number of ticks ellapsed before restarting the Scale animation to allow
-    // the Content rasterization to be triggered after the Idle State is reached
-    // or a zoom factor change operation completed.
-    static constexpr int s_zoomFactorAnimationRestartTicks = 4;
+    // Number of ticks ellapsed before restarting the Translation and Scale animations to allow the Content
+    // rasterization to be triggered after the Idle State is reached or a zoom factor change operation completed.
+    static constexpr int s_translationAndZoomFactorAnimationsRestartTicks = 4;
 
     // Mouse-wheel-triggered scrolling/zooming constants
     // Mouse wheel delta amount required per initial velocity unit
@@ -372,8 +371,8 @@ private:
     void StopTransformExpressionAnimations(
         const winrt::UIElement& content,
         bool forAnimationsInterruption);
-    bool StartZoomFactorExpressionAnimation(bool interruptCountdown = false);
-    void StopZoomFactorExpressionAnimation();
+    bool StartTranslationAndZoomFactorExpressionAnimations(bool interruptCountdown = false);
+    void StopTranslationAndZoomFactorExpressionAnimations();
     void StartExpressionAnimationSourcesAnimations();
     void StartScrollControllerExpressionAnimationSourcesAnimations(
         ScrollerDimension dimension);
@@ -790,10 +789,9 @@ private:
     uint32_t m_screenWidthInRawPixels{};
     uint32_t m_screenHeightInRawPixels{};
 
-    // Number of ticks remaining before restarting the Scale animation to allow
-    // the Content rasterization to be triggered after the Idle State is reached
-    // or a zoom factor change operation completed.
-    uint8_t m_zoomFactorAnimationRestartTicksCountdown{};
+    // Number of ticks remaining before restarting the Translation and Scale animations to allow the Content
+    // rasterization to be triggered after the Idle State is reached or a zoom factor change operation completed.
+    uint8_t m_translationAndZoomFactorAnimationsRestartTicksCountdown{};
 
     // For perf reasons, the value of ContentOrientation is cached.
     winrt::ContentOrientation m_contentOrientation{ s_defaultContentOrientation };

--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
@@ -659,6 +659,7 @@
 
             <StackPanel Orientation="Horizontal" Grid.Row="1">
                 <Button x:Name="btnClearScrollerEvents" Content="Clear" Click="BtnClearScrollerEvents_Click" Margin="1"/>
+                <Button x:Name="btnCopyScrollerEvents" Content="Copy into Clipboard" Click="BtnCopyScrollerEvents_Click" Margin="1"/>
                 <CheckBox x:Name="chkLogScrollerMessages" Content="Log Scroller Messages?" Margin="1" Checked="ChkLogScrollerMessages_Checked" Unchecked="ChkLogScrollerMessages_Unchecked"/>
                 <CheckBox x:Name="chkLogScrollerEvents" Content="Log Scroller Events?" Margin="1" Checked="ChkLogScrollerEvents_Checked" Unchecked="ChkLogScrollerEvents_Unchecked"/>
             </StackPanel>

--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml.cs
@@ -17,7 +17,6 @@ using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Shapes;
 using MUXControlsTestApp.Utilities;
 
-#if !BUILD_WINDOWS
 using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
 using ContentOrientation = Microsoft.UI.Xaml.Controls.ContentOrientation;
 using ChainingMode = Microsoft.UI.Xaml.Controls.ChainingMode;
@@ -43,7 +42,6 @@ using ScrollerTestHooks = Microsoft.UI.Private.Controls.ScrollerTestHooks;
 using ScrollerViewChangeResult = Microsoft.UI.Private.Controls.ScrollerViewChangeResult;
 using MUXControlsTestHooks = Microsoft.UI.Private.Controls.MUXControlsTestHooks;
 using MUXControlsTestHooksLoggingMessageEventArgs = Microsoft.UI.Private.Controls.MUXControlsTestHooksLoggingMessageEventArgs;
-#endif
 
 namespace MUXControlsTestApp
 {
@@ -1391,6 +1389,20 @@ namespace MUXControlsTestApp
         private void BtnClearScrollerEvents_Click(object sender, RoutedEventArgs e)
         {
             lstScrollerEvents.Items.Clear();
+        }
+
+        private void BtnCopyScrollerEvents_Click(object sender, RoutedEventArgs e)
+        {
+            string logs = string.Empty;
+
+            foreach (object log in lstScrollerEvents.Items)
+            {
+                logs += log.ToString() + "\n";
+            }
+
+            var dataPackage = new Windows.ApplicationModel.DataTransfer.DataPackage();
+            dataPackage.SetText(logs);
+            Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
         }
 
         private void BtnScrollTo_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Fixes #541 
During the Scroller's Content rasterization, the Content.Scale animation alone was temporarily halted.
If a view change was started during that pause (for example through a mouse wheel input), the Content.Translation changes would still be reflected visually, causing the Content to shift momentarily.
The fix is two-fold:
- not only stop the Content.Scale façade animation, but also momentarily stop the Content.Translation façade animation. As a result no unwanted visual translation occurs during the short pause.
- prematurely restart both animations if the InteractionTracker leaves the Idle state during the pause. This guarantees a faster visual feedback for the view change.
The tests that use Scroller.ZoomTo/ZoomBy/ZoomFrom were updated accordingly.

