### PR TITLE
TabView keyboarding improvements

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -132,6 +132,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("When the selected tab is closed, selection should move to the next one.");
                 // Use Tab's close button:
                 closeButton.InvokeAndWait();
+                VerifyElement.NotFound("FirstTab", FindBy.Name);
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
 
                 Log.Comment("Select last tab.");
@@ -144,6 +145,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 // Use Middle Click to close the tab:
                 lastTab.Click(PointerButtons.Middle);
+                Wait.ForIdle();
+                VerifyElement.NotFound("LastTab", FindBy.Name);
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
             }
         }
@@ -330,9 +333,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(Key.F4, ModifierKey.Control);
                 Wait.ForIdle();
 
-                ElementCache.Refresh();
-                UIObject firstTab2 = TryFindElement.ByName("FirstTab");
-                Verify.IsNull(firstTab2);
+                VerifyElement.NotFound("FirstTab", FindBy.Name);
             }
         }
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -130,6 +130,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
 
                 Log.Comment("When the selected tab is closed, selection should move to the next one.");
+                // Use Tab's close button:
                 closeButton.InvokeAndWait();
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
 
@@ -140,9 +141,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "3");
 
                 Log.Comment("When the selected tab is last and is closed, selection should move to the previous item.");
-                closeButton = FindCloseButton(lastTab);
-                Verify.IsNotNull(closeButton);
-                closeButton.InvokeAndWait();
+
+                // Use Middle Click to close the tab:
+                lastTab.Click(PointerButtons.Middle);
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
             }
         }

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -264,27 +264,110 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void KeyboardTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ functionality (specifically, KeyboardAccelerators)");
-                return;
-            }
-
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
                 Log.Comment("Set focus inside the TabView");
                 UIObject tabContent = FindElement.ByName("FirstTabContent");
                 tabContent.SetFocus();
 
+                TabItem firstTab = FindElement.ByName<TabItem>("FirstTab");
+                TabItem secondTab = FindElement.ByName<TabItem>("SecondTab");
+                TabItem lastTab = FindElement.ByName<TabItem>("LastTab");
+
+                Button addButton = FindElement.ById<Button>("AddButton");
+
+                Verify.IsTrue(firstTab.IsSelected, "First Tab should be selected initially");
+                Button firstTabButton = FindElement.ByName<Button>("FirstTabButton");
+                Verify.IsTrue(firstTabButton.HasKeyboardFocus, "Focus should start in the First Tab");
+
+                // Ctrl+Tab to the second tab:
+                KeyboardHelper.PressKey(Key.Tab, ModifierKey.Control);
+                Verify.IsTrue(secondTab.IsSelected, "Ctrl+Tab should move selection to Second Tab");
+                Button secondTabButton = FindElement.ByName<Button>("SecondTabButton");
+                Verify.IsTrue(secondTabButton.HasKeyboardFocus, "Focus should move to the content of the Second Tab");
+
+                // Ctrl+Shift+Tab to the first tab:
+                KeyboardHelper.PressKey(Key.Tab, ModifierKey.Control | ModifierKey.Shift);
+                Verify.IsTrue(firstTab.IsSelected, "Ctrl+Shift+Tab should move selection to First Tab");
+                Verify.IsTrue(firstTabButton.HasKeyboardFocus, "Focus should move to the content of the First Tab");
+
+                // Ctrl+Shift+Tab to the last tab:
+                KeyboardHelper.PressKey(Key.Tab, ModifierKey.Control | ModifierKey.Shift);
+                Verify.IsTrue(lastTab.IsSelected, "Ctrl+Shift+Tab should move selection to Last Tab");
+                Verify.IsTrue(lastTab.HasKeyboardFocus, "Focus should move to the last tab (since it has no focusable content)");
+
+                // Ctrl+Tab to the first tab:
+                KeyboardHelper.PressKey(Key.Tab, ModifierKey.Control);
+                Verify.IsTrue(firstTab.IsSelected, "Ctrl+Tab should move selection to First Tab");
+                Verify.IsTrue(firstTab.HasKeyboardFocus, "Focus should move to the first tab");
+
+                KeyboardHelper.PressKey(Key.Up);
+                Verify.IsTrue(firstTab.HasKeyboardFocus, "Up key should not move focus");
+
+                KeyboardHelper.PressKey(Key.Down);
+                Verify.IsTrue(firstTab.HasKeyboardFocus, "Down key should not move focus");
+
+                KeyboardHelper.PressKey(Key.Right);
+                Verify.IsTrue(secondTab.HasKeyboardFocus, "Right Key should move focus to the second tab");
+
+                KeyboardHelper.PressKey(Key.Left);
+                Verify.IsTrue(firstTab.HasKeyboardFocus, "Left Key should move focus to the first tab");
+
+                addButton.SetFocus();
+                Verify.IsTrue(addButton.HasKeyboardFocus, "AddButton should have keyboard focus");
+
+                KeyboardHelper.PressKey(Key.Left);
+                Verify.IsTrue(lastTab.HasKeyboardFocus, "Left Key from AddButton should move focus to last tab");
+
+                KeyboardHelper.PressKey(Key.Right);
+                Verify.IsTrue(addButton.HasKeyboardFocus, "Right Key from Last Tab should move focus to Add Button");
+
+                firstTab.SetFocus();
+
+                // Ctrl+f4 to close the tab:
                 Log.Comment("Verify that pressing ctrl-f4 closes the tab");
