### PR TITLE
Fixing AutoSuggestBox list for April 2018 Update and earlier OS versions

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.757
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dev", "dev", "{67599AD5-51EC-44CB-85CE-B60CD8CBA270}"
 EndProject
@@ -672,6 +672,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ComboBox_APITests", "dev\Co
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AutoSuggestBox_APITests", "dev\AutoSuggestBox\APITests\AutoSuggestBox_APITests.shproj", "{84673739-208C-427E-A19E-E090EC3733CE}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AutoSuggestBox_InteractionTests", "dev\AutoSuggestBox\InteractionTests\AutoSuggestBox_InteractionTests.shproj", "{ED3E2182-D259-4DC0-B7BB-9B4219762F4C}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		dev\ComboBox\ComboBox.vcxitems*{00523caf-422a-4185-9392-d374b72a019a}*SharedItemsImports = 9
@@ -963,6 +965,7 @@ Global
 		dev\NavigationView\NavigationView_ApiTests\NavigationView_ApiTests.projitems*{e98f3da3-3c00-4f2e-bf3b-2d2ad9d176bc}*SharedItemsImports = 13
 		dev\ColorPicker\APITests\ColorPicker_APITests.projitems*{e9ac4938-ec2a-46d3-85bf-27316db8cc4d}*SharedItemsImports = 13
 		test\MUXControls.Test\MUXControls.Test.Shared.projitems*{e9fc52cd-519a-41bb-8092-523ffa9d5617}*SharedItemsImports = 13
+		dev\AutoSuggestBox\InteractionTests\AutoSuggestBox_InteractionTests.projitems*{ed3e2182-d259-4dc0-b7bb-9b4219762f4c}*SharedItemsImports = 13
 		dev\PullToRefresh\RefreshVisualizer\RefreshVisualizer.vcxitems*{ed7dba65-8f09-44f3-8d25-7bb5a7a89609}*SharedItemsImports = 9
 		dev\TreeView\TreeView.vcxitems*{eeb38379-3a5c-439f-bb5e-535d75f2b6c1}*SharedItemsImports = 9
 		dev\PullToRefresh\RefreshContainer\InteractionTests\RefreshContainer_InteractionTests.projitems*{f30fe0d3-2e44-405e-8519-ec3ab098c41f}*SharedItemsImports = 13
@@ -1667,6 +1670,7 @@ Global
 		{D8CEA3B7-0012-4F74-B50F-B46E9A93C979} = {7DAE09F6-69EB-4FB3-9F52-AF746CA84DC9}
 		{CA704A8C-2624-4630-89A0-D86CB1EE409A} = {4C9CEC92-77C8-4B7B-8595-6C736A660F93}
 		{84673739-208C-427E-A19E-E090EC3733CE} = {CFAFD6A7-FC7B-4C96-B292-A440C7C65D89}
+		{ED3E2182-D259-4DC0-B7BB-9B4219762F4C} = {CFAFD6A7-FC7B-4C96-B292-A440C7C65D89}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D93836AB-52D3-4DE2-AE25-23F26F55ECED}

--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -410,6 +410,9 @@
                                     BorderBrush="{ThemeResource AutoSuggestBoxSuggestionsListBorderBrush}"
                                     Background="{ThemeResource AutoSuggestBoxSuggestionsListBackground}"
                                     CornerRadius="{TemplateBinding CornerRadius}">
+                                <Border.RenderTransform>
+                                    <contract7NotPresent:TranslateTransform x:Name="UpwardTransform" />
+                                </Border.RenderTransform>
                                 <ListView
                                     x:Name="SuggestionsList"
                                     DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
@@ -418,7 +421,11 @@
                                     ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                     ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
                                     MaxHeight="{ThemeResource AutoSuggestListMaxHeight}"
-                                    Margin="{ThemeResource AutoSuggestListPadding}" />
+                                    Margin="{ThemeResource AutoSuggestListPadding}">
+                                    <ListView.ItemContainerTransitions>
+                                        <contract7NotPresent:TransitionCollection />
+                                    </ListView.ItemContainerTransitions>
+                                </ListView>
                             </Border>
                         </Popup>
 

--- a/dev/AutoSuggestBox/InteractionTests/AutoSuggestBoxTests.cs
+++ b/dev/AutoSuggestBox/InteractionTests/AutoSuggestBoxTests.cs
@@ -16,13 +16,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
-using Microsoft.Windows.Apps.Test.Automation;
-using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
 using Microsoft.Windows.Apps.Test.Foundation.Patterns;
