### PR TITLE
CornerRadius updates/fixes

### DIFF
--- a/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
+++ b/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using System.Linq;
 using System.Collections.Generic;
+using MUXControlsTestApp;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -64,9 +65,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var textBox = TestUtilities.FindDescendents<TextBox>(autoSuggestBox).Where(e => e.Name == "TextBox").Single();
                 Verify.AreEqual(new CornerRadius(2, 2, 0, 0), textBox.CornerRadius);
 
+                var overlayCornerRadius = new CornerRadius(0, 0, 0, 0);
+                var radius = App.Current.Resources["OverlayCornerRadius"];
+                if (radius != null)
+                {
+                    overlayCornerRadius = (CornerRadius)radius;
+                }
                 var popup = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
                 var popupBorder = popup.Child as Border;
-                Verify.AreEqual(new CornerRadius(0, 0, 2, 2), popupBorder.CornerRadius);
+
+                Verify.AreEqual(new CornerRadius(0, 0, overlayCornerRadius.BottomRight, overlayCornerRadius.BottomLeft), popupBorder.CornerRadius);
             });
         }
 

--- a/dev/AutoSuggestBox/AutoSuggestBoxHelper.cpp
+++ b/dev/AutoSuggestBox/AutoSuggestBoxHelper.cpp
@@ -104,12 +104,11 @@ void AutoSuggestBoxHelper::OnAutoSuggestBoxLoaded(const winrt::IInspectable& sen
 void AutoSuggestBoxHelper::UpdateCornerRadius(const winrt::AutoSuggestBox& autoSuggestBox, bool isPopupOpen)
 {
     auto textBoxRadius = unbox_value<winrt::CornerRadius>(ResourceLookup(autoSuggestBox, box_value(c_controlCornerRadiusKey)));
-    auto popupRadius = textBoxRadius;
+    auto popupRadius = unbox_value<winrt::CornerRadius>(ResourceLookup(autoSuggestBox, box_value(c_overlayCornerRadiusKey)));
 
     if (winrt::IControl7 autoSuggextBoxControl7 = autoSuggestBox)
     {
         textBoxRadius = autoSuggextBoxControl7.CornerRadius();
-        popupRadius = autoSuggextBoxControl7.CornerRadius();
     }
 
     if (isPopupOpen)

--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -414,8 +414,7 @@
                                     BorderThickness="{ThemeResource AutoSuggestListBorderThemeThickness}"
                                     BorderBrush="{ThemeResource AutoSuggestBoxSuggestionsListBorderBrush}"
                                     Background="{ThemeResource AutoSuggestBoxSuggestionsListBackground}"
-                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                    contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
+                                    CornerRadius="{ThemeResource OverlayCornerRadius}">
                                 <Border.RenderTransform>
                                     <contract7NotPresent:TranslateTransform x:Name="UpwardTransform" />
                                 </Border.RenderTransform>

--- a/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
+++ b/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
@@ -215,7 +215,8 @@
                                     DayOfWeekFormat="{TemplateBinding DayOfWeekFormat}"
                                     CalendarIdentifier="{TemplateBinding CalendarIdentifier}"
                                     IsOutOfScopeEnabled="{TemplateBinding IsOutOfScopeEnabled}"
-                                    IsGroupLabelVisible="{TemplateBinding IsGroupLabelVisible}" />
+                                    IsGroupLabelVisible="{TemplateBinding IsGroupLabelVisible}"
+                                    contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}" />
                             </Flyout>
                         </FlyoutBase.AttachedFlyout>
 

--- a/dev/ComboBox/APITests/ComboBoxTests.cs
+++ b/dev/ComboBox/APITests/ComboBoxTests.cs
@@ -6,6 +6,7 @@ using MUXControlsTestApp.Utilities;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using System.Linq;
+using MUXControlsTestApp;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -49,9 +50,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var background = TestUtilities.FindDescendents<Border>(comboBox).Where(e => e.Name == "Background").Single();
                 Verify.AreEqual(new CornerRadius(2, 2, 2, 2), background.CornerRadius);
 
+                var overlayCornerRadius = new CornerRadius(0, 0, 0, 0);
+                var radius = App.Current.Resources["OverlayCornerRadius"];
+                if (radius != null)
+                {
+                    overlayCornerRadius = (CornerRadius)radius;
+                }
                 var popup = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
                 var popupBorder = TestUtilities.FindDescendents<Border>(popup).Where(e => e.Name=="PopupBorder").Single();
-                Verify.AreEqual(new CornerRadius(2, 2, 2, 2), popupBorder.CornerRadius);
+                Verify.AreEqual(overlayCornerRadius, popupBorder.CornerRadius);
             });
         }
 
