### PR TITLE
Update Min OS Version for MUX to RS2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,6 @@ NuGet package version:
 | April 2018 Update (17134)          | <!-- Yes/No? -->   |
 | Fall Creators Update (16299)       | <!-- Yes/No? -->   |
 | Creators Update (15063)            | <!-- Yes/No? -->   |
-| Anniversary Update (14393)         | <!-- Yes/No? -->   |
 
 <!-- Which device form factors did you see the issue on? Leave blank if you didn't try that device. -->
 | Device form factor | Saw the problem? |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You don't need version checks or conditional XAML markup to use WinUI controls o
 
 ### Version support
 
-The Microsoft.UI.Xaml 2.2 NuGet package requires your project to have TargetPlatformVersion &gt;= 10.0.18362.0 and TargetPlatformMinVersion &gt;= 10.0.14393.0 when building. 
+The Microsoft.UI.Xaml 2.2 NuGet package requires your project to have TargetPlatformVersion &gt;= 10.0.18362.0 and TargetPlatformMinVersion &gt;= 10.0.15063.0 when building. 
 
 Your app's users can be on any of the following supported Windows versions:
 * Windows Insider Previews
@@ -70,7 +70,6 @@ Your app's users can be on any of the following supported Windows versions:
 * April 2018 Update (17134 aka "Redstone 4")
 * Fall Creators Update (16299 aka "Redstone 3")
 * Creators Update (15063 aka "Redstone 2")
-* Anniversary Update (14393 aka "Redstone 1")
 
 Some features may have a reduced or slightly different user experience on older versions, particularly on builds before 15063. This should not impact overall usability.
 

--- a/build/FrameworkPackage/FrameworkPackage.csproj
+++ b/build/FrameworkPackage/FrameworkPackage.csproj
@@ -52,8 +52,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.10586.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/build/FrameworkPackage/FrameworkPackageContents/AppxManifest.xml
+++ b/build/FrameworkPackage/FrameworkPackageContents/AppxManifest.xml
@@ -12,7 +12,7 @@
     <Resource Language="en-US" />
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14393.0" MaxVersionTested="10.0.17706.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.15063.0" MaxVersionTested="10.0.18362.0" />
   </Dependencies>
   <mp:PhoneIdentity PhoneProductId="3F0E3E5D-C663-407a-9187-9A5F47398F11" PhonePublisherId="1AC97219-40D1-4c98-B175-2BFCD96578C3" />
   <Extensions>

--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -220,21 +220,6 @@ if ($Configuration -ilike "debug")
     #$PackageName += ".Debug"
 }
 
-# On RS1 we do not have support for DefaultStyleResourceUri which enables our controls to point the XAML framework to load 
-# their  default style out of the framework package's versioned generic.xaml. The support exists on RS2 and greater so for 
-# RS1 we include a generic.xaml in the default app location that the framework looks for component styles and have that 
-# file just be a pointer to the framework package rs1 generic.xaml.
-$rs1_genericxaml = 
-@"
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="ms-appx://$PackageName/Microsoft.UI.Xaml/Themes/generic.xaml"/>
-    </ResourceDictionary.MergedDictionaries>
-</ResourceDictionary>
-"@
-
-Set-Content -Value $rs1_genericxaml $fullOutputPath\rs1_themes_generic.xaml
-
 # Allow single URI to access Compact.xaml from both framework package and nuget package
 $compactxaml = 
 @"

--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -7,8 +7,8 @@
       <MicrosoftUIXamlTargetPlatformMinCheckValue>$([System.Version]::Parse('$(TargetPlatformMinVersion)').Build)</MicrosoftUIXamlTargetPlatformMinCheckValue>
     </PropertyGroup>
     <Error 
-        Text="Microsoft.UI.Xaml nuget package requires TargetPlatformMinVersion &gt;= 10.0.14393.0 (current project is $(MicrosoftUIXamlTargetPlatformMinCheckValue))" 
-        Condition="$(MicrosoftUIXamlTargetPlatformMinCheckValue) &lt; 14393" />
+        Text="Microsoft.UI.Xaml nuget package requires TargetPlatformMinVersion &gt;= 10.0.15063.0 (current project is $(MicrosoftUIXamlTargetPlatformMinCheckValue))" 
+        Condition="$(MicrosoftUIXamlTargetPlatformMinCheckValue) &lt; 15063" />
     <PropertyGroup>
       <MicrosoftUIXamlTargetPlatformCheckValue>$([System.Version]::Parse('$(TargetPlatformVersion)').Build)</MicrosoftUIXamlTargetPlatformCheckValue>
     </PropertyGroup>

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -129,14 +129,6 @@
       <PackagingOutputs Remove="@(XamlCompactXbfPackagingOutputToBeRemoved)" />
     </ItemGroup>
   </Target>
