### PR TITLE
fix flaky tests due to loss  of focus.

### DIFF
--- a/build/Helix/EnsureMachineState.ps1
+++ b/build/Helix/EnsureMachineState.ps1
@@ -2,11 +2,6 @@
 Write-Host "All processes running:"
 Get-Process
 
-
-# Minimize all windows:
-$shell = New-Object -ComObject "Shell.Application"
-$shell.minimizeall()
-
 # Kill any instances of Windows Security Alert:
 $windowTitleToMatch = "*Windows Security Alert*"
 $procs = Get-Process | Where {$_.MainWindowTitle -like "*Windows Security Alert*"}


### PR DESCRIPTION
In a previous change, we minimized all windows before tests started. This might be causing issues with tests that deal with focus. 