@@ -78,9 +85,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var editableText = TestUtilities.FindDescendents<TextBox>(comboBox).Where(e => e.Name == "EditableText").Single();
                 Verify.AreEqual(new CornerRadius(2, 2, 0, 0), editableText.CornerRadius);
 
+                var overlayCornerRadius = new CornerRadius(0, 0, 0, 0);
+                var radius = App.Current.Resources["OverlayCornerRadius"];
+                if (radius != null)
+                {
+                    overlayCornerRadius = (CornerRadius)radius;
+                }
                 var popup = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
                 var popupBorder = TestUtilities.FindDescendents<Border>(popup).Where(e => e.Name == "PopupBorder").Single();
-                Verify.AreEqual(new CornerRadius(0, 0, 2, 2), popupBorder.CornerRadius);
+                Verify.AreEqual(new CornerRadius(0, 0, overlayCornerRadius.BottomRight, overlayCornerRadius.BottomLeft), popupBorder.CornerRadius);
             });
         }
 

--- a/dev/ComboBox/ComboBoxHelper.cpp
+++ b/dev/ComboBox/ComboBoxHelper.cpp
@@ -107,7 +107,7 @@ void ComboBoxHelper::UpdateCornerRadius(const winrt::ComboBox& comboBox, bool is
             auto cornerRadiusConverter = winrt::make_self<CornerRadiusFilterConverter>();
 
             auto popupRadiusFilter = isOpenDown ? winrt::CornerRadiusFilterKind::Bottom : winrt::CornerRadiusFilterKind::Top;
-            popupRadius = cornerRadiusConverter->Convert(textBoxRadius, popupRadiusFilter);
+            popupRadius = cornerRadiusConverter->Convert(popupRadius, popupRadiusFilter);
 
             auto textBoxRadiusFilter = isOpenDown ? winrt::CornerRadiusFilterKind::Top : winrt::CornerRadiusFilterKind::Bottom;
             textBoxRadius = cornerRadiusConverter->Convert(textBoxRadius, textBoxRadiusFilter);

--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -674,8 +674,7 @@
                                 Margin="0,-1,0,-1"
                                 Padding="{ThemeResource ComboBoxDropdownBorderPadding}"
                                 HorizontalAlignment="Stretch"
-                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
+                                CornerRadius="{ThemeResource OverlayCornerRadius}">
                                 <ScrollViewer x:Name="ScrollViewer"
                                     Foreground="{ThemeResource ComboBoxDropDownForeground}"
                                     MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"

--- a/dev/CommonStyles/CornerRadius_themeresources.xaml
+++ b/dev/CommonStyles/CornerRadius_themeresources.xaml
@@ -5,16 +5,16 @@
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
-            <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+            <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
+            <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
-            <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+            <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
+            <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
-            <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+            <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
+            <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 

--- a/dev/CommonStyles/MediaTransportControls_themeresources.xaml
+++ b/dev/CommonStyles/MediaTransportControls_themeresources.xaml
@@ -2,6 +2,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -69,6 +71,7 @@
                                 <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
                                 <Setter Property="FocusVisualMargin" Value="-7,0,-7,0" />
                                 <Setter Property="IsFocusEngagementEnabled" Value="True" />
+                                <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Slider">
@@ -231,9 +234,25 @@
                                                             <RowDefinition Height="Auto" />
                                                             <RowDefinition Height="18" />
                                                         </Grid.RowDefinitions>
-                                                        <Rectangle x:Name="HorizontalTrackRect" Fill="{TemplateBinding Background}" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Grid.ColumnSpan="3" />
+                                                        <Rectangle
+                                                            x:Name="HorizontalTrackRect"
+                                                            Fill="{TemplateBinding Background}"
+                                                            Height="{ThemeResource SliderTrackThemeHeight}"
+                                                            Grid.Row="1"
+                                                            Grid.ColumnSpan="3"
+                                                            contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                                            contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                                            contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                                            contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
                                                         <ProgressBar x:Name="DownloadProgressIndicator" Style="{StaticResource MediaSliderProgressBarStyle}" Grid.Row="1" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
-                                                        <Rectangle x:Name="HorizontalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Row="1" />
+                                                        <Rectangle
+                                                            x:Name="HorizontalDecreaseRect"
+                                                            Fill="{TemplateBinding Foreground}"
+                                                            Grid.Row="1"
+                                                            contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                                            contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                                            contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                                            contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
                                                         <TickBar x:Name="TopTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Height="{ThemeResource SliderOutsideTickBarThemeHeight}" VerticalAlignment="Bottom" Margin="0,0,0,4" Grid.ColumnSpan="3" />
                                                         <TickBar x:Name="HorizontalInlineTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderInlineTickBarFill}" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Grid.ColumnSpan="3" />
                                                         <TickBar x:Name="BottomTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Height="{ThemeResource SliderOutsideTickBarThemeHeight}" VerticalAlignment="Top" Margin="0,4,0,0" Grid.Row="2" Grid.ColumnSpan="3" />
@@ -264,8 +283,25 @@
                                                             <ColumnDefinition Width="Auto" />
                                                             <ColumnDefinition Width="18" />
                                                         </Grid.ColumnDefinitions>
-                                                        <Rectangle x:Name="VerticalTrackRect" Fill="{TemplateBinding Background}" Width="{ThemeResource SliderTrackThemeHeight}" Grid.Column="1" Grid.RowSpan="3" />
-                                                        <Rectangle x:Name="VerticalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Column="1" Grid.Row="2" />
+                                                        <Rectangle
+                                                            x:Name="VerticalTrackRect"
+                                                            Fill="{TemplateBinding Background}"
+                                                            Width="{ThemeResource SliderTrackThemeHeight}"
+                                                            Grid.Column="1"
+                                                            Grid.RowSpan="3"
+                                                            contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                                            contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                                            contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                                            contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
+                                                        <Rectangle
+                                                            x:Name="VerticalDecreaseRect"
+                                                            Fill="{TemplateBinding Foreground}"
+                                                            Grid.Column="1"
+                                                            Grid.Row="2"
+                                                            contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                                            contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                                            contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                                            contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
                                                         <TickBar x:Name="LeftTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Width="{ThemeResource SliderOutsideTickBarThemeHeight}" HorizontalAlignment="Right" Margin="0,0,4,0" Grid.RowSpan="3" />
                                                         <TickBar x:Name="VerticalInlineTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderInlineTickBarFill}" Width="{ThemeResource SliderTrackThemeHeight}" Grid.Column="1" Grid.RowSpan="3" />
                                                         <TickBar x:Name="RightTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Width="{ThemeResource SliderOutsideTickBarThemeHeight}" HorizontalAlignment="Left" Margin="4,0,0,0" Grid.Column="2" Grid.RowSpan="3" />

--- a/dev/CommonStyles/ProgressBar_themeresources.xaml
+++ b/dev/CommonStyles/ProgressBar_themeresources.xaml
@@ -2,7 +2,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <x:Double x:Key="ProgressBarIndicatorPauseOpacity">0.6</x:Double>
@@ -42,6 +43,7 @@
         <Setter Property="MinHeight" Value="{ThemeResource ProgressBarThemeMinHeight}" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="VerticalAlignment" Value="Center" />
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ProgressBar">
@@ -241,8 +243,22 @@
                                 </Ellipse>
                             </Border>
                         </StackPanel>
-                        <Border x:Name="DeterminateRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
-                            <Rectangle x:Name="ProgressBarIndicator" Margin="{TemplateBinding Padding}" Fill="{TemplateBinding Foreground}" HorizontalAlignment="Left" />
+                        <Border
+                            x:Name="DeterminateRoot"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                            contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
+                            <Rectangle
+                                x:Name="ProgressBarIndicator"
+                                Margin="{TemplateBinding Padding}"
+                                Fill="{TemplateBinding Foreground}"
+                                HorizontalAlignment="Left"
+                                contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
+                                contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
                         </Border>
                     </Grid>
                 </ControlTemplate>

--- a/dev/CommonStyles/TestUI/CornerRadiusPage.xaml
+++ b/dev/CommonStyles/TestUI/CornerRadiusPage.xaml
@@ -136,16 +136,16 @@
                         <ListBoxItem Content="Item 3"/>
                     </ListBox>
                 </Grid>
-                <Grid Grid.Row="5" Style="{StaticResource RightColumn}">
-                    <ListBox contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}">
-                        <ListBoxItem Content="Item 1"/>
-                        <ListBoxItem Content="Item 2"/>
-                        <ListBoxItem Content="Item 3"/>
-                    </ListBox>
+                <Grid Grid.Row="5" Style="{StaticResource RightColumn}" VerticalAlignment="Center">
+                    <TextBlock VerticalAlignment="Center">N/A</TextBlock>
                 </Grid>
 
                 <TextBlock Grid.Row="6" Text="ComboBox" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="6" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <ComboBox>
                         <ComboBoxItem Content="Item 1"/>
                         <ComboBoxItem Content="Item 2"/>