-using Microsoft.Windows.Apps.Test.Foundation.Waiters;
-using Image = Microsoft.Windows.Apps.Test.Foundation.Controls.Image;
-using Point = System.Drawing.Point;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {

--- a/dev/AutoSuggestBox/InteractionTests/AutoSuggestBoxTests.cs
+++ b/dev/AutoSuggestBox/InteractionTests/AutoSuggestBoxTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+using Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+
+#if USING_TAEF
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+using WEX.Logging.Interop;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+#endif
+
+using Microsoft.Windows.Apps.Test.Automation;
+using Microsoft.Windows.Apps.Test.Foundation;
+using Microsoft.Windows.Apps.Test.Foundation.Controls;
+using Microsoft.Windows.Apps.Test.Foundation.Patterns;
+using Microsoft.Windows.Apps.Test.Foundation.Waiters;
+using Image = Microsoft.Windows.Apps.Test.Foundation.Controls.Image;
+using Point = System.Drawing.Point;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
+{
+    [TestClass]
+    public class AutoSuggestBox
+    {
+        [ClassInitialize]
+        [TestProperty("RunAs", "User")]
+        [TestProperty("Classification", "Integration")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TestEnvironment.Initialize(testContext);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TestCleanupHelper.Cleanup();
+        }
+        
+        [TestMethod]
+        public void CanSelectSuggestion()
+        {
+            using (var setup = new TestSetupHelper("AutoSuggestBox Tests"))
+            {
+                Edit autoSuggestBoxTextBox = new Edit(FindElement.ByNameAndClassName("With suggestions", "TextBox"));
+                FocusHelper.SetFocus(autoSuggestBoxTextBox);
+                KeyboardHelper.EnterText(autoSuggestBoxTextBox, "test");
+                KeyboardHelper.PressKey(Key.Enter);
+                InvokeImplementation dolorItem = new InvokeImplementation(FindElement.ByNameAndClassName("dolor", "ListViewItem"));
+
+                using (ValueChangedEventWaiter waiter = new ValueChangedEventWaiter(autoSuggestBoxTextBox, "dolor"))
+                {
+                    dolorItem.Invoke();
+                }
+
+                Verify.AreEqual("dolor", autoSuggestBoxTextBox.Value);
+            }
+        }
+    }
+}

--- a/dev/AutoSuggestBox/InteractionTests/AutoSuggestBox_InteractionTests.projitems
+++ b/dev/AutoSuggestBox/InteractionTests/AutoSuggestBox_InteractionTests.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>afaad014-132c-4d2a-a28e-4ef717d3e647</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>AutoSuggestBox_InteractionTests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AutoSuggestBoxTests.cs" />
+  </ItemGroup>
+</Project>

--- a/dev/AutoSuggestBox/InteractionTests/AutoSuggestBox_InteractionTests.shproj
+++ b/dev/AutoSuggestBox/InteractionTests/AutoSuggestBox_InteractionTests.shproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{ED3E2182-D259-4DC0-B7BB-9B4219762F4C}</ProjectGuid>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="AutoSuggestBox_InteractionTests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/dev/AutoSuggestBox/TestUI/AutoSuggestBoxPage.xaml
+++ b/dev/AutoSuggestBox/TestUI/AutoSuggestBoxPage.xaml
@@ -12,6 +12,7 @@
     <StackPanel>
         <AutoSuggestBox/>
         <AutoSuggestBox Header="WithHeader"/>
+        <AutoSuggestBox Header="With suggestions" QuerySubmitted="AutoSuggestBox_QuerySubmitted" />
     </StackPanel>
 
 </local:TestPage>

--- a/dev/AutoSuggestBox/TestUI/AutoSuggestBoxPage.xaml.cs
+++ b/dev/AutoSuggestBox/TestUI/AutoSuggestBoxPage.xaml.cs
@@ -6,9 +6,23 @@ namespace MUXControlsTestApp
     [TopLevelTestPage(Name = "AutoSuggestBox", Icon = "AutoSuggestBox.png")]
     public sealed partial class AutoSuggestBoxPage : TestPage
     {
+        string[] suggestions =
+        {
+            "Lorem",
+            "ipsum",
+            "dolor",
+            "sit",
+            "amet"
+        };
+
         public AutoSuggestBoxPage()
         {
             this.InitializeComponent();
+        }
+
+        private void AutoSuggestBox_QuerySubmitted(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxQuerySubmittedEventArgs args)
+        {
+            sender.ItemsSource = string.IsNullOrWhiteSpace(args.QueryText) ? null : suggestions;
         }
     }
 }

--- a/test/MUXControls.Test/MUXControls.Test.Shared.targets
+++ b/test/MUXControls.Test/MUXControls.Test.Shared.targets
@@ -27,6 +27,7 @@
   <Import Project="..\..\dev\RadioMenuFlyoutItem\InteractionTests\RadioMenuFlyoutItem_InteractionTests.projitems" Label="Shared" Condition="$(FeatureRadioMenuFlyoutItemEnabled) == 'true'" />
   <Import Project="..\..\dev\TeachingTip\InteractionTests\TeachingTip_InteractionTests.projitems" Label="Shared" Condition="$(FeatureTeachingTipEnabled) == 'true'" />
   <Import Project="..\..\dev\AnimatedVisualPlayer\InteractionTests\AnimatedVisualPlayer_InteractionTests.projitems" Label="Shared" Condition="$(FeatureAnimatedVisualPlayerEnabled) == 'true'" />
+  <Import Project="..\..\dev\AutoSuggestBox\InteractionTests\AutoSuggestBox_InteractionTests.projitems" Label="Shared" Condition="$(FeatureAutoSuggestBoxEnabled) == 'true'" />
   <!-- These two depend on the type InteractionBase, which is behind the Velocity feature Feature_Xaml2018 in the OS repo.
        We can't compile them without attaching the same feature annotation, and MIDL doesn't let us attach feature attributes
        to non-public types.  So for now we'll just exclude these from the OS repo. -->


### PR DESCRIPTION
During our consolidation of templates, a couple parts from the AutoSuggestBox's template from the April 2018 Update and earlier versions was mistakenly removed, which broke the ASB's list display.  I've put those components back specifically for those OS versions, and have added a regression test to ensure this doesn't regress in the future.