### PR TITLE
Miscellaneous TabView fixes

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -244,6 +244,27 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void KeyboardTest()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Log.Comment("Set focus inside the TabView");
+                UIObject tabContent = FindElement.ByName("FirstTabContent");
+                tabContent.SetFocus();
+
+                Log.Comment("Verify that pressing ctrl-f4 closes the tab");
+                KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
+                TextInput.SendText("{F4}");
+                KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
+                Wait.ForIdle();
+
+                ElementCache.Refresh();
+                UIObject firstTab = TryFindElement.ByName("FirstTab");
+                Verify.IsNull(firstTab);
+            }
+        }
+
         Button FindCloseButton(UIObject tabItem)
         {
             foreach (UIObject elem in tabItem.Children)

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -247,6 +247,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void KeyboardTest()
         {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ functionality (specifically, KeyboardAccelerators)");
+                return;
+            }
+
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
                 Log.Comment("Set focus inside the TabView");

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -31,7 +31,7 @@ TabView::TabView()
 
     Loaded({ this, &TabView::OnLoaded });
     SizeChanged({ this, &TabView::OnSizeChanged });
-    KeyUp({ this, &TabView::OnTabViewKeyUp });
+    KeyDown({ this, &TabView::OnTabViewKeyDown });
 }
 
 void TabView::OnApplyTemplate()
@@ -322,7 +322,7 @@ void TabView::UpdateTabWidths()
         {
             widthTaken += addButtonColumn.ActualWidth();
         }
-        if (auto rightContentColumn = m_rightContentColumn.get())
+        if (auto&& rightContentColumn = m_rightContentColumn.get())
         {
             if (auto rightContentPresenter = m_rightContentPresenter.get())
             {
@@ -436,7 +436,7 @@ winrt::DependencyObject TabView::ContainerFromIndex(int index)
     return nullptr;
 }
 
-void TabView::OnTabViewKeyUp(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args)
+void TabView::OnTabViewKeyDown(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args)
 {
     winrt::CoreVirtualKeyStates ctrlState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Control);
 

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -31,6 +31,7 @@ TabView::TabView()
 
     Loaded({ this, &TabView::OnLoaded });
     SizeChanged({ this, &TabView::OnSizeChanged });
+    KeyUp({ this, &TabView::OnTabViewKeyUp });
 }
 
 void TabView::OnApplyTemplate()
@@ -427,4 +428,21 @@ winrt::DependencyObject TabView::ContainerFromIndex(int index)
         return listView.ContainerFromIndex(index);
     }
     return nullptr;
+}
+
+void TabView::OnTabViewKeyUp(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args)
+{
+    winrt::VirtualKey key = args.Key();
+
+    if (key == winrt::VirtualKey::F4 && IsEnabled() && SelectedItem())
+    {
+        winrt::CoreVirtualKeyStates ctrlState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Control);
+
+        if ((ctrlState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down)
+        {
+            // Close the tab on ctrl + F4
+            CloseTab(SelectedItem().as<winrt::TabViewItem>());
+            args.Handled(true);
+        }
+    }
 }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -447,16 +447,13 @@ winrt::DependencyObject TabView::ContainerFromIndex(int index)
 
 void TabView::OnCtrlF4Invoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args)
 {
-    if (IsEnabled())
+    if (auto selectedTab = SelectedItem().try_as<winrt::TabViewItem>())
     {
-        if (auto selectedTab = SelectedItem().try_as<winrt::TabViewItem>())
+        if (selectedTab.IsCloseable())
         {
-            if (selectedTab.IsCloseable())
-            {
-                // Close the tab on ctrl + F4
-                CloseTab(selectedTab);
-                args.Handled(true);
-            }
+            // Close the tab on ctrl + F4
+            CloseTab(selectedTab);
+            args.Handled(true);
         }
     }
 }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -39,6 +39,7 @@ void TabView::OnApplyTemplate()
     winrt::IControlProtected controlProtected{ *this };
 
     m_tabContentPresenter.set(GetTemplateChildT<winrt::ContentPresenter>(L"TabContentPresenter", controlProtected));
+    m_rightContentPresenter.set(GetTemplateChildT<winrt::ContentPresenter>(L"RightContentPresenter", controlProtected));
     
     m_leftContentColumn.set(GetTemplateChildT<winrt::ColumnDefinition>(L"LeftContentColumn", controlProtected));
     m_tabColumn.set(GetTemplateChildT<winrt::ColumnDefinition>(L"TabColumn", controlProtected));
