### PR TITLE
Fix issue where TeachingTip's background is not correct for LightDismiss

### DIFF
--- a/dev/TeachingTip/APITests/TeachingTipTests.cs
+++ b/dev/TeachingTip/APITests/TeachingTipTests.cs
@@ -66,6 +66,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             IdleSynchronizer.Wait();
             loadedEvent.WaitOne();
+            IdleSynchronizer.Wait();
 
             RunOnUIThread.Execute(() =>
             {
@@ -89,7 +90,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     var child = popup.Child;
                     var grandChild = VisualTreeHelper.GetChild(child, 0);
                     var actualBrush = ((Grid)grandChild).Background;
-                    Verify.AreSame(lightDismissBackgroundBrush, actualBrush, "Checking LightDismiss TeachingTip Background is using resource for first invocation");
+                    Log.Comment("Checking LightDismiss TeachingTip Background is using resource for first invocation");
+                    if (lightDismissBackgroundBrush != actualBrush)
+                    {
+                        if (actualBrush is SolidColorBrush actualSolidBrush)
+                        {
+                            string teachingTipMessage = $"LightDismiss TeachingTip Background is SolidColorBrush with color {actualSolidBrush.Color}";
+                            Log.Comment(teachingTipMessage);
+                            Verify.Fail(teachingTipMessage);
+                        }
+                        else
+                        {
+                            Verify.AreSame(lightDismissBackgroundBrush, actualBrush, "Checking LightDismiss TeachingTip Background is using resource for first invocation");
+                        }
+                    }
                 }
 
                 teachingTip.IsLightDismissEnabled = true;

--- a/dev/TeachingTip/APITests/TeachingTipTests.cs
+++ b/dev/TeachingTip/APITests/TeachingTipTests.cs
@@ -24,22 +24,44 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using TeachingTip = Microsoft.UI.Xaml.Controls.TeachingTip;
 using IconSource = Microsoft.UI.Xaml.Controls.IconSource;
 using SymbolIconSource = Microsoft.UI.Xaml.Controls.SymbolIconSource;
+using Microsoft.UI.Private.Controls;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
     public class TeachingTipTests
     {
-        //[TestMethod] TODO: Re-enable once issue #643 is fixed.
+        [TestMethod]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")] // TeachingTip doesn't appear to show up correctly in OneCore.
         public void TeachingTipBackgroundTest()
         {
+            TeachingTip teachingTip = null, teachingTipLightDismiss = null;
+            SolidColorBrush blueBrush = null;
+            Brush lightDismissBackgroundBrush = null;
             var loadedEvent = new AutoResetEvent(false);
             RunOnUIThread.Execute(() =>
             {
-                TeachingTip teachingTip = new TeachingTip();
+                Grid root = new Grid();
+                teachingTip = new TeachingTip();
                 teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = teachingTip;
+
+                teachingTipLightDismiss = new TeachingTip();
+                teachingTipLightDismiss.IsLightDismissEnabled = true;
+
+                // Set LightDismiss background before show... it shouldn't take effect in the tree
+                blueBrush = new SolidColorBrush(Colors.Blue);
+                teachingTipLightDismiss.Background = blueBrush;
+
+                root.Resources.Add("TeachingTip", teachingTip);
+                root.Resources.Add("TeachingTipLightDismiss", teachingTipLightDismiss);
+
+                lightDismissBackgroundBrush = MUXControlsTestApp.App.Current.Resources["TeachingTipTransientBackground"] as Brush;
+                Verify.IsNotNull(lightDismissBackgroundBrush, "lightDismissBackgroundBrush");
+
+                teachingTip.IsOpen = true;
+                teachingTipLightDismiss.IsOpen = true;
+
+                MUXControlsTestApp.App.TestContentRoot = root;
             });
 
             IdleSynchronizer.Wait();
@@ -47,19 +69,28 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                TeachingTip teachingTip = (TeachingTip)MUXControlsTestApp.App.TestContentRoot;
                 var redBrush = new SolidColorBrush(Colors.Red);
                 teachingTip.SetValue(TeachingTip.BackgroundProperty, redBrush);
                 Verify.AreSame(redBrush, teachingTip.GetValue(TeachingTip.BackgroundProperty) as Brush);
                 Verify.AreSame(redBrush, teachingTip.Background);
 
-                var blueBrush = new SolidColorBrush(Colors.Blue);
                 teachingTip.Background = blueBrush;
                 Verify.AreSame(blueBrush, teachingTip.Background);
 
-                var child = VisualTreeHelper.GetChild(teachingTip, 0);
-                var grandChild = VisualTreeHelper.GetChild(child, 1);
-                Verify.AreSame(blueBrush, ((Grid)grandChild).Background);
+                {
+                    var popup = TeachingTipTestHooks.GetPopup(teachingTip);
+                    var child = popup.Child;
+                    var grandChild = VisualTreeHelper.GetChild(child, 0);
+                    Verify.AreSame(blueBrush, ((Grid)grandChild).Background, "Checking TeachingTip.Background TemplateBinding works");
+                }
+
+                {
+                    var popup = TeachingTipTestHooks.GetPopup(teachingTipLightDismiss);
+                    var child = popup.Child;
+                    var grandChild = VisualTreeHelper.GetChild(child, 0);
+                    var actualBrush = ((Grid)grandChild).Background;
+                    Verify.AreSame(lightDismissBackgroundBrush, actualBrush, "Checking LightDismiss TeachingTip Background is using resource for first invocation");
+                }
 
                 teachingTip.IsLightDismissEnabled = true;
             });
@@ -68,15 +99,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                TeachingTip teachingTip = (TeachingTip)MUXControlsTestApp.App.TestContentRoot;
-                var blueBrush = new SolidColorBrush(Colors.Blue);
                 Verify.AreEqual(blueBrush.Color, ((SolidColorBrush)teachingTip.Background).Color);
-                var child = VisualTreeHelper.GetChild(teachingTip, 0);
-                var grandChild = VisualTreeHelper.GetChild(child, 1);
+
+                var popup = TeachingTipTestHooks.GetPopup(teachingTip);
+                var child = popup.Child as Grid;
+                var grandChild = VisualTreeHelper.GetChild(child, 0);
                 var grandChildBackgroundBrush = ((Grid)grandChild).Background;
                 //If we can no longer cast the background brush to a solid color brush then changing the
                 //IsLightDismissEnabled has changed the background as we expected it to.
-                if(grandChildBackgroundBrush is SolidColorBrush)
+                if (grandChildBackgroundBrush is SolidColorBrush)
                 {
                     Verify.AreNotEqual(blueBrush.Color, ((SolidColorBrush)grandChildBackgroundBrush).Color);
                 }

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -101,7 +101,7 @@ void TeachingTip::OnApplyTemplate()
     }();
 
     UpdateButtonsState();
-
+    OnIsLightDismissEnabledChanged();
     OnIconSourceChanged();
 
     EstablishShadows();

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -833,6 +833,9 @@ void TeachingTip::IsOpenChangedToOpen()
     }
 
     m_acceleratorKeyActivatedRevoker = Dispatcher().AcceleratorKeyActivated(winrt::auto_revoke, { this, &TeachingTip::OnF6AcceleratorKeyClicked });
+
+    // Make sure we are in the correct VSM state after ApplyTemplate and moving the template content from the Control to the Popup:
+    OnIsLightDismissEnabledChanged();
 }
 
 void TeachingTip::IsOpenChangedToClose()


### PR DESCRIPTION
The first time a TeachingTip is shown, if IsLightDismissEnabled=true then the background was not the light dismiss background. This is because we called GoToState before the template was expanded. 

Fix is to add a call to the function that calls GoToState from OnApplyTemplate -- following the pattern that was already there.

Added a test, which failed before this change and passes after it.

Fixes #724