### PR TITLE
Re-enable RS2 and RS4 tests

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -21,9 +21,7 @@ parameters:
     Release_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'release'
-      # temporarily disabling RS2 and RS4 queues to unblock tests.
-      helixTargetQueues: 'Windows.10.Amd64.Client19H1.Open'
-      #helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.Client19H1.Open'
+      helixTargetQueues: 'Windows.10.Amd64.ClientRS2.Open%3bWindows.10.Amd64.ClientRS4.Open%3bWindows.10.Amd64.Client19H1.Open'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -31,9 +29,7 @@ jobs:
   condition: ${{ parameters.condition }}
   pool:
     vmImage: 'windows-2019'
-  # temporarily increasing timeout to 180
-  timeoutInMinutes: 180
-  #timeoutInMinutes: 120
+  timeoutInMinutes: 120
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
     taefPath: $(Build.SourcesDirectory)\build\Helix\packages\taef.redist.wlk.10.31.180822002\build\Binaries\$(buildPlatform)


### PR DESCRIPTION
A Helix lab issue was impacting our tests on RS2 and RS4 machines. The issue has been resolved so we can re-enable the tests.

Closes #871 