### PR TITLE
Fix RepeaterNoCrashTest which is failing in CI build.

### DIFF
--- a/build/Helix/EnsureMachineState.ps1
+++ b/build/Helix/EnsureMachineState.ps1
@@ -1,0 +1,39 @@
+﻿# List all processes to aid debugging:
+Write-Host "All processes running:"
+Get-Process
+
+
+# Minimize all windows:
+$shell = New-Object -ComObject "Shell.Application"
+$shell.minimizeall()
+
+# Kill any instances of Windows Security Alert:
+$windowTitleToMatch = "*Windows Security Alert*"
+$procs = Get-Process | Where {$_.MainWindowTitle -like "*Windows Security Alert*"}
+foreach ($proc in $procs)
+{
+    Write-Host "Found process with '$windowTitleToMatch' title: $proc"
+    $proc.Kill();
+}
+
+# Kill processes by name that are known to interfere with our tests:
+$processNamesToStop = @("Microsoft.Photos", "WinStore.App", "SkypeApp", "SkypeBackgroundHost")
+foreach($procName in $processNamesToStop)
+{
+    Write-Host "Attempting to kill $procName if it is running"
+    Stop-Process -ProcessName $procName -Verbose     
+}
+Write-Host "All processes running after attempting to kill unwanted processes:"
+Get-Process
+
+# Uninstall AppX packages that are known to cause issues with our tests:
+$packagesToUninstall = @("*Skype*", "*Windows.Photos*")
+foreach($pkgName in $packagesToUninstall)
+{
+    foreach($pkg in (Get-AppxPackage $pkgName).PackageFullName) 
+    {
+        Write-Output "Removing: $pkg" 
+        Remove-AppxPackage $pkg
+    } 
+}
+

--- a/build/Helix/PrepareHelixPayload.ps1
+++ b/build/Helix/PrepareHelixPayload.ps1
@@ -62,3 +62,4 @@ Copy-Item "build\helix\OutputFailedTestQuery.ps1" "$payloadDir\scripts"
 Copy-Item "build\helix\HelixTestHelpers.cs" "$payloadDir\scripts"
 Copy-Item "build\helix\runtests.cmd" $payloadDir
 Copy-Item "build\helix\InstallTestAppDependencies.ps1" "$payloadDir\scripts"
+Copy-Item "build\Helix\EnsureMachineState.ps1" "$payloadDir\scripts"

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -12,7 +12,7 @@ cd scripts
 powershell -ExecutionPolicy Bypass .\InstallTestAppDependencies.ps1
 cd ..
 
-set testBinaryCandidates=MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx MUXControls.ReleaseTest.dll NugetPackageTestApp.appx NugetPackageTestAppCX.appx
+set testBinaryCandidates=MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx MUXControls.ReleaseTest.dll
 set testBinaries=
 for %%B in (%testBinaryCandidates%) do (
     if exist %%B (

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -1,6 +1,6 @@
 setlocal ENABLEDELAYEDEXPANSION
 
-robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP
+robocopy %HELIX_CORRELATION_PAYLOAD% . /s /NP > NUL
 
 reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
 
@@ -9,6 +9,7 @@ reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t 
 taskkill -f -im dhandler.exe
 
 cd scripts
+powershell -ExecutionPolicy Bypass .\EnsureMachineState.ps1
 powershell -ExecutionPolicy Bypass .\InstallTestAppDependencies.ps1
 cd ..
 

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
@@ -29,8 +29,8 @@ namespace MUXControls.ReleaseTest
             TestEnvironment.Initialize(testContext, TestType.NugetCX);
         }
 
-        [TestCleanup]
-        public void TestCleanup()
+        [AssemblyCleanup]
+        public static void AssemblyCleanup()
         {
             TestEnvironment.AssemblyCleanupWorker(TestType.NugetCX);
         }
@@ -43,11 +43,13 @@ namespace MUXControls.ReleaseTest
             Verify.AreEqual(textBlock.DocumentText, "Loaded");
         }
 
-        [TestMethod]
+        // Disabled due to: NugetTestsCX.RepeaterNoCrashTest is failing in CI builds #908
+        //[TestMethod]
         public void RepeaterNoCrashTest()
         {
             var button = new Button(FindElement.ByName("AddItemsButton"));
             button.Click();
+            Wait.ForIdle();
 
             var item3 = FindElement.ByName("Item3");
             Verify.IsNotNull(item3);

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
@@ -43,8 +43,7 @@ namespace MUXControls.ReleaseTest
             Verify.AreEqual(textBlock.DocumentText, "Loaded");
         }
 
