### PR TITLE
TabView: Add IsClosing event and tooltip on tab item, adjust behavior of CanCloseTabs

### DIFF
--- a/dev/Generated/TabViewItem.properties.cpp
+++ b/dev/Generated/TabViewItem.properties.cpp
@@ -30,7 +30,7 @@ void TabViewItemProperties::EnsureProperties()
                 winrt::name_of<winrt::TabViewItem>(),
                 false /* isAttached */,
                 ValueHelper<winrt::IInspectable>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnHeaderPropertyChanged));
     }
     if (!s_HeaderTemplateProperty)
     {
@@ -73,6 +73,14 @@ void TabViewItemProperties::ClearProperties()
     s_HeaderTemplateProperty = nullptr;
     s_IconProperty = nullptr;
     s_IsCloseableProperty = nullptr;
+}
+
+void TabViewItemProperties::OnHeaderPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::TabViewItem>();
+    winrt::get_self<TabViewItem>(owner)->OnHeaderPropertyChanged(args);
 }
 
 void TabViewItemProperties::OnIsCloseablePropertyChanged(

--- a/dev/Generated/TabViewItem.properties.cpp
+++ b/dev/Generated/TabViewItem.properties.cpp
@@ -14,6 +14,7 @@ GlobalDependencyProperty TabViewItemProperties::s_IconProperty{ nullptr };
 GlobalDependencyProperty TabViewItemProperties::s_IsCloseableProperty{ nullptr };
 
 TabViewItemProperties::TabViewItemProperties()
+    : m_tabClosingEventSource{static_cast<TabViewItem*>(this)}
 {
     EnsureProperties();
 }
@@ -120,4 +121,14 @@ void TabViewItemProperties::IsCloseable(bool value)
 bool TabViewItemProperties::IsCloseable()
 {
     return ValueHelper<bool>::CastOrUnbox(static_cast<TabViewItem*>(this)->GetValue(s_IsCloseableProperty));
+}
+
+winrt::event_token TabViewItemProperties::TabClosing(winrt::TypedEventHandler<winrt::TabViewItem, winrt::TabViewTabClosingEventArgs> const& value)
+{
+    return m_tabClosingEventSource.add(value);
+}
+
+void TabViewItemProperties::TabClosing(winrt::event_token const& token)
+{
+    m_tabClosingEventSource.remove(token);
 }

--- a/dev/Generated/TabViewItem.properties.h
+++ b/dev/Generated/TabViewItem.properties.h
@@ -31,6 +31,11 @@ public:
     static GlobalDependencyProperty s_IconProperty;
     static GlobalDependencyProperty s_IsCloseableProperty;
 
+    winrt::event_token TabClosing(winrt::TypedEventHandler<winrt::TabViewItem, winrt::TabViewTabClosingEventArgs> const& value);
+    void TabClosing(winrt::event_token const& token);
+
+    event_source<winrt::TypedEventHandler<winrt::TabViewItem, winrt::TabViewTabClosingEventArgs>> m_tabClosingEventSource;
+
     static void EnsureProperties();
     static void ClearProperties();
 

--- a/dev/Generated/TabViewItem.properties.h
+++ b/dev/Generated/TabViewItem.properties.h
@@ -39,6 +39,10 @@ public:
     static void EnsureProperties();
     static void ClearProperties();
 
+    static void OnHeaderPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
     static void OnIsCloseablePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -190,7 +190,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(closeButton);
 
                 tab = FindElement.ByName("LongHeaderTab");
-                Log.Comment("Third close button should be visible because IsCloseable is still unset");
+                Log.Comment("Third close button should not be visible because IsCloseable is still unset");
                 closeButton = FindCloseButton(tab);
                 Verify.IsNull(closeButton);
             }
@@ -304,6 +304,53 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Verify event fired");
                 Verify.AreEqual(dragOutsideTextBlock.DocumentText, "Home");
             }
