### PR TITLE
Updated text input controls to 1px

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -241,6 +241,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushFocused}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderThickness">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderThemeThicknessFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
                                         </ObjectAnimationUsingKeyFrames>

--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -12,18 +12,21 @@
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
             <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
+            <Thickness x:Key="TextControlThemePadding">10,5,6,6</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
             <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
+            <Thickness x:Key="TextControlThemePadding">10,5,6,6</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
             <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
+            <Thickness x:Key="TextControlThemePadding">10,5,6,6</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
    

--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -10,14 +10,20 @@
         <ResourceDictionary x:Key="Default">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
+            <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
+            <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
+            <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
+            <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
+            <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
+            <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
    

--- a/dev/CommonStyles/PasswordBox_themeresources.xaml
+++ b/dev/CommonStyles/PasswordBox_themeresources.xaml
@@ -184,6 +184,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushFocused}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderThickness">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderThemeThicknessFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
                                         </ObjectAnimationUsingKeyFrames>

--- a/dev/CommonStyles/RichEditBox_themeresources.xaml
+++ b/dev/CommonStyles/RichEditBox_themeresources.xaml
@@ -87,6 +87,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushFocused}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderThickness">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderThemeThicknessFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
                                         </ObjectAnimationUsingKeyFrames>

--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
@@ -42,6 +42,10 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Text="ComboBox" Style="{StaticResource SideHeader}"/>
@@ -244,6 +248,102 @@
         </Grid>
         <Grid Grid.Column="2" Grid.Row="6" Style="{StaticResource RightColumn}">
             <ToggleSwitch/>
+        </Grid>
+
+        <TextBlock Grid.Row="7" Text="TextBox" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="7" Style="{StaticResource LeftColumn}">
+            <TextBox Width="100">
+                <TextBox.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </TextBox.Resources>
+            </TextBox>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="7" Style="{StaticResource RightColumn}">
+            <TextBox Width="100"/>
+        </Grid>
+
+        <TextBlock Grid.Row="8" Text="RichEditBox" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="8" Style="{StaticResource LeftColumn}">
+            <RichEditBox Width="100">
+                <RichEditBox.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </RichEditBox.Resources>
+            </RichEditBox>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="8" Style="{StaticResource RightColumn}">
+            <RichEditBox Width="100"/>
+        </Grid>
+
+        <TextBlock Grid.Row="9" Text="PasswordBox" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="9" Style="{StaticResource LeftColumn}">
+            <PasswordBox Width="100">
+                <PasswordBox.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </PasswordBox.Resources>
+            </PasswordBox>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="9" Style="{StaticResource RightColumn}">
+            <PasswordBox Width="100"/>
+        </Grid>
+
+        <TextBlock Grid.Row="10" Text="AutoSuggestBox" Style="{StaticResource SideHeader}"/>
+        <Grid Grid.Column="1" Grid.Row="10" Style="{StaticResource LeftColumn}">
+            <AutoSuggestBox Width="100">
+                <AutoSuggestBox.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <Thickness x:Key="TextControlBorderThemeThickness">2</Thickness>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </AutoSuggestBox.Resources>
+            </AutoSuggestBox>
+        </Grid>
+        <Grid Grid.Column="2" Grid.Row="10" Style="{StaticResource RightColumn}">
+            <AutoSuggestBox Width="100"/>
         </Grid>
 
     </Grid>

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -218,6 +218,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushFocused}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderThickness">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderThemeThicknessFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
                                         </ObjectAnimationUsingKeyFrames>

--- a/dev/dll/DensityStyles/Compact.xaml
+++ b/dev/dll/DensityStyles/Compact.xaml
@@ -1,14 +1,14 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">   
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <Style TargetType="TextBlock" >
         <Setter Property="FontSize" Value="14" />
     </Style>
     <x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
     <x:Double x:Key="ContentControlFontSize">14</x:Double>
     <x:Double x:Key="TextControlThemeMinHeight">24</x:Double>
-    <Thickness x:Key="TextControlThemePadding">2,1,6,0</Thickness>
+    <Thickness x:Key="TextControlThemePadding">2,2,6,1</Thickness>
     <x:Double x:Key="ListViewItemMinHeight">32</x:Double>
     <x:Double x:Key="TreeViewItemMinHeight">24</x:Double>
     <Thickness x:Key="TimePickerHostPadding">0,1,0,2</Thickness>


### PR DESCRIPTION
This commit updates all the text input control borders to use a thickness of 1px (#835, #1144) based on the visual comp [here](https://github.com/microsoft/microsoft-ui-xaml-specs/blob/user/chigy/borderstrokes/active/borderstrokes/images/Text%20Inputs.png).