### PR TITLE
Changing TabView to contain a ListView

### DIFF
--- a/dev/Generated/TabView.properties.cpp
+++ b/dev/Generated/TabView.properties.cpp
@@ -8,12 +8,15 @@
 
 CppWinRTActivatableClassWithDPFactory(TabView)
 
+GlobalDependencyProperty TabViewProperties::s_AddButtonCommandProperty{ nullptr };
+GlobalDependencyProperty TabViewProperties::s_AddButtonCommandParameterProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_CanCloseTabsProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_CanDragDropTabsProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_IsAddButtonVisibleProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_ItemsProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_ItemsSourceProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_ItemTemplateProperty{ nullptr };
+GlobalDependencyProperty TabViewProperties::s_ItemTemplateSelectorProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_LeftCustomContentProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_LeftCustomContentTemplateProperty{ nullptr };
 GlobalDependencyProperty TabViewProperties::s_RightCustomContentProperty{ nullptr };
@@ -32,6 +35,28 @@ TabViewProperties::TabViewProperties()
 
 void TabViewProperties::EnsureProperties()
 {
+    if (!s_AddButtonCommandProperty)
+    {
+        s_AddButtonCommandProperty =
+            InitializeDependencyProperty(
+                L"AddButtonCommand",
+                winrt::name_of<winrt::ICommand>(),
+                winrt::name_of<winrt::TabView>(),
+                false /* isAttached */,
+                ValueHelper<winrt::ICommand>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_AddButtonCommandParameterProperty)
+    {
+        s_AddButtonCommandParameterProperty =
+            InitializeDependencyProperty(
+                L"AddButtonCommandParameter",
+                winrt::name_of<winrt::IInspectable>(),
+                winrt::name_of<winrt::TabView>(),
+                false /* isAttached */,
+                ValueHelper<winrt::IInspectable>::BoxedDefaultValue(),
+                nullptr);
+    }
     if (!s_CanCloseTabsProperty)
     {
         s_CanCloseTabsProperty =
@@ -96,6 +121,17 @@ void TabViewProperties::EnsureProperties()
                 winrt::name_of<winrt::TabView>(),
                 false /* isAttached */,
                 ValueHelper<winrt::DataTemplate>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_ItemTemplateSelectorProperty)
+    {
+        s_ItemTemplateSelectorProperty =
+            InitializeDependencyProperty(
+                L"ItemTemplateSelector",
+                winrt::name_of<winrt::DataTemplateSelector>(),
+                winrt::name_of<winrt::TabView>(),
+                false /* isAttached */,
+                ValueHelper<winrt::DataTemplateSelector>::BoxedDefaultValue(),
                 nullptr);
     }
     if (!s_LeftCustomContentProperty)
@@ -179,12 +215,15 @@ void TabViewProperties::EnsureProperties()
 
 void TabViewProperties::ClearProperties()
 {
+    s_AddButtonCommandProperty = nullptr;
+    s_AddButtonCommandParameterProperty = nullptr;
     s_CanCloseTabsProperty = nullptr;
     s_CanDragDropTabsProperty = nullptr;
     s_IsAddButtonVisibleProperty = nullptr;
     s_ItemsProperty = nullptr;
     s_ItemsSourceProperty = nullptr;
     s_ItemTemplateProperty = nullptr;
+    s_ItemTemplateSelectorProperty = nullptr;
     s_LeftCustomContentProperty = nullptr;
     s_LeftCustomContentTemplateProperty = nullptr;
     s_RightCustomContentProperty = nullptr;
@@ -232,6 +271,26 @@ void TabViewProperties::OnTabWidthModePropertyChanged(
 {
     auto owner = sender.as<winrt::TabView>();
     winrt::get_self<TabView>(owner)->OnTabWidthModePropertyChanged(args);
+}
+
+void TabViewProperties::AddButtonCommand(winrt::ICommand const& value)
+{
+    static_cast<TabView*>(this)->SetValue(s_AddButtonCommandProperty, ValueHelper<winrt::ICommand>::BoxValueIfNecessary(value));
+}
+
+winrt::ICommand TabViewProperties::AddButtonCommand()
+{
+    return ValueHelper<winrt::ICommand>::CastOrUnbox(static_cast<TabView*>(this)->GetValue(s_AddButtonCommandProperty));
+}
+
+void TabViewProperties::AddButtonCommandParameter(winrt::IInspectable const& value)
+{
+    static_cast<TabView*>(this)->SetValue(s_AddButtonCommandParameterProperty, ValueHelper<winrt::IInspectable>::BoxValueIfNecessary(value));
+}
+
+winrt::IInspectable TabViewProperties::AddButtonCommandParameter()
+{
+    return ValueHelper<winrt::IInspectable>::CastOrUnbox(static_cast<TabView*>(this)->GetValue(s_AddButtonCommandParameterProperty));
 }
 
 void TabViewProperties::CanCloseTabs(bool value)
@@ -292,6 +351,16 @@ void TabViewProperties::ItemTemplate(winrt::DataTemplate const& value)
 winrt::DataTemplate TabViewProperties::ItemTemplate()
 {
     return ValueHelper<winrt::DataTemplate>::CastOrUnbox(static_cast<TabView*>(this)->GetValue(s_ItemTemplateProperty));
+}
+
+void TabViewProperties::ItemTemplateSelector(winrt::DataTemplateSelector const& value)
+{
+    static_cast<TabView*>(this)->SetValue(s_ItemTemplateSelectorProperty, ValueHelper<winrt::DataTemplateSelector>::BoxValueIfNecessary(value));
+}
+
+winrt::DataTemplateSelector TabViewProperties::ItemTemplateSelector()
+{
+    return ValueHelper<winrt::DataTemplateSelector>::CastOrUnbox(static_cast<TabView*>(this)->GetValue(s_ItemTemplateSelectorProperty));
 }
 
 void TabViewProperties::LeftCustomContent(winrt::IInspectable const& value)

--- a/dev/Generated/TabView.properties.h
+++ b/dev/Generated/TabView.properties.h
@@ -9,6 +9,12 @@ class TabViewProperties
 public:
     TabViewProperties();
 
+    void AddButtonCommand(winrt::ICommand const& value);
+    winrt::ICommand AddButtonCommand();
+
+    void AddButtonCommandParameter(winrt::IInspectable const& value);
+    winrt::IInspectable AddButtonCommandParameter();
+
     void CanCloseTabs(bool value);
     bool CanCloseTabs();
 
@@ -26,6 +32,9 @@ public:
 
     void ItemTemplate(winrt::DataTemplate const& value);
     winrt::DataTemplate ItemTemplate();
+
+    void ItemTemplateSelector(winrt::DataTemplateSelector const& value);
+    winrt::DataTemplateSelector ItemTemplateSelector();
 
     void LeftCustomContent(winrt::IInspectable const& value);
     winrt::IInspectable LeftCustomContent();
@@ -48,12 +57,15 @@ public:
     void TabWidthMode(winrt::TabViewWidthMode const& value);
     winrt::TabViewWidthMode TabWidthMode();
 
+    static winrt::DependencyProperty AddButtonCommandProperty() { return s_AddButtonCommandProperty; }
+    static winrt::DependencyProperty AddButtonCommandParameterProperty() { return s_AddButtonCommandParameterProperty; }
     static winrt::DependencyProperty CanCloseTabsProperty() { return s_CanCloseTabsProperty; }
     static winrt::DependencyProperty CanDragDropTabsProperty() { return s_CanDragDropTabsProperty; }
     static winrt::DependencyProperty IsAddButtonVisibleProperty() { return s_IsAddButtonVisibleProperty; }
     static winrt::DependencyProperty ItemsProperty() { return s_ItemsProperty; }
     static winrt::DependencyProperty ItemsSourceProperty() { return s_ItemsSourceProperty; }
     static winrt::DependencyProperty ItemTemplateProperty() { return s_ItemTemplateProperty; }
+    static winrt::DependencyProperty ItemTemplateSelectorProperty() { return s_ItemTemplateSelectorProperty; }
     static winrt::DependencyProperty LeftCustomContentProperty() { return s_LeftCustomContentProperty; }
     static winrt::DependencyProperty LeftCustomContentTemplateProperty() { return s_LeftCustomContentTemplateProperty; }
     static winrt::DependencyProperty RightCustomContentProperty() { return s_RightCustomContentProperty; }
@@ -62,12 +74,15 @@ public:
     static winrt::DependencyProperty SelectedItemProperty() { return s_SelectedItemProperty; }
     static winrt::DependencyProperty TabWidthModeProperty() { return s_TabWidthModeProperty; }
 
+    static GlobalDependencyProperty s_AddButtonCommandProperty;
+    static GlobalDependencyProperty s_AddButtonCommandParameterProperty;
     static GlobalDependencyProperty s_CanCloseTabsProperty;
     static GlobalDependencyProperty s_CanDragDropTabsProperty;
     static GlobalDependencyProperty s_IsAddButtonVisibleProperty;
     static GlobalDependencyProperty s_ItemsProperty;
     static GlobalDependencyProperty s_ItemsSourceProperty;
     static GlobalDependencyProperty s_ItemTemplateProperty;
+    static GlobalDependencyProperty s_ItemTemplateSelectorProperty;
     static GlobalDependencyProperty s_LeftCustomContentProperty;
     static GlobalDependencyProperty s_LeftCustomContentTemplateProperty;
     static GlobalDependencyProperty s_RightCustomContentProperty;

--- a/dev/Generated/TabView.properties.h
+++ b/dev/Generated/TabView.properties.h
@@ -12,8 +12,20 @@ public:
     void CanCloseTabs(bool value);
     bool CanCloseTabs();
 
+    void CanDragDropTabs(bool value);
+    bool CanDragDropTabs();
+
     void IsAddButtonVisible(bool value);
     bool IsAddButtonVisible();
+
+    void Items(winrt::IVector<winrt::IInspectable> const& value);
+    winrt::IVector<winrt::IInspectable> Items();
+
+    void ItemsSource(winrt::IInspectable const& value);
+    winrt::IInspectable ItemsSource();
+
+    void ItemTemplate(winrt::DataTemplate const& value);
+    winrt::DataTemplate ItemTemplate();
 
     void LeftCustomContent(winrt::IInspectable const& value);
     winrt::IInspectable LeftCustomContent();
@@ -27,35 +39,72 @@ public:
     void RightCustomContentTemplate(winrt::DataTemplate const& value);
     winrt::DataTemplate RightCustomContentTemplate();
 
+    void SelectedIndex(int value);
+    int SelectedIndex();
+
+    void SelectedItem(winrt::IInspectable const& value);
+    winrt::IInspectable SelectedItem();
+
     void TabWidthMode(winrt::TabViewWidthMode const& value);
     winrt::TabViewWidthMode TabWidthMode();
 
     static winrt::DependencyProperty CanCloseTabsProperty() { return s_CanCloseTabsProperty; }
+    static winrt::DependencyProperty CanDragDropTabsProperty() { return s_CanDragDropTabsProperty; }
     static winrt::DependencyProperty IsAddButtonVisibleProperty() { return s_IsAddButtonVisibleProperty; }
+    static winrt::DependencyProperty ItemsProperty() { return s_ItemsProperty; }
+    static winrt::DependencyProperty ItemsSourceProperty() { return s_ItemsSourceProperty; }
+    static winrt::DependencyProperty ItemTemplateProperty() { return s_ItemTemplateProperty; }
     static winrt::DependencyProperty LeftCustomContentProperty() { return s_LeftCustomContentProperty; }
     static winrt::DependencyProperty LeftCustomContentTemplateProperty() { return s_LeftCustomContentTemplateProperty; }
     static winrt::DependencyProperty RightCustomContentProperty() { return s_RightCustomContentProperty; }
     static winrt::DependencyProperty RightCustomContentTemplateProperty() { return s_RightCustomContentTemplateProperty; }
+    static winrt::DependencyProperty SelectedIndexProperty() { return s_SelectedIndexProperty; }
+    static winrt::DependencyProperty SelectedItemProperty() { return s_SelectedItemProperty; }
     static winrt::DependencyProperty TabWidthModeProperty() { return s_TabWidthModeProperty; }
 
     static GlobalDependencyProperty s_CanCloseTabsProperty;
+    static GlobalDependencyProperty s_CanDragDropTabsProperty;
     static GlobalDependencyProperty s_IsAddButtonVisibleProperty;
+    static GlobalDependencyProperty s_ItemsProperty;
+    static GlobalDependencyProperty s_ItemsSourceProperty;
+    static GlobalDependencyProperty s_ItemTemplateProperty;
     static GlobalDependencyProperty s_LeftCustomContentProperty;
     static GlobalDependencyProperty s_LeftCustomContentTemplateProperty;
     static GlobalDependencyProperty s_RightCustomContentProperty;
     static GlobalDependencyProperty s_RightCustomContentTemplateProperty;
+    static GlobalDependencyProperty s_SelectedIndexProperty;
+    static GlobalDependencyProperty s_SelectedItemProperty;
     static GlobalDependencyProperty s_TabWidthModeProperty;
 
     winrt::event_token AddButtonClick(winrt::TypedEventHandler<winrt::TabView, winrt::IInspectable> const& value);
     void AddButtonClick(winrt::event_token const& token);
+    winrt::event_token SelectionChanged(winrt::SelectionChangedEventHandler const& value);
+    void SelectionChanged(winrt::event_token const& token);
     winrt::event_token TabClosing(winrt::TypedEventHandler<winrt::TabView, winrt::TabViewTabClosingEventArgs> const& value);
     void TabClosing(winrt::event_token const& token);
 
     event_source<winrt::TypedEventHandler<winrt::TabView, winrt::IInspectable>> m_addButtonClickEventSource;
+    event_source<winrt::SelectionChangedEventHandler> m_selectionChangedEventSource;
     event_source<winrt::TypedEventHandler<winrt::TabView, winrt::TabViewTabClosingEventArgs>> m_tabClosingEventSource;
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnItemsPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnItemsSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnSelectedIndexPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnSelectedItemPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnTabWidthModePropertyChanged(
         winrt::DependencyObject const& sender,

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -66,6 +66,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Verify content is displayed for newly selected tab.");
                 tabContent = FindElement.ByName("LastTabContent");
                 Verify.IsNotNull(tabContent);
+
+                Log.Comment("Verify that setting SelectedItem changes selection.");
+                Button selectItemButton = FindElement.ByName<Button>("SelectItemButton");
+                selectItemButton.InvokeAndWait();
+
+                TextBlock selectedIndexTextBlock = FindElement.ByName<TextBlock>("SelectedIndexTextBlock");
+                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "1");
+
+                Log.Comment("Verify that setting SelectedIndex changes selection.");
+                Button selectIndexButton = FindElement.ByName<Button>("SelectIndexButton");
+                selectIndexButton.InvokeAndWait();
+                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
             }
         }
 
@@ -100,7 +112,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 UIObject smallerTab = FindElement.ByName("FirstTab");
                 UIObject largerTab = FindElement.ByName("LongHeaderTab");
 
-                Log.Comment("Fixed size tabs should all be the same size.");
+                Log.Comment("Equal size tabs should all be the same size.");
                 Verify.AreEqual(smallerTab.BoundingRectangle.Width, largerTab.BoundingRectangle.Width);
 
                 Log.Comment("Changing tab width mode to SizeToContent.");

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -49,8 +49,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             TestCleanupHelper.Cleanup();
         }
 
-        // TODO: This test doesn't pass because it can't find the tab content -- this is an acc bug.
-        //[TestMethod]
+        [TestMethod]
         public void SelectionTest()
         {
             using (var setup = new TestSetupHelper("TabView Tests"))
@@ -70,8 +69,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // TODO: This test doesn't pass because it can't find the tab content -- this is an acc bug.
-        //[TestMethod]
+        [TestMethod]
         public void AddRemoveTest()
         {
             using (var setup = new TestSetupHelper("TabView Tests"))
@@ -214,8 +212,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // TODO: This test doesn't pass because it can't find the tab content -- this is an acc bug.
-        //[TestMethod]
+        [TestMethod]
         public void AddButtonTest()
         {
             using (var setup = new TestSetupHelper("TabView Tests"))

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -334,7 +334,7 @@ void TabView::UpdateTabWidths()
                 tabColumn.MaxWidth(availableWidth);
                 tabColumn.Width(winrt::GridLengthHelper::FromValueAndType(1.0, winrt::GridUnitType::Auto));
             }
-            else if (TabWidthMode() == winrt::TabViewWidthMode::Fixed)
+            else if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
             {
                 // Tabs should all be the same size, proportional to the amount of space.
                 double minTabWidth = unbox_value<double>(SharedHelpers::FindResource(c_tabViewItemMinWidthName, winrt::Application::Current().Resources(), box_value(c_tabMinimumWidth)));

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -40,39 +40,53 @@ public:
     // IUIElement
     winrt::AutomationPeer OnCreateAutomationPeer();
 
-    // IItemsControlOverrides
-    void OnItemsChanged(winrt::IInspectable const& item);
+    // From ListView
+    winrt::DependencyObject ContainerFromItem(winrt::IInspectable const& item);
+    winrt::DependencyObject ContainerFromIndex(int index);
 
     // Internal
+    void OnItemsPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnItemsSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnTabWidthModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnSelectedIndexPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnSelectedItemPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+
+    void OnItemsChanged(winrt::IInspectable const& item);
 
     void CloseTab(winrt::TabViewItem const& item);
 
 private:
     void OnLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
+    void OnListViewLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollViewerLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
-    void OnSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
+    void OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
     void OnAddButtonClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollDecreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollIncreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
 
+    void UpdateItemsSource();
+    void UpdateSelectedItem();
+    void UpdateSelectedIndex();
+
     void UpdateTabContent();
     void UpdateTabWidths();
-
-    std::optional<int> m_indexToSelectOnSelectionChanged;
 
     tracker_ref<winrt::ColumnDefinition> m_leftContentColumn{ this };
     tracker_ref<winrt::ColumnDefinition> m_tabColumn{ this };
     tracker_ref<winrt::ColumnDefinition> m_addButtonColumn{ this };
     tracker_ref<winrt::ColumnDefinition> m_rightContentColumn{ this };
 
+    tracker_ref<winrt::ListView> m_listView{ this };
     tracker_ref<winrt::ContentPresenter> m_tabContentPresenter{ this };
     tracker_ref<winrt::Grid> m_tabContainerGrid{ this };
     tracker_ref<winrt::FxScrollViewer> m_scrollViewer{ this };
     tracker_ref<winrt::Button> m_addButton{ this };
     tracker_ref<winrt::RepeatButton> m_scrollDecreaseButton{ this };
     tracker_ref<winrt::RepeatButton> m_scrollIncreaseButton{ this };
+
+    winrt::ListView::Loaded_revoker m_listViewLoadedRevoker{};
+    winrt::Selector::SelectionChanged_revoker m_listViewSelectionChangedRevoker{};
 
     winrt::ScrollViewer::Loaded_revoker m_scrollViewerLoadedRevoker{};
 

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -6,7 +6,7 @@
 enum TabViewWidthMode
 {
     SizeToContent = 0,
-    Fixed = 1,
+    Equal = 1,
 };
 
 [WUXC_VERSION_PREVIEW]

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -20,7 +20,7 @@ runtimeclass TabViewTabClosingEventArgs
 
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
-unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.ListView
+unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.Control
 {
     TabView();
 
@@ -30,6 +30,9 @@ unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.ListView
 
     [MUX_DEFAULT_VALUE("true")]
     Boolean CanCloseTabs{ get; set; };
+
+    [MUX_DEFAULT_VALUE("true")]
+    Boolean CanDragDropTabs{ get; set; };
 
     Object LeftCustomContent{ get; set; };
     Windows.UI.Xaml.DataTemplate LeftCustomContentTemplate{ get; set; };
@@ -44,13 +47,41 @@ unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.ListView
 
     event Windows.Foundation.TypedEventHandler<TabView, Object> AddButtonClick;
 
+    // From ListView
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Object ItemsSource;
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Windows.Foundation.Collections.IVector<Object> Items{ get; };
+
+    Windows.UI.Xaml.DataTemplate ItemTemplate;
+
+    [MUX_DEFAULT_VALUE("-1")]
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Int32 SelectedIndex;
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Object SelectedItem;
+
+    Windows.UI.Xaml.DependencyObject ContainerFromItem(Object item);
+    Windows.UI.Xaml.DependencyObject ContainerFromIndex(Int32 index);
+
+    event Windows.UI.Xaml.Controls.SelectionChangedEventHandler SelectionChanged;
+
     static Windows.UI.Xaml.DependencyProperty TabWidthModeProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty CanCloseTabsProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty CanDragDropTabsProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty LeftCustomContentProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty LeftCustomContentTemplateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty RightCustomContentProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty RightCustomContentTemplateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty IsAddButtonVisibleProperty{ get; };
+
+    static Windows.UI.Xaml.DependencyProperty ItemsSourceProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty ItemsProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty ItemTemplateProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty SelectedIndexProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty SelectedItemProperty{ get; };
 }
 
 [WUXC_VERSION_PREVIEW]
@@ -77,12 +108,24 @@ unsealed runtimeclass TabViewItem : Windows.UI.Xaml.Controls.ListViewItem
 
 }
 
+namespace MU_XCP_NAMESPACE
+{
+
+[WUXC_VERSION_PREVIEW]
+[webhosthidden]
+unsealed runtimeclass TabViewListView : Windows.UI.Xaml.Controls.ListView
+{
+    TabViewListView();
+}
+
+}
+
 namespace MU_XAP_NAMESPACE
 {
 
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
-unsealed runtimeclass TabViewAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewAutomationPeer
+unsealed runtimeclass TabViewAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {
     TabViewAutomationPeer(MU_XC_NAMESPACE.TabView owner);
 }

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -42,6 +42,8 @@ unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.Control
 
     [MUX_DEFAULT_VALUE("true")]
     Boolean IsAddButtonVisible{ get; set; };
+    Windows.UI.Xaml.Input.ICommand AddButtonCommand{ get; set; };
+    Object AddButtonCommandParameter{ get; set; };
 
     event Windows.Foundation.TypedEventHandler<TabView, TabViewTabClosingEventArgs> TabClosing;
 
@@ -55,6 +57,7 @@ unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.Control
     Windows.Foundation.Collections.IVector<Object> Items{ get; };
 
     Windows.UI.Xaml.DataTemplate ItemTemplate;
+    Windows.UI.Xaml.Controls.DataTemplateSelector ItemTemplateSelector{ get; set; };
 
     [MUX_DEFAULT_VALUE("-1")]
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
@@ -76,10 +79,13 @@ unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty RightCustomContentProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty RightCustomContentTemplateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty IsAddButtonVisibleProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty AddButtonCommandProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty AddButtonCommandParameterProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty ItemsSourceProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty ItemsProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty ItemTemplateProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty ItemTemplateSelectorProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty SelectedIndexProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty SelectedItemProperty{ get; };
 }

--- a/dev/TabView/TabView.vcxitems
+++ b/dev/TabView/TabView.vcxitems
@@ -17,6 +17,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TabView.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TabViewItem.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TabViewAutomationPeer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)TabViewListView.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\TabView.properties.cpp" />
@@ -24,6 +25,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)TabView.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TabViewItem.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TabViewAutomationPeer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)TabViewListView.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)TabView.xaml">

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -3,42 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
-    xmlns:local="using:Microsoft.UI.Xaml.Controls">
+    xmlns:local="using:Microsoft.UI.Xaml.Controls"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
 
