### PR TITLE
Add MUX-SimpleBuildAndTest Pipeline

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateHelixProjFile-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateHelixProjFile-Steps.yml
@@ -3,6 +3,7 @@ parameters:
   testFilePath: ''
   outputProjFileName: ''
   testSuite: ''
+  taefQuery: ''
 
 steps:
   - task: powershell@2
@@ -11,4 +12,4 @@ steps:
     inputs:
       targetType: filePath
       filePath: build\Helix\GenerateTestProjFile.ps1
-      arguments: -TestFile '${{ parameters.testFilePath }}' -OutputProjFile '$(Build.ArtifactStagingDirectory)\${{ parameters.outputProjFileName }}' -JobTestSuiteName '${{ parameters.testSuite }}' -TaefPath '$(Build.SourcesDirectory)\build\Helix\packages\taef.redist.wlk.10.31.180822002\build\Binaries\x86'
+      arguments: -TestFile '${{ parameters.testFilePath }}' -OutputProjFile '$(Build.ArtifactStagingDirectory)\${{ parameters.outputProjFileName }}' -JobTestSuiteName '${{ parameters.testSuite }}' -TaefPath '$(Build.SourcesDirectory)\build\Helix\packages\taef.redist.wlk.10.31.180822002\build\Binaries\x86' -TaefQuery "${{ parameters.taefQuery }}"

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -6,6 +6,7 @@ parameters:
   runTests: 'true'
   pkgArtifactPath: ''
   nugetConfigPath: test\MUXControlsReleaseTest\nuget.config
+  helixType: 'test/nuget'
   matrix: 
     Debug_x86:
       buildPlatform: 'x86'
@@ -117,6 +118,7 @@ jobs:
       name: ${{ parameters.runTestJobName }}
       dependsOn: ${{ parameters.buildJobName }}
       testSuite: 'NugetTestSuite'
+      helixType: ${{ parameters.helixType }}
       artifactName: ${{ parameters.buildArtifactName }}
       rerunPassesRequiredToAvoidFailure: 5
   

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -3,9 +3,15 @@ parameters:
   dependsOn: ''
   condition: ''
   testSuite: ''
+  # If a Pipeline runs this template more than once, this parameter should be unique per build flavor to differentiate the
+  # the different test runs:
+  helixType: 'test/devtest' 
   artifactName: 'drop'
   maxParallel: 4
   rerunPassesRequiredToAvoidFailure: 5
+  taefQuery: ''
+  # if 'useBuildOutputFromBuildId' is set, we will default to using a build from this pipeline:
+  useBuildOutputFromPipeline: $(System.DefinitionId)
   matrix: 
     Release_x86:
       buildPlatform: 'x86'
@@ -68,7 +74,7 @@ jobs:
       buildType: specific
       buildVersionToDownload: specific
       project: $(System.TeamProjectId)
-      pipeline: $(System.DefinitionId)
+      pipeline: $(useBuildOutputFromPipeline)
       buildId: $(useBuildOutputFromBuildId)
       artifactName: ${{ parameters.artifactName }} 
       downloadPath: '$(artifactsDir)'
@@ -92,6 +98,7 @@ jobs:
       testFilePath: '$(artifactsDir)\${{ parameters.artifactName }}\$(buildConfiguration)\$(buildPlatform)\Test\MUXControls.Test.dll'
       outputProjFileName: 'RunTestsInHelix-InteractionTests.proj'
       testSuite: '${{ parameters.testSuite }}'
+      taefQuery: ${{ parameters.taefQuery }}
 
   - template: MUX-CreateHelixProjFile-Steps.yml
     parameters:
@@ -99,6 +106,7 @@ jobs:
       testFilePath: '$(artifactsDir)\${{ parameters.artifactName }}\$(buildConfiguration)\$(buildPlatform)\AppxPackages\MUXControlsTestApp_Test\MUXControlsTestApp.appx'
       outputProjFileName: 'RunTestsInHelix-ApiTests.proj'
       testSuite: '${{ parameters.testSuite }}'
+      taefQuery: ${{ parameters.taefQuery }}
 
   - template: MUX-CreateHelixProjFile-Steps.yml
     parameters:
@@ -106,6 +114,7 @@ jobs:
       testFilePath: '$(artifactsDir)\${{ parameters.artifactName }}\$(buildConfiguration)\$(buildPlatform)\AppxPackages\IXMPTestApp_Test\IXMPTestApp.appx'
       outputProjFileName: 'RunTestsInHelix-IXMPTestAppTests.proj'
       testSuite: '${{ parameters.testSuite }}'
+      taefQuery: ${{ parameters.taefQuery }}
 
   - template: MUX-CreateHelixProjFile-Steps.yml
     parameters:
@@ -113,6 +122,7 @@ jobs:
       testFilePath: '$(artifactsDir)\${{ parameters.artifactName }}\$(buildConfiguration)\$(buildPlatform)\Test\MUXControls.ReleaseTest.dll'
       outputProjFileName: 'RunTestsInHelix-NugetTests.proj'
       testSuite: '${{ parameters.testSuite }}'
