### PR TITLE
Add some release tests for pogo training

### DIFF
--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTests.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTests.cs
@@ -58,15 +58,47 @@ namespace MUXControls.ReleaseTest
         }
 
         [TestMethod]
-        public void RepeaterNoCrashTest()
+        public void RepeaterBasicTests()
         {
             using (var setup = new TestSetupHelper("Repeater Tests"))
             {
-                var button = new Button(FindElement.ByName("AddItemsButton"));
-                button.Click();
+                var AddItemsButton = new Button(FindElement.ByName("AddItemsButton"));
+                AddItemsButton.Click();
 
-                var item3 = FindElement.ByName("Item3");
-                Verify.IsNotNull(item3);
+                Verify.IsNotNull(FindElement.ByName("Item1"));
+                Verify.IsNotNull(FindElement.ByName("Item2"));
+                Verify.IsNotNull(FindElement.ByName("Item3"));
+
+                var clearOutputButton = new Button(FindElement.ByName("ClearOutputButton"));
+                clearOutputButton.Click();
+
+                var removeItemButton = new Button(FindElement.ByName("RemoveItemButton"));
+                removeItemButton.Click();
+                var outputText = new TextBlock(FindElement.ByName("OutputText"));
+                Verify.IsTrue(outputText.DocumentText.Contains("Element Cleared"));
+
+                clearOutputButton.Click();
+
+                var gridLayoutButton = new Button(FindElement.ByName("UniformGridLayoutButton"));
+                gridLayoutButton.Click();
+                Verify.IsTrue(outputText.DocumentText.Contains("Element Cleared"));
+                Verify.IsTrue(outputText.DocumentText.Contains("0Prepared"));
+                Verify.IsTrue(outputText.DocumentText.Contains("1Prepared"));
+            }
+        }
+
+        // This test covers loading nav view, reveal and acrylic brushes for PGO training
+        [TestMethod]
+        public void NavigationViewBasicTest()
+        {
+            using (var setup = new TestSetupHelper("NavigationView Tests"))
+            {
+                var button = new Button(FindElement.ByName("Close Navigation"));
+                button.Click();
+                Verify.IsNotNull(FindElement.ByName("Item1"));
+                Verify.IsNotNull(FindElement.ByName("Item2"));
+                Verify.IsNotNull(FindElement.ByName("Item3"));
+                button.Click();
             }
         }
     }

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -99,6 +99,9 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TestPages\NavigationViewTestPage.xaml.cs">
+      <DependentUpon>NavigationViewTestPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="TestPages\CompactDictionaryTestPage.xaml.cs">
       <DependentUpon>CompactDictionaryTestPage.xaml</DependentUpon>
     </Compile>
@@ -135,6 +138,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="TestPages\NavigationViewTestPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="TestPages\CompactDictionaryTestPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestInventory.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestInventory.cs
@@ -27,6 +27,11 @@ namespace NugetPackageTestApp
                     Name = "Repeater Tests",
                     PageType = typeof(RepeaterTestPage),
                 },
+                new TestDeclaration()
+                {
+                    Name = "NavigationView Tests",
+                    PageType = typeof(NavigationViewTestPage),
+                },
             };
         }
 

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/NavigationViewTestPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/NavigationViewTestPage.xaml
@@ -1,4 +1,5 @@
-﻿<utils:TestPage
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<utils:TestPage
     x:Class="NugetPackageTestApp.NavigationViewTestPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/NavigationViewTestPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/NavigationViewTestPage.xaml
