### PR TITLE
Updated Picker Controls to have 1px borders

### DIFF
--- a/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
+++ b/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
@@ -9,7 +9,7 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
+            <Thickness x:Key="CalendarDatePickerBorderThemeThickness">1</Thickness>
             <StaticResource x:Key="CalendarDatePickerForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CalendarDatePickerForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="CalendarDatePickerCalendarGlyphForeground" ResourceKey="SystemControlForegroundBaseMediumHighBrush" />
@@ -48,10 +48,10 @@
             <StaticResource x:Key="CalendarDatePickerBorderBrushPressed" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
             <StaticResource x:Key="CalendarDatePickerBorderBrushDisabled" ResourceKey="SystemControlDisabledBaseLowBrush" />
             <StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
-            <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
+            <Thickness x:Key="CalendarDatePickerBorderThemeThickness">1</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
+            <Thickness x:Key="CalendarDatePickerBorderThemeThickness">1</Thickness>
             <StaticResource x:Key="CalendarDatePickerForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CalendarDatePickerForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="CalendarDatePickerCalendarGlyphForeground" ResourceKey="SystemControlForegroundBaseMediumHighBrush" />

--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -14,7 +14,7 @@
             <x:Double x:Key="ComboBoxThemeMinWidth">64</x:Double>
             <x:Double x:Key="ComboBoxPopupThemeMinWidth">80</x:Double>
             <x:Double x:Key="ComboBoxPopupThemeTouchMinWidth">240</x:Double>
-            <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>
+            <Thickness x:Key="ComboBoxBorderThemeThickness">1</Thickness>
             <Thickness x:Key="ComboBoxDropdownBorderThickness">1</Thickness>
             <Thickness x:Key="ComboBoxHeaderThemeMargin">0,0,0,4</Thickness>
             <Thickness x:Key="ComboBoxPopupBorderThemeThickness">2</Thickness>
@@ -184,7 +184,7 @@
             <x:Double x:Key="ComboBoxThemeMinWidth">64</x:Double>
             <x:Double x:Key="ComboBoxPopupThemeMinWidth">80</x:Double>
             <x:Double x:Key="ComboBoxPopupThemeTouchMinWidth">240</x:Double>
-            <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>
+            <Thickness x:Key="ComboBoxBorderThemeThickness">1</Thickness>
             <Thickness x:Key="ComboBoxDropdownBorderThickness">1</Thickness>
             <Thickness x:Key="ComboBoxHeaderThemeMargin">0,0,0,4</Thickness>
             <Thickness x:Key="ComboBoxPopupBorderThemeThickness">2</Thickness>
@@ -242,7 +242,7 @@
             <x:Double x:Key="ComboBoxThemeMinWidth">64</x:Double>
             <x:Double x:Key="ComboBoxPopupThemeMinWidth">80</x:Double>
             <x:Double x:Key="ComboBoxPopupThemeTouchMinWidth">240</x:Double>
-            <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>
+            <Thickness x:Key="ComboBoxBorderThemeThickness">1</Thickness>
             <Thickness x:Key="ComboBoxDropdownBorderThickness">1</Thickness>
             <Thickness x:Key="ComboBoxHeaderThemeMargin">0,0,0,4</Thickness>
             <Thickness x:Key="ComboBoxPopupBorderThemeThickness">2</Thickness>
@@ -358,7 +358,7 @@
     <x:Int32 x:Key="ComboBoxPopupMaxNumberOfItemsThatCanBeShownOnOneSide">7</x:Int32>
 
     <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
-    <Thickness x:Key="ComboBoxEditableTextPadding">10,3,30,5</Thickness>
+    <Thickness x:Key="ComboBoxEditableTextPadding">10,4,30,5</Thickness>
     <Thickness x:Key="ComboBoxMinHeight">32</Thickness>
 
     <Style TargetType="ComboBox">
@@ -515,17 +515,17 @@
                                 <VisualState x:Name="Opened">
                                     <Storyboard>
                                         <SplitOpenThemeAnimation OpenedTargetName="PopupBorder"
