### PR TITLE
Fix NavView VisualState for pane closing

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -596,6 +596,7 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
     if (previousMode == winrt::NavigationViewDisplayMode::Expanded
         && displayMode == winrt::NavigationViewDisplayMode::Compact)
     {
+        m_initialListSizeStateSet = false;
         ClosePane();
     }
 }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3885,6 +3885,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
                 Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be False");
 
+                var getVisualStateButton = new Button(FindElement.ByName("GetNavViewActiveVisualStates"));
+                getVisualStateButton.Invoke();
+                Wait.ForIdle();
+                var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
+                Verify.IsTrue(result.GetText().Contains("ListSizeCompact"), "Verify pane list is in ListSizeCompact state");
+
                 // Maximize the window
                 KeyboardHelper.PressKey(Key.Right, ModifierKey.Windows, 1);
                 KeyboardHelper.PressKey(Key.Up, ModifierKey.Windows, 1);


### PR DESCRIPTION
Fixes #726.

When m_initialListSizeStateSet is set to true, NavView skips list size VisualState updates in NavigationView::UpdateIsClosedCompact, which causes this PaneCustomContent layout updating bug when pane open/closes. Set m_initialListSizeStateSet to false before closing NavView pane to fix the issue.