### PR TITLE
Skip PR build for PRs that only contain changes to .md files

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -74,7 +74,7 @@ jobs:
       buildType: specific
       buildVersionToDownload: specific
       project: $(System.TeamProjectId)
-      pipeline: $(useBuildOutputFromPipeline)
+      pipeline: ${{ parameters.useBuildOutputFromPipeline }}
       buildId: $(useBuildOutputFromBuildId)
       artifactName: ${{ parameters.artifactName }} 
       downloadPath: '$(artifactsDir)'

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -1,8 +1,22 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
+- job: Setup
+  steps:
+    - task: powershell@2
+      name: checkPayload
+      displayName: 'Check if build is required for this PR'
+      inputs:
+        targetType: filePath
+        filePath: build\ShouldSkipPRBuild.ps1
+ 
 - job: Build
-  condition:
-    eq(variables['useBuildOutputFromBuildId'],'') 
+  dependsOn: Setup
+  condition: |
+    and
+    (
+      eq(variables['useBuildOutputFromBuildId'],''), 
+      ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
+    )
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 120
@@ -31,8 +45,15 @@ jobs:
 - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
   parameters:
     name: 'RunTestsInHelix'
-    dependsOn: Build
-    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    dependsOn: 
+    - Setup 
+    - Build
+    condition: |
+      and
+      (
+        ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True'),
+        in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+      )
     testSuite: 'DevTestSuite'
 
 # Create Nuget Package

--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -1,0 +1,49 @@
+﻿# Determine if the current PR payload requires a build.
+# We skip the build if the only files changed are .md files.
+
+function AllChangedFilesAreSkippable
+{
+    Param($files)
+
+    $skipExts = @(".md")
+    $allFilesAreSkippable = $true
+
+    foreach($file in $files)
+    {
+        Write-Host "Checking '$file'"
+        $ext = (Get-Item $file).Extension
+        $fileIsSkippable = $ext -in $skipExts
+        Write-Host "File '$file' is skippable: '$fileIsSkippable'"
+
+        if(!$fileIsSkippable)
+        {
+            $allFilesAreSkippable = $false
+        }
+    }
+
+    return $allFilesAreSkippable
+}
+
+$shouldSkipBuild = $false
+
+if($env:BUILD_REASON -eq "PullRequest")
+{
+    $targetBranch = "origin/$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
+
+    $gitCommandLine = "git diff $targetBranch --name-only"
+    Write-Host "$gitCommandLine"
+
+    $diffOutput = Invoke-Expression $gitCommandLine
+    Write-Host $diffOutput
+
+    $files = $diffOutput.Split([Environment]::NewLine)
+
+    Write-Host "Files changed: $files"
+    
+
+    $shouldSkipBuild = AllChangedFilesAreSkippable($files)
+}
+
+Write-Host "shouldSkipBuild = $shouldSkipBuild"
+
+Write-Host "##vso[task.setvariable variable=shouldSkipPRBuild;isOutput=true]$shouldSkipBuild"


### PR DESCRIPTION
It is unnecessary to run the build and test passes for PRs that do not include anything that affects the build.

This change updates the PR build to check the payload of the change. If it only contains .md files, then we skip over building and testing allowing the check to complete in a few seconds.

Note: This change intentionally only updates the PR build. The CI build will still run for changes that are skipped by the PR build. The CI build will still run as a sanity check.

Closes #578