-                                        ClosedTargetName="ContentPresenter"
-                                        OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
-                                        OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+                                            ClosedTargetName="ContentPresenter"
+                                            OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+                                            OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Closed">
                                     <Storyboard>
                                         <SplitCloseThemeAnimation OpenedTargetName="PopupBorder"
-                                        ClosedTargetName="ContentPresenter"
-                                        OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
-                                        OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+                                            ClosedTargetName="ContentPresenter"
+                                            OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+                                            OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -533,21 +533,21 @@
                                 <VisualState x:Name="TextBoxFocused">
                                     <VisualState.Setters>
                                         <Setter Target="DropDownGlyph.Foreground" Value="{ThemeResource ComboBoxEditableDropDownGlyphForeground}" />
-                                        <Setter Target="DropDownOverlay.Margin" Value="0,3,2,2" />
+                                        <Setter Target="DropDownOverlay.Margin" Value="0,2,2,2" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="TextBoxFocusedOverlayPointerOver">
                                     <VisualState.Setters>
                                         <Setter Target="DropDownGlyph.Foreground" Value="{ThemeResource ComboBoxEditableDropDownGlyphForeground}" />
                                         <Setter Target="DropDownOverlay.Background" Value="{ThemeResource ComboBoxFocusedDropDownBackgroundPointerOver}" />
-                                        <Setter Target="DropDownOverlay.Margin" Value="0,3,2,2" />
+                                        <Setter Target="DropDownOverlay.Margin" Value="0,2,2,2" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="TextBoxFocusedOverlayPressed">
                                     <VisualState.Setters>
                                         <Setter Target="DropDownGlyph.Foreground" Value="{ThemeResource ComboBoxEditableDropDownGlyphForeground}" />
                                         <Setter Target="DropDownOverlay.Background" Value="{ThemeResource ComboBoxFocusedDropDownBackgroundPointerPressed}" />
-                                        <Setter Target="DropDownOverlay.Margin" Value="0,3,2,2" />
+                                        <Setter Target="DropDownOverlay.Margin" Value="0,2,2,2" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="TextBoxOverlayPointerOver">

