### PR TITLE
Fix TintLuminosityOpacity crash by removing const_cast and passing by non-const

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dev", "dev", "{67599AD5-51EC-44CB-85CE-B60CD8CBA270}"
 EndProject
@@ -99,9 +99,9 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Scroller_APITests", "dev\Sc
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{CDC531B5-F8D8-4A8D-8653-0470B07B2404}"
 	ProjectSection(SolutionItems) = preProject
+		version.props = version.props
 		mux.controls.props = mux.controls.props
 		build\SignConfig.xml = build\SignConfig.xml
-		version.props = version.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{5654F115-F01A-495B-91C7-09408ABF14F0}"
@@ -831,6 +831,7 @@ Global
 		dev\TeachingTip\TeachingTip.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Telemetry\Telemetry.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TestHooks\TestHooks.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
+		dev\Slider\Slider.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TimePicker\TimePicker.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\ToolTip\ToolTip.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TreeView\TreeView.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
@@ -875,6 +876,7 @@ Global
 		dev\CheckBox\TestUI\CheckBox_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ColorPicker\APITests\ColorPicker_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ColorPicker\TestUI\ColorPicker_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
+		dev\ComboBox\APITests\ComboBox_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ComboBox\TestUI\ComboBox_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\CommandBarFlyout\APITests\CommandBarFlyout_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\CommandBarFlyout\TestUI\CommandBarFlyout_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
@@ -887,6 +889,7 @@ Global
 		dev\FlipView\TestUI\FlipView_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\IconSource\APITests\IconSource_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\LayoutPanel\APITests\LayoutPanel_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
+		dev\lights\ApiTests\Lights_ApiTests\Lights_ApiTests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Materials\Acrylic\TestUI\AcrylicBrush_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Materials\Reveal\APITests\Reveal_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
@@ -953,6 +956,7 @@ Global
 		dev\CheckBox\TestUI\CheckBox_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ColorPicker\APITests\ColorPicker_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ColorPicker\TestUI\ColorPicker_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
+		dev\ComboBox\APITests\ComboBox_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ComboBox\TestUI\ComboBox_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\CommandBarFlyout\APITests\CommandBarFlyout_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\CommandBarFlyout\TestUI\CommandBarFlyout_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
@@ -965,6 +969,7 @@ Global
 		dev\FlipView\TestUI\FlipView_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\IconSource\APITests\IconSource_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\LayoutPanel\APITests\LayoutPanel_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
+		dev\lights\ApiTests\Lights_ApiTests\Lights_ApiTests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Materials\Acrylic\TestUI\AcrylicBrush_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Materials\Reveal\APITests\Reveal_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4

--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29009.5
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dev", "dev", "{67599AD5-51EC-44CB-85CE-B60CD8CBA270}"
 EndProject
@@ -99,9 +99,9 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Scroller_APITests", "dev\Sc
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{CDC531B5-F8D8-4A8D-8653-0470B07B2404}"
 	ProjectSection(SolutionItems) = preProject
-		version.props = version.props
 		mux.controls.props = mux.controls.props
 		build\SignConfig.xml = build\SignConfig.xml
+		version.props = version.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{5654F115-F01A-495B-91C7-09408ABF14F0}"
@@ -831,7 +831,6 @@ Global
 		dev\TeachingTip\TeachingTip.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Telemetry\Telemetry.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TestHooks\TestHooks.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\Slider\Slider.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TimePicker\TimePicker.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\ToolTip\ToolTip.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TreeView\TreeView.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
@@ -876,7 +875,6 @@ Global
 		dev\CheckBox\TestUI\CheckBox_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ColorPicker\APITests\ColorPicker_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ColorPicker\TestUI\ColorPicker_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
-		dev\ComboBox\APITests\ComboBox_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ComboBox\TestUI\ComboBox_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\CommandBarFlyout\APITests\CommandBarFlyout_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\CommandBarFlyout\TestUI\CommandBarFlyout_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
@@ -889,7 +887,6 @@ Global
 		dev\FlipView\TestUI\FlipView_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\IconSource\APITests\IconSource_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\LayoutPanel\APITests\LayoutPanel_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
