### PR TITLE
Updated ToggleSwitch width to 40px

### DIFF
--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -379,7 +379,7 @@
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="KnobTranslateTransform"
                                             Storyboard.TargetProperty="X"
-                                            To="24"
+                                            To="20"
                                             Duration="0" />
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SwitchKnobBounds" Storyboard.TargetProperty="Opacity">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
@@ -500,7 +500,7 @@
                             <Rectangle x:Name="OuterBorder"
                                 Grid.Row="1"
                                 Height="20"
-                                Width="44"
+                                Width="40"
                                 RadiusX="10"
                                 RadiusY="10"
                                 Fill="{ThemeResource ToggleSwitchFillOff}"
@@ -509,7 +509,7 @@
                             <Rectangle x:Name="SwitchKnobBounds"
                                 Grid.Row="1"
                                 Height="20"
-                                Width="44"
+                                Width="40"
                                 RadiusX="10"
                                 RadiusY="10"
                                 Fill="{ThemeResource ToggleSwitchFillOn}"


### PR DESCRIPTION
There is an consistency effort across apps running on Windows as well as Fabric to align as much of the unnecessary differences as possible. This is one of them.

Windows design evaluated this size and this is more balanced with the text and also makes it feel less swipable (they are going after 'tappable' model) due to its size.

Fix: #836 