--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
@@ -1,0 +1,172 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    xmlns:local="using:MUXControlsTestApp"
+    x:Class="MUXControlsTestApp.BorderThicknessPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 5)"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid
+        contract5Present:RowSpacing="10"
+        contract5Present:ColumnSpacing="10">
+        <Grid.Resources>
+            <Style x:Key="SideHeader" TargetType="TextBlock">
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="Grid.Column" Value="0"/>
+            </Style>
+            <Style x:Key="LeftColumn" TargetType="Grid">
+                <Setter Property="HorizontalAlignment" Value="Left"/>
+                <Setter Property="VerticalAlignment" Value="Top"/>
+                <Setter Property="Grid.Column" Value="1"/>
+            </Style>
+            <Style x:Key="RightColumn" TargetType="Grid">
+                <Setter Property="HorizontalAlignment" Value="Left"/>
+                <Setter Property="VerticalAlignment" Value="Top"/>
+                <Setter Property="Grid.Column" Value="2"/>
+            </Style>
+        </Grid.Resources>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="150"/>
+            <ColumnDefinition />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="ComboBox" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="0" Style="{StaticResource LeftColumn}">
+            <StackPanel>
+                <StackPanel.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="ComboBoxBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </StackPanel.Resources>
+                <ComboBox SelectedIndex="0">
+                    <ComboBoxItem Content="Item 1"/>
+                    <ComboBoxItem Content="Item 2"/>
+                    <ComboBoxItem Content="Item 3"/>
+                </ComboBox>
+
+                <TextBlock Text="ComboBox IsEditable==true:" Margin="0,20,0,0"/>
+                <ComboBox SelectedIndex="0" IsEditable="True">
+                    <ComboBoxItem Content="Item 1"/>
+                    <ComboBoxItem Content="Item 2"/>
+                    <ComboBoxItem Content="Item 3"/>
+                </ComboBox>
+            </StackPanel>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="0" Style="{StaticResource RightColumn}">
+            <StackPanel Grid.Column="2" Grid.Row="0">
+                <ComboBox SelectedIndex="0">
+                    <ComboBoxItem Content="Item 1"/>
+                    <ComboBoxItem Content="Item 2"/>
+                    <ComboBoxItem Content="Item 3"/>
+                </ComboBox>
+
+                <TextBlock Text="ComboBox IsEditable==true:" Margin="0,20,0,0"/>
+                <ComboBox SelectedIndex="0" IsEditable="True">
+                    <ComboBoxItem Content="Item 1"/>
+                    <ComboBoxItem Content="Item 2"/>
+                    <ComboBoxItem Content="Item 3"/>
+                </ComboBox>
+            </StackPanel>
+        </Grid>
+
+        <TextBlock Grid.Row="1" Text="CalendarDatePicker" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="1" Style="{StaticResource LeftColumn}">
+            <CalendarDatePicker>
+                <CalendarDatePicker.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="CalendarDatePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </CalendarDatePicker.Resources>
+            </CalendarDatePicker>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="1" Style="{StaticResource RightColumn}">
+            <CalendarDatePicker />
+        </Grid>
+
+        <TextBlock Grid.Row="2" Text="DatePicker" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="2" Style="{StaticResource LeftColumn}">
+            <DatePicker>
+                <DatePicker.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <x:Double x:Key="DatePickerSpacerThemeWidth">2</x:Double>
+                                <Thickness x:Key="DatePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <x:Double x:Key="DatePickerSpacerThemeWidth">2</x:Double>
+                                <Thickness x:Key="DatePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <x:Double x:Key="DatePickerSpacerThemeWidth">2</x:Double>
+                                <Thickness x:Key="DatePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </DatePicker.Resources>
+            </DatePicker>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="2" Style="{StaticResource RightColumn}">
+            <DatePicker/>
+        </Grid>
+
+        <TextBlock Grid.Row="3" Text="TimePicker" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="3" Style="{StaticResource LeftColumn}">
+            <TimePicker>
+                <TimePicker.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <x:Double x:Key="TimePickerSpacerThemeWidth">2</x:Double>
+                                <Thickness x:Key="TimePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <x:Double x:Key="TimePickerSpacerThemeWidth">2</x:Double>
+                                <Thickness x:Key="TimePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <x:Double x:Key="TimePickerSpacerThemeWidth">2</x:Double>
+                                <Thickness x:Key="TimePickerBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </TimePicker.Resources>
+            </TimePicker>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="3" Style="{StaticResource RightColumn}">
+            <TimePicker/>
+        </Grid>
+
+    </Grid>
+</local:TestPage>

--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace MUXControlsTestApp
+{
+    [TopLevelTestPage(Name = "BorderThickness")]
+    public sealed partial class BorderThicknessPage : TestPage
+    {
+        public BorderThicknessPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/dev/CommonStyles/TestUI/CommonStyles_TestUI.projitems
+++ b/dev/CommonStyles/TestUI/CommonStyles_TestUI.projitems
@@ -10,6 +10,11 @@
     <Import_RootNamespace>CommonStyles_TestUI</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)BorderThicknessPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <IncludeInWindowsAppx>false</IncludeInWindowsAppx>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)CommonStylesPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -22,6 +27,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)BorderThicknessPage.xaml.cs">
+      <DependentUpon>BorderThicknessPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)CommonStylesPage.xaml.cs">
       <DependentUpon>CommonStylesPage.xaml</DependentUpon>
     </Compile>
@@ -29,7 +37,7 @@
       <DependentUpon>CornerRadiusPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
-    <ItemGroup>
+  <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)CompactPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/dev/DatePicker/DatePicker_themeresources.xaml
+++ b/dev/DatePicker/DatePicker_themeresources.xaml
@@ -8,6 +8,7 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <x:Double x:Key="DatePickerSelectorThemeMinWidth">80</x:Double>
+            <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
             <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
             <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
             <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
