### PR TITLE
Fix memory leak because Binding.Source

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -2924,11 +2924,7 @@ void NavigationView::SwapPaneHeaderContent(tracker_ref<winrt::ContentControl> ne
             oldParent.ClearValue(winrt::ContentControl::ContentProperty());
         }
 
-        auto binding = winrt::Binding();
-        auto propertyPath = winrt::PropertyPath(propertyPathName);
-        binding.Path(propertyPath);
-        binding.Source(*this);
-        winrt::BindingOperations::SetBinding(newParent, winrt::ContentControl::ContentProperty(), binding);
+        SharedHelpers::SetBinding(propertyPathName, newParent, winrt::ContentControl::ContentProperty());
     }
 }
 
@@ -2954,11 +2950,7 @@ void NavigationView::UpdateContentBindingsForPaneDisplayMode()
             notControl.ClearValue(winrt::ContentControl::ContentProperty());
         }
 
-        auto binding = winrt::Binding();
-        auto propertyPath = winrt::PropertyPath(L"AutoSuggestBox");
-        binding.Path(propertyPath);
-        binding.Source(*this);
-        winrt::BindingOperations::SetBinding(autoSuggestBoxContentControl, winrt::ContentControl::ContentProperty(), binding);
+        SharedHelpers::SetBinding(L"AutoSuggestBox", autoSuggestBoxContentControl, winrt::ContentControl::ContentProperty());
     }
 }
 

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -162,36 +162,6 @@ void NavigationView::OnApplyTemplate()
         }
     }
 
-    if (auto leftNavPaneHeaderContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneHeaderContentBorder, controlProtected))
-    {
-        m_leftNavPaneHeaderContentBorder.set(leftNavPaneHeaderContentBorder);
-    }
-
-    if (auto leftNavPaneCustomContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneCustomContentBorder, controlProtected))
-    {
-        m_leftNavPaneCustomContentBorder.set(leftNavPaneCustomContentBorder);
-    }
-
-    if (auto leftNavFooterContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavFooterContentBorder, controlProtected))
-    {
-        m_leftNavFooterContentBorder.set(leftNavFooterContentBorder);
-    }
-
-    if (auto paneHeaderOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneHeaderOnTopPane, controlProtected))
-    {
-        m_paneHeaderOnTopPane.set(paneHeaderOnTopPane);
-    }
-
-    if (auto paneCustomContentOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneCustomContentOnTopPane, controlProtected))
-    {
-        m_paneCustomContentOnTopPane.set(paneCustomContentOnTopPane);
-    }
-
-    if (auto paneFooterOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneFooterOnTopPane, controlProtected))
-    {
-        m_paneFooterOnTopPane.set(paneFooterOnTopPane);
-    }
-
     if (auto textBlock = GetTemplateChildT<winrt::TextBlock>(c_paneTitleTextBlock, controlProtected))
     {
         m_paneTitleTextBlock.set(textBlock);
@@ -278,16 +248,6 @@ void NavigationView::OnApplyTemplate()
     if (auto topNavContentOverlayAreaGrid = GetTemplateChildT<winrt::Border>(c_topNavContentOverlayAreaGrid, controlProtected))
     {
         m_topNavContentOverlayAreaGrid.set(topNavContentOverlayAreaGrid);
-    }
-
-    if (auto leftNavSearchContentControl = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneAutoSuggestBoxPresenter, controlProtected))
-    {
-        m_leftNavPaneAutoSuggestBoxPresenter.set(leftNavSearchContentControl);
-    }
-
-    if (auto topNavSearchContentControl = GetTemplateChildT<winrt::ContentControl>(c_topNavPaneAutoSuggestBoxPresenter, controlProtected))
-    {
-        m_topNavPaneAutoSuggestBoxPresenter.set(topNavSearchContentControl);
     }
 
     // Get pointer to the pane content area, for use in the selection indicator animation
