### PR TITLE
Uninstall previous versions of MUX Framework Package and test apps before running

### DIFF
--- a/build/Helix/PrepareHelixPayload.ps1
+++ b/build/Helix/PrepareHelixPayload.ps1
@@ -56,11 +56,12 @@ Copy-If-Exists "$repoDirectory\Artifacts\$ArtifactName\$Configuration\$Platform\
 Copy-If-Exists "$repoDirectory\Artifacts\$ArtifactName\$Configuration\$Platform\AppxPackages\NugetPackageTestAppCX_Test\Dependencies\$Platform\*" $payloadDir
 
 # Copy files from the repo
-New-Item -ItemType Directory -Force -Path "$payloadDir\scripts"
-Copy-Item "build\helix\ConvertWttLogToXUnit.ps1" "$payloadDir\scripts"
-Copy-Item "build\helix\OutputFailedTestQuery.ps1" "$payloadDir\scripts"
-Copy-Item "build\helix\OutputSubResultsJsonFiles.ps1" "$payloadDir\scripts"
-Copy-Item "build\helix\HelixTestHelpers.cs" "$payloadDir\scripts"
+New-Item -ItemType Directory -Force -Path "$payloadDir"
+Copy-Item "build\helix\ConvertWttLogToXUnit.ps1" "$payloadDir"
+Copy-Item "build\helix\OutputFailedTestQuery.ps1" "$payloadDir"
+Copy-Item "build\helix\OutputSubResultsJsonFiles.ps1" "$payloadDir"
+Copy-Item "build\helix\HelixTestHelpers.cs" "$payloadDir"
 Copy-Item "build\helix\runtests.cmd" $payloadDir
-Copy-Item "build\helix\InstallTestAppDependencies.ps1" "$payloadDir\scripts"
-Copy-Item "build\Helix\EnsureMachineState.ps1" "$payloadDir\scripts"
+Copy-Item "build\helix\InstallTestAppDependencies.ps1" "$payloadDir"
+Copy-Item "build\Helix\EnsureMachineState.ps1" "$payloadDir"
+Copy-Item "version.props" "$payloadDir"

--- a/build/Helix/runtests.cmd
+++ b/build/Helix/runtests.cmd
@@ -8,10 +8,8 @@ reg add HKLM\Software\Policies\Microsoft\Windows\Appx /v AllowAllTrustedApps /t 
 :: expected to show UI we don't want it running.
 taskkill -f -im dhandler.exe
 
-cd scripts
 powershell -ExecutionPolicy Bypass .\EnsureMachineState.ps1
 powershell -ExecutionPolicy Bypass .\InstallTestAppDependencies.ps1
-cd ..
 
 set testBinaryCandidates=MUXControls.Test.dll MUXControlsTestApp.appx IXMPTestApp.appx MUXControls.ReleaseTest.dll
 set testBinaries=
@@ -31,12 +29,10 @@ FOR %%I in (WexLogFileOutput\*.jpg) DO (
     %HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\upload_result.py -result %%I -result_name %%~nI%%~xI 
 )
 
-cd scripts
 set FailedTestQuery=
-for /F "tokens=* usebackq" %%I IN (`powershell -ExecutionPolicy Bypass .\OutputFailedTestQuery.ps1 ..\te_original.wtl`) DO (
+for /F "tokens=* usebackq" %%I IN (`powershell -ExecutionPolicy Bypass .\OutputFailedTestQuery.ps1 te_original.wtl`) DO (
   set FailedTestQuery=%%I
 )
-cd ..
 
 rem The first time, we'll just re-run failed tests once.  In many cases, tests fail very rarely, such that
 rem a single re-run will be sufficient to detect many unreliable tests.
@@ -56,12 +52,10 @@ rem If there are still failing tests remaining, we'll run them eight more times,
 rem If any tests fail all ten times, we can be pretty confident that these are actual test failures rather than unreliable tests.
 if not exist te_rerun.wtl goto :SkipReruns
 
-cd scripts
 set FailedTestQuery=
-for /F "tokens=* usebackq" %%I IN (`powershell -ExecutionPolicy Bypass .\OutputFailedTestQuery.ps1 ..\te_rerun.wtl`) DO (
+for /F "tokens=* usebackq" %%I IN (`powershell -ExecutionPolicy Bypass .\OutputFailedTestQuery.ps1 te_rerun.wtl`) DO (
   set FailedTestQuery=%%I
 )
-cd ..
 
 if "%FailedTestQuery%" == "" goto :SkipReruns
 
@@ -77,10 +71,8 @@ FOR %%I in (WexLogFileOutput\*.jpg) DO (
 
 :SkipReruns
 
-cd scripts
-powershell -ExecutionPolicy Bypass .\OutputSubResultsJsonFiles.ps1 ..\te_original.wtl ..\te_rerun.wtl ..\te_rerun_multiple.wtl %testnameprefix%
-powershell -ExecutionPolicy Bypass .\ConvertWttLogToXUnit.ps1 ..\te_original.wtl ..\te_rerun.wtl ..\te_rerun_multiple.wtl ..\testResults.xml %testnameprefix%
-cd ..
+powershell -ExecutionPolicy Bypass .\OutputSubResultsJsonFiles.ps1 te_original.wtl te_rerun.wtl te_rerun_multiple.wtl %testnameprefix%
+powershell -ExecutionPolicy Bypass .\ConvertWttLogToXUnit.ps1 te_original.wtl te_rerun.wtl te_rerun_multiple.wtl testResults.xml %testnameprefix%
 
 FOR %%I in (*_subresults.json) DO (
     echo Uploading %%I to "%HELIX_RESULTS_CONTAINER_URI%/%%I%HELIX_RESULTS_CONTAINER_RSAS%"


### PR DESCRIPTION
Updates EnsureMachineState.ps1 to uninstall previous versions of MUX Framework Package and test apps that may have been left around from previous test passes on the machine.

We don't want to uninstall all versions of the MUX Framework package, as there may be other apps preinstalled on the system that depend on it. We only uninstall the Framework package that corresponds to the version of MUX that we are testing. We do this by parsing version.props to determine the current version of MUX under development.

This also includes some minor cleanup in the test scripts. We used to deploy all of our ps scripts into a separate 'scripts' directory on the test machine. This was due to the fact that we used to deploy .net core runtime binaries directly into the root test directory which would interfere with running ps scripts in the same dir. Since we don't do that anymore we don't need the scripts directory and we don't need to keep cd'ing in and out of it.

Closes #984 