@@ -162,6 +162,10 @@
 
                 <TextBlock Grid.Row="7" Text="ComboBox (IsEditable)" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="7" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <ComboBox contract7Present:IsEditable="True">
                         <ComboBoxItem Content="Item 1"/>
                         <ComboBoxItem Content="Item 2"/>
@@ -178,6 +182,10 @@
 
                 <TextBlock Grid.Row="8" Text="AutoSuggestBox" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="8" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <AutoSuggestBox ItemsSource="{x:Bind AutoSuggestSource}"/>
                 </Grid>
                 <Grid Grid.Row="8" Style="{StaticResource RightColumn}">
@@ -186,6 +194,10 @@
 
                 <TextBlock Grid.Row="9" Text="DatePicker" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="9" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <DatePicker />
                 </Grid>
                 <Grid Grid.Row="9" Style="{StaticResource RightColumn}">
@@ -194,6 +206,10 @@
 
                 <TextBlock Grid.Row="10" Text="TimePicker" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="10" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <TimePicker/>
                 </Grid>
                 <Grid Grid.Row="10" Style="{StaticResource RightColumn}">
@@ -216,24 +232,16 @@
                         </CommandBar.Content>
                     </CommandBar>
                 </Grid>
-                <Grid Grid.Row="11" Style="{StaticResource RightColumn}">
-                    <CommandBar contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}">
-                        <AppBarButton Icon="AddFriend"/>
-                        <AppBarButton Icon="World" Label="World"/>
-                        <AppBarToggleButton Icon="Volume" Label="Volume"/>
-                        <CommandBar.SecondaryCommands>
-                            <AppBarButton Label="Like"/>
-                            <AppBarButton Label="Dislike"/>
-                            <AppBarToggleButton Label="Toggle"/>
-                        </CommandBar.SecondaryCommands>
-                        <CommandBar.Content>
-                            <TextBlock Text="Hello World" Margin="12"/>
-                        </CommandBar.Content>
-                    </CommandBar>
+                <Grid Grid.Row="11" Style="{StaticResource RightColumn}" VerticalAlignment="Center">
+                    <TextBlock>N/A</TextBlock>
                 </Grid>
 
                 <TextBlock Grid.Row="12" Text="Flyout" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="12" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <Button Content="Click me">
                         <Button.Flyout>
                             <Flyout>
