### PR TITLE
Scroller: Simulating WUX ScrollViewer.ChangeView method in test app

### DIFF
--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
@@ -515,9 +515,9 @@
 
                     <TextBlock Text="ScrollTo/By Options" Margin="2" Grid.ColumnSpan="2"/>
                     <TextBlock Text="Horizontal Offset:" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCOAHO" Text="0" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtScrollHorizontalOffset" Text="0" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center"/>
                     <TextBlock Text="Vertical Offset:" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCOAVO" Text="0" Grid.Column="1" Grid.Row="2" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtScrollVerticalOffset" Text="0" Grid.Column="1" Grid.Row="2" VerticalAlignment="Center"/>
                     <TextBlock Text="AnimationMode:" Grid.Column="0" Grid.Row="3" VerticalAlignment="Center"/>
                     <ComboBox x:Name="cmbScrollAnimationMode" Grid.Column="1" Grid.Row="3" VerticalAlignment="Center" SelectedIndex="2">
                         <ComboBoxItem>Disabled</ComboBoxItem>
@@ -548,13 +548,13 @@
 
                     <TextBlock Text="ScrollFrom Options" Grid.Row="8" Margin="2" Grid.ColumnSpan="2"/>
                     <TextBlock Text="Horizontal Velocity:" Grid.Column="0" Grid.Row="9" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCOWAVAHV" Text="0" Grid.Column="1" Grid.Row="9" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtScrollHorizontalVelocity" Text="0" Grid.Column="1" Grid.Row="9" VerticalAlignment="Center"/>
                     <TextBlock Text="Vertical Velocity:" Grid.Column="0" Grid.Row="10" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCOWAVAVV" Text="0" Grid.Column="1" Grid.Row="10" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtScrollVerticalVelocity" Text="0" Grid.Column="1" Grid.Row="10" VerticalAlignment="Center"/>
                     <TextBlock Text="Horiz. InertiaDecayRate:" Grid.Column="0" Grid.Row="11" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCOWAVAHIDR" Text="null" Grid.Column="1" Grid.Row="11" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtScrollHorizontalInertiaDecayRate" Text="null" Grid.Column="1" Grid.Row="11" VerticalAlignment="Center"/>
                     <TextBlock Text="Verti. InertiaDecayRate:" Grid.Column="0" Grid.Row="12" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCOWAVAVIDR" Text="null" Grid.Column="1" Grid.Row="12" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtScrollVerticalInertiaDecayRate" Text="null" Grid.Column="1" Grid.Row="12" VerticalAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" Grid.ColumnSpan="2" Grid.Row="13">
                         <Button x:Name="btnScrollFrom" Content="ScrollFrom" Margin="2" Click="BtnScrollFrom_Click"/>
                         <Button x:Name="btnCancelScrollFrom" Content="Cancel" Margin="2" Click="BtnCancelScrollFrom_Click"/>
@@ -562,9 +562,9 @@
 
                     <TextBlock Text="ZoomTo/By Options" Margin="2,4,2,2" Grid.Row="14" Grid.ColumnSpan="2"/>
                     <TextBlock Text="ZoomFactor:" Grid.Column="0" Grid.Row="15" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCZFAZF" Text="1" Grid.Column="1" Grid.Row="15" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtZoomZoomFactor" Text="1" Grid.Column="1" Grid.Row="15" VerticalAlignment="Center"/>
                     <TextBlock Text="CenterPoint:" Grid.Column="0" Grid.Row="16" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCZFACP" Text="0, 0"  Grid.Column="1" Grid.Row="16" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtZoomCenterPoint" Text="0, 0"  Grid.Column="1" Grid.Row="16" VerticalAlignment="Center"/>
                     <TextBlock Text="AnimationMode:" Grid.Column="0" Grid.Row="17" VerticalAlignment="Center"/>
                     <ComboBox x:Name="cmbZoomAnimationMode" Grid.Column="1" Grid.Row="17" VerticalAlignment="Center" SelectedIndex="2">
                         <ComboBoxItem>Disabled</ComboBoxItem>