@@ -39,6 +40,7 @@
             <StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <SolidColorBrush x:Key="DatePickerHeaderForegroundThemeBrush" Color="#FFFFFFFF" />
             <SolidColorBrush x:Key="DatePickerForegroundThemeBrush" Color="#FF000000" />
+            <Thickness x:Key="DatePickerBorderThemeThickness">1</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="DatePickerSpacerFill" ResourceKey="SystemControlForegroundBaseLowBrush" />
@@ -67,15 +69,18 @@
             <StaticResource x:Key="DatePickerFlyoutPresenterHighlightFill" ResourceKey="SystemControlHighlightListAccentLowBrush" />
             <StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <x:Double x:Key="DatePickerSelectorThemeMinWidth">80</x:Double>
+            <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
             <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
             <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
             <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
             <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
             <SolidColorBrush x:Key="DatePickerHeaderForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
             <SolidColorBrush x:Key="DatePickerForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <Thickness x:Key="DatePickerBorderThemeThickness">1</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <x:Double x:Key="DatePickerSelectorThemeMinWidth">80</x:Double>
+            <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
             <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
             <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
             <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
@@ -107,6 +112,7 @@
             <StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <SolidColorBrush x:Key="DatePickerHeaderForegroundThemeBrush" Color="#FF000000" />
             <SolidColorBrush x:Key="DatePickerForegroundThemeBrush" Color="#FF000000" />
+            <Thickness x:Key="DatePickerBorderThemeThickness">1</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -116,7 +122,7 @@
     <x:Double x:Key="DatePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
     <x:Double x:Key="DatePickerThemeMinWidth">296</x:Double>
     <x:Double x:Key="DatePickerThemeMaxWidth">456</x:Double>
-    
+
     <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
     <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,3,0,6</Thickness>
     
@@ -211,7 +217,7 @@
                                                 <ContentPresenter x:Name="ContentPresenter"
                                                     BorderBrush="{ThemeResource DatePickerButtonBorderBrush}"
                                                     Background="{ThemeResource DatePickerButtonBackground}"
-                                                    BorderThickness="2"
+                                                    BorderThickness="{ThemeResource DatePickerBorderThemeThickness}"
                                                     Content="{TemplateBinding Content}"
                                                     Foreground="{TemplateBinding Foreground}"
                                                     HorizontalContentAlignment="Stretch"
@@ -327,12 +333,12 @@
                                 <Rectangle x:Name="FirstPickerSpacing"
                                     Fill="{ThemeResource DatePickerSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource DatePickerSpacerThemeWidth}"
                                     Grid.Column="1" />
                                 <Rectangle x:Name="SecondPickerSpacing"
                                     Fill="{ThemeResource DatePickerSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource DatePickerSpacerThemeWidth}"
                                     Grid.Column="3" />
                             </Grid>
                         </Button>
@@ -391,12 +397,12 @@
                                 <Rectangle x:Name="FirstPickerSpacing"
                                     Fill="{ThemeResource DatePickerFlyoutPresenterSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource DatePickerSpacerThemeWidth}"
                                     Grid.Column="1" />
                                 <Rectangle x:Name="SecondPickerSpacing"
                                     Fill="{ThemeResource DatePickerFlyoutPresenterSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource DatePickerSpacerThemeWidth}"
                                     Grid.Column="3" />
                             </Grid>
                             <Grid Grid.Row="1" Height="{ThemeResource DatePickerFlyoutPresenterAcceptDismissHostGridHeight}" x:Name="AcceptDismissHostGrid">
@@ -405,7 +411,7 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Rectangle Height="2"
+                                <Rectangle Height="{ThemeResource DatePickerSpacerThemeWidth}"
                                     VerticalAlignment="Top"
                                     Fill="{ThemeResource DatePickerFlyoutPresenterSpacerFill}"
                                     Grid.ColumnSpan="2" />
@@ -436,4 +442,3 @@
     </Style>
 
 </ResourceDictionary>
-

--- a/dev/TimePicker/TimePicker_themeresources.xaml
+++ b/dev/TimePicker/TimePicker_themeresources.xaml
@@ -8,6 +8,8 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
+            <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
+            <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
             <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
             <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
