### PR TITLE
Collapse header if AlwaysShowHeader is false and  PaneDisplayMode is Top

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -2970,7 +2970,7 @@ void NavigationView::UpdateHeaderVisibility()
 
 void NavigationView::UpdateHeaderVisibility(winrt::NavigationViewDisplayMode displayMode)
 {
-    // Ignore AlwaysShowHeader property in case DisplayMode is minimum and we're not a Top NavigationView
+    // Ignore AlwaysShowHeader property in case DisplayMode is Minimal and it's not Top NavigationView
     bool showHeader = AlwaysShowHeader() || (!IsTopNavigationView() && displayMode == winrt::NavigationViewDisplayMode::Minimal);
 
     // Like bug 17517627, Customer like WallPaper Studio 10 expects a HeaderContent visual even if Header() is null. 

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -2970,7 +2970,9 @@ void NavigationView::UpdateHeaderVisibility()
 
 void NavigationView::UpdateHeaderVisibility(winrt::NavigationViewDisplayMode displayMode)
 {
-    bool showHeader = AlwaysShowHeader() || displayMode == winrt::NavigationViewDisplayMode::Minimal;
+    // Ignore AlwaysShowHeader property in case DisplayMode is minimum and we're not a Top NavigationView
+    bool showHeader = AlwaysShowHeader() || (!IsTopNavigationView() && displayMode == winrt::NavigationViewDisplayMode::Minimal);
+
     // Like bug 17517627, Customer like WallPaper Studio 10 expects a HeaderContent visual even if Header() is null. 
     // App crashes when they have dependency on that visual, but the crash is not directly state that it's a header problem.   
     // NavigationView doesn't use quirk, but we determine the version by themeresource.

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -558,6 +558,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     headerVisibilityCheckbox.Check();
                     Wait.ForIdle();
                     VerifyElement.Found("Home as header", FindBy.Name);
+
+                    // PaneDisplayMode and Top option were added on RS5, so just run the next tests if we are not using RS4 Style
+                    if (!testScenario.IsUsingRS4Style)
+                    {
+                        var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+                        Log.Comment("Set PaneDisplayMode to Top");
+                        panelDisplayModeComboBox.SelectItemByName("Top");
+                        Wait.ForIdle();
+
+                        Log.Comment("Verify that header is visible in Top display mode when AlwaysShowHeader == true");
+                        VerifyElement.Found("Home as header", FindBy.Name);
+
+                        Log.Comment("Verify that header is not visible in Top display mode when AlwaysShowHeader == false");
+                        headerVisibilityCheckbox.Uncheck();
+                        Wait.ForIdle();
+                        VerifyElement.NotFound("Home as header", FindBy.Name);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When updating the header visibility, we were ignoring the AlwaysShowHeader property if the DisplayMode was minimal.  The problem is that when the PaneDisplayMode is Top, the DisplayMode is automatically Minimal, therefore we were also ignoring AlwaysShowHeader property in this scenario. This commit fixes it by checking also if the navigation is Top in addition to checking if DisplayMode is Minimal.

Fix #757