@@ -2821,9 +2781,17 @@ void NavigationView::UpdatePaneDisplayMode()
     {
         UpdateAdaptiveLayout(ActualWidth(), true /*forceSetDisplayMode*/);
 
-        SwapPaneHeaderContent(m_leftNavPaneHeaderContentBorder, m_paneHeaderOnTopPane, L"PaneHeader");
-        SwapPaneHeaderContent(m_leftNavPaneCustomContentBorder, m_paneCustomContentOnTopPane, L"PaneCustomContent");
-        SwapPaneHeaderContent(m_leftNavFooterContentBorder, m_paneFooterOnTopPane, L"PaneFooter");
+        winrt::IControlProtected controlProtected = *this;
+        auto leftNavPaneHeaderContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneHeaderContentBorder, controlProtected);
+        auto leftNavPaneCustomContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneCustomContentBorder, controlProtected);
+        auto leftNavFooterContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavFooterContentBorder, controlProtected);
+        auto paneHeaderOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneHeaderOnTopPane, controlProtected);
+        auto paneCustomContentOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneCustomContentOnTopPane, controlProtected);
+        auto paneFooterOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneFooterOnTopPane, controlProtected);
+
+        SwapContentBinding(leftNavPaneHeaderContentBorder, paneHeaderOnTopPane, L"PaneHeader");
+        SwapContentBinding(leftNavPaneCustomContentBorder, paneCustomContentOnTopPane, L"PaneCustomContent");
+        SwapContentBinding(leftNavFooterContentBorder, paneFooterOnTopPane, L"PaneFooter");
 
         CreateAndHookEventsToSettings(c_settingsName);
 
@@ -2841,9 +2809,17 @@ void NavigationView::UpdatePaneDisplayMode()
         ClosePane();
         SetDisplayMode(winrt::NavigationViewDisplayMode::Minimal, true);
 
-        SwapPaneHeaderContent(m_paneHeaderOnTopPane, m_leftNavPaneHeaderContentBorder, L"PaneHeader");
-        SwapPaneHeaderContent(m_paneCustomContentOnTopPane, m_leftNavPaneCustomContentBorder, L"PaneCustomContent");
-        SwapPaneHeaderContent(m_paneFooterOnTopPane, m_leftNavFooterContentBorder, L"PaneFooter");
+        winrt::IControlProtected controlProtected = *this;
+        auto leftNavPaneHeaderContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneHeaderContentBorder, controlProtected);
+        auto leftNavPaneCustomContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneCustomContentBorder, controlProtected);
+        auto leftNavFooterContentBorder = GetTemplateChildT<winrt::ContentControl>(c_leftNavFooterContentBorder, controlProtected);
+        auto paneHeaderOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneHeaderOnTopPane, controlProtected);
+        auto paneCustomContentOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneCustomContentOnTopPane, controlProtected);
+        auto paneFooterOnTopPane = GetTemplateChildT<winrt::ContentControl>(c_paneFooterOnTopPane, controlProtected);
+
+        SwapContentBinding(paneHeaderOnTopPane, leftNavPaneHeaderContentBorder, L"PaneHeader");
+        SwapContentBinding(paneCustomContentOnTopPane, leftNavPaneCustomContentBorder, L"PaneCustomContent");
+        SwapContentBinding(paneFooterOnTopPane, leftNavFooterContentBorder, L"PaneFooter");
 
         CreateAndHookEventsToSettings(c_settingsNameTopNav);
 
@@ -2915,11 +2891,16 @@ void NavigationView::UpdatePaneVisibility()
     }
 }
 