-    <!--  Default style for compatibility with WPF migrators.  -->
     <Style TargetType="local:TabView">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Padding" Value="{ThemeResource TabViewHeaderPadding}" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="TabNavigation" Value="Local" />
-        <Setter Property="IsSwipeEnabled" Value="False" />
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
-        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Enabled" />
-        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
-        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
-        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
-        <Setter Property="ItemContainerTransitions">
-            <Setter.Value>
-                <TransitionCollection>
-                    <AddDeleteThemeTransition />
-                    <ContentThemeTransition />
-                    <ReorderThemeTransition />
-                    <EntranceThemeTransition IsStaggeringEnabled="False" />
-                </TransitionCollection>
-            </Setter.Value>
-        </Setter>
-
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <StackPanel Orientation="Horizontal" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
 
         <Setter Property="Template">
             <Setter.Value>
@@ -60,31 +31,18 @@
                             </Grid.ColumnDefinitions>
 
                             <ContentPresenter
+                                Grid.Column="0"
                                 x:Name="LeftContentPresenter"
                                 Content="{TemplateBinding LeftCustomContent}"
                                 ContentTemplate="{TemplateBinding LeftCustomContentTemplate}"/>
 
-                            <ScrollViewer x:Name="ScrollViewer"
+                            <primitives:TabViewListView
                                 Grid.Column="1"