-                KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
-                TextInput.SendText("{F4}");
-                KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
+                KeyboardHelper.PressKey(Key.F4, ModifierKey.Control);
                 Wait.ForIdle();
 
                 ElementCache.Refresh();
-                UIObject firstTab = TryFindElement.ByName("FirstTab");
-                Verify.IsNull(firstTab);
+                UIObject firstTab2 = TryFindElement.ByName("FirstTab");
+                Verify.IsNull(firstTab2);
+            }
+        }
+
+        [TestMethod]
+        public void GamePadTest()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Button tabContent = FindElement.ByName<Button>("FirstTabButton");
+                Button backButton = FindElement.ById<Button>("__BackButton");
+                TabItem firstTab = FindElement.ByName<TabItem>("FirstTab");
+                TabItem secondTab = FindElement.ByName<TabItem>("SecondTab");
+                TabItem lastTab = FindElement.ByName<TabItem>("LastTab");
+                Button addButton = FindElement.ById<Button>("AddButton");
+
+                firstTab.SetFocus();
+
+                GamepadHelper.PressButton(null, GamepadButton.LeftThumbstickRight);
+                Wait.ForIdle();
+                Verify.IsTrue(secondTab.HasKeyboardFocus, "GamePad Right should move focus to second tab");
+
+                GamepadHelper.PressButton(null, GamepadButton.LeftThumbstickLeft);
+                Wait.ForIdle();
+                Verify.IsTrue(firstTab.HasKeyboardFocus, "GamePad Left should move focus to first tab");
+
+                GamepadHelper.PressButton(null, GamepadButton.LeftThumbstickDown);
+                Wait.ForIdle();
+                Verify.IsTrue(tabContent.HasKeyboardFocus, "GamePad Down should move focus to tab content");
+
+                GamepadHelper.PressButton(null, GamepadButton.LeftThumbstickUp);
+                Wait.ForIdle();
+                Verify.IsTrue(firstTab.HasKeyboardFocus, "GamePad Up should move focus to tabs");
+
+                GamepadHelper.PressButton(null, GamepadButton.LeftThumbstickUp);
+                Wait.ForIdle();
+                Verify.IsTrue(backButton.HasKeyboardFocus, "GamePad Up should move to back button");
             }
         }
 

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -94,9 +94,8 @@ private:
     void OnCtrlTabInvoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
     void OnCtrlShiftTabInvoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
 
-    bool SelectNextTab();
-    bool SelectPreviousTab();
     bool CloseCurrentTab();
+    bool SelectNextTab(int increment);
 
     void UpdateItemsSource();
     void UpdateSelectedItem();

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -59,6 +59,9 @@ public:
     winrt::DependencyObject ContainerFromItem(winrt::IInspectable const& item);
     winrt::DependencyObject ContainerFromIndex(int index);
 
+    // Control
+    void OnKeyDown(winrt::KeyRoutedEventArgs const& e);
+
     // Internal
     void OnItemsPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnItemsSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
@@ -87,6 +90,12 @@ private:
     void OnListViewDrop(const winrt::IInspectable& sender, const winrt::DragEventArgs& args);
 
     void OnCtrlF4Invoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
