### PR TITLE
Avoid reset of containers when anchor element is replaced in ItemsRepeater

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -29,8 +29,10 @@ using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFacto
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
 using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
 using FlowLayout = Microsoft.UI.Xaml.Controls.FlowLayout;
+using UniformGridLayout = Microsoft.UI.Xaml.Controls.UniformGridLayout;
 using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHost;
 using AnimationContext = Microsoft.UI.Xaml.Controls.AnimationContext;
+using System.Collections.Generic;
 #endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
@@ -307,6 +309,50 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
+        public void VerifyElement0OwnershipInUniformGridLayout()
+        {
+            CustomItemsSource dataSource = null;
+            RunOnUIThread.Execute(() => dataSource = new CustomItemsSource(new List<int>()));
+            ItemsRepeater repeater = null;
+            int elementsCleared = 0;
+            int elementsPrepared = 0;
+
+            RunOnUIThread.Execute(() =>
+            {
+                repeater = SetupRepeater(dataSource, new UniformGridLayout());
+                repeater.ElementPrepared += (sender, args) => { elementsPrepared++; };
+                repeater.ElementClearing += (sender, args) => { elementsCleared++; };
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Log.Comment("Add two item");
+                dataSource.Insert(index: 0, count: 1, reset: false);
+                dataSource.Insert(index: 1, count: 1, reset: false);
+                repeater.UpdateLayout();
+                var realized = VerifyRealizedRange(repeater, dataSource);
+                Verify.AreEqual(2, realized);
+
+                Log.Comment("replace the first item");
+                dataSource.Replace(index: 0, oldCount: 1, newCount: 1, reset: false);
+                repeater.UpdateLayout();
+                realized = VerifyRealizedRange(repeater, dataSource);
+                Verify.AreEqual(2, realized);
+
+                Log.Comment("Remove two items");
+                dataSource.Remove(index: 1, count: 1, reset: false);
+                dataSource.Remove(index: 0, count: 1, reset:false);
+                repeater.UpdateLayout();
+                realized = VerifyRealizedRange(repeater, dataSource);
+                Verify.AreEqual(0, realized);
+
+                Verify.AreEqual(elementsPrepared, elementsCleared);
+            });
+        }
+
+        [TestMethod]
         public void EnsureReplaceOfAnchorDoesNotResetAllContainers()
         {
             CustomItemsSource dataSource = null;
@@ -469,8 +515,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             };
 
             Content.UpdateLayout();