@@ -274,6 +282,10 @@
 
                 <TextBlock Grid.Row="13" Text="MenuFlyout" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="13" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <Button Content="Click me">
                         <Button.Flyout>
                             <MenuFlyout>
@@ -350,6 +362,10 @@
 
                 <TextBlock Grid.Row="14" Text="ContentDialog" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="14" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <Button Content="Click me" Click="ShowDialog_Click"/>
                 </Grid>
                 <Grid Grid.Row="14" Style="{StaticResource RightColumn}">
@@ -358,6 +374,10 @@
 
                 <TextBlock Grid.Row="15" Text="ToolTip" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="15" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <ToolTip>
                         <TextBlock Text="Hello world"/>
                     </ToolTip>
@@ -370,6 +390,10 @@
 
                 <TextBlock Grid.Row="17" Text="CalendarView" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="17" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <CalendarView/>
                 </Grid>
                 <Grid Grid.Row="17" Style="{StaticResource RightColumn}">
@@ -378,6 +402,10 @@
 
                 <TextBlock Grid.Row="18" Text="CalendarDatePicker" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="18" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <CalendarDatePicker/>
                 </Grid>
                 <Grid Grid.Row="18" Style="{StaticResource RightColumn}">
@@ -388,71 +416,75 @@
                 <Grid Grid.Row="20" Style="{StaticResource LeftColumn}">
                     <ToggleSwitch/>
                 </Grid>