-
-  <!-- Workaround for apps that need RS1 support, include this only if min version is RS1 -->
-  <ItemGroup Condition="($([System.Version]::Parse('$(TargetPlatformMinVersion)').Build) &lt; 15063) And '$(DisableMicrosoftUIXamlRS1ThemesWorkaround)'==''">
-    <Page Include="$(MSBuildThisFileDirectory)rs1_themes\generic.xaml">
-      <SubType>Designer</SubType>
-      <Link>Microsoft.UI.Xaml\Themes\generic.xaml</Link>
-    </Page>
-  </ItemGroup>
   
   <!-- Make this URI works in framework package "ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" -->
   <ItemGroup>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -32,7 +32,6 @@
     <file target="build\Common.targets" src="MUXControls-Nuget-Common.targets"/>
     <file target="build\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-FrameworkPackage.targets"/>
-    <file target="build\rs1_themes\generic.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\rs1_themes_generic.xaml"/>
     <file target="build\DensityStyles\Compact.xaml" src="$BUILDOUTPUT$\$BUILDFLAVOR$\$BUILDARCH$\FrameworkPackage\Compact.xaml"/>
   </files>
 </package>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -290,11 +290,6 @@
     <ResourceCompile Include="Microsoft.UI.Xaml.rc" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="$(OutDir)Generic.xaml">
-      <SubType>Designer</SubType>
-      <ThemeResource>true</ThemeResource>
-      <Link>Themes\%(Filename)%(Extension)</Link>
-    </Page>
     <Page Include="$(MSBuildProjectDirectory)\DensityStyles\Compact.xaml">
       <SubType>Designer</SubType>
       <ThemeResource>true</ThemeResource>
@@ -304,16 +299,6 @@
       <SubType>Designer</SubType>
       <ThemeResource>true</ThemeResource>
       <Link>DensityStyles\%(Filename)%(Extension)</Link>
-    </Page>
-    <Page Include="$(OutDir)rs1_themeresources.xaml">
-      <SubType>Designer</SubType>
-      <ThemeResource>true</ThemeResource>
-      <Link>Themes\%(Filename)%(Extension)</Link>
-    </Page>
-    <Page Include="$(OutDir)rs1_compact_themeresources.xaml">
-      <SubType>Designer</SubType>
-      <ThemeResource>true</ThemeResource>
-      <Link>Themes\%(Filename)%(Extension)</Link>
     </Page>
     <!-- Pages which needs CustomCompile to run a different version of GenXBF, we attach MinSDKVersionRequired to Page to help CompileXaml to identify the min SDK Version -->
     <PageRequiringCustomCompilation Include="$(OutDir)rs2_generic.xaml">
@@ -483,7 +468,7 @@
   <Target Name="GenerateGenericResourceFile" DependsOnTargets="CategorizeSharedPages" BeforeTargets="$(GenerateXamlFileBeforeTargets)" Inputs="@(RS1StylePage);@(RS2StylePage);@(RS3StylePage);@(RS4StylePage);@(RS5StylePage);@(NineteenH1StylePage)" Outputs="$(OutDir)Generic.xaml;$(OutDir)rs1_generic.xaml;$(OutDir)rs2_generic.xaml;$(OutDir)rs3_generic.xaml;$(OutDir)rs4_generic.xaml;$(OutDir)rs5_generic.xaml;$(OutDir)19h1_generic.xaml;">
     <Message Text="Generating generic resources XAML file " />
     <BatchMergeXaml RS1Pages="@(RS1StylePage)" RS2Pages="@(RS2StylePage)" RS3Pages="@(RS3StylePage)" RS4Pages="@(RS4StylePage)" RS5Pages="@(RS5StylePage)" N19H1Pages="@(NineteenH1StylePage)" PostfixForGeneratedFile="generic" OutputDirectory="$(OutDir)" />
-    <Copy SourceFiles="$(OutDir)rs1_generic.xaml" DestinationFiles="$(OutDir)Generic.xaml" />
+    <Copy SourceFiles="$(OutDir)rs2_generic.xaml" DestinationFiles="$(OutDir)Generic.xaml" />
     <!-- NB: We have to use CreateProperty here instead of PropertyGroup.	
       PropertyGroup values are always evaluated even when their enclosing target is skipped,	
       whereas CreateProperty has the TaskParameter ValueSetByTask that can be used	

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -19,7 +19,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <!-- Use 64-bit compilers because 32-bit compilers run out of heap space -->
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj.filters
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj.filters
@@ -113,12 +113,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(OutDir)Generic.xaml" />
-    <Page Include="$(OutDir)rs1_themeresources.xaml" />
     <Page Include="@(PageRequiringCustomCompilation)" />
     <Page Include="$(MSBuildProjectDirectory)\DensityStyles\Compact.xaml" />
     <Page Include="$(MSBuildProjectDirectory)\DensityStyles\CompactDatePickerTimePickerFlyout.xaml" />
     <Page Include="@(PageRequiringCustomCompilation)" />
