### PR TITLE
NuGet package does not robustly detect missing WindowsTargetPlatformMinVersion

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -2,7 +2,8 @@
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Check TargetPlatformMinVersion during build to block unsupported configurations. -->
-  <Target Name="MicrosoftUIXamlCheckTargetPlatformVersion" BeforeTargets="PrepareForBuild" Condition="'$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'==''">
+  <Target Name="MicrosoftUIXamlCheckTargetPlatformVersion" BeforeTargets="PrepareForBuild" 
+      Condition="'$(TargetPlatformVersion)' != '' and '$(TargetPlatformMinVersion)' != '' and '$(SkipMicrosoftUIXamlCheckTargetPlatformVersion)'==''">
     <PropertyGroup>
       <MicrosoftUIXamlTargetPlatformMinCheckValue>$([System.Version]::Parse('$(TargetPlatformMinVersion)').Build)</MicrosoftUIXamlTargetPlatformMinCheckValue>
     </PropertyGroup>


### PR DESCRIPTION
UWP apps always have TargetPlatformVersion and TargetPlatformMinVersion. For in non-UWP scenarios, these might not be defined. The .targets file in our nuget package attempts to validate these versions. We update the check to be more robust in the case where these properties are not set.

Fixes #295 