-                <Grid Grid.Row="20" Style="{StaticResource RightColumn}">
-                    <ToggleSwitch contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
+                <Grid Grid.Row="20" Style="{StaticResource RightColumn}" VerticalAlignment="Center">
+                    <TextBlock>N/A</TextBlock>
                 </Grid>
 
                 <TextBlock Grid.Row="21" Text="Slider" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="21" Style="{StaticResource LeftColumn}" MinWidth="200">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                        <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
+                    </Grid.Resources>
                     <Slider Orientation="Horizontal"/>
                 </Grid>
                 <Grid Grid.Row="21" Style="{StaticResource RightColumn}" MinWidth="200">
-                    <Grid.Resources>
-                        <!-- Rounding slider thumb until that becomes the default -->
-                        <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
-                    </Grid.Resources>
                     <Slider Orientation="Horizontal" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
                 </Grid>
 
                 <TextBlock Grid.Row="22" Text="Slider" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="22" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                        <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
+                    </Grid.Resources>
                     <Slider Orientation="Horizontal" TickFrequency="1" Width="200" TickPlacement="Outside"/>
                 </Grid>
                 <Grid Grid.Row="22" Style="{StaticResource RightColumn}">
-                    <Grid.Resources>
-                        <!-- Rounding slider thumb until that becomes the default -->
-                        <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
-                    </Grid.Resources>
                     <Slider Orientation="Horizontal" TickFrequency="1" Width="200" TickPlacement="Outside" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
                 </Grid>
 
                 <TextBlock Grid.Row="23" Text="" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="23" Style="{StaticResource LeftColumn}" MinHeight="100">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                        <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
+                    </Grid.Resources>
                     <Slider Orientation="Vertical"/>
                 </Grid>
                 <Grid Grid.Row="23" Style="{StaticResource RightColumn}" MinHeight="100">
-                    <Grid.Resources>
-                        <!-- Rounding slider thumb until that becomes the default -->
-                        <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
-                    </Grid.Resources>
                     <Slider Orientation="Vertical" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
                 </Grid>
 
                 <TextBlock Grid.Row="24" Text="" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="24" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                        <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
+                    </Grid.Resources>
                     <Slider Orientation="Vertical" TickFrequency="1" Height="100" TickPlacement="Outside"/>
                 </Grid>
                 <Grid Grid.Row="24" Style="{StaticResource RightColumn}">
-                    <Grid.Resources>
-                        <!-- Rounding slider thumb until that becomes the default -->
-                        <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
-                    </Grid.Resources>
                     <Slider Orientation="Vertical" TickFrequency="1" Height="100" TickPlacement="Outside" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
                 </Grid>
 
@@ -462,10 +494,8 @@
                         <AppBarButton Icon="World"/>
                     </AppBar>
                 </Grid>
-                <Grid Grid.Row="25" Style="{StaticResource RightColumn}">
-                    <AppBar contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}">
-                        <AppBarButton Icon="World"/>
-                    </AppBar>
+                <Grid Grid.Row="25" Style="{StaticResource RightColumn}" VerticalAlignment="Center">
+                    <TextBlock>N/A</TextBlock>
                 </Grid>
 
                 <TextBlock Grid.Row="26" Text="MenuBar" Style="{StaticResource SideHeader}"/>
@@ -522,6 +552,10 @@
 
                 <TextBlock Grid.Row="31" Text="ProgressBar" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="31" Style="{StaticResource LeftColumn}" MinWidth="100">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <ProgressBar Minimum="0" Maximum="100" Value="50"/>
                 </Grid>
                 <Grid Grid.Row="31" Style="{StaticResource RightColumn}" MinWidth="100">
@@ -550,6 +584,10 @@
 
                 <TextBlock Grid.Row="34" Text="CheckBox" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="34" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <CheckBox Content="Hello World"/>
                 </Grid>
                 <Grid Grid.Row="34" Style="{StaticResource RightColumn}">
@@ -558,6 +596,10 @@
 
                 <TextBlock Grid.Row="35" Text="Button" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="35" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <Button Content="Hello World"/>
                 </Grid>
                 <Grid Grid.Row="35" Style="{StaticResource RightColumn}">