-        // Disabled due to: NugetTestsCX.RepeaterNoCrashTest is failing in CI builds #908
-        //[TestMethod]
+        [TestMethod]
         public void RepeaterNoCrashTest()
         {
             var button = new Button(FindElement.ByName("AddItemsButton"));

--- a/test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln
+++ b/test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2047
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29001.49
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NugetPackageTestAppCX", "NugetPackageTestAppCX\NugetPackageTestAppCX.vcxproj", "{2F339B02-2B8C-4ED8-9C20-93E24A183A2B}"
 EndProject
@@ -24,6 +24,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MUXControls.Test", "..\MUXControls.Test\MSTest\MUXControls.Test.csproj", "{EAEB5D2C-B447-41BC-9DE7-BFCB964B6CA5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MUXControls.Test.TAEF", "..\MUXControls.Test\TAEF\MUXControls.Test.TAEF.csproj", "{4D8C5D1B-F982-44A1-B744-DD0E51651BF2}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MUXTestUtilities", "..\MUXTestUtilities\MUXTestUtilities.vcxproj", "{E7D6B510-3761-478A-8E22-72558DAD924E}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -139,6 +141,22 @@ Global
 		{4D8C5D1B-F982-44A1-B744-DD0E51651BF2}.Release|x64.Build.0 = Release|Any CPU
 		{4D8C5D1B-F982-44A1-B744-DD0E51651BF2}.Release|x86.ActiveCfg = Release|Any CPU
 		{4D8C5D1B-F982-44A1-B744-DD0E51651BF2}.Release|x86.Build.0 = Release|Any CPU
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|ARM.ActiveCfg = Debug|ARM
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|ARM.Build.0 = Debug|ARM
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|arm64.ActiveCfg = Debug|arm64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|arm64.Build.0 = Debug|arm64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|x64.ActiveCfg = Debug|x64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|x64.Build.0 = Debug|x64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|x86.ActiveCfg = Debug|Win32
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Debug|x86.Build.0 = Debug|Win32
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|ARM.ActiveCfg = Release|ARM
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|ARM.Build.0 = Release|ARM
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|arm64.ActiveCfg = Release|arm64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|arm64.Build.0 = Release|arm64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|x64.ActiveCfg = Release|x64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|x64.Build.0 = Release|x64
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|x86.ActiveCfg = Release|Win32
+		{E7D6B510-3761-478A-8E22-72558DAD924E}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
@@ -13,9 +13,14 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Grid
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal"
             x:Name="AutomationHelpersPanel"
             Height="0"
+            VerticalAlignment="Top"
             HorizontalAlignment="Stretch">
 
             <!--  Automation Helpers  -->
@@ -23,11 +28,8 @@
                 These are not visible, but are used via UIA. They are fundamental to the operation of our test automation, so they should not be collapsed since
                 that prevents them from showing up in the UIA tree.
             -->
-            <Button
-                x:Name="CloseAppInvokerButton"
-                AutomationProperties.AutomationId="__CloseAppInvoker"
-                Click="CloseAppInvokerButton_Click" />
-            <Button x:Name="WaitForIdleInvokerButton" AutomationProperties.AutomationId="__WaitForIdleInvoker" />
+            <Button x:Name="CloseAppInvokerButton" AutomationProperties.AutomationId="__CloseAppInvoker" Click="CloseAppInvokerButton_Click" />
+            <Button x:Name="WaitForIdleInvokerButton" AutomationProperties.AutomationId="__WaitForIdleInvoker" Click="WaitForIdleInvokerButton_Click" />
             <CheckBox x:Name="IdleStateEnteredCheckBox" AutomationProperties.AutomationId="__IdleStateEnteredCheckBox" />
             <TextBox x:Name="ErrorReportingTextBox" AutomationProperties.AutomationId="__ErrorReportingTextBox" />
             <TextBox x:Name="LogReportingTextBox" AutomationProperties.AutomationId="__LogReportingTextBox" />
@@ -35,15 +37,11 @@
             <Button x:Name="WaitForDebuggerInvokerButton" AutomationProperties.AutomationId="__WaitForDebuggerInvoker" />
             <CheckBox x:Name="DebuggerAttachedCheckBox" AutomationProperties.AutomationId="__DebuggerAttachedCheckBox" />
             <TextBox x:Name="UnhandledExceptionReportingTextBox" AutomationProperties.AutomationId="__UnhandledExceptionReportingTextBox" />
-            <CheckBox
-                x:Name="TestContentLoadedCheckBox"
-                AutomationProperties.AutomationId="__TestContentLoadedCheckBox"
-                Content="TestContentLoadedCheckbox"
-                IsChecked="False" />
+            <CheckBox x:Name="TestContentLoadedCheckBox" AutomationProperties.AutomationId="__TestContentLoadedCheckBox" Content="TestContentLoadedCheckbox" IsChecked="False" />
 
-        </Grid>
+        </StackPanel>
 
-        <Grid>
+        <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
@@ -46,10 +46,12 @@
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <Button Click="OnAddItemsButtonClick" Content="Add Items" />
-            <ScrollViewer Grid.Row="1">
+            <TextBlock x:Name="TestTextBlock" AutomationProperties.Name="TestTextBlock" Text="Loaded"/>
+            <Button Grid.Row="1" Click="OnAddItemsButtonClick" Content="Add Items" AutomationProperties.Name="AddItemsButton"  />
+            <ScrollViewer Grid.Row="2">
                 <controls:ItemsRepeater x:Name="Repeater" />
             </ScrollViewer>
         </Grid>

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-//
-// MainPage.xaml.cpp
-// Implementation of the MainPage class.
-//
-
 #include "pch.h"
 #include "MainPage.xaml.h"
 
@@ -23,8 +18,6 @@ using namespace Windows::UI::Xaml::Data;
 using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Navigation;
-
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
 MainPage::MainPage() :
     mItems(ref new Vector<String^>())
@@ -51,4 +44,23 @@ void NugetPackageTestAppCX::MainPage::OnAddItemsButtonClick(Platform::Object^ se
     mItems->Append(L"Item1");
     mItems->Append(L"Item2");
     mItems->Append(L"Item3");
+}
+
+void NugetPackageTestAppCX::MainPage::WaitForIdleInvokerButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    IdleStateEnteredCheckBox->IsChecked = false;
+
+    MainPage^ spThis = this;
+    auto workItem = ref new Windows::System::Threading::WorkItemHandler([spThis](IAsyncAction^ workItem) mutable
+    {
+        MUXTestUtilities::IdleSynchronizer::Wait();
+
+        spThis->Dispatcher->RunAsync(
+            Windows::UI::Core::CoreDispatcherPriority::Low,
+            ref new Windows::UI::Core::DispatchedHandler([spThis]()
+        {
+            spThis->IdleStateEnteredCheckBox->IsChecked = true;
+        }));
+    });
+    auto asyncAction = Windows::System::Threading::ThreadPool::RunAsync(workItem);
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.h
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.h
@@ -1,24 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-//
-// MainPage.xaml.h
-// Declaration of the MainPage class.
-//
-
 #pragma once
 
 #include "MainPage.g.h"
 
 namespace NugetPackageTestAppCX
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	public ref class MainPage sealed
-	{
-	public:
-		MainPage();
+    public ref class MainPage sealed
+    {
+    public:
+        MainPage();
 
     private:
         void CloseAppInvokerButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
@@ -26,5 +18,6 @@ namespace NugetPackageTestAppCX
         void OnAddItemsButtonClick(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 
         Platform::Collections::Vector<Platform::String^>^ mItems;
+        void WaitForIdleInvokerButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
     };
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
@@ -189,6 +189,11 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MUXTestUtilities\MUXTestUtilities.vcxproj">
+      <Project>{e7d6b510-3761-478a-8e22-72558dad924e}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
Fixes #908 NugetTestsCX.RepeaterNoCrashTest is failing in CI builds.

The test is failing in CI due to the fact that WaitForIdle functionality is not implemented in NuGetPackageTestAppCX. For C# apps, this and other such critical functionality is implemented in MUXControlsTestApp.TestFrame, but that is a C# only type. Long term we should create an equivalent to this type for use by C++/CX types. This is tracked by #907.

We already have a native implementation of IdleSynchronizer. So, I've updated the CX test app to use that to unblock the CI build.

We are also hitting some unrelated test failures in CI and PR builds. Updating this PR to include those fixes too.

Sometime we are hitting test issues due to the state of the helix machine. Issues include:
1. Windows Firewall dialog appearing over everything which interferes with UI interaction.
2. Sometimes we hit appx install issues due to certain other apps running. When we were running in Atlas/WTT we killed and uninstalled certain apps. So duplicating that behavior here for Helix.
3. Also minimizing all windows to help with other unexpected windows being open.

All of this logic is consolidated in EnsureMachineState.ps1. As we run into other issues, we can update this script to ensure that the machine is in the state that we need it to execute tests.

CI build:
https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=21565&view=logs