@@ -595,11 +595,11 @@
 
                     <TextBlock Text="ZoomFrom Options" Margin="2,4,2,2" Grid.Row="22" Grid.ColumnSpan="2"/>
                     <TextBlock Text="ZoomFactor Velocity:" Grid.Column="0" Grid.Row="23" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCZFWAVAAV" Text="1" Grid.Column="1" Grid.Row="23" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtZoomFromVelocity" Text="1" Grid.Column="1" Grid.Row="23" VerticalAlignment="Center"/>
                     <TextBlock Text="InertiaDecayRate:" Grid.Column="0" Grid.Row="24" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCZFWAVAIDR" Text="null" Grid.Column="1" Grid.Row="24" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtZoomFromInertiaDecayRate" Text="null" Grid.Column="1" Grid.Row="24" VerticalAlignment="Center"/>
                     <TextBlock Text="CenterPoint:" Grid.Column="0" Grid.Row="25" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtCZFWAVACP" Text="0, 0"  Grid.Column="1" Grid.Row="25" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtZoomFromCenterPoint" Text="0, 0"  Grid.Column="1" Grid.Row="25" VerticalAlignment="Center"/>
                     <StackPanel Orientation="Horizontal" Grid.ColumnSpan="2" Grid.Row="26">
                         <Button x:Name="btnZoomFrom" Content="ZoomFrom" Margin="2" Click="BtnZoomFrom_Click"/>
                         <Button x:Name="btnCancelZoomFrom" Content="Cancel" Margin="2" Click="BtnCancelZoomFrom_Click"/>

--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml
@@ -506,6 +506,7 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -604,10 +605,13 @@
                         <Button x:Name="btnCancelZoomFrom" Content="Cancel" Margin="2" Click="BtnCancelZoomFrom_Click"/>
                     </StackPanel>
 
-                    <TextBlock Text="Snaps Points" Margin="2,4,2,2" Grid.Row="27" Grid.ColumnSpan="2"/>
+                    <Button x:Name="btnChangeView" Content="ChangeView" HorizontalAlignment="Stretch"
+                        Grid.Row="27" Grid.ColumnSpan="2" Margin="2,4,2,2" Click="BtnChangeView_Click"/>
+                    
+                    <TextBlock Text="Snaps Points" Margin="2,4,2,2" Grid.Row="28" Grid.ColumnSpan="2"/>
 
-                    <TextBlock Text="SnapPointKind:" Grid.Column="0" Grid.Row="28" VerticalAlignment="Center"/>
-                    <ComboBox x:Name="cmbSnapPointKind" Grid.Column="1" Grid.Row="28" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0"
+                    <TextBlock Text="SnapPointKind:" Grid.Column="0" Grid.Row="29" VerticalAlignment="Center"/>
+                    <ComboBox x:Name="cmbSnapPointKind" Grid.Column="1" Grid.Row="29" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0"
                         SelectionChanged="CmbSnapPointKind_SelectionChanged">
                         <ComboBoxItem>Vertical</ComboBoxItem>
                         <ComboBoxItem>Horizontal</ComboBoxItem>
@@ -615,35 +619,35 @@
                     </ComboBox>
 
                     <Button x:Name="btnClearSnapPoints" Content="Clear Snap Points" HorizontalAlignment="Stretch"
-                        Grid.Row="29" Grid.ColumnSpan="2" Margin="2" Click="BtnClearSnapPoints_Click"/>
+                        Grid.Row="30" Grid.ColumnSpan="2" Margin="2" Click="BtnClearSnapPoints_Click"/>
 
-                    <TextBlock Text="Alignment:" Grid.Column="0" Grid.Row="30" VerticalAlignment="Center" Margin="0,2,0,0"/>
+                    <TextBlock Text="Alignment:" Grid.Column="0" Grid.Row="31" VerticalAlignment="Center" Margin="0,2,0,0"/>
                     <ComboBox x:Name="cmbSnapPointAlignment" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0"
-                        Grid.Column="1" Grid.Row="30" >
+                        Grid.Column="1" Grid.Row="31" >
                         <ComboBoxItem>Near</ComboBoxItem>
                         <ComboBoxItem>Center</ComboBoxItem>
                         <ComboBoxItem>Far</ComboBoxItem>
                     </ComboBox>
 
-                    <TextBlock Text="Value:" Grid.Column="0" Grid.Row="31" VerticalAlignment="Center" Margin="0,2,0,0"/>
-                    <TextBox x:Name="txtIrregularSnapPointValue" Grid.Column="1" Grid.Row="31" VerticalAlignment="Center" Margin="0,2,0,0"/>
+                    <TextBlock Text="Value:" Grid.Column="0" Grid.Row="32" VerticalAlignment="Center" Margin="0,2,0,0"/>
+                    <TextBox x:Name="txtIrregularSnapPointValue" Grid.Column="1" Grid.Row="32" VerticalAlignment="Center" Margin="0,2,0,0"/>
                     <!--
                     <TextBlock Text="ApplicableValueRange:" Grid.Column="0" Grid.Row="" VerticalAlignment="Center"/>
                     <TextBox x:Name="txtSnapPointValueRange" Text="0, 100000" Grid.Column="1" Grid.Row="" VerticalAlignment="Center"/>
                     -->
                     <Button x:Name="btnAddIrregularSnapPoint" Content="Add Irregular Snap Point" HorizontalAlignment="Stretch"
