### PR TITLE
Realize a single element even if the repeater is outside the realized range bug being measured

### DIFF
--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -117,7 +117,11 @@ winrt::FlowLayoutAnchorInfo StackLayout::GetAnchorForRealizationRect(
         const double realizationWindowOffsetInExtent = realizationRect.*MajorStart() - lastExtent.*MajorStart();
         const double majorSize = lastExtent.*MajorSize() == 0 ? std::max(0.0, averageElementSize * itemsCount - m_itemSpacing) : lastExtent.*MajorSize();
         if (itemsCount > 0 &&
-            realizationRect.*MajorSize() > 0 &&
+            realizationRect.*MajorSize() >= 0 &&
+            // MajorSize = 0 will account for when a nested repeater is outside the realization rect but still being measured. Also,
+            // note that if we are measuring this repeater, then we are already realizing an element to figure out the size, so we could
+            // just keep that element alive. It also helps in XYFocus scenarios to have an element realized for XYFocus to find a candidate
+            // in the navigating direction.
             realizationWindowOffsetInExtent + realizationRect.*MajorSize() >= 0 && realizationWindowOffsetInExtent <= majorSize)
         {
             anchorIndex = (int)(realizationWindowOffsetInExtent / averageElementSize);


### PR DESCRIPTION
In nested cases where the outer and inner repeaters are scroll able in different directions, it would help to realize at least one element when the realization rect is empty. In this case we end up realizing an element and then throwing it away. Instead if we keep the element, it helps stand in as an XYFocus candidate allowing us to navigate in that direction more reliably. 

Fixes: #853