### PR TITLE
Updated Selector Controls to have 1px borders

### DIFF
--- a/dev/CheckBox/CheckBox_themeresources.xaml
+++ b/dev/CheckBox/CheckBox_themeresources.xaml
@@ -6,7 +6,7 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <x:Double x:Key="CheckBoxBorderThemeThickness">2</x:Double>
+            <x:Double x:Key="CheckBoxBorderThemeThickness">1</x:Double>
             <x:Double x:Key="CheckBoxCheckedStrokeThickness">0</x:Double>
             <StaticResource x:Key="CheckBoxForegroundUnchecked" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CheckBoxForegroundUncheckedPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -168,8 +168,8 @@
             <StaticResource x:Key="CheckBoxCheckGlyphForegroundIndeterminatePointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CheckBoxCheckGlyphForegroundIndeterminatePressed" ResourceKey="SystemControlForegroundBaseMediumBrush" />
             <StaticResource x:Key="CheckBoxCheckGlyphForegroundIndeterminateDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <x:Double x:Key="CheckBoxBorderThemeThickness">2</x:Double>
-            <x:Double x:Key="CheckBoxCheckedStrokeThickness">2</x:Double>
+            <x:Double x:Key="CheckBoxBorderThemeThickness">1</x:Double>
+            <x:Double x:Key="CheckBoxCheckedStrokeThickness">1</x:Double>
             <SolidColorBrush x:Key="CheckBoxBackgroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
             <SolidColorBrush x:Key="CheckBoxBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
             <SolidColorBrush x:Key="CheckBoxContentDisabledForegroundThemeBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
@@ -186,7 +186,7 @@
             <SolidColorBrush x:Key="CheckBoxPressedForegroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <x:Double x:Key="CheckBoxBorderThemeThickness">2</x:Double>
+            <x:Double x:Key="CheckBoxBorderThemeThickness">1</x:Double>
             <x:Double x:Key="CheckBoxCheckedStrokeThickness">0</x:Double>
             <StaticResource x:Key="CheckBoxForegroundUnchecked" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CheckBoxForegroundUncheckedPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />

--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
@@ -39,6 +39,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Text="ComboBox" Style="{StaticResource SideHeader}"/>
@@ -166,6 +169,81 @@
         </Grid>
         <Grid Grid.Column="2" Grid.Row="3" Style="{StaticResource RightColumn}">
             <TimePicker/>
+        </Grid>
+
+        <TextBlock Grid.Row="4" Text="CheckBox" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="4" Style="{StaticResource LeftColumn}">
+            <CheckBox Content="CheckBox">
+                <CheckBox.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <x:Double x:Key="CheckBoxBorderThemeThickness">2</x:Double>
+                                <Thickness x:Key="CheckBoxCheckedStrokeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <x:Double x:Key="CheckBoxBorderThemeThickness">2</x:Double>
+                                <Thickness x:Key="CheckBoxCheckedStrokeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <x:Double x:Key="CheckBoxBorderThemeThickness">2</x:Double>
+                                <Thickness x:Key="CheckBoxCheckedStrokeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </CheckBox.Resources>
+            </CheckBox>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="4" Style="{StaticResource RightColumn}">
+            <CheckBox/>
+        </Grid>
+
+        <TextBlock Grid.Row="5" Text="RadioButton" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="5" Style="{StaticResource LeftColumn}">
+            <RadioButton Content="RadioButton">
+                <RadioButton.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="RadioButtonBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="RadioButtonBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="RadioButtonBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </RadioButton.Resources>
+            </RadioButton>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="5" Style="{StaticResource RightColumn}">
+            <RadioButton/>
+        </Grid>
+
+        <TextBlock Grid.Row="6" Text="ToggleSwitch" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="6" Style="{StaticResource LeftColumn}">
+            <ToggleSwitch>
+                <ToggleSwitch.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <x:Double x:Key="ToggleSwitchOuterBorderStrokeThickness">2</x:Double>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <x:Double x:Key="ToggleSwitchOuterBorderStrokeThickness">2</x:Double>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <x:Double x:Key="ToggleSwitchOuterBorderStrokeThickness">2</x:Double>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </ToggleSwitch.Resources>
+            </ToggleSwitch>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="6" Style="{StaticResource RightColumn}">
+            <ToggleSwitch/>
         </Grid>
 
     </Grid>

--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -8,6 +8,7 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <x:Double x:Key="ToggleSwitchOnStrokeThickness">0</x:Double>
+            <x:Double x:Key="ToggleSwitchOuterBorderStrokeThickness">1</x:Double>
             <StaticResource x:Key="ToggleSwitchContentForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="ToggleSwitchContentForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="ToggleSwitchHeaderForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -99,7 +100,8 @@
             <StaticResource x:Key="ToggleSwitchKnobFillOnPressed" ResourceKey="SystemControlHighlightAltChromeWhiteBrush" />
             <StaticResource x:Key="ToggleSwitchKnobFillOnDisabled" ResourceKey="SystemControlPageBackgroundBaseLowBrush" />
 
-            <x:Double x:Key="ToggleSwitchOnStrokeThickness">2</x:Double>
+            <x:Double x:Key="ToggleSwitchOnStrokeThickness">1</x:Double>
+            <x:Double x:Key="ToggleSwitchOuterBorderStrokeThickness">1</x:Double>
             <SolidColorBrush x:Key="ToggleSwitchCurtainBackgroundThemeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <SolidColorBrush x:Key="ToggleSwitchCurtainDisabledBackgroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
             <SolidColorBrush x:Key="ToggleSwitchCurtainPointerOverBackgroundThemeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
@@ -126,6 +128,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <x:Double x:Key="ToggleSwitchOnStrokeThickness">0</x:Double>
+            <x:Double x:Key="ToggleSwitchOuterBorderStrokeThickness">1</x:Double>
             <StaticResource x:Key="ToggleSwitchContentForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="ToggleSwitchContentForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="ToggleSwitchHeaderForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -505,7 +508,7 @@
                                 RadiusY="10"
                                 Fill="{ThemeResource ToggleSwitchFillOff}"
                                 Stroke="{ThemeResource ToggleSwitchStrokeOff}"
-                                StrokeThickness="2" />
+                                StrokeThickness="{ThemeResource ToggleSwitchOuterBorderStrokeThickness}" />
                             <Rectangle x:Name="SwitchKnobBounds"
                                 Grid.Row="1"
                                 Height="20"

--- a/dev/RadioButtons/RadioButtons_themeresources.xaml
+++ b/dev/RadioButtons/RadioButtons_themeresources.xaml
@@ -3,6 +3,17 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <Thickness x:Key="RadioButtonBorderThemeThickness">1</Thickness>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+            <Thickness x:Key="RadioButtonBorderThemeThickness">1</Thickness>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+            <Thickness x:Key="RadioButtonBorderThemeThickness">1</Thickness>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 
     <Style TargetType="ListViewItem" x:Key="RadioButtonsItemStyle">
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
@@ -137,8 +148,8 @@
                                 StrokeThickness="{ThemeResource RadioButtonBorderThemeThickness}" />
 
                             <Ellipse x:Name="CheckGlyph"
-                                Width="10"
-                                Height="10"
+                                Width="12"
+                                Height="12"
                                 UseLayoutRounding="False"
                                 Opacity="0"
                                 Fill="{ThemeResource RadioButtonCheckGlyphFill}"


### PR DESCRIPTION
This commit updates all the Selectors borders to use a thickness of 1px (#835) based on the visual comp [here](https://github.com/microsoft/microsoft-ui-xaml-specs/blob/user/chigy/borderstrokes/active/borderstrokes/images/Selectors.png).