### PR TITLE
Changing the job attempt count check in OutputTestResults.ps1 to only function for PRs

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -31,4 +31,4 @@ jobs:
     inputs:
       targetType: filePath
       filePath: build\Helix\OutputTestResults.ps1
-      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}' -CheckJobAttempt $$${{ parameters.checkJobAttempt }}
+      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}' -CheckJobAttempt $${{ parameters.checkJobAttempt }}

--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -2,6 +2,7 @@ parameters:
   dependsOn: ''
   rerunPassesRequiredToAvoidFailure: 5
   minimumExpectedTestsExecutedCount: 3000
+  checkJobAttempt: false
 
 jobs:
 - job: ProcessTestResults
@@ -30,4 +31,4 @@ jobs:
     inputs:
       targetType: filePath
       filePath: build\Helix\OutputTestResults.ps1
-      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}'
+      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}' -CheckJobAttempt '${{ parameters.checkJobAttempt }}'

--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -31,4 +31,4 @@ jobs:
     inputs:
       targetType: filePath
       filePath: build\Helix\OutputTestResults.ps1
-      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}' -CheckJobAttempt '${{ parameters.checkJobAttempt }}'
+      arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}' -CheckJobAttempt $$${{ parameters.checkJobAttempt }}

--- a/build/Helix/OutputTestResults.ps1
+++ b/build/Helix/OutputTestResults.ps1
@@ -33,6 +33,7 @@ foreach ($testRun in ($testRuns.value | Sort-Object -Property "completedDate"))
 {
     # The same build for a pull request can have multiple test runs associated with it if the build owner opted to re-run a test run.
     # We should only pay attention to the current attempt version.
+    # NB: If in the future we have pull request builds do multiple test runs as part of the same build definition, we'll need to revisit this.
     if ($BuildReason -ieq "PullRequest")
     {
         if (-not $timesSeenByRunName.ContainsKey($testRun.name))

--- a/build/Helix/OutputTestResults.ps1
+++ b/build/Helix/OutputTestResults.ps1
@@ -7,7 +7,7 @@ Param(
     [string]$TeamProject = $env:SYSTEM_TEAMPROJECT,
     [string]$BuildUri = $env:BUILD_BUILDURI,
     [int]$JobAttempt = $env:SYSTEM_JOBATTEMPT,
-    [string]$BuildReason = $env:BUILD_REASON
+    [bool]$CheckJobAttempt
 )
 
 $azureDevOpsRestApiHeaders = @{
@@ -34,7 +34,7 @@ foreach ($testRun in ($testRuns.value | Sort-Object -Property "completedDate"))
     # The same build for a pull request can have multiple test runs associated with it if the build owner opted to re-run a test run.
     # We should only pay attention to the current attempt version.
     # NB: If in the future we have pull request builds do multiple test runs as part of the same build definition, we'll need to revisit this.
-    if ($BuildReason -ieq "PullRequest")
+    if ($CheckJobAttempt)
     {
         if (-not $timesSeenByRunName.ContainsKey($testRun.name))
         {

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -83,3 +83,4 @@ jobs:
     dependsOn: RunTestsInHelix
     rerunPassesRequiredToAvoidFailure: 5
     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+    checkJobAttempt: true


### PR DESCRIPTION
In my last change I had us make sure that we're only considering the latest test run in cases where a PR has multiple test runs associated with the same build.  However, that caused problems in CI builds where we have multiple test runs in the same build definition, and Azure DevOps doesn't seem to provide an obvious way to tell between the two cases.

Since CI builds are the only builds that have multiple test runs in the same build definition, and since PR builds are the only case where we care about change authors scheduling multiple test runs in a row, I've changed things so we only do this behavior for PR builds.

If in the future we change the PR build definition to include multiple test runs, we'll need to revisit this, but for now this should suffice.  I've added a comment indicating as much.