### PR TITLE
Fixing the test number check for MUX-Release

### DIFF
--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -1,6 +1,6 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
-  minimumExpectedTestsExecutedCount: 50  # Sanity check for minimum expected tests to be reported
+  minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
 jobs:
 - job: ComponentDetection
   pool:


### PR DESCRIPTION
We only having 35 tests we run in the NuGet suite, so 50 is too large a number for our sanity checking purposes.  Updating to 35.