-                                AutomationProperties.AccessibilityView="Raw"
-                                BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
-                                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                                IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
-                                IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
-                                TabNavigation="{TemplateBinding TabNavigation}"
-                                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                                Style="{StaticResource TabScrollViewerStyle}">
-
-                                <ItemsPresenter x:Name="TabsItemsPresenter"
-                                    Padding="{TemplateBinding Padding}" />
-
-                            </ScrollViewer>
+                                x:Name="TabListView"
+                                CanReorderItems="{TemplateBinding CanDragDropTabs}"
+                                CanDragItems="{TemplateBinding CanDragDropTabs}"
+                                AllowDrop="{TemplateBinding CanDragDropTabs}"
+                                Style="{StaticResource TabViewListViewStyle}"/>
 
                             <Button
                                 Grid.Column="2"
@@ -107,6 +65,62 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" />
                     </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Name="TabViewListViewStyle" TargetType="ListView">
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="Padding" Value="{ThemeResource TabViewHeaderPadding}" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="TabNavigation" Value="Local" />
+        <Setter Property="IsSwipeEnabled" Value="False" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Enabled" />
+        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
+        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListView">
+
+                    <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
+                        <ScrollViewer x:Name="ScrollViewer"
+                            Grid.Column="1"
+                            AutomationProperties.AccessibilityView="Raw"
+                            BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                            IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                            IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                            IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
+                            IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                            IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
+                            TabNavigation="{TemplateBinding TabNavigation}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                            VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                            ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+                            Style="{StaticResource TabScrollViewerStyle}">
+
+                            <ItemsPresenter x:Name="TabsItemsPresenter"
+                                Padding="{TemplateBinding Padding}" />
+
+                        </ScrollViewer>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -42,12 +42,15 @@
                                 CanReorderItems="{TemplateBinding CanDragDropTabs}"
                                 CanDragItems="{TemplateBinding CanDragDropTabs}"
                                 AllowDrop="{TemplateBinding CanDragDropTabs}"