@@ -566,6 +608,10 @@
 
                 <TextBlock Grid.Row="36" Text="TextBox" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="36" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <TextBox Text="Hello World"/>
                 </Grid>
                 <Grid Grid.Row="36" Style="{StaticResource RightColumn}">
@@ -574,6 +620,10 @@
 
                 <TextBlock Grid.Row="37" Text="PasswordBox" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="37" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <PasswordBox Password="Hello World"/>
                 </Grid>
                 <Grid Grid.Row="37" Style="{StaticResource RightColumn}">
@@ -582,6 +632,10 @@
 
                 <TextBlock Grid.Row="38" Text="RichEditBox" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="38" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <RichEditBox/>
                 </Grid>
                 <Grid Grid.Row="38" Style="{StaticResource RightColumn}">
@@ -589,6 +643,10 @@
                 </Grid>
                 <TextBlock Grid.Row="39" Text="FlipView" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="39" Style="{StaticResource LeftColumn}" Width="200" Height="200">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <FlipView>
                         <Grid Background="Red"/>
                         <Grid Background="Green"/>
@@ -611,16 +669,16 @@
                         <RadioButton Content="Item 3"/>
                     </StackPanel>
                 </Grid>
-                <Grid Grid.Row="40" Style="{StaticResource RightColumn}">
-                    <StackPanel Orientation="Vertical">
-                        <RadioButton Content="Item 1" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
-                        <RadioButton Content="Item 2" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
-                        <RadioButton Content="Item 3" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
-                    </StackPanel>
+                <Grid Grid.Row="40" Style="{StaticResource RightColumn}" VerticalAlignment="Center">
+                    <TextBlock>N/A</TextBlock>
                 </Grid>
 
                 <TextBlock Grid.Row="41" Text="ToggleButton" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="41" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <ToggleButton Content="Hello World"/>
                 </Grid>
                 <Grid Grid.Row="41" Style="{StaticResource RightColumn}">
@@ -629,6 +687,10 @@
 
                 <TextBlock Grid.Row="42" Text="ToggleSplitButton" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="42" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <controls:ToggleSplitButton Content="Hello World">
                         <controls:ToggleSplitButton.Flyout>
                             <Flyout>
@@ -653,6 +715,10 @@
 
                 <TextBlock Grid.Row="43" Text="RepeatButton" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="43" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <RepeatButton Content="Hello World"/>
                 </Grid>
                 <Grid Grid.Row="43" Style="{StaticResource RightColumn}">
@@ -663,12 +729,16 @@
                 <Grid Grid.Row="44" Style="{StaticResource LeftColumn}">
                     <HyperlinkButton Content="Hello World"/>
                 </Grid>
-                <Grid Grid.Row="44" Style="{StaticResource RightColumn}">
-                    <HyperlinkButton Content="Hello World" contract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
+                <Grid Grid.Row="44" Style="{StaticResource RightColumn}" VerticalAlignment="Center">
+                    <TextBlock>N/A</TextBlock>
                 </Grid>
 
                 <TextBlock Grid.Row="45" Text="DropDownButton" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="45" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <controls:DropDownButton Content="Hello World">
                         <controls:DropDownButton.Flyout>
                             <Flyout>
@@ -692,6 +762,10 @@
                 </Grid>
                 <TextBlock Grid.Row="46" Text="SplitButton" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="46" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <controls:SplitButton Content="Hello World">
                         <controls:SplitButton.Flyout>
                             <Flyout>
@@ -715,6 +789,15 @@
                 </Grid>
                 <TextBlock Grid.Row="47" Text="ColorPicker" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="47" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                        <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
+                        <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
+                        <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
+                    </Grid.Resources>
                     <controls:ColorPicker IsAlphaEnabled="True"/>
                 </Grid>
                 <Grid Grid.Row="47" Style="{StaticResource RightColumn}">
@@ -728,12 +811,6 @@
                         <contract7Present:Style TargetType="primitives:ColorPickerSlider">
                             <Setter Property="CornerRadius" Value="{Binding ControlCornerRadius, Mode=OneWay}"/>
                         </contract7Present:Style>
-                        <!-- Rounding slider thumb until that becomes the default -->
-                        <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
-                        <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
                     </Grid.Resources>
                     <controls:ColorPicker IsAlphaEnabled="True" muxContract7Present:CornerRadius="{x:Bind ControlCornerRadius, Mode=OneWay}"/>
                 </Grid>
