### PR TITLE
Fix url for nuget and framework pkg tests in Release pipeline

### DIFF
--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -123,6 +123,7 @@ jobs:
     buildJobName: 'BuildNugetPkgTests'
     buildArtifactName: 'NugetPkgTestsDrop'
     runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop'
    
@@ -132,6 +133,7 @@ jobs:
     buildJobName: 'BuildFrameworkPkgTests'
     buildArtifactName: 'FrameworkPkgTestsDrop'
     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
     dependsOn: CreateNugetPackage
     pkgArtifactPath: '$(artifactDownloadPath)\drop\FrameworkPackage'
 


### PR DESCRIPTION
Already fixed for CI Pipeline, but missed the Release Pipeline.

See #878 MUX-CI submits multiple Helix jobs with the same name, preventing access to the logs 