+    void OnCtrlTabInvoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
+    void OnCtrlShiftTabInvoked(const winrt::KeyboardAccelerator& sender, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
+
+    bool SelectNextTab();
+    bool SelectPreviousTab();
+    bool CloseCurrentTab();
 
     void UpdateItemsSource();
     void UpdateSelectedItem();
@@ -94,6 +103,10 @@ private:
 
     void UpdateTabContent();
     void UpdateTabWidths();
+
+    void OnListViewGettingFocus(const winrt::IInspectable& sender, const winrt::GettingFocusEventArgs& args);
+
+    int GetItemCount();
 
     tracker_ref<winrt::ColumnDefinition> m_leftContentColumn{ this };
     tracker_ref<winrt::ColumnDefinition> m_tabColumn{ this };
@@ -111,6 +124,7 @@ private:
 
     winrt::ListView::Loaded_revoker m_listViewLoadedRevoker{};
     winrt::Selector::SelectionChanged_revoker m_listViewSelectionChangedRevoker{};
+    winrt::UIElement::GettingFocus_revoker m_listViewGettingFocusRevoker{};
 
     winrt::ListView::DragItemsStarting_revoker m_listViewDragItemsStartingRevoker{};
     winrt::ListView::DragItemsCompleted_revoker m_listViewDragItemsCompletedRevoker{};

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -10,6 +10,7 @@
 #include "TabView.properties.h"
 #include "TabViewTabClosingEventArgs.g.h"
 #include "TabViewTabDraggedOutsideEventArgs.g.h"
+#include "DispatcherHelper.h"
 
 class TabViewTabClosingEventArgs :
     public winrt::implementation::TabViewTabClosingEventArgsT<TabViewTabClosingEventArgs>
@@ -137,4 +138,6 @@ private:
 
     winrt::RepeatButton::Click_revoker m_scrollDecreaseClickRevoker{};
     winrt::RepeatButton::Click_revoker m_scrollIncreaseClickRevoker{};
+
+    DispatcherHelper m_dispatcherHelper{ *this };
 };

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -19,9 +19,9 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
-
                         <Grid x:Name="TabContainerGrid"
-                            Background="{ThemeResource TabViewBackground}">
+                            Background="{ThemeResource TabViewBackground}"
+                            XYFocusKeyboardNavigation="Enabled" >
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" x:Name="LeftContentColumn"/>
                                 <ColumnDefinition Width="Auto" x:Name="TabColumn"/>
@@ -45,6 +45,7 @@
                                 ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"/>
 
                             <Button
+                                
                                 Grid.Column="2"
                                 x:Name="AddButton"
                                 Content="&#xE710;"
@@ -77,7 +78,7 @@
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Padding" Value="{ThemeResource TabViewHeaderPadding}" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="TabNavigation" Value="Local" />
+        <Setter Property="TabNavigation" Value="Once" />
         <Setter Property="IsSwipeEnabled" Value="False" />
         <Setter Property="SingleSelectionFollowsFocus" Value="False"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
@@ -111,7 +112,6 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="primitives:TabViewListView">
-
                     <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
                         <ScrollViewer x:Name="ScrollViewer"
                             Grid.Column="1"

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -27,11 +27,20 @@ public:
     void OnIsCloseablePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnHeaderPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
+    void OnPointerEntered(winrt::PointerRoutedEventArgs const& args);
+    void OnPointerExited(winrt::PointerRoutedEventArgs const& args);
+    void OnPointerPressed(winrt::PointerRoutedEventArgs const& args);
+    void OnPointerReleased(winrt::PointerRoutedEventArgs const& args);
+    void OnPointerCanceled(winrt::PointerRoutedEventArgs const& args);
+    void OnPointerCaptureLost(winrt::PointerRoutedEventArgs const& args);
+
  private:
     tracker_ref<winrt::Button> m_closeButton{ this };
     tracker_ref<winrt::ToolTip> m_toolTip{ this };
 
+    bool CanClose();
     void UpdateCloseButton();
+    void TryClose();
 
     bool m_firstTimeSettingToolTip{ true };
 
@@ -41,4 +50,7 @@ public:
     void OnLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnCloseButtonPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void OnCloseButtonClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
+
+    bool m_hasPointerCapture = false;
+    bool m_isMiddlePointerButtonPressed = false;
 };

--- a/dev/TabView/TabView_themeresources.xaml
+++ b/dev/TabView/TabView_themeresources.xaml
@@ -34,7 +34,7 @@
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="TabViewBackground"                        ResourceKey="SystemControlBackgroundBaseLowBrush" />
             <StaticResource x:Key="TabViewItemHeaderBackground"              ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"      ResourceKey="SystemControlBackgroundAltHighBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"      ResourceKey="SystemControlHighlightBaseHighBrush" />
             <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"   ResourceKey="SystemControlHighlightListLowBrush" />
             <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"       ResourceKey="SystemControlHighlightListMediumBrush" />
             <StaticResource x:Key="TabViewItemHeaderForeground"              ResourceKey="SystemControlForegroundBaseMediumBrush" />

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -91,15 +91,33 @@
                     </controls:TabViewItem>
 
                     <controls:TabViewItem x:Name="SecondTab" AutomationProperties.Name="SecondTab" Icon="Shop" Header="Shop" IsCloseable="True">