@@ -68,6 +70,8 @@
             <StaticResource x:Key="TimePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
             <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+            <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
+            <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
             <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
             <FontWeight x:Key="TimePickerHeaderThemeFontWeight">Normal</FontWeight>
@@ -76,6 +80,8 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
+            <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
+            <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
             <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
             <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
@@ -208,7 +214,7 @@
                                                 <ContentPresenter x:Name="ContentPresenter"
                                                     BorderBrush="{ThemeResource TimePickerButtonBorderBrush}"
                                                     Background="{ThemeResource TimePickerButtonBackground}"
-                                                    BorderThickness="2"
+                                                    BorderThickness="{ThemeResource TimePickerBorderThemeThickness}"
                                                     Content="{TemplateBinding Content}"
                                                     Foreground="{TemplateBinding Foreground}"
                                                     HorizontalContentAlignment="Stretch"
@@ -308,7 +314,7 @@
                                 <Rectangle x:Name="FirstColumnDivider"
                                     Fill="{ThemeResource TimePickerSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource TimePickerSpacerThemeWidth}"
                                     Grid.Column="1" />
                                 <Border x:Name="SecondPickerHost" Grid.Column="2">
                                     <TextBlock x:Name="MinuteTextBlock"
@@ -322,7 +328,7 @@
                                 <Rectangle x:Name="SecondColumnDivider"
                                     Fill="{ThemeResource TimePickerSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource TimePickerSpacerThemeWidth}"
                                     Grid.Column="3" />
                                 <Border x:Name="ThirdPickerHost" Grid.Column="4">
                                     <TextBlock x:Name="PeriodTextBlock"
@@ -391,13 +397,13 @@
                                 <Rectangle x:Name="FirstPickerSpacing"
                                     Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource TimePickerSpacerThemeWidth}"
                                     Grid.Column="1" />
                                 <Border x:Name="SecondPickerHost" Grid.Column="2" />
                                 <Rectangle x:Name="SecondPickerSpacing"
                                     Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}"
                                     HorizontalAlignment="Center"
-                                    Width="2"
+                                    Width="{ThemeResource TimePickerSpacerThemeWidth}"
                                     Grid.Column="3" />
                                 <Border x:Name="ThirdPickerHost" Grid.Column="4" />
                             </Grid>
@@ -407,7 +413,7 @@
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Rectangle Height="2"
+                                <Rectangle Height="{ThemeResource TimePickerSpacerThemeWidth}"
                                     VerticalAlignment="Top"
                                     Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}"
                                     Grid.ColumnSpan="2" />

--- a/dev/dll/DensityStyles/Compact.xaml
+++ b/dev/dll/DensityStyles/Compact.xaml
@@ -11,8 +11,8 @@
     <Thickness x:Key="TextControlThemePadding">2,1,6,0</Thickness>
     <x:Double x:Key="ListViewItemMinHeight">32</x:Double>
     <x:Double x:Key="TreeViewItemMinHeight">24</x:Double>
-    <Thickness x:Key="TimePickerHostPadding">0,0,0,1</Thickness>
-    <Thickness x:Key="DatePickerHostPadding">0,0,0,1</Thickness>
+    <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>
+    <Thickness x:Key="DatePickerHostPadding">0,1,0,2</Thickness>
     <Thickness x:Key="DatePickerHostMonthPadding">9,0,0,1</Thickness>
     <Thickness x:Key="ComboBoxEditableTextPadding">10,0,30,0</Thickness>
     <Thickness x:Key="ComboBoxMinHeight">24</Thickness>


### PR DESCRIPTION
This commit updates all the Pickers borders to use a thickness of 1px (#835 ) based on the visual comps [here](https://raw.githubusercontent.com/microsoft/microsoft-ui-xaml-specs/user/chigy/borderstrokes/active/borderstrokes/images/Pickers.png) and [here](https://raw.githubusercontent.com/microsoft/microsoft-ui-xaml-specs/user/chigy/borderstrokes/active/borderstrokes/images/Pickers%20cont%20....png).