+      taefQuery: ${{ parameters.taefQuery }}
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish generated .proj files'
@@ -128,7 +138,7 @@ jobs:
       command: custom
       projects: build\Helix\RunTestsInHelix.proj
       custom: msbuild
-      arguments: '/binaryLogger:$(Build.SourcesDirectory)/${{parameters.name}}.$(buildPlatform).$(buildConfiguration).binlog /p:Creator=WinUI /p:IsExternal=true /p:HelixBuild=$(Build.BuildId).$(buildPlatform).$(buildConfiguration) /p:Platform=$(buildPlatform) /p:Configuration=$(buildConfiguration) /p:HelixTargetQueues=$(helixTargetQueues) /p:TestSuite=${{parameters.testSuite}} /p:ProjFilesPath=$(Build.ArtifactStagingDirectory)'
+      arguments: '/binaryLogger:$(Build.SourcesDirectory)/${{parameters.name}}.$(buildPlatform).$(buildConfiguration).binlog /p:Creator=WinUI /p:IsExternal=true /p:HelixBuild=$(Build.BuildId).$(buildPlatform).$(buildConfiguration) /p:Platform=$(buildPlatform) /p:Configuration=$(buildConfiguration) /p:HelixTargetQueues=$(helixTargetQueues) /p:HelixType=${{parameters.helixType}} /p:TestSuite=${{parameters.testSuite}} /p:ProjFilesPath=$(Build.ArtifactStagingDirectory)'
       
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{parameters.name}} binlog'

--- a/build/Helix/RunTestsInHelix.proj
+++ b/build/Helix/RunTestsInHelix.proj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
   <PropertyGroup>
     <HelixSource>pr/winui/$(BUILD_SOURCEBRANCH)/</HelixSource>
-    <HelixType>test/product/</HelixType>
     <EnableXUnitReporter>true</EnableXUnitReporter>
     <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
     <FailOnMissionControlTestFailure>true</FailOnMissionControlTestFailure>

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -52,6 +52,7 @@ jobs:
     buildJobName: 'BuildNugetPkgTests'
     buildArtifactName: 'NugetPkgTestsDrop'
     runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop'
    
@@ -61,6 +62,7 @@ jobs:
     buildJobName: 'BuildFrameworkPkgTests'
     buildArtifactName: 'FrameworkPkgTestsDrop'
     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop\FrameworkPackage'
 

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
     vmImage: 'windows-2019'
   timeoutInMinutes: 120
   variables:
-    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration2)\$(buildPlatform2)\AppxPackages
+    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
     publishDir : $(Build.ArtifactStagingDirectory)
   steps:
@@ -30,9 +30,10 @@ jobs:
     testSuite: 'DevTestSuite'
     taefQuery: $(taefQuery)
     useBuildOutputFromPipeline: $(useBuildOutputFromPipeline)
+    # Specify a dummy matrix to override the default matrix
     matrix: 
       config:
-        foo: bar
+        isDummyMatrix: true
 
 - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
   parameters:

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -1,0 +1,40 @@
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+# The following variables are set at queue time:
+#   buildPlatform
+#   buildConfiguration
+#   helixTargetQueues
+#   taefQuery
+#   useBuildOutputFromBuildId
+#   useBuildOutputFromPipeline
+jobs:
+- job: Build
+  condition:
+    eq(variables['useBuildOutputFromBuildId'],'') 
+  pool:
+    vmImage: 'windows-2019'
+  timeoutInMinutes: 120
+  variables:
+    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration2)\$(buildPlatform2)\AppxPackages
+    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+    publishDir : $(Build.ArtifactStagingDirectory)
+  steps:
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+
+- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    dependsOn:
+    - Build
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    testSuite: 'DevTestSuite'
+    taefQuery: $(taefQuery)
+    useBuildOutputFromPipeline: $(useBuildOutputFromPipeline)
+    matrix: 
+      config:
+        foo: bar
+
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn: RunTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5


### PR DESCRIPTION
This add a new SimpleBuildAndTest Pipeline to help investigate test failures.

This pipeline only does a single build and runs tests. It is mostly configured via queue time variables. 

At queue time you can specify: 

- buildPlatform and buildConfiguration to specify what flavor to build
- helixTargetQueues to specify what queues to run the tests on
- useBuildOutputFromBuildId to skip the build step and use a previous build
- useBuildOutputFromPipeline to use a build from a different Pipeline (e.g. from a PR build)
- taefQuery to only run specific tests (e.g. filter to ColorPicker tests).

The corresponding Pipeline is here:
https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=158&_a=summary

Limitations: This Pipeline only does a single build flavor, you cannot specify multiple. I wasn't able to find a way to dynamically create "matrix" object in yml.

This is useful for investigating test issues when you don't need to run all tests or all configs.

This also fixes #878 - MUX-CI submits multiple Helix jobs with the same name, preventing access to the logs 