@@ -323,7 +324,12 @@ void TabView::UpdateTabWidths()
         }
         if (auto rightContentColumn = m_rightContentColumn.get())
         {
-            widthTaken += rightContentColumn.ActualWidth();
+            if (auto rightContentPresenter = m_rightContentPresenter.get())
+            {
+                winrt::Size rightContentSize = rightContentPresenter.DesiredSize();
+                rightContentColumn.MinWidth(rightContentSize.Width);
+                widthTaken += rightContentSize.Width;
+            }
         }
 
         if (auto tabColumn = m_tabColumn.get())

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -438,17 +438,25 @@ winrt::DependencyObject TabView::ContainerFromIndex(int index)
 
 void TabView::OnTabViewKeyUp(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args)
 {
-    winrt::VirtualKey key = args.Key();
+    winrt::CoreVirtualKeyStates ctrlState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Control);
 
-    if (key == winrt::VirtualKey::F4 && IsEnabled() && SelectedItem())
+    if (IsEnabled()
+        && SelectedItem()
+        && (ctrlState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down)
     {
-        winrt::CoreVirtualKeyStates ctrlState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Control);
+        winrt::VirtualKey key = args.Key();
 
-        if ((ctrlState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down)
+        if (key == winrt::VirtualKey::F4)
         {
-            // Close the tab on ctrl + F4
-            CloseTab(SelectedItem().as<winrt::TabViewItem>());
-            args.Handled(true);
+            if (auto selectedTab = SelectedItem().as<winrt::TabViewItem>())
+            {
+                if (selectedTab.IsCloseable())
+                {
+                    // Close the tab on ctrl + F4
+                    CloseTab(selectedTab);
+                    args.Handled(true);
+                }
+            }
         }
     }
 }

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -80,6 +80,7 @@ private:
 
     tracker_ref<winrt::ListView> m_listView{ this };
     tracker_ref<winrt::ContentPresenter> m_tabContentPresenter{ this };
+    tracker_ref<winrt::ContentPresenter> m_rightContentPresenter{ this };
     tracker_ref<winrt::Grid> m_tabContainerGrid{ this };
     tracker_ref<winrt::FxScrollViewer> m_scrollViewer{ this };
     tracker_ref<winrt::Button> m_addButton{ this };

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -64,7 +64,8 @@ private:
     void OnScrollDecreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollIncreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
-    void OnTabViewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
+
+    void OnCtrlF4Invoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
 
     void UpdateItemsSource();
     void UpdateSelectedItem();

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -64,7 +64,7 @@ private:
     void OnScrollDecreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollIncreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
-    void OnTabViewKeyUp(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
+    void OnTabViewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
 
     void UpdateItemsSource();
     void UpdateSelectedItem();

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -64,6 +64,7 @@ private:
     void OnScrollDecreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollIncreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
+    void OnTabViewKeyUp(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
 
     void UpdateItemsSource();
     void UpdateSelectedItem();

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -136,5 +136,12 @@ unsealed runtimeclass TabViewAutomationPeer : Windows.UI.Xaml.Automation.Peers.F
     TabViewAutomationPeer(MU_XC_NAMESPACE.TabView owner);
 }
 
+[WUXC_VERSION_PREVIEW]
+[webhosthidden]
+unsealed runtimeclass TabViewItemAutomationPeer : Windows.UI.Xaml.Automation.Peers.ListViewItemAutomationPeer
+{
+    TabViewItemAutomationPeer(MU_XC_NAMESPACE.TabViewItem owner);
+}
+
 }
 

--- a/dev/TabView/TabView.vcxitems
+++ b/dev/TabView/TabView.vcxitems
@@ -17,6 +17,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TabView.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TabViewItem.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TabViewAutomationPeer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)TabViewItemAutomationPeer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TabViewListView.h" />
   </ItemGroup>
   <ItemGroup>
@@ -25,6 +26,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)TabView.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TabViewItem.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TabViewAutomationPeer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)TabViewItemAutomationPeer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TabViewListView.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -79,6 +79,7 @@
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsSwipeEnabled" Value="False" />
+        <Setter Property="SingleSelectionFollowsFocus" Value="False"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Enabled" />
@@ -199,6 +200,7 @@
 
     <Style TargetType="local:TabViewItem">
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="UseSystemFocusVisuals" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TabViewItem">
@@ -423,7 +425,8 @@
                                 FontSize="10"
                                 Padding="0"
                                 Margin="8,0,0,0"
-                                Content="&#xE711;">
+                                Content="&#xE711;"
+                                IsTabStop="False">
                                 <Button.Resources>
                                     <ResourceDictionary>
                                         <Thickness x:Key="ButtonBorderThemeThickness">0</Thickness>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -26,8 +26,7 @@
                                 <ColumnDefinition Width="Auto" x:Name="LeftContentColumn"/>
                                 <ColumnDefinition Width="Auto" x:Name="TabColumn"/>
                                 <ColumnDefinition Width="Auto" x:Name="AddButtonColumn"/>