-                                Style="{StaticResource TabViewListViewStyle}"/>
+                                ItemTemplate="{TemplateBinding ItemTemplate}"
+                                ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"/>
 
                             <Button
                                 Grid.Column="2"
                                 x:Name="AddButton"
                                 Content="&#xE710;"
+                                Command="{TemplateBinding AddButtonCommand}"
+                                CommandParameter="{TemplateBinding AddButtonCommandParameter}"
                                 Visibility="{Binding IsAddButtonVisible, RelativeSource={RelativeSource TemplatedParent}}"
                                 Style="{StaticResource TabViewButtonStyle}"/>
 
@@ -70,7 +73,7 @@
         </Setter>
     </Style>
 
-    <Style x:Name="TabViewListViewStyle" TargetType="ListView">
+    <Style TargetType="primitives:TabViewListView">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Padding" Value="{ThemeResource TabViewHeaderPadding}" />
         <Setter Property="IsTabStop" Value="False" />

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -31,7 +31,7 @@ void TabViewItem::OnApplyTemplate()
         return closeButton;
     }());
 
-    if (auto tabView = winrt::ItemsControl::ItemsControlFromItemContainer(*this).as<winrt::TabView>())
+    if (auto tabView = SharedHelpers::GetAncestorOfType<winrt::TabView>(winrt::VisualTreeHelper::GetParent(*this)))
     {
         m_CanCloseTabsChangedRevoker = RegisterPropertyChanged(tabView, winrt::TabView::CanCloseTabsProperty(), { this, &TabViewItem::OnCloseButtonPropertyChanged });
     }