-    <Page Include="$(OutDir)rs1_compact_themeresources.xaml" />
     <Page Include="@(PageRequiringCustomCompilation)" />
   </ItemGroup>
   <ItemGroup>

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -97,8 +97,7 @@ void SetDefaultStyleKeyWorker(winrt::IControlProtected const& controlProtected, 
     {
         winrt::Uri uri{
             []() -> PCWSTR {
-            // Our RS2 styles depend on XamlCompositionBrushBase so use that as the condition here.
-            bool isRS2OrHigher = SharedHelpers::IsXamlCompositionBrushBaseAvailable();
+            
             // RS3 styles should be used on builds where ListViewItemPresenter's VSM integration works.
             bool isRS3OrHigher = SharedHelpers::DoesListViewItemPresenterVSMWork();
             bool isRS4OrHigher = SharedHelpers::IsRS4OrHigher();
@@ -124,14 +123,9 @@ void SetDefaultStyleKeyWorker(winrt::IControlProtected const& controlProtected, 
                 {
                     return L"ms-appx://" MUXCONTROLS_PACKAGE_NAME "/" MUXCONTROLSROOT_NAMESPACE_STR "/Themes/rs3_generic.xaml";
                 }
-                else if (isRS2OrHigher)
-                {
-                    return L"ms-appx://" MUXCONTROLS_PACKAGE_NAME "/" MUXCONTROLSROOT_NAMESPACE_STR "/Themes/rs2_generic.xaml";
-                }
                 else
                 {
-                    MUX_FAIL_FAST();
-                    return L"";
+                    return L"ms-appx://" MUXCONTROLS_PACKAGE_NAME "/" MUXCONTROLSROOT_NAMESPACE_STR "/Themes/rs2_generic.xaml";
                 }
             }
             else
@@ -152,14 +146,9 @@ void SetDefaultStyleKeyWorker(winrt::IControlProtected const& controlProtected, 
                 {
                     return L"ms-appx:///" MUXCONTROLSROOT_NAMESPACE_STR "/Themes/rs3_generic.xaml";
                 }
-                else if (isRS2OrHigher)
-                {
-                    return L"ms-appx:///" MUXCONTROLSROOT_NAMESPACE_STR "/Themes/rs2_generic.xaml";
-                }
                 else
                 {
-                    MUX_FAIL_FAST();
-                    return L"";
+                    return L"ms-appx:///" MUXCONTROLSROOT_NAMESPACE_STR "/Themes/rs2_generic.xaml";
                 }
             }
         }()

--- a/test/IXMPTestApp/IXMPTestApp.Shared.projitems
+++ b/test/IXMPTestApp/IXMPTestApp.Shared.projitems
@@ -24,7 +24,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
+++ b/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <!-- We need to define NuGet references using this newer style for running tests locally in VS to work.
        However, for some reason, specifially in lab builds, using the below to resolve NuGet references
-       causes it to complain that the uap10.0.14393 framework wasn't referenced.
+       causes it to complain that the uap10.0.15063 framework wasn't referenced.
        As such, we'll use the more old-school package.json NuGet reference format for lab builds. -->
   <PropertyGroup Condition="'$(XES_DFSDROP)' == ''">
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/test/IXMPTestApp/MSTest/project.json
+++ b/test/IXMPTestApp/MSTest/project.json
@@ -7,7 +7,7 @@
     "MSTest.TestFramework": "1.3.2"
   },
   "frameworks": {
-    "uap10.0.14393": {}
+    "uap10.0.15063": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/IXMPTestApp/Package.appxmanifest
+++ b/test/IXMPTestApp/Package.appxmanifest
@@ -9,7 +9,7 @@
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.10586.0" MaxVersionTested="10.0.14393.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.15063.0" MaxVersionTested="10.0.18362.0" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/test/IXMPTestApp/TAEF/project.json
+++ b/test/IXMPTestApp/TAEF/project.json
@@ -6,7 +6,7 @@
     "TAEF.Redist.Wlk": "10.31.180822002"
   },
   "frameworks": {
-    "uap10.0.14393": {}
+    "uap10.0.15063": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/MUXControls.ReleaseTest.Shared.projitems
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/MUXControls.ReleaseTest.Shared.projitems
@@ -20,7 +20,7 @@
     <RootNamespace>MUXControls.ReleaseTest</RootNamespace>
     <AssemblyName>MUXControls.ReleaseTest</AssemblyName>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(ReleaseTestSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -14,7 +14,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <!-- We need to define NuGet references using this newer style for running tests locally in VS to work.
        However, for some reason, specifially in lab builds, using the below to resolve NuGet references
-       causes it to complain that the uap10.0.14393 framework wasn't referenced.
+       causes it to complain that the uap10.0.15063 framework wasn't referenced.
        As such, we'll use the more old-school package.json NuGet reference format for lab builds. -->
   <PropertyGroup Condition="'$(XES_DFSDROP)' == ''">
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/test/MUXControlsTestApp/MSTest/project.json
+++ b/test/MUXControlsTestApp/MSTest/project.json
@@ -8,7 +8,7 @@
     "DiffPlex": "1.2.1"
   },
   "frameworks": {
-    "uap10.0.14393": {}
+    "uap10.0.15063": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -24,7 +24,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsTestApp/TAEF/project.json
+++ b/test/MUXControlsTestApp/TAEF/project.json
@@ -8,7 +8,7 @@
     "Win2D.uwp": "1.22.0"
   },
   "frameworks": {
-    "uap10.0.14393": {}
+    "uap10.0.15063": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/MUXControlsTestApp/ThemeResourcesTests.cs
+++ b/test/MUXControlsTestApp/ThemeResourcesTests.cs
@@ -131,14 +131,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             IdleSynchronizer.TryWait();
         }
 
-        // These files only apply to MUX, so there's no need to run these tests for WUXC.
-#if !BUILD_WINDOWS
-        //[TestMethod] TODO: Re-enable after fixing bug 17186090.
-        public void VerifyRS1DefaultStyleDictionariesWereMergedCorrectly()
-        {
-            VerifyDictionariesWereMergedCorrectly(GetRS1DefaultStyleDictionaries(), "Microsoft.UI.Xaml/Themes/Generic.xaml");
-        }
-
         [TestMethod]
         public void VerifyRS2DefaultStyleDictionariesWereMergedCorrectly()
         {
@@ -182,12 +174,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 VerifyDictionariesWereMergedCorrectly(Get19H1DefaultStyleDictionaries(), "Microsoft.UI.Xaml/Themes/19h1_generic.xaml");
             }
-        }
-
-        [TestMethod]
-        public void VerifyRS1ThemeResourceDictionariesWereMergedCorrectly()
-        {
-            VerifyDictionariesWereMergedCorrectly(GetRS1ThemeResourceDictionaries(), "Microsoft.UI.Xaml/Themes/rs1_themeresources.xaml");
         }
 
         [TestMethod]
@@ -529,6 +515,5 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         #endregion
-#endif
     }
 }

