### PR TITLE
NavigationView: Adding boolean property NavigationView.IsTitleBarAutoPaddingEnabled

### DIFF
--- a/dev/Generated/NavigationView.properties.cpp
+++ b/dev/Generated/NavigationView.properties.cpp
@@ -23,6 +23,7 @@ GlobalDependencyProperty NavigationViewProperties::s_IsPaneOpenProperty{ nullptr
 GlobalDependencyProperty NavigationViewProperties::s_IsPaneToggleButtonVisibleProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_IsPaneVisibleProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_IsSettingsVisibleProperty{ nullptr };
+GlobalDependencyProperty NavigationViewProperties::s_IsTitleBarAutoPaddingEnabledProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_MenuItemContainerStyleProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_MenuItemContainerStyleSelectorProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_MenuItemsProperty{ nullptr };
@@ -222,6 +223,17 @@ void NavigationViewProperties::EnsureProperties()
                 false /* isAttached */,
                 ValueHelper<bool>::BoxValueIfNecessary(true),
                 winrt::PropertyChangedCallback(&OnIsSettingsVisiblePropertyChanged));
+    }
+    if (!s_IsTitleBarAutoPaddingEnabledProperty)
+    {
+        s_IsTitleBarAutoPaddingEnabledProperty =
+            InitializeDependencyProperty(
+                L"IsTitleBarAutoPaddingEnabled",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::NavigationView>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxValueIfNecessary(true),
+                winrt::PropertyChangedCallback(&OnIsTitleBarAutoPaddingEnabledPropertyChanged));
     }
     if (!s_MenuItemContainerStyleProperty)
     {
@@ -451,6 +463,7 @@ void NavigationViewProperties::ClearProperties()
     s_IsPaneToggleButtonVisibleProperty = nullptr;
     s_IsPaneVisibleProperty = nullptr;
     s_IsSettingsVisibleProperty = nullptr;
+    s_IsTitleBarAutoPaddingEnabledProperty = nullptr;
     s_MenuItemContainerStyleProperty = nullptr;
     s_MenuItemContainerStyleSelectorProperty = nullptr;
     s_MenuItemsProperty = nullptr;
@@ -607,6 +620,14 @@ void NavigationViewProperties::OnIsPaneVisiblePropertyChanged(
 }
 
 void NavigationViewProperties::OnIsSettingsVisiblePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::NavigationView>();
+    winrt::get_self<NavigationView>(owner)->OnPropertyChanged(args);
+}
+
+void NavigationViewProperties::OnIsTitleBarAutoPaddingEnabledPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
@@ -903,6 +924,16 @@ void NavigationViewProperties::IsSettingsVisible(bool value)
 bool NavigationViewProperties::IsSettingsVisible()
 {
     return ValueHelper<bool>::CastOrUnbox(static_cast<NavigationView*>(this)->GetValue(s_IsSettingsVisibleProperty));
+}
+
+void NavigationViewProperties::IsTitleBarAutoPaddingEnabled(bool value)
+{
+    static_cast<NavigationView*>(this)->SetValue(s_IsTitleBarAutoPaddingEnabledProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+}
+
+bool NavigationViewProperties::IsTitleBarAutoPaddingEnabled()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<NavigationView*>(this)->GetValue(s_IsTitleBarAutoPaddingEnabledProperty));
 }
 
 void NavigationViewProperties::MenuItemContainerStyle(winrt::Style const& value)

--- a/dev/Generated/NavigationView.properties.h
+++ b/dev/Generated/NavigationView.properties.h
@@ -54,6 +54,9 @@ public:
     void IsSettingsVisible(bool value);
     bool IsSettingsVisible();
 
+    void IsTitleBarAutoPaddingEnabled(bool value);
+    bool IsTitleBarAutoPaddingEnabled();
+
     void MenuItemContainerStyle(winrt::Style const& value);
     winrt::Style MenuItemContainerStyle();
 
