### PR TITLE
InspectingDataSource attaches the wrong event handler type to IBindableObservableVector.

### DIFF
--- a/dev/Repeater/InspectingDataSource.h
+++ b/dev/Repeater/InspectingDataSource.h
@@ -36,6 +36,10 @@ private:
         const winrt::IInspectable& sender,
         const winrt::NotifyCollectionChangedEventArgs& e);
 
+    void OnBindableVectorChanged(
+        const winrt::IBindableObservableVector& sender,
+        const winrt::IInspectable& e);
+
     void OnVectorChanged(
         const winrt::Collections::IObservableVector<winrt::IInspectable>& sender,
         const winrt::Collections::IVectorChangedEventArgs& e);

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTests.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTests.cs
@@ -55,5 +55,18 @@ namespace MUXControls.ReleaseTest
                 Verify.IsNotNull(textBlock);
             }
         }
+
+        [TestMethod]
+        public void RepeaterNoCrashTest()
+        {
+            using (var setup = new TestSetupHelper("Repeater Tests"))
+            {
+                var button = new Button(FindElement.ByName("AddItemsButton"));
+                button.Click();
+
+                var item3 = FindElement.ByName("Item3");
+                Verify.IsNotNull(item3);
+            }
+        }
     }
 }

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
@@ -42,5 +42,15 @@ namespace MUXControls.ReleaseTest
             Verify.IsNotNull(textBlock);
             Verify.AreEqual(textBlock.DocumentText, "Loaded");
         }
+
+        [TestMethod]
+        public void RepeaterNoCrashTest()
+        {
+            var button = new Button(FindElement.ByName("AddItemsButton"));
+            button.Click();
+
+            var item3 = FindElement.ByName("Item3");
+            Verify.IsNotNull(item3);
+        }
     }
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -115,6 +115,9 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestInventory.cs" />
+    <Compile Include="TestPages\RepeaterTestPage.xaml.cs">
+      <DependentUpon>RepeaterTestPage.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -148,6 +151,10 @@
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="TestPages\RepeaterTestPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestInventory.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestInventory.cs
@@ -13,7 +13,8 @@ namespace NugetPackageTestApp
             Tests = new List<TestDeclaration>
             {
                 new TestDeclaration("PullToRefresh Tests", typeof(PullToRefreshTestPage)),
-                new TestDeclaration("CompactDictionary Tests", typeof(CompactDictionaryTestPage))
+                new TestDeclaration("CompactDictionary Tests", typeof(CompactDictionaryTestPage)),
+                new TestDeclaration("Repeater Tests", typeof(RepeaterTestPage))
             };
         }
 

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml
@@ -1,0 +1,26 @@
+﻿<utils:TestPage
+    x:Class="NugetPackageTestApp.RepeaterTestPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:NugetPackageTestApp.TestPages"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:utils="using:MUXControlsTestApp"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Button
+            AutomationProperties.Name="AddItemsButton"
+            Click="OnAddItemsButtonClick"
+            Content="Add Items" />
+        <ScrollViewer Grid.Row="1">
+            <controls:ItemsRepeater x:Name="Repeater" />
+        </ScrollViewer>
+    </Grid>
+</utils:TestPage>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MUXControlsTestApp;
+
+namespace NugetPackageTestApp
+{
+    public sealed partial class RepeaterTestPage : TestPage
+    {
+        private ObservableCollection<string> items;
+
+        public RepeaterTestPage()
+        {
+            this.InitializeComponent();
+
+            this.items = new ObservableCollection<string>();
+            this.Repeater.ItemsSource = items;
+        }
+
+        public void OnAddItemsButtonClick(Object sender, RoutedEventArgs e)
+        {
+            items.Add("Item1");
+            items.Add("Item2");
+            items.Add("Item3");
+        }
+    }
+}

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
@@ -1,33 +1,57 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!--  Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information.  -->
 <Page
     x:Class="NugetPackageTestAppCX.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:NugetPackageTestAppCX"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:NugetPackageTestAppCX"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+    xmlns:utils="using:MUXControlsTestApp"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    Loaded="PageLoaded">
+    Loaded="PageLoaded"
+    mc:Ignorable="d">
 
     <Grid>
-        <Grid x:Name="AutomationHelpersPanel" Height="0" HorizontalAlignment="Stretch">
+        <Grid
+            x:Name="AutomationHelpersPanel"
+            Height="0"
+            HorizontalAlignment="Stretch">
 
-            <!-- Automation Helpers -->
-            <!-- These are not visible, but are used via UIA. They are fundamental to the operation of our test automation, so they should not be collapsed since 
-                                that prevents them from showing up in the UIA tree.-->
-            <Button x:Name="CloseAppInvokerButton" AutomationProperties.AutomationId="__CloseAppInvoker" Click="CloseAppInvokerButton_Click"/>
+            <!--  Automation Helpers  -->
+            <!--
+                These are not visible, but are used via UIA. They are fundamental to the operation of our test automation, so they should not be collapsed since
+                that prevents them from showing up in the UIA tree.
+            -->
+            <Button
+                x:Name="CloseAppInvokerButton"
+                AutomationProperties.AutomationId="__CloseAppInvoker"
+                Click="CloseAppInvokerButton_Click" />
             <Button x:Name="WaitForIdleInvokerButton" AutomationProperties.AutomationId="__WaitForIdleInvoker" />
             <CheckBox x:Name="IdleStateEnteredCheckBox" AutomationProperties.AutomationId="__IdleStateEnteredCheckBox" />
             <TextBox x:Name="ErrorReportingTextBox" AutomationProperties.AutomationId="__ErrorReportingTextBox" />