-		dev\lights\ApiTests\Lights_ApiTests\Lights_ApiTests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Materials\Acrylic\TestUI\AcrylicBrush_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Materials\Reveal\APITests\Reveal_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
@@ -956,7 +953,6 @@ Global
 		dev\CheckBox\TestUI\CheckBox_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ColorPicker\APITests\ColorPicker_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ColorPicker\TestUI\ColorPicker_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
-		dev\ComboBox\APITests\ComboBox_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ComboBox\TestUI\ComboBox_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\CommandBarFlyout\APITests\CommandBarFlyout_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\CommandBarFlyout\TestUI\CommandBarFlyout_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
@@ -969,7 +965,6 @@ Global
 		dev\FlipView\TestUI\FlipView_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\IconSource\APITests\IconSource_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\LayoutPanel\APITests\LayoutPanel_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
-		dev\lights\ApiTests\Lights_ApiTests\Lights_ApiTests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Materials\Acrylic\TestUI\AcrylicBrush_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Materials\Reveal\APITests\Reveal_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4

--- a/dev/Generated/AcrylicBrush.properties.cpp
+++ b/dev/Generated/AcrylicBrush.properties.cpp
@@ -198,8 +198,9 @@ winrt::Color AcrylicBrushProperties::TintColor()
 
 void AcrylicBrushProperties::TintLuminosityOpacity(winrt::IReference<double> const& value)
 {
-    static_cast<AcrylicBrush*>(this)->CoerceToZeroOneRange_Nullable(value);
-    static_cast<AcrylicBrush*>(this)->SetValue(s_TintLuminosityOpacityProperty, ValueHelper<winrt::IReference<double>>::BoxValueIfNecessary(value));
+    winrt::IReference<double> coercedValue = value;
+    static_cast<AcrylicBrush*>(this)->CoerceToZeroOneRange_Nullable(coercedValue);
+    static_cast<AcrylicBrush*>(this)->SetValue(s_TintLuminosityOpacityProperty, ValueHelper<winrt::IReference<double>>::BoxValueIfNecessary(coercedValue));
 }
 
 winrt::IReference<double> AcrylicBrushProperties::TintLuminosityOpacity()