@@ -126,6 +129,7 @@ public:
     static winrt::DependencyProperty IsPaneToggleButtonVisibleProperty() { return s_IsPaneToggleButtonVisibleProperty; }
     static winrt::DependencyProperty IsPaneVisibleProperty() { return s_IsPaneVisibleProperty; }
     static winrt::DependencyProperty IsSettingsVisibleProperty() { return s_IsSettingsVisibleProperty; }
+    static winrt::DependencyProperty IsTitleBarAutoPaddingEnabledProperty() { return s_IsTitleBarAutoPaddingEnabledProperty; }
     static winrt::DependencyProperty MenuItemContainerStyleProperty() { return s_MenuItemContainerStyleProperty; }
     static winrt::DependencyProperty MenuItemContainerStyleSelectorProperty() { return s_MenuItemContainerStyleSelectorProperty; }
     static winrt::DependencyProperty MenuItemsProperty() { return s_MenuItemsProperty; }
@@ -161,6 +165,7 @@ public:
     static GlobalDependencyProperty s_IsPaneToggleButtonVisibleProperty;
     static GlobalDependencyProperty s_IsPaneVisibleProperty;
     static GlobalDependencyProperty s_IsSettingsVisibleProperty;
+    static GlobalDependencyProperty s_IsTitleBarAutoPaddingEnabledProperty;
     static GlobalDependencyProperty s_MenuItemContainerStyleProperty;
     static GlobalDependencyProperty s_MenuItemContainerStyleSelectorProperty;
     static GlobalDependencyProperty s_MenuItemsProperty;
@@ -263,6 +268,10 @@ public:
         winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnIsSettingsVisiblePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnIsTitleBarAutoPaddingEnabledPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/NavigationView/NavigationView.idl
+++ b/dev/NavigationView/NavigationView.idl
@@ -265,6 +265,11 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
         static Windows.UI.Xaml.DependencyProperty ShoulderNavigationEnabledProperty { get; };
         static Windows.UI.Xaml.DependencyProperty OverflowLabelModeProperty { get; };
     }
+
+    [MUX_DEFAULT_VALUE("true")]
+    Boolean IsTitleBarAutoPaddingEnabled { get; set; };
+
+    static Windows.UI.Xaml.DependencyProperty IsTitleBarAutoPaddingEnabledProperty { get; };
 }
 
 [WUXC_VERSION_RS3]

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -3,15 +3,11 @@
 
 using MUXControlsTestApp.Utilities;
 
-using System;
-using System.Collections.Generic;
-using Windows.Foundation.Metadata;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Markup;
-using Windows.UI.Xaml.Shapes;
-using System.Collections.ObjectModel;
 using Common;
+using System;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Shapes;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -22,13 +18,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
-#if !BUILD_WINDOWS
 using NavigationViewDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode;
 using NavigationViewPaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode;
 using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
 using NavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
 using NavigationViewBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationViewBackButtonVisible;
-#endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -128,7 +122,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             Setter styleSetter = null;
             Style hamburgerStyle = null;
 