-                        <TextBlock Padding="16">Shop text</TextBlock>
+                        <StackPanel>
+                            <TextBlock Padding="16">Shop text</TextBlock>
+                            <Button Content="SecondTabButton" AutomationProperties.Name="SecondTabButton" />
+                        </StackPanel>
+                        
                     </controls:TabViewItem>
 
                     <controls:TabViewItem x:Name="LongHeaderTab" AutomationProperties.Name="LongHeaderTab" Icon="Emoji" Header="Longer Header">
-                        <TextBlock Padding="16">Emoji text</TextBlock>
+                        <StackPanel>
+                            <TextBlock Padding="16">Emoji text</TextBlock>
+                            <Button Content="Button 3" />
+                        </StackPanel>
+                        
                     </controls:TabViewItem>
 
                     <controls:TabViewItem x:Name="NotCloseableTab" AutomationProperties.Name="NotCloseableTab" Icon="Video" Header="Video" IsCloseable="False">
-                        <TextBlock Padding="16">This tab can't be closed.</TextBlock>
+                        <StackPanel>
+                            <TextBlock Padding="16">This tab can't be closed.</TextBlock>
+                            <controls:TabView x:Name="innerTabView" >
+                                <controls:TabView.ItemTemplate>
+                                    <DataTemplate x:DataType="local:TabDataItem">
+                                        <controls:TabViewItem Header="{x:Bind Header}" Content="{x:Bind Content}" Icon="Accept" />
+                                    </DataTemplate>
+                                </controls:TabView.ItemTemplate>
+                            </controls:TabView>
+                        </StackPanel>
+                        
                     </controls:TabViewItem>
 
                     <controls:TabViewItem x:Name="LastTab" AutomationProperties.Name="LastTab" Icon="Contact" Header="Contact">

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -17,6 +17,12 @@ using TabViewTabClosingEventArgs = Microsoft.UI.Xaml.Controls.TabViewTabClosingE
 
 namespace MUXControlsTestApp
 {
+    public class TabDataItem
+    {
+        public string Header { get; set; }
+        public string Content { get; set; }
+    }
+
     [TopLevelTestPage(Name = "TabView")]
     public sealed partial class TabViewPage : TestPage
     {
@@ -25,6 +31,25 @@ namespace MUXControlsTestApp
         public TabViewPage()
         {
             this.InitializeComponent();
+            
+            this.innerTabView.ItemsSource = new []
+            {
+                new TabDataItem 
+                {
+                    Header = "Header 1",
+                    Content = "Content 1"
+                },
+                new TabDataItem
+                {
+                    Header = "Header 2",
+                    Content = "Content 2"
+                },
+                new TabDataItem
+                {
+                    Header = "Header 3",
+                    Content = "Content 3"
+                }
+            };
         }
 
         public void CanCloseCheckBox_CheckChanged(object sender, RoutedEventArgs e)

--- a/test/MUXControls.Test/Common/KeyboardHelper.cs
+++ b/test/MUXControls.Test/Common/KeyboardHelper.cs
@@ -38,6 +38,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common
         Space,
         Backspace,
         F10,
+        F4,
         F6
     }
 
@@ -69,6 +70,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common
             { Key.Space, "{SPACE}" },
             { Key.Backspace, "{BACKSPACE}" },
             { Key.F10, "{F10}" },
+            { Key.F4, "{F4}" },
             { Key.F6, "{F6}" },
         };
 


### PR DESCRIPTION
Includes the following changes:

**Ctrl+Tab/Ctrl+Shift+Tab to switch tabs.**
This is implemented as a KeyboardAccelerator.
In order to get down-level RS2 devices to work, it is also implemented as a KeyDown handler behind a platform check. When WinUI 3 is available, we could remove the KeyDown implementation, since KeyboardAccelerator would be available everywhere.
Also updated the existing Ctrl+F4 behavior to use KeyDown on RS2.

**Left/Right Arrow Navigation between tabs and '+' Button**
This is enabled with XYFocusKeyboardNavigation. However, this hit an issue due to the fact that the tabs slightly overlap by 1px to get the desired visuals. This results in unusual 2d navigation: Up/Down would always navigate to a tab to the left of the right. A fix for this was added TabView::OnListViewGettingFocus to detect when this was happening and block it in the case of Keyboard (up/down should go nowhere) and forward focus elsewhere in the case of Gamepad.

**High Contrast Fix**
Updates selected tab color so that it is visible in High Contrast mode.

**Added test cases for Keyboard and GamePad navigation**

**Middle Click closes tabs**

Closes #1142