+        }
+
+        [TestMethod]
+        public void ToolTipDefaultTest()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Log.Comment("If the app sets custom tooltip text, it should be preserved.");
+                VerifyTooltipText("GetTab0ToolTipButton", "Tab0ToolTipTextBlock", "Custom Tooltip");
+
+                Log.Comment("If the app does not set a custom tooltip, it should be the same as the header text.");
+                VerifyTooltipText("GetTab1ToolTipButton", "Tab1ToolTipTextBlock", "Shop");
+
+                Button changeShopTextButton = FindElement.ByName<Button>("ChangeShopTextButton");
+                changeShopTextButton.InvokeAndWait();
+
+                Log.Comment("If the tab's header changes, the tooltip should update.");
+                VerifyTooltipText("GetTab1ToolTipButton", "Tab1ToolTipTextBlock", "Changed");
+            }
+        }
+
+        [TestMethod]
+        public void ToolTipUpdateTest()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Button customTooltipButton = FindElement.ByName<Button>("CustomTooltipButton");
+                customTooltipButton.InvokeAndWait();
+
+                Log.Comment("If the app updates the tooltip, it should change to their custom one.");
+                VerifyTooltipText("GetTab1ToolTipButton", "Tab1ToolTipTextBlock", "Custom");
+
+                Button changeShopTextButton = FindElement.ByName<Button>("ChangeShopTextButton");
+                changeShopTextButton.InvokeAndWait();
+
+                Log.Comment("The tooltip should not update if the header changes.");
+                VerifyTooltipText("GetTab1ToolTipButton", "Tab1ToolTipTextBlock", "Custom");
+            }
+        }
+
+        public void VerifyTooltipText(String buttonName, String textBlockName, String expectedText)
+        {
+            Button button = FindElement.ByName<Button>(buttonName);
+            button.InvokeAndWait();
+
+            TextBlock textBlock = FindElement.ByName<TextBlock>(textBlockName);
+            Verify.AreEqual(textBlock.DocumentText, expectedText);
         }
 
         Button FindCloseButton(UIObject tabItem)

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -179,7 +179,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Wait.ForIdle();
 
                 ElementCache.Refresh();
+
+                Log.Comment("First close button should be visible because IsCloseable was set to true");
                 closeButton = FindCloseButton(firstTab);
+                Verify.IsNotNull(closeButton);
+
+                UIObject tab = FindElement.ByName("SecondTab");
+                Log.Comment("Second close button should be visible because IsCloseable was set to true in xaml");
+                closeButton = FindCloseButton(tab);
+                Verify.IsNotNull(closeButton);
+
+                tab = FindElement.ByName("LongHeaderTab");
+                Log.Comment("Third close button should be visible because IsCloseable is still unset");
+                closeButton = FindCloseButton(tab);
                 Verify.IsNull(closeButton);
             }
         }
@@ -205,9 +217,22 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(firstTab);
 
                 cancelCloseCheckBox.Uncheck();
+
+                CheckBox cancelItemCloseCheckBox = FindElement.ByName<CheckBox>("CancelItemCloseCheckBox");
+                cancelCloseCheckBox.Check();
                 Wait.ForIdle();
 
-                Log.Comment("Clicking close button should close tab if app doesn't handle TabClosing event.");
+                Log.Comment("Clicking close button should not close tab if the tab item returns cancel = true.");
+                closeButton.InvokeAndWait();
+
+                ElementCache.Refresh();
+                firstTab = TryFindElement.ByName("FirstTab");
+                Verify.IsNotNull(firstTab);
+
+                cancelCloseCheckBox.Uncheck();
+                Wait.ForIdle();
+
+                Log.Comment("Clicking close button should close tab if app doesn't handle either TabClosing event.");
                 closeButton.InvokeAndWait();
 
                 ElementCache.Refresh();

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -121,6 +121,8 @@ unsealed runtimeclass TabViewItem : Windows.UI.Xaml.Controls.ListViewItem
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Boolean IsCloseable{ get; set; };
 