-
             RunOnUIThread.Execute(() =>
             {
                 footer = new Rectangle();
@@ -152,6 +145,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.IsNull(navView.Header);
                 Verify.IsTrue(navView.IsSettingsVisible);
                 Verify.IsTrue(navView.IsPaneToggleButtonVisible);
+                Verify.IsTrue(navView.IsTitleBarAutoPaddingEnabled);
                 Verify.IsTrue(navView.AlwaysShowHeader);
                 Verify.AreEqual(48, navView.CompactPaneLength);
                 Verify.AreEqual(320, navView.OpenPaneLength);
@@ -170,6 +164,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.Header = header;
                 navView.IsSettingsVisible = false;
                 navView.IsPaneToggleButtonVisible = false;
+                navView.IsTitleBarAutoPaddingEnabled = false;
                 navView.AlwaysShowHeader = false;
                 navView.CompactPaneLength = 40;
                 navView.OpenPaneLength = 300;
@@ -191,6 +186,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual(header, navView.Header);
                 Verify.IsFalse(navView.IsSettingsVisible);
                 Verify.IsFalse(navView.IsPaneToggleButtonVisible);
+                Verify.IsFalse(navView.IsTitleBarAutoPaddingEnabled);
                 Verify.IsFalse(navView.AlwaysShowHeader);
                 Verify.AreEqual(40, navView.CompactPaneLength);
                 Verify.AreEqual(300, navView.OpenPaneLength);
@@ -347,25 +343,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
-#if BUILD_WINDOWS
-        [TestMethod]
-        [TestProperty("BUG", "RS3:12705080")]
-        public void CanLoadSimpleNavigationView()
-        {
-            RunOnUIThread.Execute(() =>
-            {
-                XamlReader.Load(@"
-                    <NavigationView xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
-                        <NavigationView.MenuItems>
-                            <NavigationViewItem Icon='Save' Content='Save' />
-                        </NavigationView.MenuItems>
-                        <TextBlock>Hello World</TextBlock>
-                    </NavigationView>");
-            });
-        }
-#endif
-
-#if !BUILD_WINDOWS
         // Disabled per GitHub Issue #211
         //[TestMethod]
         public void VerifyCanNotAddWUXItems()
@@ -395,6 +372,5 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.Throws<Exception>(() => { navView.UpdateLayout(); });
             });
         }
-#endif
     }
 }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1,15 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Linq;
-
 using Common;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.Text;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -20,19 +18,10 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
-#if BUILD_WINDOWS
-using System.Windows.Automation;
-using MS.Internal.Mita.Foundation;
-using MS.Internal.Mita.Foundation.Controls;
-using MS.Internal.Mita.Foundation.Patterns;
-using MS.Internal.Mita.Foundation.Waiters;
-#else
 using Microsoft.Windows.Apps.Test.Automation;
 using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
-using Microsoft.Windows.Apps.Test.Foundation.Patterns;
 using Microsoft.Windows.Apps.Test.Foundation.Waiters;