-            int realized = VerifyRealizedRange(repeater, dataSource);
-            Verify.IsGreaterThan(realized, 0);
+            if (dataSource.Count > 0)
+            {
+                int realized = VerifyRealizedRange(repeater, dataSource);
+                Verify.IsGreaterThan(realized, 0);
+            }
 
             return repeater;
         }

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -103,7 +103,7 @@ void ElementManager::Insert(int realizedIndex, int dataIndex, const winrt::UIEle
 void ElementManager::ClearRealizedRange(int realizedIndex, int count)
 {
     MUX_ASSERT(IsVirtualizingContext());
-    for (int i = 0 ; i < count; i++)
+    for (int i = 0; i < count; i++)
     {
         // Clear from the edges so that ItemsRepeater can optimize on maintaining 
         // realized indices without walking through all the children every time.
@@ -240,7 +240,7 @@ bool ElementManager::IsWindowConnected(const winrt::Rect& window, const ScrollOr
         auto effectiveOrientation = scrollOrientationSameAsFlow ?
             (orientation == ScrollOrientation::Vertical ? ScrollOrientation::Horizontal : ScrollOrientation::Vertical) :
             orientation;
-            
+
 
         auto windowStart = effectiveOrientation == ScrollOrientation::Vertical ? window.Y : window.X;
         auto windowEnd = effectiveOrientation == ScrollOrientation::Vertical ? window.Y + window.Height : window.X + window.Width;
@@ -270,8 +270,36 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
 
         case winrt::NotifyCollectionChangedAction::Replace:
         {
-            OnItemsRemoved(args.OldStartingIndex(), args.OldItems().Size());
-            OnItemsAdded(args.NewStartingIndex(), args.NewItems().Size());
+            int oldSize = args.OldItems().Size();
+            int newSize = args.NewItems().Size();
+            int oldStartIndex = args.OldStartingIndex();
+            int newStartIndex = args.NewStartingIndex();
+
+            if (oldSize == newSize &&
+                oldStartIndex == newStartIndex &&
+                IsDataIndexRealized(oldStartIndex) &&
+                IsDataIndexRealized(oldStartIndex + oldSize))
+            {
+                // Straight up replace of n items within the realization window.
+                // Removing and adding might causes us to lose the anchor causing us
+                // to throw away all containers and start from scratch.
+                // Instead, we can just clear those items and set the element to
+                // null (sentinel) and let the next measure get new containers for them.
+                auto startRealizedIndex = GetRealizedRangeIndexFromDataIndex(oldStartIndex);
+                for (int realizedIndex = startRealizedIndex; realizedIndex < startRealizedIndex + oldSize; realizedIndex++)
+                {
+                    if (auto elementRef = m_realizedElements[realizedIndex])
+                    {
+                        m_context.RecycleElement(elementRef.get());
+                        m_realizedElements[realizedIndex] = tracker_ref<winrt::UIElement>{ m_owner, nullptr };
+                    }
+                }
+            }
+            else
+            {
+                OnItemsRemoved(args.OldStartingIndex(), oldSize);
+                OnItemsAdded(args.NewStartingIndex(), newSize);
+            }
         }
         break;
 

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -278,7 +278,7 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             if (oldSize == newSize &&
                 oldStartIndex == newStartIndex &&
                 IsDataIndexRealized(oldStartIndex) &&
-                IsDataIndexRealized(oldStartIndex + oldSize))
+                IsDataIndexRealized(oldStartIndex + oldSize -1))
             {
                 // Straight up replace of n items within the realization window.
                 // Removing and adding might causes us to lose the anchor causing us
@@ -297,8 +297,8 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             }
             else
             {
-                OnItemsRemoved(args.OldStartingIndex(), oldSize);
-                OnItemsAdded(args.NewStartingIndex(), newSize);
+                OnItemsRemoved(oldStartIndex, oldSize);
+                OnItemsAdded(newStartIndex, newSize);
             }
         }
         break;

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -72,7 +72,7 @@ winrt::Size UniformGridLayout::MeasureOverride(
 
     // If after Measure the first item is in the realization rect, then we revoke grid state's ownership,
     // and only use the layout when to clear it when it's done.
-    gridState->EnsureFirstElementOwnership();
+    gridState->EnsureFirstElementOwnership(context);
 
     return { desiredSize.Width, desiredSize.Height };
 }

--- a/dev/Repeater/UniformGridLayoutState.cpp
+++ b/dev/Repeater/UniformGridLayoutState.cpp
@@ -119,10 +119,13 @@ void UniformGridLayoutState::SetSize(
     }
 }
 
-void UniformGridLayoutState::EnsureFirstElementOwnership()
+void UniformGridLayoutState::EnsureFirstElementOwnership(winrt::VirtualizingLayoutContext const& context)
 {
-    if (m_flowAlgorithm.GetElementIfRealized(0))
+    if (m_cachedFirstElement != nullptr && m_flowAlgorithm.GetElementIfRealized(0))
     {
+        // We created the element, but then flowlayout algorithm took ownership, so we can clear it and
+        // let flowlayout algorithm do its thing.
+        context.RecycleElement(m_cachedFirstElement);
         m_cachedFirstElement = nullptr;
     }
 }

--- a/dev/Repeater/UniformGridLayoutState.h
+++ b/dev/Repeater/UniformGridLayoutState.h
@@ -22,7 +22,7 @@ public:
     double EffectiveItemHeight() { return m_effectiveItemHeight; }
 
     // If it's realized then we shouldn't be caching it
-    void EnsureFirstElementOwnership();
+    void EnsureFirstElementOwnership(winrt::VirtualizingLayoutContext const& context);
 
     void EnsureElementSize(
         const winrt::Size availableSize,


### PR DESCRIPTION
Currently replace is modeled as a remove and an add, but unfortunately if the remove ends up removing the anchor element, then during next measure we think we are disconnected and throw all the containers away and start from scratch. This causes a flash of all the images which is undesirable. With this change, if we are doing a replace in the realized range, then we can just clear those items and set the containers as null (sentinels). We already look for sentinels during the measure pass and realize them as needed. This will ensure that only the replaced containers will get cleared/prepared again.

Fixes #915
Fixes #935 