@@ -1,0 +1,14 @@
+﻿<utils:TestPage
+    x:Class="NugetPackageTestApp.NavigationViewTestPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:media="using:Microsoft.UI.Xaml.Media"
+    xmlns:utils="using:MUXControlsTestApp"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    
+    <StackPanel>
+        <controls:NavigationView
+            x:Name="navView" />
+    </StackPanel>
+</utils:TestPage>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/NavigationViewTestPage.xaml.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/NavigationViewTestPage.xaml.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MUXControlsTestApp;
+using System.Collections.Generic;
+using NavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
+
+namespace NugetPackageTestApp
+{
+    public sealed partial class NavigationViewTestPage : TestPage
+    {
+        public NavigationViewTestPage()
+        {
+            this.InitializeComponent();
+            navView.MenuItemsSource = new List<NavigationViewItem>()
+            {
+                new NavigationViewItem() { Content = "Item1" },
+                new NavigationViewItem() { Content = "Item2" },
+                new NavigationViewItem() { Content = "Item3" },
+            };
+        }
+    }
+}

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml
@@ -3,24 +3,27 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:NugetPackageTestApp.TestPages"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:utils="using:MUXControlsTestApp"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    mc:Ignorable="d">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+    <StackPanel>
+        <ScrollViewer Grid.Row="1" Height="400">
+            <controls:ItemsRepeater x:Name="Repeater" ElementPrepared="OnElementPrepared" ElementClearing="OnElementClearing"/>
+        </ScrollViewer>
         <Button
             AutomationProperties.Name="AddItemsButton"
-            Click="OnAddItemsButtonClick"
+            Click="OnAddItemsClicked"
             Content="Add Items" />
-        <ScrollViewer Grid.Row="1">
-            <controls:ItemsRepeater x:Name="Repeater" />
-        </ScrollViewer>
-    </Grid>
+        <Button
+            AutomationProperties.Name="RemoveItemButton"
+            Click="OnRemoveItemClicked"
+            Content="Remove Item" />
+        <Button AutomationProperties.Name="UniformGridLayoutButton"
+            Click="OnUniformGridLayoutClicked"
+            Content="Switch to UniformGrid Layout" />
+        <Button AutomationProperties.Name="ClearOutputButton"
+            Click="OnClearOutputClicked"
+            Content="Clear Output" />
+        <TextBlock AutomationProperties.Name="OutputText" x:Name="OutputText" />
+    </StackPanel>
 </utils:TestPage>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml.cs
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/TestPages/RepeaterTestPage.xaml.cs
@@ -1,39 +1,54 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp;
+using System;
+using System.Collections.ObjectModel;
+using Windows.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace NugetPackageTestApp
 {
     public sealed partial class RepeaterTestPage : TestPage
     {
-        private ObservableCollection<string> items;
+        private ObservableCollection<string> items = new ObservableCollection<string>();
 
         public RepeaterTestPage()
         {
-            this.InitializeComponent();
+            InitializeComponent();
 
-            this.items = new ObservableCollection<string>();
-            this.Repeater.ItemsSource = items;
+            Repeater.ItemsSource = items;
         }
 
-        public void OnAddItemsButtonClick(Object sender, RoutedEventArgs e)
+        public void OnAddItemsClicked(Object sender, RoutedEventArgs e)
         {
             items.Add("Item1");
             items.Add("Item2");
             items.Add("Item3");
+        }
+
+        public void OnRemoveItemClicked(Object sender, RoutedEventArgs e)
+        {
+            items.RemoveAt(0);
+        }
+
+        public void OnUniformGridLayoutClicked(Object sender, RoutedEventArgs e)
+        {
+            Repeater.Layout = new UniformGridLayout();
+        }
+        public void OnClearOutputClicked(Object sender, RoutedEventArgs e)
+        {
+            OutputText.Text = string.Empty;
+        }
+        
+        private void OnElementPrepared(ItemsRepeater sender,ItemsRepeaterElementPreparedEventArgs args)
+        {
+            OutputText.Text += args.Index + "Prepared" + Environment.NewLine;
+        }
+
+        private void OnElementClearing(ItemsRepeater sender, ItemsRepeaterElementClearingEventArgs args)
+        {
+            OutputText.Text += "Element Cleared" + Environment.NewLine;
         }
     }
 }


### PR DESCRIPTION
Add some repeater and nav view tests which will load acrylic and reveal brushes in turn to release tests. This should help with profile guided optimize these features which are usually in the app load path.