--- a/test/MUXControlsTestAppForIslands/MUXControlsTestAppForIslands.csproj
+++ b/test/MUXControlsTestAppForIslands/MUXControlsTestAppForIslands.csproj
@@ -15,7 +15,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsTestAppForIslands/project.json
+++ b/test/MUXControlsTestAppForIslands/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {
-    "uap10.0.14393": {}
+    "uap10.0.15063": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/MUXControlsTestAppWPFPackage/MUXControlsTestAppWPFPackage.wapproj
+++ b/test/MUXControlsTestAppWPFPackage/MUXControlsTestAppWPFPackage.wapproj
@@ -58,7 +58,7 @@
   <PropertyGroup>
     <ProjectGuid>03f7f4f7-0250-435e-a730-ed82f6a08652</ProjectGuid>
     <TargetPlatformVersion>$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <EntryPointProjectUniqueName>..\MUXControlsTestAppWPF\MUXControlsTestAppWPF.csproj</EntryPointProjectUniqueName>
   </PropertyGroup>

--- a/test/MUXControlsTestAppWPFPackage/Package.appxmanifest
+++ b/test/MUXControlsTestAppWPFPackage/Package.appxmanifest
@@ -9,7 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.15063.0" MaxVersionTested="10.0.18362.0" />
     <PackageDependency Name="Microsoft.VCLibs.140.00.Debug" MinVersion="14.0.26428.1" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
   <Resources>

--- a/test/MUXTestUtilities/MUXTestUtilities.vcxproj
+++ b/test/MUXTestUtilities/MUXTestUtilities.vcxproj
@@ -18,7 +18,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <StlVersion>110</StlVersion>
   </PropertyGroup>

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -12,7 +12,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.14393.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <PackageCertificateKeyFile>..\..\build\MSTest.pfx</PackageCertificateKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
There is further clean up that we could do to remove RS1 references in our code. For example we are still generating RS1 xaml output from BatchMergeXaml.

Rather than spending a ton of time updating the code, we should do a much larger change once we have WinUI 3, which is to remove almost all of our platform version handling logic from the codebase. Any piecemeal removal of RS1 would just be throw-away work.

The larger refactoring is tracked by #975.

Running CI build here: https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=22984