+    event Windows.Foundation.TypedEventHandler<TabViewItem, TabViewTabClosingEventArgs> TabClosing;
+
     static Windows.UI.Xaml.DependencyProperty HeaderProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty IconProperty{ get; };

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -111,6 +111,7 @@ unsealed runtimeclass TabViewItem : Windows.UI.Xaml.Controls.ListViewItem
 {
     TabViewItem();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Object Header{ get; set; };
 
     Windows.UI.Xaml.DataTemplate HeaderTemplate{ get; set; };

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -55,12 +55,10 @@ void TabViewItem::UpdateCloseButton()
         bool canClose = IsCloseable();
         if (auto tabView = SharedHelpers::GetAncestorOfType<winrt::TabView>(winrt::VisualTreeHelper::GetParent(*this)))
         {
-            if (!tabView.CanCloseTabs())
+            // IsCloseable defaults to true, but if it hasn't been set then CanCloseTabs should override it.
+            if (!tabView.CanCloseTabs() && ReadLocalValue(IsCloseableProperty()) == winrt::DependencyProperty::UnsetValue())
             {
-                if (!canClose || ReadLocalValue(IsCloseableProperty()) == winrt::DependencyProperty::UnsetValue())
-                {
-                    canClose = false;
-                }
+                canClose = false;
             }
         }
 

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -25,6 +25,7 @@ public:
     winrt::AutomationPeer OnCreateAutomationPeer();
 
     void OnIsCloseablePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnHeaderPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
  private:
     tracker_ref<winrt::Button> m_closeButton{ this };

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -29,8 +29,11 @@ public:
 
  private:
     tracker_ref<winrt::Button> m_closeButton{ this };
+    tracker_ref<winrt::ToolTip> m_toolTip{ this };
 
     void UpdateCloseButton();
+
+    bool m_firstTimeSettingToolTip{ true };
 
     PropertyChanged_revoker m_CanCloseTabsChangedRevoker{};
     winrt::ButtonBase::Click_revoker m_closeButtonClickRevoker{};

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -24,9 +24,11 @@
                 <CheckBox x:Name="CancelItemCloseCheckBox" AutomationProperties.Name="CancelItemCloseCheckBox" Content="Cancel Closing on first item"/>
                 <CheckBox x:Name="IsAddButtonVisibleCheckBox" AutomationProperties.Name="IsAddButtonVisibleCheckBox" Content="Add button visible" IsChecked="{x:Bind Tabs.IsAddButtonVisible, Mode=TwoWay}"/>
 
-                <Button x:Name="RemoveTabButton" AutomationProperties.Name="RemoveTabButton"  Content="Remove Tab" Margin="0,0,0,8" Click="RemoveTabButton_Click"/>
-                <Button x:Name="SelectItemButton" AutomationProperties.Name="SelectItemButton"  Content="Select Item 1" Margin="0,0,0,8" Click="SelectItemButton_Click"/>
-                <Button x:Name="SelectIndexButton" AutomationProperties.Name="SelectIndexButton"  Content="Select Index 2" Margin="0,0,0,8" Click="SelectIndexButton_Click"/>
+                <Button x:Name="RemoveTabButton" AutomationProperties.Name="RemoveTabButton" Content="Remove Tab" Margin="0,0,0,8" Click="RemoveTabButton_Click"/>
+                <Button x:Name="SelectItemButton" AutomationProperties.Name="SelectItemButton" Content="Select Item 1" Margin="0,0,0,8" Click="SelectItemButton_Click"/>
+                <Button x:Name="SelectIndexButton" AutomationProperties.Name="SelectIndexButton" Content="Select Index 2" Margin="0,0,0,8" Click="SelectIndexButton_Click"/>
+                <Button x:Name="ChangeShopTextButton" AutomationProperties.Name="ChangeShopTextButton" Content="Change Shop text" Margin="0,0,0,8" Click="ChangeShopTextButton_Click"/>
+                <Button x:Name="CustomTooltipButton" AutomationProperties.Name="CustomTooltipButton" Content="Custom Tooltip" Margin="0,0,0,8" Click="CustomTooltipButton_Click"/>
 
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                     <TextBlock VerticalAlignment="Center">Tab Width:</TextBlock>
@@ -44,6 +46,16 @@
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                     <TextBlock>Tab dragged out:</TextBlock>
                     <TextBlock x:Name="TabDraggedOutsideTextBlock" AutomationProperties.Name="TabDraggedOutsideTextBlock" Margin="4,0,0,0" Text=""/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="GetTab0ToolTipButton" AutomationProperties.Name="GetTab0ToolTipButton" Content="Tooltip0" Click="GetTab0ToolTipButton_Click"/>
+                    <TextBlock x:Name="Tab0ToolTipTextBlock" AutomationProperties.Name="Tab0ToolTipTextBlock" Margin="4,0,0,0" Text=""/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="GetTab1ToolTipButton" AutomationProperties.Name="GetTab1ToolTipButton" Content="Tooltip1" Click="GetTab1ToolTipButton_Click"/>
+                    <TextBlock x:Name="Tab1ToolTipTextBlock" AutomationProperties.Name="Tab1ToolTipTextBlock" Margin="4,0,0,0" Text=""/>
                 </StackPanel>
             </StackPanel>
 
@@ -71,7 +83,7 @@
 
                 <controls:TabView.Items>
 
-                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Icon="Home" Header="Home" TabClosing="FirstTab_TabClosing">
+                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Icon="Home" Header="Home" TabClosing="FirstTab_TabClosing" ToolTipService.ToolTip="Custom Tooltip">
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8">Home Button</Button>
                             <Button x:Name="FirstTabButton2" AutomationProperties.Name="FirstTabButton2" Margin="8">Another Button</Button>

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -21,6 +21,7 @@
                 <CheckBox x:Name="CanCloseCheckBox" AutomationProperties.Name="CanCloseCheckBox" Checked="CanCloseCheckBox_CheckChanged" Unchecked="CanCloseCheckBox_CheckChanged" IsChecked="True" Content="CanCloseTabs"/>
                 <CheckBox x:Name="IsCloseableCheckBox" AutomationProperties.Name="IsCloseableCheckBox" Checked="IsCloseableCheckBox_CheckChanged" Unchecked="IsCloseableCheckBox_CheckChanged" IsChecked="True" Content="IsCloseable on first tab"/>
                 <CheckBox x:Name="CancelCloseCheckBox" AutomationProperties.Name="CancelCloseCheckBox" Content="Cancel Closing event"/>
+                <CheckBox x:Name="CancelItemCloseCheckBox" AutomationProperties.Name="CancelItemCloseCheckBox" Content="Cancel Closing on first item"/>
                 <CheckBox x:Name="IsAddButtonVisibleCheckBox" AutomationProperties.Name="IsAddButtonVisibleCheckBox" Content="Add button visible" IsChecked="{x:Bind Tabs.IsAddButtonVisible, Mode=TwoWay}"/>
 
                 <Button x:Name="RemoveTabButton" AutomationProperties.Name="RemoveTabButton"  Content="Remove Tab" Margin="0,0,0,8" Click="RemoveTabButton_Click"/>
@@ -70,14 +71,14 @@
 
                 <controls:TabView.Items>
 
-                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Icon="Home" Header="Home">
+                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Icon="Home" Header="Home" TabClosing="FirstTab_TabClosing">
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8">Home Button</Button>
                             <Button x:Name="FirstTabButton2" AutomationProperties.Name="FirstTabButton2" Margin="8">Another Button</Button>
                         </StackPanel>
                     </controls:TabViewItem>
 
-                    <controls:TabViewItem x:Name="SecondTab" AutomationProperties.Name="SecondTab" Icon="Shop" Header="Shop">
+                    <controls:TabViewItem x:Name="SecondTab" AutomationProperties.Name="SecondTab" Icon="Shop" Header="Shop" IsCloseable="True">
                         <TextBlock Padding="16">Shop text</TextBlock>
                     </controls:TabViewItem>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -110,6 +110,14 @@ namespace MUXControlsTestApp
             }
         }
 