-#endif
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {
@@ -1494,28 +1483,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Top NavigationView Store Test" }))
             {
                 var moveContentUnderTitleBarButton = new Button(FindElement.ById("MoveContentUnderTopnavTitleBar"));
+                var flipIsTitleBarAutoPaddingEnabledButton = new Button(FindElement.ById("FlipIsTitleBarAutoPaddingEnabledButton"));
                 var getTopPaddingHeightButton = new Button(FindElement.ById("GetTopPaddingHeightButton"));
                 var fullScreenButton = new Button(FindElement.ById("FullScreenInvokerButton"));
+                var navViewIsTitleBarAutoPaddingEnabledId = "NavViewIsTitleBarAutoPaddingEnabled";
                 var topPaddingRenderedValueId = "TopPaddingRenderedValue";
+                UIObject navViewIsTitleBarAutoPaddingEnabled = null;
                 UIObject topNavTopPadding = null;
 
-                // Checking top padding is added for regular Desktop                
+                // Checking top padding is added for regular Desktop
+                Log.Comment("Setting TitleBar.ExtendViewIntoTitleBar to True");
                 moveContentUnderTitleBarButton.Click();
                 Wait.ForIdle();
+
+                Log.Comment("Accessing TopPadding Height");
                 getTopPaddingHeightButton.Click();
                 Wait.ForIdle();
+
+                navViewIsTitleBarAutoPaddingEnabled = TryFindElement.ById(navViewIsTitleBarAutoPaddingEnabledId);
+                Verify.IsNotNull(navViewIsTitleBarAutoPaddingEnabled);
+                Log.Comment($"NavView.IsTitleBarAutoPaddingEnabled: {navViewIsTitleBarAutoPaddingEnabled.GetText()}");
+                Verify.AreEqual("True", navViewIsTitleBarAutoPaddingEnabled.GetText());
+
                 topNavTopPadding = TryFindElement.ById(topPaddingRenderedValueId);
+                Verify.IsNotNull(topNavTopPadding);
+                Log.Comment($"TopPadding Height: {topNavTopPadding.GetText()}");
 
                 if (PlatformConfiguration.IsDevice(DeviceType.Phone))
                 {
                     // For phone we only check once to make sure the padding is 0
-                    Verify.AreEqual(0, Int32.Parse(topNavTopPadding.GetText()));
+                    Verify.AreEqual("0", topNavTopPadding.GetText());
                     return;
                 }
 
                 if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
                 {
-                    Verify.AreEqual(32, Int32.Parse(topNavTopPadding.GetText()));
+                    Verify.AreEqual("32", topNavTopPadding.GetText());
                 }
                 else
                 {
@@ -1528,24 +1531,49 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     }
                     else
                     {
-                        Verify.AreEqual(0, Int32.Parse(topNavTopPadding.GetText()));
+                        Verify.AreEqual("0", topNavTopPadding.GetText());
                     }
                 }
 
+                Log.Comment("Setting IsTitleBarAutoPaddingEnabled to False");
+                flipIsTitleBarAutoPaddingEnabledButton.Click();
+                Wait.ForIdle();
+
+                Log.Comment($"NavView.IsTitleBarAutoPaddingEnabled: {navViewIsTitleBarAutoPaddingEnabled.GetText()}");
+                Verify.AreEqual("False", navViewIsTitleBarAutoPaddingEnabled.GetText());
+
+                Log.Comment("Accessing TopPadding Height");
+                getTopPaddingHeightButton.Click();
+                Wait.ForIdle();
+                Log.Comment($"TopPadding Height: {topNavTopPadding.GetText()}");
+                Verify.AreEqual("0", topNavTopPadding.GetText());
+
+                Log.Comment("Setting IsTitleBarAutoPaddingEnabled to True");
+                flipIsTitleBarAutoPaddingEnabledButton.Click();
+                Wait.ForIdle();
+
+                Log.Comment($"NavView.IsTitleBarAutoPaddingEnabled: {navViewIsTitleBarAutoPaddingEnabled.GetText()}");
+                Verify.AreEqual("True", navViewIsTitleBarAutoPaddingEnabled.GetText());
+
                 // Checking top padding is NOT added for fullscreen Desktop
+                Log.Comment("Setting TitleBar.ExtendViewIntoTitleBar to False");
                 moveContentUnderTitleBarButton.Click();
                 Wait.ForIdle();
                 fullScreenButton.Click();
                 Wait.ForIdle();
+
+                Log.Comment("Setting TitleBar.ExtendViewIntoTitleBar to True");
                 moveContentUnderTitleBarButton.Click();
                 Wait.ForIdle();
+
+                Log.Comment("Accessing TopPadding Height");
                 getTopPaddingHeightButton.Click();
                 Wait.ForIdle();
-
-                topNavTopPadding = TryFindElement.ById(topPaddingRenderedValueId);
-                Verify.AreEqual(0, Int32.Parse(topNavTopPadding.GetText()));
+                Log.Comment($"TopPadding Height: {topNavTopPadding.GetText()}");
+                Verify.AreEqual("0", topNavTopPadding.GetText());
 
                 // Reverting changes to leave app in original state
+                Log.Comment("Setting TitleBar.ExtendViewIntoTitleBar to False");
                 moveContentUnderTitleBarButton.Click();
                 Wait.ForIdle();
                 fullScreenButton.Click();

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml
@@ -194,6 +194,7 @@
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
+                        <CheckBox x:Name="IsTitleBarAutoPaddingEnabledCheckbox" AutomationProperties.Name="IsTitleBarAutoPaddingEnabledCheckbox" Content="Title Bar Auto-Padding Enabled" Checked="IsTitleBarAutoPaddingEnabledCheckbox_Checked" Unchecked="IsTitleBarAutoPaddingEnabledCheckbox_Unchecked" IsChecked="True"  Margin="5"/>
                         <CheckBox x:Name="TitleBarCheckbox" AutomationProperties.Name="TitleBarCheckbox" Content="Show Title Bar" Checked="TitleBarCheckbox_Checked" Unchecked="TitleBarCheckbox_Unchecked" IsChecked="True"  Margin="5"/>
                         <CheckBox x:Name="TestFrameCheckbox" AutomationProperties.Name="TestFrameCheckbox" Content="Show Test Frame" Checked="TestFrameCheckbox_Checked" Unchecked="TestFrameCheckbox_Unchecked" IsChecked="True"  Margin="5"/>
                         <Button x:Name="ReverseButton" AutomationProperties.Name="ReverseButton" Content="Reverse Titles" Click="ScrambleButton_Click"/>

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
@@ -328,6 +328,16 @@ namespace MUXControlsTestApp
             TVItem.IsEnabled = false;
         }
 
