### PR TITLE
Sanity check: verify minimum number of test results reported for Pipeline

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -1,6 +1,7 @@
 parameters:
   dependsOn: ''
   rerunPassesRequiredToAvoidFailure: 5
+  minimumExpectedTestsExecutedCount: 3000
 
 jobs:
 - job: ProcessTestResults
@@ -29,3 +30,4 @@ jobs:
     inputs:
       targetType: filePath
       filePath: build\Helix\OutputTestResults.ps1
+      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}'

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -1,4 +1,6 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+variables:
+  minimumExpectedTestsExecutedCount: 3000  # Sanity check for minimum expected tests to be reported
 jobs:
 - job: Build
   pool:
@@ -73,3 +75,4 @@ jobs:
     - RunNugetPkgTestsInHelix
     - RunFrameworkPkgTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -1,4 +1,6 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+variables:
+  minimumExpectedTestsExecutedCount: 3000  # Sanity check for minimum expected tests to be reported
 jobs:
 - job: Setup
   steps:
@@ -80,3 +82,4 @@ jobs:
   parameters:
     dependsOn: RunTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -1,4 +1,6 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+variables:
+  minimumExpectedTestsExecutedCount: 50  # Sanity check for minimum expected tests to be reported
 jobs:
 - job: ComponentDetection
   pool:
@@ -143,6 +145,7 @@ jobs:
     - RunNugetPkgTestsInHelix
     - RunFrameworkPkgTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
 # NuGet package WACK tests 
 - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -39,3 +39,4 @@ jobs:
   parameters:
     dependsOn: RunTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: 1


### PR DESCRIPTION
We have hit issues in the past where a test execution issue has occurred that caused silent failures. Test results would fail to get reported. But since there were no "failures" reported the Pipeline reported success. This can result in us not being aware that tests are failing to execute, since on the surface everything looks ok.

The specific problems that we hit previously have been resolved and no longer result in silent failures. This change is to add a 'sanity check' for our test passes to validate that a specified minimum number of tests have gotten executed. For example, the PR Pipeline must report at least 3000 tests. This is intentionally just a rough number to act as a sanity check. We don't try to specify an exact number that will need to be updated constantly.

We can update this number from time to time, but we don't have to keep it very up to date.

*Q: Since we are doing dynamic test discovery in the Pipeline, wouldn't it be possible to get an exact number for the count of the tests?*

A: We could do this, but the whole point of the check is to ensure against things silently failing. For example, if something happens that causes our TAEF query to return 0 results, we want to catch that.


Fixes #92