+        private void FirstTab_TabClosing(object sender, Microsoft.UI.Xaml.Controls.TabViewTabClosingEventArgs e)
+        {
+            if (CancelItemCloseCheckBox.IsChecked == true)
+            {
+                e.Cancel = true;
+            }
+        }
+
         private void TabViewTabDraggedOutside(object sender, Microsoft.UI.Xaml.Controls.TabViewTabDraggedOutsideEventArgs e)
         {
             TabViewItem tab = e.Tab;

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -84,6 +84,39 @@ namespace MUXControlsTestApp
             }
         }
 
+        public void ChangeShopTextButton_Click(object sender, RoutedEventArgs e)
+        {
+            SecondTab.Header = "Changed";
+        }
+
+        public void CustomTooltipButton_Click(object sender, RoutedEventArgs e)
+        {
+            ToolTipService.SetToolTip(SecondTab, "Custom");
+        }
+
+        public void GetTab0ToolTipButton_Click(object sender, RoutedEventArgs e)
+        {
+            GetToolTipStringForTab(FirstTab, Tab0ToolTipTextBlock);
+        }
+
+        public void GetTab1ToolTipButton_Click(object sender, RoutedEventArgs e)
+        {
+            GetToolTipStringForTab(SecondTab, Tab1ToolTipTextBlock);
+        }
+
+        public void GetToolTipStringForTab(TabViewItem item, TextBlock textBlock)
+        {
+            var tooltip = ToolTipService.GetToolTip(item);
+            if (tooltip is ToolTip)
+            {
+                textBlock.Text = (tooltip as ToolTip).Content.ToString();
+            }
+            else
+            {
+                textBlock.Text = tooltip.ToString();
+            }
+        }
+
         private void TabWidthComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (Tabs != null)
@@ -104,18 +137,12 @@ namespace MUXControlsTestApp
 
         private void TabViewTabClosing(object sender, Microsoft.UI.Xaml.Controls.TabViewTabClosingEventArgs e)
         {
-            if (CancelCloseCheckBox.IsChecked == true)
-            {
-                e.Cancel = true;
-            }
+            e.Cancel = (bool)CancelCloseCheckBox.IsChecked;
         }
 
         private void FirstTab_TabClosing(object sender, Microsoft.UI.Xaml.Controls.TabViewTabClosingEventArgs e)
         {
-            if (CancelItemCloseCheckBox.IsChecked == true)
-            {
-                e.Cancel = true;
-            }
+            e.Cancel = (bool)CancelItemCloseCheckBox.IsChecked;
         }
 
         private void TabViewTabDraggedOutside(object sender, Microsoft.UI.Xaml.Controls.TabViewTabDraggedOutsideEventArgs e)


### PR DESCRIPTION
CanCloseTabs is a default, it doesn't override IsCloseable on the individual tabs. I updated the tab closing test case also. IsClosing was already on TabView, now added to TabViewItem and updated the test. Tabs also have tooltips now in case the header text doesn't fit.