@@ -777,6 +854,10 @@
 
                 <TextBlock Grid.Row="50" Text="TreeView" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="50" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <controls:TreeView SelectionMode="Multiple">
                         <controls:TreeView.RootNodes>
                             <controls:TreeViewNode Content="Item 1" IsExpanded="True">
@@ -814,11 +895,23 @@
                 </Grid>
                 <TextBlock Grid.Row="51" Text="MediaPlayerElement" Style="{StaticResource SideHeader}"/>
                 <Grid Grid.Row="51" Style="{StaticResource LeftColumn}">
+                    <Grid.Resources>
+                        <CornerRadius x:Key="ControlCornerRadius">0,0,0,0</CornerRadius>
+                        <CornerRadius x:Key="OverlayCornerRadius">0,0,0,0</CornerRadius>
+                    </Grid.Resources>
                     <MediaPlayerElement 
                         Width="200"
                         Height="100"
                         x:Name="mediaPlayer"
                         AreTransportControlsEnabled="True" />
+                </Grid>
+                
+                <Grid Grid.Row="51" Style="{StaticResource RightColumn}">
+                    <MediaPlayerElement 
+                        Width="200"
+                        Height="100"
+                        AreTransportControlsEnabled="True"
+                        contract7Present:CornerRadius="{x:Bind ControlCornerRadius}" />
                 </Grid>
             </Grid>
 

--- a/dev/DatePicker/DatePicker_themeresources.xaml
+++ b/dev/DatePicker/DatePicker_themeresources.xaml
@@ -362,6 +362,7 @@
         <Setter Property="AutomationProperties.AutomationId" Value="DatePickerFlyoutPresenter" />
         <Setter Property="BorderBrush" Value="{ThemeResource DatePickerFlyoutPresenterBorderBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource DateTimeFlyoutBorderThickness}" />
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="DatePickerFlyoutPresenter">

--- a/dev/Slider/Slider_themeresources.xaml
+++ b/dev/Slider/Slider_themeresources.xaml
@@ -167,11 +167,11 @@
     <x:Double x:Key="SliderPostContentMargin">15</x:Double>
     <x:Double x:Key="SliderHorizontalHeight">32</x:Double>
     <x:Double x:Key="SliderVerticalWidth">32</x:Double>
-    <x:Double x:Key="SliderThumbCornerRadius">4</x:Double>
-    <x:Double x:Key="SliderHorizontalThumbWidth">8</x:Double>
-    <x:Double x:Key="SliderHorizontalThumbHeight">24</x:Double>
-    <x:Double x:Key="SliderVerticalThumbWidth">24</x:Double>
-    <x:Double x:Key="SliderVerticalThumbHeight">8</x:Double>
+    <x:Double x:Key="SliderThumbCornerRadius">10</x:Double>
+    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
+    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
+    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
+    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
     
     <Style TargetType="Slider">
         <Setter Property="Background" Value="{ThemeResource SliderTrackFill}" />

--- a/dev/Slider/Slider_themeresources.xaml
+++ b/dev/Slider/Slider_themeresources.xaml
@@ -435,13 +435,17 @@
                                     Grid.Column="1"
                                     Grid.RowSpan="3"
                                     contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                    contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                    contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
                                 <Rectangle x:Name="VerticalDecreaseRect"
                                     Fill="{TemplateBinding Foreground}"
                                     Grid.Column="1"
                                     Grid.Row="2"
                                     contract7Present:RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.TopLeft}"
-                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"/>
+                                    contract7Present:RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius.BottomRight}"
+                                    contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Path=TopLeft}"
+                                    contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Path=BottomRight}" />
                                 <TickBar x:Name="LeftTickBar"
                                     Visibility="Collapsed"
                                     Fill="{ThemeResource SliderTickBarFill}"


### PR DESCRIPTION
- Updated DataPicker, ProgressBar and MediaPlayerElement to reference ControlCornerRadius resource value.
- Updated Slider thumb default width, height, CornerRadius.
- Fixed AutoSuggestBox and ComboBox dropdown CornerRadius, they should use OverlayCornerRadius per our spec (they were binding to control's CornerRadius value before).

![20190814144242](https://user-images.githubusercontent.com/4424330/63058944-ec4d9e80-bea2-11e9-8955-734b7ba63a76.png)
- Updated CornerRadiusPage to explicitly set CornerRadius to 0 on left columns, so they can stay 0 when we change default values.
- Updated default corner radius values.