### PR TITLE
Fixed SplitButton secondary button alignment on touch

### DIFF
--- a/dev/SplitButton/SplitButton.xaml
+++ b/dev/SplitButton/SplitButton.xaml
@@ -273,6 +273,7 @@
                             VerticalContentAlignment="Stretch"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            Padding="0,0,9,0"
                             IsTabStop="False"
                             AutomationProperties.AccessibilityView="Raw">
                             <Button.Content>
@@ -281,7 +282,7 @@
                                     FontSize="12"
                                     Text="&#xE70D;"
                                     VerticalAlignment="Center"
-                                    HorizontalAlignment="Center"
+                                    HorizontalAlignment="Right"
                                     AutomationProperties.AccessibilityView="Raw"/>
                             </Button.Content>
                         </Button>

--- a/dev/SplitButton/SplitButton_rs1.xaml
+++ b/dev/SplitButton/SplitButton_rs1.xaml
@@ -294,6 +294,7 @@
                             VerticalContentAlignment="Stretch"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            Padding="0,0,9,0"
                             IsTabStop="False"
                             AutomationProperties.AccessibilityView="Raw">
                             <Button.Content>
@@ -303,7 +304,7 @@
                                     FontSize="12"
                                     Text="&#xE70D;"
                                     VerticalAlignment="Center"
-                                    HorizontalAlignment="Center"
+                                    HorizontalAlignment="Right"
                                     AutomationProperties.AccessibilityView="Raw"/>
                             </Button.Content>
                         </Button>


### PR DESCRIPTION
Reverted the Secondary Button alignment and adjusted the padding.
Fix #835.