### PR TITLE
Set fixed height on NavigationView icon ViewBox

### DIFF
--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -592,7 +592,6 @@
                             </Grid.ColumnDefinitions>
 
                             <Viewbox x:Name="IconBox"
-                                Width="16"
                                 Height="16"
                                 Margin="{ThemeResource NavigationViewItemOnLeftIconBoxMargin}">
                                 <ContentPresenter 
@@ -689,7 +688,6 @@
 
                             <Viewbox 
                                 x:Name="IconBox"                                
-                                Width="16"
                                 Height="16"
                                 Margin="{ThemeResource NavigationViewItemOnLeftIconBoxMargin}">
                                 <ContentPresenter 

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -591,7 +591,9 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
-                            <Viewbox x:Name="IconBox"                                
+                            <Viewbox x:Name="IconBox"
+                                Width="16"
+                                Height="16"
                                 Margin="{ThemeResource NavigationViewItemOnLeftIconBoxMargin}">
                                 <ContentPresenter 
                                     x:Name="Icon" 
@@ -687,6 +689,8 @@
 
                             <Viewbox 
                                 x:Name="IconBox"                                
+                                Width="16"
+                                Height="16"
                                 Margin="{ThemeResource NavigationViewItemOnLeftIconBoxMargin}">
                                 <ContentPresenter 
                                     x:Name="Icon" 


### PR DESCRIPTION
Fixes #822

We removed the fixed height on NavigationViewItem to allow dynamic height adjusting, but this makes the NavViewItem icon size inconsistent when using custom ones. Icons will just render at their default sizes since there's no constrains.

Fixing it by giving a fixed height to icon ViewBox.