-            <TextBox x:Name="LogReportingTextBox" AutomationProperties.AutomationId="__LogReportingTextBox"/>
-            <CheckBox x:Name="ViewScalingCheckBox" AutomationProperties.AutomationId="__ViewScalingCheckBox"/>
-            <Button x:Name="WaitForDebuggerInvokerButton" AutomationProperties.AutomationId="__WaitForDebuggerInvoker"/>
-            <CheckBox x:Name="DebuggerAttachedCheckBox" AutomationProperties.AutomationId="__DebuggerAttachedCheckBox"/>
-            <TextBox x:Name="UnhandledExceptionReportingTextBox" AutomationProperties.AutomationId="__UnhandledExceptionReportingTextBox"/>
-            <CheckBox x:Name="TestContentLoadedCheckBox" IsChecked="False" AutomationProperties.AutomationId="__TestContentLoadedCheckBox" Content="TestContentLoadedCheckbox"/>
+            <TextBox x:Name="LogReportingTextBox" AutomationProperties.AutomationId="__LogReportingTextBox" />
+            <CheckBox x:Name="ViewScalingCheckBox" AutomationProperties.AutomationId="__ViewScalingCheckBox" />
+            <Button x:Name="WaitForDebuggerInvokerButton" AutomationProperties.AutomationId="__WaitForDebuggerInvoker" />
+            <CheckBox x:Name="DebuggerAttachedCheckBox" AutomationProperties.AutomationId="__DebuggerAttachedCheckBox" />
+            <TextBox x:Name="UnhandledExceptionReportingTextBox" AutomationProperties.AutomationId="__UnhandledExceptionReportingTextBox" />
+            <CheckBox
+                x:Name="TestContentLoadedCheckBox"
+                AutomationProperties.AutomationId="__TestContentLoadedCheckBox"
+                Content="TestContentLoadedCheckbox"
+                IsChecked="False" />
 
         </Grid>
-        <TextBlock x:Name="TestTextBlock" AutomationProperties.Name="TestTextBlock" Text="Loaded"/>
+
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Button Click="OnAddItemsButtonClick" Content="Add Items" />
+            <ScrollViewer Grid.Row="1">
+                <controls:ItemsRepeater x:Name="Repeater" />
+            </ScrollViewer>
+        </Grid>
     </Grid>
 </Page>

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
@@ -31,9 +31,9 @@ MainPage::MainPage() :
 {
 	InitializeComponent();
 
-    Repeater->ItemsSource = mItems;
-
     AutomationProperties::SetName(this, L"MainPage");
+        
+    Repeater->ItemsSource = mItems;
 }
 
 void NugetPackageTestAppCX::MainPage::CloseAppInvokerButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
@@ -12,9 +12,11 @@
 using namespace NugetPackageTestAppCX;
 
 using namespace Platform;
+using namespace Platform::Collections;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
 using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Automation;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Controls::Primitives;
 using namespace Windows::UI::Xaml::Data;
@@ -24,19 +26,29 @@ using namespace Windows::UI::Xaml::Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
-MainPage::MainPage()
+MainPage::MainPage() :
+    mItems(ref new Vector<String^>())
 {
 	InitializeComponent();
-}
 
+    Repeater->ItemsSource = mItems;
+
+    AutomationProperties::SetName(this, L"MainPage");
+}
 
 void NugetPackageTestAppCX::MainPage::CloseAppInvokerButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
     Application::Current->Exit();
 }
 
-
 void NugetPackageTestAppCX::MainPage::PageLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
     TestContentLoadedCheckBox->IsChecked = true;
+}
+
+void NugetPackageTestAppCX::MainPage::OnAddItemsButtonClick(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    mItems->Append(L"Item1");
+    mItems->Append(L"Item2");
+    mItems->Append(L"Item3");
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.h
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.h
@@ -23,5 +23,8 @@ namespace NugetPackageTestAppCX
     private:
         void CloseAppInvokerButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void PageLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnAddItemsButtonClick(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+
+        Platform::Collections::Vector<Platform::String^>^ mItems;
     };
 }


### PR DESCRIPTION
This PR fixes a bug in InspectingDataSource where the wrong event handler type is attached to an IBindableObservableVector causing an InvalidCastException when a change notification is raised by the Platform::Collections::Vector class in collection.h.

When attaching to a IBindableObservableVector, the event handler passed is of type VectorChangedEventHandler<T> which is incorrect and should be of type BindableVectorChangedEventHandler.

I also swapped the order of IBindableObservableVector and IObervableVector<IInspectable> as the former seems much more common.