+        private void IsTitleBarAutoPaddingEnabledCheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            NavView.IsTitleBarAutoPaddingEnabled = true;
+        }
+
+        private void IsTitleBarAutoPaddingEnabledCheckbox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            NavView.IsTitleBarAutoPaddingEnabled = false;
+        }
+
         private void TitleBarCheckbox_Checked(object sender, RoutedEventArgs e)
         {
             CoreApplicationViewTitleBar titleBar = CoreApplication.GetCurrentView().TitleBar;

--- a/dev/NavigationView/TestUI/NavigationViewTopNavStorePage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewTopNavStorePage.xaml
@@ -22,7 +22,7 @@
             PaneDisplayMode="Top"
             ShoulderNavigationEnabled="WhenSelectionFollowsFocus"
             ItemInvoked="OnNavItemInvoked">
-            
+
             <controls:NavigationView.PaneHeader>
                 <CommandBar>
                     <AppBarToggleButton Icon="Shuffle" Label="Shuffle" Click="AppBarButton_Click" />
@@ -59,27 +59,38 @@
             <StackPanel Background="BurlyWood">
                 <ScrollViewer x:Name="ContentScrollViewer" VerticalAlignment="Top">
                     <StackPanel x:Name="ContentStackPanel" Orientation="Vertical">
-                        <Button x:Name="MoveContentUnderTopnav" AutomationProperties.Name="MoveContentUnderTopnavButton" Content="Move/Remove content under Top nav + Scrollviewer checkup" Click="MoveContentUnderTopnav_Click"/>
-                        <Button x:Name="MoveContentUnderTopnavTitleBar" AutomationProperties.Name="MoveContentUnderTopnavTitleBarButton" Content="Move/Remove content under Top nav + Scrollviewer checkup + Titlebar take over" Click="MoveContentUnderTopnavTitleBar_Click"/>
-                        <Button x:Name="GetTopPaddingHeightButton" AutomationProperties.Name="GetTopPaddingHeightButton" Content="Get top padding height" Click="GetTopPaddingHeightButton_Click"/>
-                        <Button x:Name="AddItemButton" AutomationProperties.Name="AddItemButton" Content="Add Item" Click="AddButton_Click"/>
-                        <Button x:Name="AddItemSuppressSelectionButton" AutomationProperties.Name="AddItemSuppressSelectionButton" Content="Add Item with SupppressSelection" Click="AddButtonSuppressSelection_Click"/>
-                        <Button x:Name="RemoveItemButton" AutomationProperties.Name="RemoveItemButton" Content="Remove Item" Click="RemoveButton_Click"/>
-                        <Button x:Name="ChangeToIEnumerableButton" AutomationProperties.Name="ChangeToIEnumerableButton" Content="Make it IEnumerable" Click="ChangeToIEnumerableButton_Clicks"/>
-                        <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Content="Flip Orientation" Click="FlipOrientation_Click"/>
-                        <Button x:Name="AddRemoveContentOverlay" AutomationProperties.Name="AddRemoveContentOverlayButton" Content="Add/Remove Content Overlay (top nav)" Click="AddRemoveContentOverlay_Click"/>
-                        <Button x:Name="ChangeContentOverlayVisibility" AutomationProperties.Name="ChangeContentOverlayVisibilityButton" Content="Change Content Overlay Visibility (top nav)" Click="ChangeContentOverlayVisibility_Click"/>
-                        <Button x:Name="ChangeTopNavVisibility" AutomationProperties.Name="ChangeTopNavVisibilityButton" Content="Change Top Nav Visibility" Click="ChangeTopNavVisibility_Click"/>                        
-                        <Button x:Name="ChangeSelectionInCode" AutomationProperties.Name="ChangeSelectionInCodeButton" Content="Change Selection In Code" Click="ChangeSelectionInCode_Click"/>
-                        <Button x:Name="EnableSelectionFollowsFocusButton" AutomationProperties.Name="EnableSelectionFollowsFocusButton" Content="Enable Selection Follows Focus" Click="EnableSelectionFollowsFocus_Click"/>
-                        <Button x:Name="GetActiveVisualState" AutomationProperties.Name="GetActiveVisualState" Content="Get Active VisualState" Click="GetActiveVisualState_Click" />
-                        <Button x:Name="GetNavItemActiveVisualState" AutomationProperties.Name="GetNavItemActiveVisualState" Content="Get Selected NavItem Active VisualState" Click="GetNavItemActiveNavItemVisualState_Click" />
-                        <Button x:Name="ClearItemInvokedTextButton" AutomationProperties.Name="ClearItemInvokedTextButton" Content="Clear Item Invoked Text" Click="ClearItemInvokedTextButton_Click" />
+                        <StackPanel Orientation="Horizontal">
+                            <Button x:Name="MoveContentUnderTopnav" AutomationProperties.Name="MoveContentUnderTopnavButton" Margin="1" Content="Move/Remove content under Top nav + Scrollviewer checkup" Click="MoveContentUnderTopnav_Click"/>
+                            <Button x:Name="MoveContentUnderTopnavTitleBar" AutomationProperties.Name="MoveContentUnderTopnavTitleBarButton" Margin="1" Content="Move/Remove content under Top nav + Scrollviewer checkup + Titlebar take over" Click="MoveContentUnderTopnavTitleBar_Click"/>
+                            <Button x:Name="GetTopPaddingHeightButton" AutomationProperties.Name="GetTopPaddingHeightButton" Margin="1" Content="Get top padding height" Click="GetTopPaddingHeightButton_Click"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <Button x:Name="AddItemButton" AutomationProperties.Name="AddItemButton" Margin="1" Content="Add Item" Click="AddButton_Click"/>
+                            <Button x:Name="AddItemSuppressSelectionButton" AutomationProperties.Name="AddItemSuppressSelectionButton" Margin="1" Content="Add Item with SupppressSelection" Click="AddButtonSuppressSelection_Click"/>
+                            <Button x:Name="RemoveItemButton" AutomationProperties.Name="RemoveItemButton" Margin="1" Content="Remove Item" Click="RemoveButton_Click"/>
+                            <Button x:Name="ChangeToIEnumerableButton" AutomationProperties.Name="ChangeToIEnumerableButton" Margin="1" Content="Make it IEnumerable" Click="ChangeToIEnumerableButton_Clicks"/>
+                            <Button x:Name="FlipIsTitleBarAutoPaddingEnabledButton" AutomationProperties.Name="FlipIsTitleBarAutoPaddingEnabledButton" Margin="1" Content="Flip IsTitleBarAutoPaddingEnabled" Click="FlipIsTitleBarAutoPaddingEnabledButton_Click"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Margin="1" Content="Flip Orientation" Click="FlipOrientation_Click"/>
+                            <Button x:Name="AddRemoveContentOverlay" AutomationProperties.Name="AddRemoveContentOverlayButton" Margin="1" Content="Add/Remove Content Overlay (top nav)" Click="AddRemoveContentOverlay_Click"/>
+                            <Button x:Name="ChangeContentOverlayVisibility" AutomationProperties.Name="ChangeContentOverlayVisibilityButton" Margin="1" Content="Change Content Overlay Visibility (top nav)" Click="ChangeContentOverlayVisibility_Click"/>
+                            <Button x:Name="ChangeTopNavVisibility" AutomationProperties.Name="ChangeTopNavVisibilityButton" Margin="1" Content="Change Top Nav Visibility" Click="ChangeTopNavVisibility_Click"/>
+                            <Button x:Name="ChangeSelectionInCode" AutomationProperties.Name="ChangeSelectionInCodeButton" Margin="1" Content="Change Selection In Code" Click="ChangeSelectionInCode_Click"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <Button x:Name="EnableSelectionFollowsFocusButton" AutomationProperties.Name="EnableSelectionFollowsFocusButton" Margin="1" Content="Enable Selection Follows Focus" Click="EnableSelectionFollowsFocus_Click"/>
+                            <Button x:Name="GetActiveVisualState" AutomationProperties.Name="GetActiveVisualState" Margin="1" Content="Get Active VisualState" Click="GetActiveVisualState_Click" />
+                            <Button x:Name="GetNavItemActiveVisualState" AutomationProperties.Name="GetNavItemActiveVisualState" Margin="1" Content="Get Selected NavItem Active VisualState" Click="GetNavItemActiveNavItemVisualState_Click" />
+                            <Button x:Name="ClearItemInvokedTextButton" AutomationProperties.Name="ClearItemInvokedTextButton" Margin="1" Content="Clear Item Invoked Text" Click="ClearItemInvokedTextButton_Click" />
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
                 <TextBlock Text="Active NavigationItem Visual States: "/>
                 <TextBlock x:Name="ActiveVisualStates" AutomationProperties.Name="ActiveVisualStates"/>
                 <TextBlock x:Name="NavItemActiveVisualStates" AutomationProperties.Name="NavItemActiveVisualStates"/>
+                <TextBlock Text="NavView.IsTitleBarAutoPaddingEnabled: "/>
+                <TextBlock x:Name="NavViewIsTitleBarAutoPaddingEnabled"/>
                 <TextBlock Text="Top padding Height: "/>
                 <TextBlock x:Name="TopPaddingRenderedValue"/>
                 <TextBlock Text="TitleBar.IsVisible: "/>
@@ -89,5 +100,4 @@
             </StackPanel>
         </controls:NavigationView>
     </Grid>
-
 </local:TestPage>

--- a/dev/NavigationView/TestUI/NavigationViewTopNavStorePage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewTopNavStorePage.xaml.cs
@@ -54,6 +54,8 @@ namespace MUXControlsTestApp
 
             NavView.MenuItemsSource = m_menuItems;
             NavView.SelectedItem = m_menuItems[currentSelectedItem];
+
+            NavViewIsTitleBarAutoPaddingEnabled.Text = NavView.IsTitleBarAutoPaddingEnabled.ToString();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
@@ -93,6 +95,12 @@ namespace MUXControlsTestApp
             newMenuItems.AddLast("IIterator/Enumerable/LinkedList Item 3");
 
             NavView.MenuItemsSource = newMenuItems;
+        }
+
+        private void FlipIsTitleBarAutoPaddingEnabledButton_Click(object sender, RoutedEventArgs e)
+        {
+            NavView.IsTitleBarAutoPaddingEnabled = !NavView.IsTitleBarAutoPaddingEnabled;
+            NavViewIsTitleBarAutoPaddingEnabled.Text = NavView.IsTitleBarAutoPaddingEnabled.ToString();
         }
 
         private void FlipOrientation_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Incremental work done for Issue #347.

We are adding a NavigationView.IsTitleBarAutoPaddingEnabled boolean property set to True by default.
When set to False, we skip adding the top padding that has the height of the title bar.

As part of these changes I also fixed the following:
- In OnApplyTemplate, the section "// Register for changes in title bar layout" was misplaced as the m_topNavGrid field was not set yet.
- NavigationView::UpdateTitleBarPadding, m_togglePaneTopPadding.Height / m_contentPaneTopPadding.Height were not reset to 0 when needsTopPadding is False.

Updated a couple of tests using the new property.