-                            Grid.Row="32" Grid.ColumnSpan="2" Margin="2" Click="BtnAddIrregularSnapPoint_Click"/>
+                            Grid.Row="33" Grid.ColumnSpan="2" Margin="2" Click="BtnAddIrregularSnapPoint_Click"/>
 
-                    <TextBlock Text="Offset:" Grid.Column="0" Grid.Row="33" VerticalAlignment="Center" Margin="0,2,0,0"/>
-                    <TextBox x:Name="txtRepeatedSnapPointOffset" Grid.Column="1" Grid.Row="33" VerticalAlignment="Center"/>
-                    <TextBlock Text="Interval:" Grid.Column="0" Grid.Row="34" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtRepeatedSnapPointInterval" Grid.Column="1" Grid.Row="34" VerticalAlignment="Center"/>
-                    <TextBlock Text="Start:" Grid.Column="0" Grid.Row="35" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtRepeatedSnapPointStart" Grid.Column="1" Grid.Row="35" VerticalAlignment="Center"/>
-                    <TextBlock Text="End:" Grid.Column="0" Grid.Row="36" VerticalAlignment="Center"/>
-                    <TextBox x:Name="txtRepeatedSnapPointEnd" Grid.Column="1" Grid.Row="36" VerticalAlignment="Center"/>
+                    <TextBlock Text="Offset:" Grid.Column="0" Grid.Row="34" VerticalAlignment="Center" Margin="0,2,0,0"/>
+                    <TextBox x:Name="txtRepeatedSnapPointOffset" Grid.Column="1" Grid.Row="34" VerticalAlignment="Center"/>
+                    <TextBlock Text="Interval:" Grid.Column="0" Grid.Row="35" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtRepeatedSnapPointInterval" Grid.Column="1" Grid.Row="35" VerticalAlignment="Center"/>
+                    <TextBlock Text="Start:" Grid.Column="0" Grid.Row="36" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtRepeatedSnapPointStart" Grid.Column="1" Grid.Row="36" VerticalAlignment="Center"/>
+                    <TextBlock Text="End:" Grid.Column="0" Grid.Row="37" VerticalAlignment="Center"/>
+                    <TextBox x:Name="txtRepeatedSnapPointEnd" Grid.Column="1" Grid.Row="37" VerticalAlignment="Center"/>
                     <Button x:Name="btnAddRepeatedSnapPoint" Content="Add Repeated Snap Point" HorizontalAlignment="Stretch"
-                            Grid.Row="37" Grid.ColumnSpan="2" Margin="2" Click="BtnAddRepeatedSnapPoint_Click"/>
+                            Grid.Row="38" Grid.ColumnSpan="2" Margin="2" Click="BtnAddRepeatedSnapPoint_Click"/>
                 </Grid>
             </Grid>
         </ScrollViewer>

