### PR TITLE
Workaround for Azure DevOps' 4000 character limit

### DIFF
--- a/build/Helix/OutputSubResultsJsonFiles.ps1
+++ b/build/Helix/OutputSubResultsJsonFiles.ps1
@@ -1,0 +1,32 @@
+Param(
+    [Parameter(Mandatory = $true)] 
+    [string]$WttInputPath,
+
+    [Parameter(Mandatory = $true)] 
+    [string]$WttSingleRerunInputPath,
+
+    [Parameter(Mandatory = $true)] 
+    [string]$WttMultipleRerunInputPath,
+
+    [Parameter(Mandatory = $true)] 
+    [string]$TestNamePrefix
+)
+
+# Ideally these would be passed as parameters to the script. However ps makes it difficult to deal with string literals containing '&', so we just 
+# read the values directly from the environment variables
+$helixResultsContainerUri = $Env:HELIX_RESULTS_CONTAINER_URI
+$helixResultsContainerRsas = $Env:HELIX_RESULTS_CONTAINER_RSAS
+
+Add-Type -Language CSharp -ReferencedAssemblies System.Xml,System.Xml.Linq,System.Runtime.Serialization,System.Runtime.Serialization.Json (Get-Content $PSScriptRoot\HelixTestHelpers.cs -Raw)
+
+$testResultParser = [HelixTestHelpers.TestResultParser]::new($TestNamePrefix, $helixResultsContainerUri, $helixResultsContainerRsas)
+[System.Collections.Generic.Dictionary[string, string]]$subResultsJsonByMethodName = $testResultParser.GetSubResultsJsonByMethodName($WttInputPath, $WttSingleRerunInputPath, $WttMultipleRerunInputPath)
+
+$subResultsJsonDirectory = [System.IO.Path]::GetDirectoryName($WttInputPath)
+
+foreach ($methodName in $subResultsJsonByMethodName.Keys)
+{
+    $subResultsJson = $subResultsJsonByMethodName[$methodName]
+    $subResultsJsonPath = [System.IO.Path]::Combine($subResultsJsonDirectory, $methodName + "_subresults.json")
+    Out-File $subResultsJsonPath -Encoding utf8 -InputObject $subResultsJson
+}

--- a/build/Helix/PrepareHelixPayload.ps1
+++ b/build/Helix/PrepareHelixPayload.ps1
@@ -59,6 +59,7 @@ Copy-If-Exists "$repoDirectory\Artifacts\$ArtifactName\$Configuration\$Platform\
 New-Item -ItemType Directory -Force -Path "$payloadDir\scripts"
 Copy-Item "build\helix\ConvertWttLogToXUnit.ps1" "$payloadDir\scripts"
 Copy-Item "build\helix\OutputFailedTestQuery.ps1" "$payloadDir\scripts"
+Copy-Item "build\helix\OutputSubResultsJsonFiles.ps1" "$payloadDir\scripts"
 Copy-Item "build\helix\HelixTestHelpers.cs" "$payloadDir\scripts"
 Copy-Item "build\helix\runtests.cmd" $payloadDir
 Copy-Item "build\helix\InstallTestAppDependencies.ps1" "$payloadDir\scripts"

--- a/build/Helix/UpdateUnreliableTests.ps1
+++ b/build/Helix/UpdateUnreliableTests.ps1
@@ -36,7 +36,8 @@ foreach ($testRun in $testRuns.value)
         {
             Write-Host "  Test $($testResult.testCaseTitle) was detected as unreliable. Updating..."
             
-            $rerunResults = ConvertFrom-Json $testResult.errorMessage
+            # The errorMessage field contains a link to the JSON-encoded rerun result data.
+            $rerunResults = ConvertFrom-Json (New-Object System.Net.WebClient).DownloadString($testResult.errorMessage)
             [System.Collections.Generic.List[System.Collections.Hashtable]]$rerunDataList = @()
             $attemptCount = 0
             $passCount = 0

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -78,7 +78,13 @@ FOR %%I in (WexLogFileOutput\*.jpg) DO (
 :SkipReruns
 
 cd scripts
+powershell -ExecutionPolicy Bypass .\OutputSubResultsJsonFiles.ps1 ..\te_original.wtl ..\te_rerun.wtl ..\te_rerun_multiple.wtl %testnameprefix%
 powershell -ExecutionPolicy Bypass .\ConvertWttLogToXUnit.ps1 ..\te_original.wtl ..\te_rerun.wtl ..\te_rerun_multiple.wtl ..\testResults.xml %testnameprefix%
 cd ..
+
+FOR %%I in (*_subresults.json) DO (
+    echo Uploading %%I to "%HELIX_RESULTS_CONTAINER_URI%/%%I%HELIX_RESULTS_CONTAINER_RSAS%"
+    %HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\upload_result.py -result %%I -result_name %%I
+)
 
 type testResults.xml


### PR DESCRIPTION
Currently, our test rerun infrastructure returns rerun metadata as JSON in the errorMessage field of a test that we mark as skipped to indicate that it's unreliable.  That works as a method to return a string from the test machine to the build machine, but Azure DevOps enforces a 4000 character limit on the errorMessage field, meaning that if the error message is sufficiently long, the JSON can get truncated and we fail to parse it properly.  This occurred, for example, in this run, when the error message included a full callstack for an app crash:

https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=22238&view=logs

As an alternative, the contents of this PR change things so we instead upload the JSON data as a text file to blob storage, and return a link to that uploaded text file in the errorMessage field rather than the JSON data itself.  We then retrieve the JSON and parse it from that link.  This allows the JSON to be as long as we like without having a character limit enforced on it, and should prevent the above infrastructure error from happening again.