--- a/dev/TabView/TabViewListView.cpp
+++ b/dev/TabView/TabViewListView.cpp
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "ResourceAccessor.h"
+#include "Utils.h"
+#include "TabViewListView.h"
+#include "TabViewItem.h"
+#include "TabView.h"
+#include "SharedHelpers.h"
+
+CppWinRTActivatableClassWithBasicFactory(TabViewListView);
+
+// IItemsControlOverrides
+
+winrt::DependencyObject TabViewListView::GetContainerForItemOverride()
+{
+    return winrt::make<TabViewItem>();
+}
+
+bool TabViewListView::IsItemItsOwnContainerOverride(winrt::IInspectable const& args)
+{
+    bool isItemItsOwnContainer = false;
+    if (args)
+    {
+        auto item = args.try_as<winrt::TabViewItem>();
+        isItemItsOwnContainer = static_cast<bool>(item);
+    }
+    return isItemItsOwnContainer;
+}
+
+void TabViewListView::OnItemsChanged(winrt::IInspectable const& item)
+{
+    if (auto tabView = SharedHelpers::GetAncestorOfType<winrt::TabView>(winrt::VisualTreeHelper::GetParent(*this)))
+    {
+        auto internalTabView = winrt::get_self<TabView>(tabView);
+        internalTabView->OnItemsChanged(item);
+    }
+}