-                                <ColumnDefinition Width="*"/> <!-- Padding -->
-                                <ColumnDefinition Width="Auto" x:Name="RightContentColumn"/>
+                                <ColumnDefinition Width="*" x:Name="RightContentColumn"/>
                             </Grid.ColumnDefinitions>
 
                             <ContentPresenter
@@ -55,8 +54,9 @@
                                 Style="{StaticResource TabViewButtonStyle}"/>
 
                             <ContentPresenter
-                                Grid.Column="4"
+                                Grid.Column="3"
                                 x:Name="RightContentPresenter"
+                                HorizontalAlignment="Stretch"
                                 Content="{TemplateBinding RightCustomContent}"
                                 ContentTemplate="{TemplateBinding RightCustomContentTemplate}"/>
 
@@ -89,6 +89,16 @@
         <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
         <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+        <Setter Property="ItemContainerTransitions">
+            <Setter.Value>
+                <TransitionCollection>
+                    <AddDeleteThemeTransition />
+                    <ContentThemeTransition />
+                    <ReorderThemeTransition />
+                    <EntranceThemeTransition IsStaggeringEnabled="False" />
+                </TransitionCollection>
+            </Setter.Value>
+        </Setter>
 
         <Setter Property="ItemsPanel">
             <Setter.Value>
@@ -100,7 +110,7 @@
 
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="ListView">
+                <ControlTemplate TargetType="primitives:TabViewListView">
 
                     <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
                         <ScrollViewer x:Name="ScrollViewer"

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -210,7 +210,7 @@
 
     <Style TargetType="local:TabViewItem">
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="UseSystemFocusVisuals" Value="True"/>
+        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TabViewItem">

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -37,6 +37,11 @@ void TabViewItem::OnApplyTemplate()
     }
 }
 
+winrt::AutomationPeer TabViewItem::OnCreateAutomationPeer()
+{
+    return winrt::make<TabViewItemAutomationPeer>(*this);
+}
+
 void TabViewItem::OnLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args)
 {
     UpdateCloseButton();

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -8,6 +8,7 @@
 
 #include "TabViewItem.g.h"
 #include "TabViewItem.properties.h"
+#include "TabViewItemAutomationPeer.h"
 
 class TabViewItem :
     public ReferenceTracker<TabViewItem, winrt::implementation::TabViewItemT>,
@@ -20,6 +21,9 @@ public:
 
     // IFrameworkElement
     void OnApplyTemplate();
+
+    // IUIElement
+    winrt::AutomationPeer OnCreateAutomationPeer();
 
     void OnIsCloseablePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "ResourceAccessor.h"
+#include "TabViewItem.h"
+#include "TabViewItemAutomationPeer.h"
+#include "Utils.h"
+
+TabViewItemAutomationPeer::TabViewItemAutomationPeer(winrt::TabViewItem const& owner)
+    : ReferenceTracker(owner)
+{
+}
+
+// IAutomationPeerOverrides
+hstring TabViewItemAutomationPeer::GetClassNameCore()
+{
+    return winrt::hstring_name_of<winrt::TabViewItem>();
+}
+
+winrt::AutomationControlType TabViewItemAutomationPeer::GetAutomationControlTypeCore()
+{
+    return winrt::AutomationControlType::TabItem;
+}
+

--- a/dev/TabView/TabViewItemAutomationPeer.h
+++ b/dev/TabView/TabViewItemAutomationPeer.h
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "TabViewItem.h"
+#include "TabViewItemAutomationPeer.g.h"
+
+class TabViewItemAutomationPeer :
+    public ReferenceTracker<TabViewItemAutomationPeer, winrt::implementation::TabViewItemAutomationPeerT>
+{
+
+public:
+    TabViewItemAutomationPeer(winrt::TabViewItem const& owner);
+    ~TabViewItemAutomationPeer() {}
+
+    // IAutomationPeerOverrides
+    hstring GetClassNameCore();
+    winrt::AutomationControlType GetAutomationControlTypeCore();
+};
+
+CppWinRTActivatableClassWithBasicFactory(TabViewItemAutomationPeer);

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -51,7 +51,15 @@
                 AddButtonClick="AddButtonClick">
 
                 <controls:TabView.RightCustomContent>
-                    <TextBlock Text="Right" Margin="6,3,6,0" VerticalAlignment="Center"/>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="Middle" Margin="6,3,6,0" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="Right" Margin="6,3,6,0" VerticalAlignment="Center"/>
+                    </Grid>
                 </controls:TabView.RightCustomContent>
 
                 <controls:TabView.Items>


### PR DESCRIPTION
- Added focus rect on tabs.
- Selection no longer follows focus.
- Close button is no longer a tab stop (this matches Edge behavior).
- Tabs are now reported as TabItems in accessibility tools.
- Ctrl-F4 closes the current tab; added test to verify this.
- The right content area is now appropriately sized and allows the app to position content aligned left or right (or both).