@@ -209,8 +210,9 @@ winrt::IReference<double> AcrylicBrushProperties::TintLuminosityOpacity()
 
 void AcrylicBrushProperties::TintOpacity(double value)
 {
-    static_cast<AcrylicBrush*>(this)->CoerceToZeroOneRange(value);
-    static_cast<AcrylicBrush*>(this)->SetValue(s_TintOpacityProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<AcrylicBrush*>(this)->CoerceToZeroOneRange(coercedValue);
+    static_cast<AcrylicBrush*>(this)->SetValue(s_TintOpacityProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double AcrylicBrushProperties::TintOpacity()

--- a/dev/Generated/NavigationView.properties.cpp
+++ b/dev/Generated/NavigationView.properties.cpp
@@ -795,8 +795,9 @@ winrt::AutoSuggestBox NavigationViewProperties::AutoSuggestBox()
 
 void NavigationViewProperties::CompactModeThresholdWidth(double value)
 {
-    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(value);
-    static_cast<NavigationView*>(this)->SetValue(s_CompactModeThresholdWidthProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(coercedValue);
+    static_cast<NavigationView*>(this)->SetValue(s_CompactModeThresholdWidthProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double NavigationViewProperties::CompactModeThresholdWidth()
@@ -806,8 +807,9 @@ double NavigationViewProperties::CompactModeThresholdWidth()
 
 void NavigationViewProperties::CompactPaneLength(double value)
 {
-    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(value);
-    static_cast<NavigationView*>(this)->SetValue(s_CompactPaneLengthProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(coercedValue);
+    static_cast<NavigationView*>(this)->SetValue(s_CompactPaneLengthProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double NavigationViewProperties::CompactPaneLength()
@@ -837,8 +839,9 @@ winrt::NavigationViewDisplayMode NavigationViewProperties::DisplayMode()
 
 void NavigationViewProperties::ExpandedModeThresholdWidth(double value)
 {
-    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(value);
-    static_cast<NavigationView*>(this)->SetValue(s_ExpandedModeThresholdWidthProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(coercedValue);
+    static_cast<NavigationView*>(this)->SetValue(s_ExpandedModeThresholdWidthProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double NavigationViewProperties::ExpandedModeThresholdWidth()
@@ -998,8 +1001,9 @@ winrt::DataTemplateSelector NavigationViewProperties::MenuItemTemplateSelector()
 
 void NavigationViewProperties::OpenPaneLength(double value)
 {
-    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(value);
-    static_cast<NavigationView*>(this)->SetValue(s_OpenPaneLengthProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<NavigationView*>(this)->CoerceToGreaterThanZero(coercedValue);
+    static_cast<NavigationView*>(this)->SetValue(s_OpenPaneLengthProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double NavigationViewProperties::OpenPaneLength()

--- a/dev/Generated/ScrollViewer.properties.cpp
+++ b/dev/Generated/ScrollViewer.properties.cpp
@@ -575,8 +575,9 @@ winrt::ContentOrientation ScrollViewerProperties::ContentOrientation()
 
 void ScrollViewerProperties::HorizontalAnchorRatio(double value)
 {
-    static_cast<ScrollViewer*>(this)->ValidateAnchorRatio(value);
-    static_cast<ScrollViewer*>(this)->SetValue(s_HorizontalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<ScrollViewer*>(this)->ValidateAnchorRatio(coercedValue);
+    static_cast<ScrollViewer*>(this)->SetValue(s_HorizontalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollViewerProperties::HorizontalAnchorRatio()
@@ -646,8 +647,9 @@ winrt::InputKind ScrollViewerProperties::IgnoredInputKind()
 
 void ScrollViewerProperties::MaxZoomFactor(double value)
 {
-    static_cast<ScrollViewer*>(this)->ValidateZoomFactoryBoundary(value);
-    static_cast<ScrollViewer*>(this)->SetValue(s_MaxZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<ScrollViewer*>(this)->ValidateZoomFactoryBoundary(coercedValue);
+    static_cast<ScrollViewer*>(this)->SetValue(s_MaxZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollViewerProperties::MaxZoomFactor()
@@ -657,8 +659,9 @@ double ScrollViewerProperties::MaxZoomFactor()
 
 void ScrollViewerProperties::MinZoomFactor(double value)
 {
-    static_cast<ScrollViewer*>(this)->ValidateZoomFactoryBoundary(value);
-    static_cast<ScrollViewer*>(this)->SetValue(s_MinZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<ScrollViewer*>(this)->ValidateZoomFactoryBoundary(coercedValue);
+    static_cast<ScrollViewer*>(this)->SetValue(s_MinZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollViewerProperties::MinZoomFactor()
@@ -669,8 +672,9 @@ double ScrollViewerProperties::MinZoomFactor()
 
 void ScrollViewerProperties::VerticalAnchorRatio(double value)
 {
-    static_cast<ScrollViewer*>(this)->ValidateAnchorRatio(value);
-    static_cast<ScrollViewer*>(this)->SetValue(s_VerticalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<ScrollViewer*>(this)->ValidateAnchorRatio(coercedValue);
+    static_cast<ScrollViewer*>(this)->SetValue(s_VerticalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollViewerProperties::VerticalAnchorRatio()

--- a/dev/Generated/Scroller.properties.cpp
+++ b/dev/Generated/Scroller.properties.cpp
@@ -439,8 +439,9 @@ winrt::ContentOrientation ScrollerProperties::ContentOrientation()
 
 void ScrollerProperties::HorizontalAnchorRatio(double value)
 {
-    static_cast<Scroller*>(this)->ValidateAnchorRatio(value);
-    static_cast<Scroller*>(this)->SetValue(s_HorizontalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<Scroller*>(this)->ValidateAnchorRatio(coercedValue);
+    static_cast<Scroller*>(this)->SetValue(s_HorizontalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollerProperties::HorizontalAnchorRatio()
@@ -490,8 +491,9 @@ winrt::InputKind ScrollerProperties::IgnoredInputKind()
 
 void ScrollerProperties::MaxZoomFactor(double value)
 {
-    static_cast<Scroller*>(this)->ValidateZoomFactoryBoundary(value);
-    static_cast<Scroller*>(this)->SetValue(s_MaxZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<Scroller*>(this)->ValidateZoomFactoryBoundary(coercedValue);
+    static_cast<Scroller*>(this)->SetValue(s_MaxZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollerProperties::MaxZoomFactor()
@@ -501,8 +503,9 @@ double ScrollerProperties::MaxZoomFactor()
 
 void ScrollerProperties::MinZoomFactor(double value)
 {
-    static_cast<Scroller*>(this)->ValidateZoomFactoryBoundary(value);
-    static_cast<Scroller*>(this)->SetValue(s_MinZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<Scroller*>(this)->ValidateZoomFactoryBoundary(coercedValue);
+    static_cast<Scroller*>(this)->SetValue(s_MinZoomFactorProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollerProperties::MinZoomFactor()
@@ -512,8 +515,9 @@ double ScrollerProperties::MinZoomFactor()
 
 void ScrollerProperties::VerticalAnchorRatio(double value)
 {
-    static_cast<Scroller*>(this)->ValidateAnchorRatio(value);
-    static_cast<Scroller*>(this)->SetValue(s_VerticalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    double coercedValue = value;
+    static_cast<Scroller*>(this)->ValidateAnchorRatio(coercedValue);
+    static_cast<Scroller*>(this)->SetValue(s_VerticalAnchorRatioProperty, ValueHelper<double>::BoxValueIfNecessary(coercedValue));
 }
 
 double ScrollerProperties::VerticalAnchorRatio()

--- a/dev/Materials/Acrylic/AcrylicBrush.cpp
+++ b/dev/Materials/Acrylic/AcrylicBrush.cpp
@@ -1127,15 +1127,11 @@ void AcrylicBrush::CoerceToZeroOneRange(double& value)
     }
 }
 
-void AcrylicBrush::CoerceToZeroOneRange_Nullable(winrt::IReference<double> const& value)
+void AcrylicBrush::CoerceToZeroOneRange_Nullable(winrt::IReference<double>& value)
 {
-    // TODO: Get rid of const_cast<> when following bug is fixed:
-    // Bug 19638177: MUX CodeGen for winrt::IReferenence<Double> setter w/ MUX_PROPERTY_VALIDATION_CALLBACK marks arg const& preventing validation callback from modifying the value
-    winrt::IReference<double>& modifiedValue = const_cast<winrt::IReference<double>&>(value);
-
-    if (modifiedValue && !isnan(modifiedValue.GetDouble()))
+    if (value && !isnan(value.Value()))
     {
-        modifiedValue = std::clamp(modifiedValue.GetDouble(), 0.0, 1.0);
+        value = std::clamp(value.Value(), 0.0, 1.0);
     }
 }
 

--- a/dev/Materials/Acrylic/AcrylicBrush.h
+++ b/dev/Materials/Acrylic/AcrylicBrush.h
@@ -68,7 +68,7 @@ public:
         bool useCache = false);
 
     void CoerceToZeroOneRange(double& value);
-    void CoerceToZeroOneRange_Nullable(winrt::IReference<double> const& value);
+    void CoerceToZeroOneRange_Nullable(winrt::IReference<double>& value);
 
 protected: // AcrylicTestApi needs CreateAcrylicBrush be public or protected
     void CreateAcrylicBrush(bool useCrossFadeEffect, bool forceCreateAcrylicBrush = false);

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -416,7 +416,7 @@
        IXamlMetadataProvider implementation. -->
   <Target Name="ComputeXamlGeneratedCompileInputs" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets')" />
+    <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.45\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.45\build\native\MUXCustomBuildTasks.targets')" />
     <Import Project="..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.targets" Condition="Exists('..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.targets')" />
     <Import Project="..\..\packages\Microsoft.SourceLink.Common.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.Common.targets" Condition="Exists('..\..\packages\Microsoft.SourceLink.Common.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.Common.targets')" />
     <Import Project="..\..\packages\Microsoft.SourceLink.GitHub.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.GitHub.targets" Condition="Exists('..\..\packages\Microsoft.SourceLink.GitHub.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.GitHub.targets')" />
@@ -643,7 +643,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeAnalysis.BinSkim.1.3.9\tools\x86\BinSkim.exe'))" />
-    <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.44\build\native\MUXCustomBuildTasks.targets'))" />
+    <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.45\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.45\build\native\MUXCustomBuildTasks.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.SourceLink.Common.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.Common.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.SourceLink.Common.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.Common.props'))" />

--- a/dev/dll/packages.config
+++ b/dev/dll/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.SourceLink.Common" version="1.0.0-beta2-18618-05" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0-beta2-18618-05" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190603.8" targetFramework="native" />
-  <package id="MUXCustomBuildTasks" version="1.0.44" targetFramework="native" />
+  <package id="MUXCustomBuildTasks" version="1.0.45" targetFramework="native" />
   <package id="MUXPGODatabase" version="0.0.2" targetFramework="native" />
 </packages>

--- a/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
+++ b/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(XES_DFSDROP)' == ''">
     <PackageReference Include="MUXCustomBuildTasks">
-      <Version>1.0.44</Version>
+      <Version>1.0.45</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Net.Native.Compiler">
       <Version>2.2.1</Version>

--- a/test/IXMPTestApp/TAEF/project.json
+++ b/test/IXMPTestApp/TAEF/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.Net.Native.Compiler": "2.2.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "MUXCustomBuildTasks": "1.0.44",
+    "MUXCustomBuildTasks": "1.0.45",
     "TAEF.Redist.Wlk": "10.31.180822002"
   },
   "frameworks": {

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(XES_DFSDROP)' == ''">
     <PackageReference Include="MUXCustomBuildTasks">
-      <Version>1.0.44</Version>
+      <Version>1.0.45</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Net.Native.Compiler">
       <Version>2.2.1</Version>

--- a/test/MUXControlsTestApp/TAEF/project.json
+++ b/test/MUXControlsTestApp/TAEF/project.json
@@ -3,7 +3,7 @@
     "DiffPlex": "1.2.1",
     "Microsoft.Net.Native.Compiler": "2.2.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "MUXCustomBuildTasks": "1.0.44",
+    "MUXCustomBuildTasks": "1.0.45",
     "TAEF.Redist.Wlk": "10.31.180822002",
     "Win2D.uwp": "1.22.0"
   },

--- a/tools/CustomTasks/DependencyPropertyCodeGen.cs
+++ b/tools/CustomTasks/DependencyPropertyCodeGen.cs
@@ -750,13 +750,15 @@ $@"    winrt::get_self<{ownerType.Name}>(owner)->{ownerFuncName}(args);");
                     sb.AppendLine(String.Format(
 @"void {0}Properties::{1}({2} {3}value)
 {{", ownerType.Name, prop.Name, prop.PropertyCppName, CppInputModifier(prop.PropertyType)));
+                    string localName = "value";
                     if (prop.PropertyValidationCallback != null)
                     {
-                        sb.AppendLine(String.Format(
-@"    static_cast<{0}*>(this)->{1}(value);", ownerType.Name, prop.PropertyValidationCallback));
+                        localName = "coercedValue";
+                        sb.AppendLine($@"    {prop.PropertyCppName} {localName} = value;");
+                        sb.AppendLine($@"    static_cast<{ownerType.Name}*>(this)->{prop.PropertyValidationCallback}({localName});");
                     }
-                    sb.AppendLine(String.Format(@"    static_cast<{0}*>(this)->SetValue(s_{1}Property, ValueHelper<{2}>::BoxValueIfNecessary(value));
-}}", ownerType.Name, prop.Name, prop.PropertyCppName));
+                    sb.AppendLine($@"    static_cast<{ownerType.Name}*>(this)->SetValue(s_{prop.Name}Property, ValueHelper<{prop.PropertyCppName}>::BoxValueIfNecessary({localName}));
+}}");
                     sb.AppendLine(String.Format(@"
 {0} {1}Properties::{2}()
 {{

--- a/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.nuspec
+++ b/tools/CustomTasks/NuSpecs/MUXCustomBuildTasks.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>MUXCustomBuildTasks</id>
-    <version>1.0.44</version>
+    <version>1.0.45</version>
     <title>MUXCustomBuildTasks</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/tools/CustomTasks/Properties/AssemblyInfo.cs
+++ b/tools/CustomTasks/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.45")]
+[assembly: AssemblyFileVersion("1.0.45")]


### PR DESCRIPTION
The DependencyProperty codegen for coercion callback was passing the const param through and forcing the callee to receive the parameter by const&, which led to someone using const_cast to try to modify the passed in value. This appeared to work but was over-releasing the incoming object and leaking the new object it had created.

The simplest solution is to make a temporary local to pass in to the coercion callback to remove the need for a const_cast.

I've changed the codegen and updated the build tasks nupkg.

Fixes #1022 