### PR TITLE
update to repeater to allow passing in uielements in itemssource

### DIFF
--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -47,20 +47,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                           <TextBlock Text='{Binding}' Height='50' />
                       </DataTemplate>");
 
-                repeater = new ItemsRepeater()
-                {
+                repeater = new ItemsRepeater() {
                     ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
                     ItemTemplate = elementFactory,
                     // Default is StackLayout, so do not have to explicitly set.
                     // Layout = new StackLayout(),
                 };
 
-                Content = new ItemsRepeaterScrollHost()
-                {
+                Content = new ItemsRepeaterScrollHost() {
                     Width = 400,
                     Height = 800,
-                    ScrollViewer = new ScrollViewer
-                    {
+                    ScrollViewer = new ScrollViewer {
                         Content = repeater
                     }
                 };
@@ -84,8 +81,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         {
             RunOnUIThread.Execute(() =>
             {
-                var repeater = new ItemsRepeater() 
-                {
+                var repeater = new ItemsRepeater() {
                     ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
                 };
 
@@ -239,7 +235,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         private void NestedRepeaterWithDataTemplateScenario(bool disableAnimation)
-        { 
+        {
             if (!disableAnimation && PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
             {
                 Log.Warning("This test is showing consistent issues with not scrolling enough on RS5 and 19H1 when animations are enabled, tracked by microsoft-ui-xaml#779");
@@ -431,7 +427,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     </controls:ItemsRepeaterScrollHost>");
 
                 rootRepeater = (ItemsRepeater)scrollhost.FindName("rootRepeater");
-                
+
                 List<List<int>> items = new List<List<int>>();
                 for (int i = 0; i < 100; i++)
                 {
@@ -455,6 +451,55 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.IsNotNull(group2Repeater);
 
                 Verify.IsNotNull(group2Repeater.TryGetElement(0));
+            });
+        }
+
+
+        [TestMethod]
+        public void VerifyUIElementsInItemsSource()
+        {
+            ItemsRepeater repeater = null;
+            RunOnUIThread.Execute(() =>
+            {
+                var scrollhost = (ItemsRepeaterScrollHost)XamlReader.Load(
+                  @"<controls:ItemsRepeaterScrollHost  
+                     xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                     xmlns:local='using:MUXControlsTestApp.Samples'
+                     xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                        <ScrollViewer>
+                            <controls:ItemsRepeater x:Name='repeater'>
+                                <controls:ItemsRepeater.ItemsSource>
+                                    <local:UICollection>
+                                        <Button>0</Button>
+                                        <Button>1</Button>
+                                        <Button>2</Button>
+                                        <Button>3</Button>
+                                        <Button>4</Button>
+                                        <Button>5</Button>
+                                        <Button>6</Button>
+                                        <Button>7</Button>
+                                        <Button>8</Button>
+                                        <Button>9</Button>
+                                    </local:UICollection>
+                                </controls:ItemsRepeater.ItemsSource>
+                            </controls:ItemsRepeater>
+                        </ScrollViewer>
+                    </controls:ItemsRepeaterScrollHost>");
+
+                repeater = (ItemsRepeater)scrollhost.FindName("repeater");
+                Content = scrollhost;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                for(int i=0; i<10;i++)
+                {
+                    var element = repeater.TryGetElement(i) as Button;
+                    Verify.AreEqual(i.ToString(), element.Content);
+                }
             });
         }
     }

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -18,6 +18,7 @@
         <StackPanel>
             <Button x:Name="defaultDemo" >Default Demo</Button>
             <Button x:Name="basicDemo" >Basic Demo</Button>
+            <Button x:Name="itemsSourceDemo" >ItemsSource Demo</Button>
             <Button x:Name="itemTemplateDemo" >ItemTemplate Demo</Button>
             <Button x:Name="collectionChangeDemo" >Collection Changes Demo</Button>
             <Button x:Name="animationsDemo" >Animations Demo</Button>

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
@@ -34,6 +34,11 @@ namespace MUXControlsTestApp
                 Frame.NavigateWithoutAnimation(typeof(BasicDemo));
             };
 
+            itemsSourceDemo.Click += delegate 
+            {
+                Frame.NavigateWithoutAnimation(typeof(ElementsInItemsSourcePage));
+            };
+
             itemTemplateDemo.Click += delegate
             {
                 Frame.NavigateWithoutAnimation(typeof(ItemTemplateDemo));

--- a/dev/Repeater/TestUI/Repeater_TestUI.projitems
+++ b/dev/Repeater/TestUI/Repeater_TestUI.projitems
@@ -44,6 +44,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Samples\ElementsInItemsSourcePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Samples\FlowLayoutDemoPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -115,6 +119,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Samples\Defaults.xaml.cs">
       <DependentUpon>Defaults.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Samples\ElementsInItemsSourcePage.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\FlowLayoutDemoPage.xaml.cs">
       <DependentUpon>FlowLayoutDemoPage.xaml</DependentUpon>
     </Compile>
@@ -194,6 +199,9 @@
   <ItemGroup>
     <Compile Update="S:\Source\GitRepos\microsoft-ui-xaml2\dev\Repeater\TestUI\Samples\ScaleAnimatedVerticalListDemo.xaml.cs">
       <DependentUpon>ScaleAnimatedVerticalListDemo.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="T:\repos\microsoft-ui-xaml\dev\Repeater\TestUI\Samples\ElementsInItemsSourcePage.xaml.cs">
+      <DependentUpon>ElementsInItemsSourcePage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/dev/Repeater/TestUI/Samples/ElementsInItemsSourcePage.xaml
+++ b/dev/Repeater/TestUI/Samples/ElementsInItemsSourcePage.xaml
@@ -1,0 +1,61 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Page
+    x:Class="MUXControlsTestApp.Samples.ElementsInItemsSourcePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:local="using:MUXControlsTestApp.Samples"
+    xmlns:coll="clr-namespace:System.Collections.ObjectModel;assembly=mscorlib">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="200" />
+        </Grid.RowDefinitions>
+
+        <StackPanel>
+            <Button x:Name="goBackButton">Back</Button>
+        </StackPanel>
+
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1">
+            <ScrollViewer x:Name="scrollViewer">
+                <controls:ItemsRepeater>
+                    <controls:ItemsRepeater.ItemsSource>
+                        <local:UICollection>
+                            <Button>1</Button>
+                            <Button>2</Button>
+                            <Button>3</Button>
+                            <Button>4</Button>
+                            <Button>5</Button>
+                            <Button>6</Button>
+                            <Button>7</Button>
+                            <Button>8</Button>
+                            <Button>9</Button>
+                            <Button>10</Button>
+                            <Button>11</Button>
+                            <Button>12</Button>
+                            <Button>13</Button>
+                            <Button>14</Button>
+                            <Button>15</Button>
+                            <Button>16</Button>
+                            <Button>17</Button>
+                            <Button>18</Button>
+                            <Button>19</Button>
+                            <Button>20</Button>
+                            <Button>21</Button>
+                            <Button>22</Button>
+                            <Button>23</Button>
+                            <Button>24</Button>
+                            <Button>25</Button>
+                            <Button>26</Button>
+                            <Button>27</Button>
+                            <Button>28</Button>
+                            <Button>29</Button>
+                            <Button>30</Button>                            
+                        </local:UICollection>
+                    </controls:ItemsRepeater.ItemsSource>
+                </controls:ItemsRepeater>
+            </ScrollViewer>
+        </controls:ItemsRepeaterScrollHost>
+    </Grid>
+</Page>

--- a/dev/Repeater/TestUI/Samples/ElementsInItemsSourcePage.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ElementsInItemsSourcePage.xaml.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.ObjectModel;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace MUXControlsTestApp.Samples
+{
+    public sealed partial class ElementsInItemsSourcePage : Page
+    {
+        public ElementsInItemsSourcePage()
+        {
+            this.InitializeComponent();
+            goBackButton.Click += delegate { Frame.GoBack(); };
+        }
+    }
+
+    public class UICollection: ObservableCollection<UIElement>
+    {
+        public UICollection()
+        {
+
+        }
+    }
+}

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -99,17 +99,15 @@ void ViewManager::ClearElement(const winrt::UIElement& element, bool isClearedDu
 
 void ViewManager::ClearElementToElementFactory(const winrt::UIElement& element)
 {
-    
+    m_owner->OnElementClearing(element);
+
     if (m_owner->ItemTemplateShim())
     {
-        m_owner->OnElementClearing(element);
-
         if (!m_ElementFactoryRecycleArgs)
         {
             // Create one.
             m_ElementFactoryRecycleArgs = tracker_ref<winrt::ElementFactoryRecycleArgs>(m_owner, *winrt::make_self<ElementFactoryRecycleArgs>());
         }
-
 
         auto context = m_ElementFactoryRecycleArgs.get();
         context.Element(element);
@@ -690,9 +688,10 @@ winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
 
     repeater->AnimationManager().OnElementPrepared(element);
 
+    repeater->OnElementPrepared(element, index);
+
     if (!itemsSourceContainsElements)
     {
-        repeater->OnElementPrepared(element, index);
         m_phaser.PhaseElement(element, virtInfo);
     }
 

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -99,25 +99,29 @@ void ViewManager::ClearElement(const winrt::UIElement& element, bool isClearedDu
 
 void ViewManager::ClearElementToElementFactory(const winrt::UIElement& element)
 {
-    auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);
-    const int clearedIndex = virtInfo->Index();
-    m_owner->OnElementClearing(element);
-
-    if (!m_ElementFactoryRecycleArgs)
+    
+    if (m_owner->ItemTemplateShim())
     {
-        // Create one.
-        m_ElementFactoryRecycleArgs = tracker_ref<winrt::ElementFactoryRecycleArgs>(m_owner, *winrt::make_self<ElementFactoryRecycleArgs>());
+        m_owner->OnElementClearing(element);
+
+        if (!m_ElementFactoryRecycleArgs)
+        {
+            // Create one.
+            m_ElementFactoryRecycleArgs = tracker_ref<winrt::ElementFactoryRecycleArgs>(m_owner, *winrt::make_self<ElementFactoryRecycleArgs>());
+        }
+
+
+        auto context = m_ElementFactoryRecycleArgs.get();
+        context.Element(element);
+        context.Parent(*m_owner);
+
+        m_owner->ItemTemplateShim().RecycleElement(context);
+
+        context.Element(nullptr);
+        context.Parent(nullptr);
     }
 
-    auto context = m_ElementFactoryRecycleArgs.get();
-    context.Element(element);
-    context.Parent(*m_owner);
-
-    m_owner->ItemTemplateShim().RecycleElement(context);
-
-    context.Element(nullptr);
-    context.Parent(nullptr);
-
+    auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);    
     virtInfo->MoveOwnershipToElementFactory();
     m_phaser.StopPhasing(element, virtInfo);
     if (m_lastFocusedElement == element)
@@ -125,6 +129,7 @@ void ViewManager::ClearElementToElementFactory(const winrt::UIElement& element)
         // Focused element is going away. Remove the tracked last focused element
         // and pick a reasonable next focus if we can find one within the layout 
         // realized elements.
+        const int clearedIndex = virtInfo->Index();
         MoveFocusFromClearedIndex(clearedIndex);
     }
 
@@ -583,33 +588,46 @@ winrt::UIElement ViewManager::GetElementFromPinnedElements(int index)
 winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
 {
     // The view generator is the provider of last resort.
-
+    auto data = m_owner->ItemsSourceView().GetAt(index);
+    
     auto itemTemplateFactory = m_owner->ItemTemplateShim();
+
+    winrt::UIElement element = nullptr;
+    bool itemsSourceContainsElements = false;
     if (!itemTemplateFactory)
     {
-        // If no ItemTemplate was provided, use a default 
-        auto factory = winrt::XamlReader::Load(L"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'><TextBlock Text='{Binding}'/></DataTemplate>").as<winrt::DataTemplate>();
-        m_owner->ItemTemplate(factory);
-        itemTemplateFactory = m_owner->ItemTemplateShim();
+        element = data.try_as<winrt::UIElement>();
+        // No item template provided and ItemsSource contains objects derived from UIElement.
+        // In this case, just use the data directly as elements.
+        itemsSourceContainsElements = element != nullptr;
     }
 
-    auto data = m_owner->ItemsSourceView().GetAt(index);
-
-    if (!m_ElementFactoryGetArgs)
+    if (!element)
     {
-        // Create one.
-        m_ElementFactoryGetArgs = tracker_ref<winrt::ElementFactoryGetArgs>(m_owner, *winrt::make_self<ElementFactoryGetArgs>());
+        if (!itemTemplateFactory)
+        {
+            // If no ItemTemplate was provided, use a default 
+            auto factory = winrt::XamlReader::Load(L"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'><TextBlock Text='{Binding}'/></DataTemplate>").as<winrt::DataTemplate>();
+            m_owner->ItemTemplate(factory);
+            itemTemplateFactory = m_owner->ItemTemplateShim();
+        }
+
+        if (!m_ElementFactoryGetArgs)
+        {
+            // Create one.
+            m_ElementFactoryGetArgs = tracker_ref<winrt::ElementFactoryGetArgs>(m_owner, *winrt::make_self<ElementFactoryGetArgs>());
+        }
+
+        auto args = m_ElementFactoryGetArgs.get();
+        args.Data(data);
+        args.Parent(*m_owner);
+        args.as<ElementFactoryGetArgs>()->Index(index);
+
+        element = itemTemplateFactory.GetElement(args);
+
+        args.Data(nullptr);
+        args.Parent(nullptr);
     }
-
-    auto args = m_ElementFactoryGetArgs.get();
-    args.Data(data);
-    args.Parent(*m_owner);
-    args.as<ElementFactoryGetArgs>()->Index(index);
-
-    winrt::UIElement element = itemTemplateFactory.GetElement(args);
-
-    args.Data(nullptr);
-    args.Parent(nullptr);
 
     auto virtInfo = ItemsRepeater::TryGetVirtualizationInfo(element);
     if (!virtInfo)
@@ -624,28 +642,31 @@ winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
         REPEATER_TRACE_PERF(L"ElementRecycled");
     }
 
-    // Prepare the element
-    // If we are phasing, run phase 0 before setting DataContext. If phase 0 is not 
-    // run before setting DataContext, when setting DataContext all the phases will be
-    // run in the OnDataContextChanged handler in code generated by the xaml compiler (code-gen).
-    auto extension = CachedVisualTreeHelpers::GetDataTemplateComponent(element);
-    if (extension)
+    if (!itemsSourceContainsElements)
     {
-        // Clear out old data. 
-        extension.Recycle();
-        int nextPhase = VirtualizationInfo::PhaseReachedEnd;
-        // Run Phase 0
-        extension.ProcessBindings(data, index, 0 /* currentPhase */, nextPhase);
+        // Prepare the element
+        // If we are phasing, run phase 0 before setting DataContext. If phase 0 is not 
+        // run before setting DataContext, when setting DataContext all the phases will be
+        // run in the OnDataContextChanged handler in code generated by the xaml compiler (code-gen).
+        auto extension = CachedVisualTreeHelpers::GetDataTemplateComponent(element);
+        if (extension)
+        {
+            // Clear out old data. 
+            extension.Recycle();
+            int nextPhase = VirtualizationInfo::PhaseReachedEnd;
+            // Run Phase 0
+            extension.ProcessBindings(data, index, 0 /* currentPhase */, nextPhase);
 
-        // Setup phasing information, so that Phaser can pick up any pending phases left.
-        // Update phase on virtInfo. Set data and templateComponent only if x:Phase was used.
-        virtInfo->UpdatePhasingInfo(nextPhase, nextPhase > 0 ? data : nullptr, nextPhase > 0 ? extension : nullptr);
-    }
-    else
-    {
-        // Set data context only if no x:Bind was used. ie. No data template component on the root.
-        auto elementAsFE = element.try_as<winrt::FrameworkElement>();
-        elementAsFE.DataContext(data);
+            // Setup phasing information, so that Phaser can pick up any pending phases left.
+            // Update phase on virtInfo. Set data and templateComponent only if x:Phase was used.
+            virtInfo->UpdatePhasingInfo(nextPhase, nextPhase > 0 ? data : nullptr, nextPhase > 0 ? extension : nullptr);
+        }
+        else
+        {
+            // Set data context only if no x:Bind was used. ie. No data template component on the root.
+            auto elementAsFE = element.try_as<winrt::FrameworkElement>();
+            elementAsFE.DataContext(data);
+        }
     }
 
     virtInfo->MoveOwnershipToLayoutFromElementFactory(
@@ -668,8 +689,12 @@ winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
     }
 
     repeater->AnimationManager().OnElementPrepared(element);
-    repeater->OnElementPrepared(element, index);
-    m_phaser.PhaseElement(element, virtInfo);
+
+    if (!itemsSourceContainsElements)
+    {
+        repeater->OnElementPrepared(element, index);
+        m_phaser.PhaseElement(element, virtInfo);
+    }
 
     // Update realized indices
     m_firstRealizedElementIndexHeldByLayout = std::min(m_firstRealizedElementIndexHeldByLayout, index);


### PR DESCRIPTION
A small change to allow Repeater to take in a list of UIElements in its ItemsSource and just use that. We take this path only when an ItemTemplate is not provided.  This makes it work similar to Items property in ItemsControl like so.

 <controls:ItemsRepeater x:Name='repeater'>
                               <controls:ItemsRepeater.ItemsSource>
                                    <local:UICollection>
                                        <Button>0</Button>
                                        <Button>1</Button>
                                        <Button>2</Button>
                                    </local:UICollection>
                                </controls:ItemsRepeater.ItemsSource>
                            </controls:ItemsRepeater>