-void NavigationView::SwapPaneHeaderContent(tracker_ref<winrt::ContentControl> newParentTrackRef, tracker_ref<winrt::ContentControl> oldParentTrackRef, winrt::hstring const& propertyPathName)
+// Be careful with this function, it may cause memory leak if it's not used correctly.
+// SetBinding creates a intermediary object – the BindingExpression – that keeps only a weak ref on the target (the control).
+// But BindingExpression.Source is a strong reference to NavigationView.
+// If NavigationView holds a tracker_ref to the content control,
+// It introduced the cycle: ContentControl -> BindingExpression -> NavigationView -> ContentControl
+void NavigationView::SwapContentBinding(winrt::ContentControl const& newParent, winrt::ContentControl const& oldParent, winrt::hstring const& propertyPathName)
 {
-    if (auto newParent = newParentTrackRef.get())
+    if (newParent)
     {
-        if (auto oldParent = oldParentTrackRef.get())
+        if (oldParent)
         {
             oldParent.ClearValue(winrt::ContentControl::ContentProperty());
         }
@@ -2934,31 +2915,17 @@ void NavigationView::SwapPaneHeaderContent(tracker_ref<winrt::ContentControl> ne
 
 void NavigationView::UpdateContentBindingsForPaneDisplayMode()
 {
-    winrt::UIElement autoSuggestBoxContentControl = nullptr;
-    winrt::UIElement notControl = nullptr;
+    winrt::IControlProtected controlProtected = *this;
+    auto leftNavAutoSuggestBox = GetTemplateChildT<winrt::ContentControl>(c_leftNavPaneAutoSuggestBoxPresenter, controlProtected);
+    auto topNavAutoSuggestBox = GetTemplateChildT<winrt::ContentControl>(c_topNavPaneAutoSuggestBoxPresenter, controlProtected);
+ 
     if (!IsTopNavigationView())
     {
-        autoSuggestBoxContentControl = m_leftNavPaneAutoSuggestBoxPresenter.get();
-        notControl = m_topNavPaneAutoSuggestBoxPresenter.get();
+        SwapContentBinding(leftNavAutoSuggestBox, topNavAutoSuggestBox, L"AutoSuggestBox");
     } 
     else
     {
-        autoSuggestBoxContentControl = m_topNavPaneAutoSuggestBoxPresenter.get();
-        notControl = m_leftNavPaneAutoSuggestBoxPresenter.get();
-    }
-
-    if (autoSuggestBoxContentControl)
-    {
-        if (notControl)
-        {
-            notControl.ClearValue(winrt::ContentControl::ContentProperty());
-        }
-
-        auto binding = winrt::Binding();
-        auto propertyPath = winrt::PropertyPath(L"AutoSuggestBox");
-        binding.Path(propertyPath);
-        binding.Source(*this);
-        winrt::BindingOperations::SetBinding(autoSuggestBoxContentControl, winrt::ContentControl::ContentProperty(), binding);
+        SwapContentBinding(topNavAutoSuggestBox, leftNavAutoSuggestBox, L"AutoSuggestBox");
     }
 }
 

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -242,7 +242,7 @@ private:
     bool AttemptClosePaneLightly();
     void ClosePaneLightly();
     void SetPaneToggleButtonAutomationName();
-    void SwapPaneHeaderContent(winrt::ContentControl const& newParent, winrt::ContentControl const& oldParent, winrt::hstring const& propertyPathName);
+    void SwapPaneHeaderContent(tracker_ref<winrt::ContentControl> newParent, tracker_ref<winrt::ContentControl> oldParent, winrt::hstring const& propertyPathName);
     void UpdateSettingsItemToolTip();
 
     void OnSplitViewClosedCompactChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
@@ -292,7 +292,18 @@ private:
     tracker_ref<winrt::FrameworkElement> m_headerContent{ this };
 
     tracker_ref<winrt::CoreApplicationViewTitleBar> m_coreTitleBar{ this };
-   
+
+    tracker_ref<winrt::ContentControl> m_leftNavPaneAutoSuggestBoxPresenter{ this };
+    tracker_ref<winrt::ContentControl> m_topNavPaneAutoSuggestBoxPresenter{ this };
+
+    tracker_ref<winrt::ContentControl> m_leftNavPaneHeaderContentBorder{ this };
+    tracker_ref<winrt::ContentControl> m_leftNavPaneCustomContentBorder{ this };
+    tracker_ref<winrt::ContentControl> m_leftNavFooterContentBorder{ this };
+
+    tracker_ref<winrt::ContentControl> m_paneHeaderOnTopPane{ this };
+    tracker_ref<winrt::ContentControl> m_paneCustomContentOnTopPane{ this };
+    tracker_ref<winrt::ContentControl> m_paneFooterOnTopPane{ this };
+    
     int m_indexOfLastSelectedItemInTopNav{ 0 };
     tracker_ref<winrt::IInspectable> m_lastSelectedItemPendingAnimationInTopNav{ this };
     std::vector<int> m_itemsRemovedFromMenuFlyout{};

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -242,7 +242,7 @@ private:
     bool AttemptClosePaneLightly();
     void ClosePaneLightly();
     void SetPaneToggleButtonAutomationName();
-    void SwapPaneHeaderContent(tracker_ref<winrt::ContentControl> newParent, tracker_ref<winrt::ContentControl> oldParent, winrt::hstring const& propertyPathName);
+    void SwapPaneHeaderContent(winrt::ContentControl const& newParent, winrt::ContentControl const& oldParent, winrt::hstring const& propertyPathName);
     void UpdateSettingsItemToolTip();
 
     void OnSplitViewClosedCompactChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
@@ -292,18 +292,7 @@ private:
     tracker_ref<winrt::FrameworkElement> m_headerContent{ this };
 
     tracker_ref<winrt::CoreApplicationViewTitleBar> m_coreTitleBar{ this };
-
-    tracker_ref<winrt::ContentControl> m_leftNavPaneAutoSuggestBoxPresenter{ this };
-    tracker_ref<winrt::ContentControl> m_topNavPaneAutoSuggestBoxPresenter{ this };
-
-    tracker_ref<winrt::ContentControl> m_leftNavPaneHeaderContentBorder{ this };
-    tracker_ref<winrt::ContentControl> m_leftNavPaneCustomContentBorder{ this };
-    tracker_ref<winrt::ContentControl> m_leftNavFooterContentBorder{ this };
-
-    tracker_ref<winrt::ContentControl> m_paneHeaderOnTopPane{ this };
-    tracker_ref<winrt::ContentControl> m_paneCustomContentOnTopPane{ this };
-    tracker_ref<winrt::ContentControl> m_paneFooterOnTopPane{ this };
-    
+   
     int m_indexOfLastSelectedItemInTopNav{ 0 };
     tracker_ref<winrt::IInspectable> m_lastSelectedItemPendingAnimationInTopNav{ this };
     std::vector<int> m_itemsRemovedFromMenuFlyout{};

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -584,11 +584,11 @@ void SharedHelpers::SetBinding(
     winrt::BindingOperations::SetBinding(target, targetProperty, binding);
 }
 
-// Be caution: this function may introduce memory leak if source holds strong reference to target
-// There’s an intermediary object – the BindingExpression in BindingOperations::SetBinding
+// Be caution: this function may introduce memory leak if Source holds strong reference to target too
+// There’s an intermediary object – the BindingExpression when BindingOperations::SetBinding
 // For example, if source is NavigationView and target is content control,
 // and there is strong reference: NavigationView -> ContentControl
-// BindingExpression.Source is a strong reference to NavigationView
+// BindingExpression.Source also make a strong reference to NavigationView
 // and it introduces the cycle: ContentControl -> BindingExpression -> NavigationView -> ContentControl
 // Prefer to use RelativeSource version of SetBinding if possible.
 void SharedHelpers::SetBinding(

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -584,7 +584,7 @@ void SharedHelpers::SetBinding(
     winrt::BindingOperations::SetBinding(target, targetProperty, binding);
 }
 
-// Be caution: this function may introduce memory leak if Source holds strong reference to target too
+// Be cautious: this function may introduce memory leak because Source holds strong reference to target too
 // There’s an intermediary object – the BindingExpression when BindingOperations::SetBinding
 // For example, if source is NavigationView and target is content control,
 // and there is strong reference: NavigationView -> ContentControl

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -570,6 +570,28 @@ winrt::IconElement SharedHelpers::MakeIconElementFrom(winrt::IconSource const& i
 }
 
 void SharedHelpers::SetBinding(
+    std::wstring_view const& pathString,
+    winrt::DependencyObject const& target,
+    winrt::DependencyProperty const& targetProperty)
+{
+    winrt::Binding binding;
+    winrt::RelativeSource relativeSource;
+    relativeSource.Mode(winrt::RelativeSourceMode::TemplatedParent);
+    binding.RelativeSource(relativeSource);
+
+    binding.Path(winrt::PropertyPath(pathString));
+
+    winrt::BindingOperations::SetBinding(target, targetProperty, binding);
+}
+
+// Be caution: this function may introduce memory leak if source holds strong reference to target
+// There’s an intermediary object – the BindingExpression in BindingOperations::SetBinding
+// For example, if source is NavigationView and target is content control,
+// and there is strong reference: NavigationView -> ContentControl
+// BindingExpression.Source is a strong reference to NavigationView
+// and it introduces the cycle: ContentControl -> BindingExpression -> NavigationView -> ContentControl
+// Prefer to use RelativeSource version of SetBinding if possible.
+void SharedHelpers::SetBinding(
     winrt::IInspectable const& source,
     std::wstring_view const& pathString,
     winrt::DependencyObject const& target,
@@ -578,8 +600,8 @@ void SharedHelpers::SetBinding(
     winrt::BindingMode mode)
 {
     winrt::Binding binding;
-
     binding.Source(source);
+
     binding.Path(winrt::PropertyPath(pathString));
     binding.Mode(mode);
 

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -225,6 +225,11 @@ public:
     static winrt::IconElement MakeIconElementFrom(winrt::IconSource const& iconSource);
 
     static void SetBinding(
+        std::wstring_view const& pathString,
+        winrt::DependencyObject const& target,
+        winrt::DependencyProperty const& targetProperty);
+
+    static void SetBinding(
         winrt::IInspectable const& source,
         std::wstring_view const& pathString,
         winrt::DependencyObject const& target,


### PR DESCRIPTION
Fix #1000

In NavigationView, NavigationView holds reference to its content control: 
There’s an intermediary object – the BindingExpression in `BindingOperations::SetBinding`
and it creates a strong reference when `binding.Source(*this)`, and BindingExpression.Source is a strong reference to NavigationView
So it introduces the cycle: ContentControl -> BindingExpression -> NavigationView -> ContentControl

Fix: Instead of binding.source, use binding.relativeSource.

Move SetBinding to SharedHelper.
SharedHelper also have a SetBinding function which is used by CommandingHelper, add comments on this since it may cause memory leak if it's not used correctly.
Double checked with Luke, it will not have problem in commanding.