--- a/dev/Scroller/TestUI/ScrollerDynamicPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerDynamicPage.xaml.cs
@@ -1456,8 +1456,8 @@ namespace MUXControlsTestApp
                 if (isRelativeChange)
                 {
                     lastOffsetsChangeId = scroller.ScrollBy(
-                        Convert.ToDouble(txtCOAHO.Text),
-                        Convert.ToDouble(txtCOAVO.Text),
+                        Convert.ToDouble(txtScrollHorizontalOffset.Text),
+                        Convert.ToDouble(txtScrollVerticalOffset.Text),
                         options).OffsetsChangeId;
                     relativeChangeIds.Add(lastOffsetsChangeId);
                     AppendAsyncEventMessage("Invoked ScrollBy Id=" + lastOffsetsChangeId);
@@ -1465,8 +1465,8 @@ namespace MUXControlsTestApp
                 else
                 {
                     lastOffsetsChangeId = scroller.ScrollTo(
-                        Convert.ToDouble(txtCOAHO.Text),
-                        Convert.ToDouble(txtCOAVO.Text),
+                        Convert.ToDouble(txtScrollHorizontalOffset.Text),
+                        Convert.ToDouble(txtScrollVerticalOffset.Text),
                         options).OffsetsChangeId;
                     AppendAsyncEventMessage("Invoked ScrollTo Id=" + lastOffsetsChangeId);
                 }
@@ -1514,14 +1514,14 @@ namespace MUXControlsTestApp
                     {
                         bool isRelativeChange = relativeChangeIds.Contains(args.ScrollInfo.OffsetsChangeId);
 
-                        double targetHorizontalOffset = Convert.ToDouble(txtCOAHO.Text);
+                        double targetHorizontalOffset = Convert.ToDouble(txtScrollHorizontalOffset.Text);
                         if (isRelativeChange)
                         {
                             targetHorizontalOffset += scroller.HorizontalOffset;
                         }
                         float targetHorizontalPosition = ComputeHorizontalPositionFromOffset(targetHorizontalOffset);
 
-                        double targetVerticalOffset = Convert.ToDouble(txtCOAVO.Text);
+                        double targetVerticalOffset = Convert.ToDouble(txtScrollVerticalOffset.Text);
                         if (isRelativeChange)
                         {
                             targetVerticalOffset += scroller.VerticalOffset;
@@ -1600,9 +1600,9 @@ namespace MUXControlsTestApp
             {
                 Vector2? inertiaDecayRate = null;
 
-                if (txtCOWAVAHIDR.Text != "null" && txtCOWAVAVIDR.Text != "null")
+                if (txtScrollHorizontalInertiaDecayRate.Text != "null" && txtScrollVerticalInertiaDecayRate.Text != "null")
                 {
-                    inertiaDecayRate = new Vector2(Convert.ToSingle(txtCOWAVAHIDR.Text), Convert.ToSingle(txtCOWAVAVIDR.Text));
+                    inertiaDecayRate = new Vector2(Convert.ToSingle(txtScrollHorizontalInertiaDecayRate.Text), Convert.ToSingle(txtScrollVerticalInertiaDecayRate.Text));
                 }
 
                 txtStockOffsetsChangeDuration.Text = string.Empty;
@@ -1610,7 +1610,7 @@ namespace MUXControlsTestApp
                 ExecuteQueuedOperations();
 
                 lastOffsetsChangeWithAdditionalVelocityId = scroller.ScrollFrom(
-                    new Vector2(Convert.ToSingle(txtCOWAVAHV.Text), Convert.ToSingle(txtCOWAVAVV.Text)),
+                    new Vector2(Convert.ToSingle(txtScrollHorizontalVelocity.Text), Convert.ToSingle(txtScrollVerticalVelocity.Text)),
                     inertiaDecayRate).OffsetsChangeId;
                 AppendAsyncEventMessage("Invoked ScrollFrom Id=" + lastOffsetsChangeWithAdditionalVelocityId);
             }
@@ -1746,8 +1746,8 @@ namespace MUXControlsTestApp
                 if (isRelativeChange)
                 {
                     lastZoomFactorChangeId = scroller.ZoomBy(
-                        Convert.ToSingle(txtCZFAZF.Text),
-                        ConvertFromStringToVector2(txtCZFACP.Text),
+                        Convert.ToSingle(txtZoomZoomFactor.Text),
+                        ConvertFromStringToVector2(txtZoomCenterPoint.Text),
                         options).ZoomFactorChangeId;
                     relativeChangeIds.Add(lastZoomFactorChangeId);
                     AppendAsyncEventMessage("Invoked ZoomBy Id=" + lastZoomFactorChangeId);
@@ -1755,8 +1755,8 @@ namespace MUXControlsTestApp
                 else
                 {
                     lastZoomFactorChangeId = scroller.ZoomTo(
-                        Convert.ToSingle(txtCZFAZF.Text),
-                        ConvertFromStringToVector2(txtCZFACP.Text),
+                        Convert.ToSingle(txtZoomZoomFactor.Text),
+                        ConvertFromStringToVector2(txtZoomCenterPoint.Text),
                         options).ZoomFactorChangeId;
                     AppendAsyncEventMessage("Invoked ZoomTo Id=" + lastZoomFactorChangeId);
                 }
@@ -1802,7 +1802,7 @@ namespace MUXControlsTestApp
 
                     if (cmbOverriddenZoomFactorChangeAnimation.SelectedIndex != 0)
                     {
-                        float targetZoomFactor = Convert.ToSingle(txtCZFAZF.Text);
+                        float targetZoomFactor = Convert.ToSingle(txtZoomZoomFactor.Text);
                         if (relativeChangeIds.Contains(args.ZoomInfo.ZoomFactorChangeId))
                         {
                             targetZoomFactor += scroller.ZoomFactor;
@@ -1880,9 +1880,9 @@ namespace MUXControlsTestApp
                 ExecuteQueuedOperations();
 
                 lastZoomFactorChangeWithAdditionalVelocityId = scroller.ZoomFrom(
-                    Convert.ToSingle(txtCZFWAVAAV.Text),
-                    ConvertFromStringToVector2(txtCZFWAVACP.Text),
-                    (txtCZFWAVAIDR.Text == "null") ? (float?)null : (float?)Convert.ToSingle(txtCZFWAVAIDR.Text)).ZoomFactorChangeId;
+                    Convert.ToSingle(txtZoomFromVelocity.Text),
+                    ConvertFromStringToVector2(txtZoomFromCenterPoint.Text),
+                    (txtZoomFromInertiaDecayRate.Text == "null") ? (float?)null : (float?)Convert.ToSingle(txtZoomFromInertiaDecayRate.Text)).ZoomFactorChangeId;
                 AppendAsyncEventMessage("Invoked ZoomFrom Id=" + lastZoomFactorChangeWithAdditionalVelocityId);
             }
             catch (Exception ex)
@@ -2012,9 +2012,9 @@ namespace MUXControlsTestApp
         {
             try
             {
-                double? horizontalOffset = string.IsNullOrWhiteSpace(txtCOAHO.Text) ? (double?)null : Convert.ToDouble(txtCOAHO.Text);
-                double? verticalOffset = string.IsNullOrWhiteSpace(txtCOAVO.Text) ? (double?)null : Convert.ToDouble(txtCOAVO.Text);
-                float? zoomFactor = string.IsNullOrWhiteSpace(txtCZFAZF.Text) ? (float?)null : Convert.ToSingle(txtCZFAZF.Text);
+                double? horizontalOffset = string.IsNullOrWhiteSpace(txtScrollHorizontalOffset.Text) ? (double?)null : Convert.ToDouble(txtScrollHorizontalOffset.Text);
+                double? verticalOffset = string.IsNullOrWhiteSpace(txtScrollVerticalOffset.Text) ? (double?)null : Convert.ToDouble(txtScrollVerticalOffset.Text);
+                float? zoomFactor = string.IsNullOrWhiteSpace(txtZoomZoomFactor.Text) ? (float?)null : Convert.ToSingle(txtZoomZoomFactor.Text);
                 bool disableAnimation = true;
 
                 if (horizontalOffset == null && verticalOffset == null && zoomFactor == null)
@@ -2025,11 +2025,11 @@ namespace MUXControlsTestApp
                 ComboBox cmbAnimationMode = (zoomFactor == null || zoomFactor == scroller.ZoomFactor) ? 
                     cmbScrollAnimationMode : cmbZoomAnimationMode;
 
-                switch (cmbAnimationMode.SelectedIndex)
+                switch (((ContentControl)cmbAnimationMode.SelectedItem).Content)
                 {
-                    case 0: // Disabled
+                    case "Disabled":
                         break;
-                    case 1: // Enabled
+                    case "Enabled":
                         disableAnimation = false;
                         break;
                     default: // Auto
@@ -2060,6 +2060,7 @@ namespace MUXControlsTestApp
                 targetHorizontalOffset = Math.Max(Math.Min(targetHorizontalOffset, scroller.ExtentWidth * targetZoomFactor - scroller.ViewportWidth), 0.0);
                 targetVerticalOffset = Math.Max(Math.Min(targetVerticalOffset, scroller.ExtentHeight * targetZoomFactor - scroller.ViewportHeight), 0.0);
             }
+            // During an animation, out-of-bounds offsets may become valid as the extents are dynamically updated, so no clamping is performed for animated view changes.
 
             if (deltaZoomFactor == 0.0f)
             {


### PR DESCRIPTION
Only the MUXControlsTestApp test app is slightly changed here. A 'ChangeView' button is added to a Scroller test page. Its behavior is close to the WUX ScrollViewer.ChangeView method and the signature is exactly the same. This can be helpful for customers familiar with the old ScrollViewer.ChangeView method - it's translating the request into a single Scroller.ScrollTo or Scroller.ZoomTo call.