### PR TITLE
Fix RunLocWorkflow.ps1 so it finds MSBuild for VS2019

### DIFF
--- a/build/Localization/RunLocWorkflow.ps1
+++ b/build/Localization/RunLocWorkflow.ps1
@@ -6,8 +6,7 @@ param(
 
 $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 
-$rootPath = & $vswhere -Latest -requires Microsoft.Component.MSBuild -property InstallationPath
-$MSBuildPath="$rootPath\MSBuild\15.0\Bin\MSBuild.exe"
+$MSBuildPath = & $vswhere -Latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
 
 if (-not (Test-Path $MSBuildPath))
 {

--- a/tools/VSTSRunLocWorkflow.cmd
+++ b/tools/VSTSRunLocWorkflow.cmd
@@ -11,9 +11,3 @@ setlocal
 )
 
 call %~dp0\..\build\localization\RunLocWorkflow.cmd Daily-%BUILDDATE%.%BUILDREVISION%
-
-REM Undo any changes that were made since we are just doing handoff and the process will automatically hand back.
-pushd %~dp0\..
-git reset -- *
-git checkout -- *
-git reset --hard


### PR DESCRIPTION
Now that I have VS2019 retail installed, I'm seeing this script fail because it was assuming a path for MSBuild. Update the script to use the more enlightened invocation of vswhere where it can do a search for the MSBuild.exe in a subdirectory.

Also update the localization yml so that it leaves the files checked out at the end of the build to cause the job to detect that files have been handed back and alert us that there's file updates that need attention.