--- a/dev/TabView/TabViewListView.cpp
+++ b/dev/TabView/TabViewListView.cpp
@@ -12,6 +12,11 @@
 
 CppWinRTActivatableClassWithBasicFactory(TabViewListView);
 
+TabViewListView::TabViewListView()
+{
+    SetDefaultStyleKey(this);
+}
+
 // IItemsControlOverrides
 
 winrt::DependencyObject TabViewListView::GetContainerForItemOverride()
@@ -22,9 +27,8 @@ winrt::DependencyObject TabViewListView::GetContainerForItemOverride()
 bool TabViewListView::IsItemItsOwnContainerOverride(winrt::IInspectable const& args)
 {
     bool isItemItsOwnContainer = false;
-    if (args)
+    if (auto item = args.try_as<winrt::TabViewItem>())
     {
-        auto item = args.try_as<winrt::TabViewItem>();
         isItemItsOwnContainer = static_cast<bool>(item);
     }
     return isItemItsOwnContainer;

--- a/dev/TabView/TabViewListView.h
+++ b/dev/TabView/TabViewListView.h
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+#include "TabViewListView.g.h"
+
+class TabViewListView :
+    public ReferenceTracker<TabViewListView, winrt::implementation::TabViewListViewT>
+{
+public:
+    TabViewListView() {};
+
+    // IItemsControlOverrides
+    winrt::DependencyObject GetContainerForItemOverride();
+    bool IsItemItsOwnContainerOverride(winrt::IInspectable const& item);
+    void OnItemsChanged(winrt::IInspectable const& item);
+
+private:
+};
+

--- a/dev/TabView/TabViewListView.h
+++ b/dev/TabView/TabViewListView.h
@@ -8,7 +8,7 @@ class TabViewListView :
     public ReferenceTracker<TabViewListView, winrt::implementation::TabViewListViewT>
 {
 public:
-    TabViewListView() {};
+    TabViewListView();
 
     // IItemsControlOverrides
     winrt::DependencyObject GetContainerForItemOverride();

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -24,12 +24,14 @@
                 <CheckBox x:Name="IsAddButtonVisibleCheckBox" AutomationProperties.Name="IsAddButtonVisibleCheckBox" Content="Add button visible" IsChecked="{x:Bind Tabs.IsAddButtonVisible, Mode=TwoWay}"/>
 
                 <Button x:Name="RemoveTabButton" AutomationProperties.Name="RemoveTabButton"  Content="Remove Tab" Margin="0,0,0,8" Click="RemoveTabButton_Click"/>
+                <Button x:Name="SelectItemButton" AutomationProperties.Name="SelectItemButton"  Content="Select Item 1" Margin="0,0,0,8" Click="SelectItemButton_Click"/>
+                <Button x:Name="SelectIndexButton" AutomationProperties.Name="SelectIndexButton"  Content="Select Index 2" Margin="0,0,0,8" Click="SelectIndexButton_Click"/>
 
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                     <TextBlock VerticalAlignment="Center">Tab Width:</TextBlock>
                     <ComboBox x:Name="TabWidthComboBox" AutomationProperties.Name="TabWidthComboBox" Margin="4,0,0,0" SelectedIndex="1" SelectionChanged="TabWidthComboBox_SelectionChanged">
                         <ComboBoxItem Content="SizeToContent"/>
-                        <ComboBoxItem Content="Fixed"/>
+                        <ComboBoxItem Content="Equal"/>
                     </ComboBox>
                 </StackPanel>
 
@@ -42,7 +44,7 @@
             <controls:TabView
                 x:Name="Tabs"
                 Grid.Column="1"
-                TabWidthMode="Fixed"
+                TabWidthMode="Equal"
                 SelectedIndex="0"
                 SelectionChanged="TabViewSelectionChanged"
                 TabClosing="TabViewTabClosing"

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -43,9 +43,7 @@
                 x:Name="Tabs"
                 Grid.Column="1"
                 TabWidthMode="Fixed"
-                CanReorderItems="True"
-                CanDragItems="True"
-                AllowDrop="True"
+                SelectedIndex="0"
                 SelectionChanged="TabViewSelectionChanged"
                 TabClosing="TabViewTabClosing"
                 AddButtonClick="AddButtonClick">
@@ -56,7 +54,7 @@
 
                 <controls:TabView.Items>
 
-                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Icon="Home" Header="Home" IsSelected="True">
+                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Icon="Home" Header="Home">
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8">Home Button</Button>
                             <Button x:Name="FirstTabButton2" AutomationProperties.Name="FirstTabButton2" Margin="8">Another Button</Button>

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -68,6 +68,23 @@ namespace MUXControlsTestApp
             }
         }
 
+
+        public void SelectItemButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (Tabs != null)
+            {
+                Tabs.SelectedItem = Tabs.Items[1];
+            }
+        }
+
+        public void SelectIndexButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (Tabs != null)
+            {
+                Tabs.SelectedIndex = 2;
+            }
+        }
+
         private void TabWidthComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (Tabs != null)
@@ -75,7 +92,7 @@ namespace MUXControlsTestApp
                 switch (TabWidthComboBox.SelectedIndex)
                 {
                     case 0: Tabs.TabWidthMode = Microsoft.UI.Xaml.Controls.TabViewWidthMode.SizeToContent; break;
-                    case 1: Tabs.TabWidthMode = Microsoft.UI.Xaml.Controls.TabViewWidthMode.Fixed; break;
+                    case 1: Tabs.TabWidthMode = Microsoft.UI.Xaml.Controls.TabViewWidthMode.Equal; break;
                 }
             }
         }


### PR DESCRIPTION
This changes TabView from being a ListView to containing a ListView. I added the customary list of properties/methods/events necessary, added tests to verify they're working, and reenabled all tests previously blocked by accessibility issues.

I also renamed TabViewWidthMode.Fixed to Equal (was a poor choice of name originally).