### PR TITLE
Add 1px Separator in SplitButton

### DIFF
--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
@@ -355,23 +355,7 @@
 
             <TextBlock Grid.Row="11" Text="Button" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="11" Style="{StaticResource LeftColumn}">
-                <Button Content="Button" MinWidth="100">
-                    <Button.Resources>
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Default">
-                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="HighContrast">
-                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Light">
-                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </Button.Resources>
-                </Button>
+                <Button Content="Button" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="11" Style="{StaticResource RightColumn}">
                 <Button Content="Button" MinWidth="100"/>
@@ -379,23 +363,7 @@
 
             <TextBlock Grid.Row="12" Text="DropDownButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="12" Style="{StaticResource LeftColumn}">
-                <controls:DropDownButton Content="DropDownButton" MinWidth="100">
-                    <controls:DropDownButton.Resources>
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Default">
-                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="HighContrast">
-                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Light">
-                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </controls:DropDownButton.Resources>
-                </controls:DropDownButton>
+                <controls:DropDownButton Content="DropDownButton" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="12" Style="{StaticResource RightColumn}">
                 <controls:DropDownButton Content="DropDownButton" MinWidth="100"/>
@@ -403,23 +371,7 @@
 
             <TextBlock Grid.Row="13" Text="SplitButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="13" Style="{StaticResource LeftColumn}">
-                <controls:SplitButton Content="Button" MinWidth="100">
-                    <controls:SplitButton.Resources>
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Default">
-                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="HighContrast">
-                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Light">
-                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </controls:SplitButton.Resources>
-                </controls:SplitButton>
+                <controls:SplitButton Content="Button" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="13" Style="{StaticResource RightColumn}">
                 <controls:SplitButton Content="Button" MinWidth="100"/>
@@ -427,23 +379,7 @@
 
             <TextBlock Grid.Row="14" Text="ToggleButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="14" Style="{StaticResource LeftColumn}">
-                <ToggleButton Content="ToggleButton" MinWidth="100">
-                    <ToggleButton.Resources>
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Default">
-                                    <x:Double x:Key="ToggleButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="HighContrast">
-                                    <x:Double x:Key="ToggleButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Light">
-                                    <x:Double x:Key="ToggleButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </ToggleButton.Resources>
-                </ToggleButton>
+                <ToggleButton Content="ToggleButton" MinWidth="100" BorderThickness="2" BorderBrush="Gray"/>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="14" Style="{StaticResource RightColumn}">
                 <ToggleButton Content="ToggleButton" MinWidth="100"/>
@@ -451,23 +387,7 @@
 
             <TextBlock Grid.Row="15" Text="ToggleSplitButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="15" Style="{StaticResource LeftColumn}">
-                <controls:ToggleSplitButton Content="ToggleSplitButton" MinWidth="100">
-                    <controls:ToggleSplitButton.Resources>
-                        <ResourceDictionary>
-                            <ResourceDictionary.ThemeDictionaries>
-                                <ResourceDictionary x:Key="Default">
-                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="HighContrast">
-                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                                <ResourceDictionary x:Key="Light">
-                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
-                                </ResourceDictionary>
-                            </ResourceDictionary.ThemeDictionaries>
-                        </ResourceDictionary>
-                    </controls:ToggleSplitButton.Resources>
-                </controls:ToggleSplitButton>
+                <controls:ToggleSplitButton Content="ToggleSplitButton" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="15" Style="{StaticResource RightColumn}">
                 <controls:ToggleSplitButton Content="ToggleSplitButton" MinWidth="100"/>

--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
@@ -355,7 +355,23 @@
 
             <TextBlock Grid.Row="11" Text="Button" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="11" Style="{StaticResource LeftColumn}">
-                <Button Content="Button" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
+                <Button Content="Button" MinWidth="100">
+                    <Button.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Default">
+                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Light">
+                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </Button.Resources>
+                </Button>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="11" Style="{StaticResource RightColumn}">
                 <Button Content="Button" MinWidth="100"/>
@@ -363,7 +379,23 @@
 
             <TextBlock Grid.Row="12" Text="DropDownButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="12" Style="{StaticResource LeftColumn}">
-                <controls:DropDownButton Content="DropDownButton" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
+                <controls:DropDownButton Content="DropDownButton" MinWidth="100">
+                    <controls:DropDownButton.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Default">
+                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Light">
+                                    <x:Double x:Key="ButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </controls:DropDownButton.Resources>
+                </controls:DropDownButton>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="12" Style="{StaticResource RightColumn}">
                 <controls:DropDownButton Content="DropDownButton" MinWidth="100"/>
@@ -371,7 +403,23 @@
 
             <TextBlock Grid.Row="13" Text="SplitButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="13" Style="{StaticResource LeftColumn}">
-                <controls:SplitButton Content="Button" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
+                <controls:SplitButton Content="Button" MinWidth="100">
+                    <controls:SplitButton.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Default">
+                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Light">
+                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </controls:SplitButton.Resources>
+                </controls:SplitButton>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="13" Style="{StaticResource RightColumn}">
                 <controls:SplitButton Content="Button" MinWidth="100"/>
@@ -379,7 +427,23 @@
 
             <TextBlock Grid.Row="14" Text="ToggleButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="14" Style="{StaticResource LeftColumn}">
-                <ToggleButton Content="ToggleButton" MinWidth="100" BorderThickness="2" BorderBrush="Gray"/>
+                <ToggleButton Content="ToggleButton" MinWidth="100">
+                    <ToggleButton.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Default">
+                                    <x:Double x:Key="ToggleButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <x:Double x:Key="ToggleButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Light">
+                                    <x:Double x:Key="ToggleButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </ToggleButton.Resources>
+                </ToggleButton>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="14" Style="{StaticResource RightColumn}">
                 <ToggleButton Content="ToggleButton" MinWidth="100"/>
@@ -387,7 +451,23 @@
 
             <TextBlock Grid.Row="15" Text="ToggleSplitButton" Style="{StaticResource SideHeader}"/>
             <Grid Grid.Column="1" Grid.Row="15" Style="{StaticResource LeftColumn}">
-                <controls:ToggleSplitButton Content="ToggleSplitButton" BorderThickness="2" BorderBrush="Gray" MinWidth="100"/>
+                <controls:ToggleSplitButton Content="ToggleSplitButton" MinWidth="100">
+                    <controls:ToggleSplitButton.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Default">
+                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Light">
+                                    <x:Double x:Key="SplitButtonBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </controls:ToggleSplitButton.Resources>
+                </controls:ToggleSplitButton>
             </Grid>
             <Grid Grid.Column="2" Grid.Row="15" Style="{StaticResource RightColumn}">
                 <controls:ToggleSplitButton Content="ToggleSplitButton" MinWidth="100"/>

--- a/dev/SplitButton/SplitButton.xaml
+++ b/dev/SplitButton/SplitButton.xaml
@@ -238,7 +238,7 @@
                             Grid.Column="2"/>
 
                         <Grid x:Name="Border"
-                            Grid.ColumnSpan="2"
+                            Grid.ColumnSpan="3"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>

--- a/dev/SplitButton/SplitButton.xaml
+++ b/dev/SplitButton/SplitButton.xaml
@@ -26,14 +26,13 @@
                 <ControlTemplate TargetType="local:SplitButton">
                     <Grid
                         x:Name="RootGrid"
-                        Background="{TemplateBinding Background}"
+                        Background="Transparent"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
 
                         <Grid.Resources>
                             <!-- Override the style of the inner buttons so that they don't affect background/foreground/border colors -->
                             <Style TargetType="Button">
-                                <Setter Property="Background" Value="Transparent" />
                                 <Setter Property="Foreground" Value="{ThemeResource SplitButtonForeground}" />
                                 <Setter Property="BorderBrush" Value="Transparent" />
                                 <Setter Property="BorderThickness" Value="{ThemeResource SplitButtonBorderThemeThickness}" />
@@ -84,7 +83,8 @@
 
                                 <VisualState x:Name="FlyoutOpen">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
@@ -93,7 +93,8 @@
 
                                 <VisualState x:Name="TouchPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
@@ -102,7 +103,6 @@
 
                                 <VisualState x:Name="PrimaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPointerOver}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPointerOver}"/>
@@ -112,7 +112,6 @@
 
                                 <VisualState x:Name="PrimaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
@@ -122,7 +121,6 @@
 
                                 <VisualState x:Name="SecondaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackground}"/>
                                         <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPointerOver}"/>
                                         <Setter Target="SecondaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}"/>
@@ -132,7 +130,6 @@
 
                                 <VisualState x:Name="SecondaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackground}"/>
                                         <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="SecondaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
@@ -142,7 +139,8 @@
 
                                 <VisualState x:Name="Checked">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
@@ -151,7 +149,8 @@
 
                                 <VisualState x:Name="CheckedFlyoutOpen">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedPressed}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedPressed}"/>
@@ -160,7 +159,8 @@
 
                                 <VisualState x:Name="CheckedTouchPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedPressed}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedPressed}"/>
@@ -169,7 +169,6 @@
 
                                 <VisualState x:Name="CheckedPrimaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPointerOver}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPointerOver}"/>
@@ -181,7 +180,6 @@
 
                                 <VisualState x:Name="CheckedPrimaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPressed}"/>
@@ -193,7 +191,6 @@
 
                                 <VisualState x:Name="CheckedSecondaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
@@ -205,7 +202,6 @@
 
                                 <VisualState x:Name="CheckedSecondaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
@@ -222,21 +218,24 @@
                                 <VisualState x:Name="SecondaryButtonSpan">
                                     <VisualState.Setters>
                                         <Setter Target="SecondaryButton.(Grid.Column)" Value="0"/>
-                                        <Setter Target="SecondaryButton.(Grid.ColumnSpan)" Value="2"/>
+                                        <Setter Target="SecondaryButton.(Grid.ColumnSpan)" Value="3"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition x:Name="FirstColumn" Width="*" MinWidth="{ThemeResource SplitButtonPrimaryButtonSize}"/>
-                            <ColumnDefinition x:Name="SecondColumn" Width="{ThemeResource SplitButtonSecondaryButtonSize}"/>
+                            <ColumnDefinition x:Name="PrimaryButtonColumn" Width="*" MinWidth="{ThemeResource SplitButtonPrimaryButtonSize}"/>
+                            <ColumnDefinition x:Name="Separator" Width="1" />
+                            <ColumnDefinition x:Name="SecondaryButtonColumn" Width="{ThemeResource SplitButtonSecondaryButtonSize}"/>
                         </Grid.ColumnDefinitions>
 
-                        <Grid x:Name="PrimaryBackgroundGrid"/>
+                        <Grid x:Name="PrimaryBackgroundGrid"
+                            Background="{TemplateBinding Background}"/>
 
                         <Grid x:Name="SecondaryBackgroundGrid"
-                            Grid.Column="1"/>
+                            Background="{TemplateBinding Background}"
+                            Grid.Column="2"/>
 
                         <Grid x:Name="Border"
                             Grid.ColumnSpan="2"
@@ -264,7 +263,7 @@
                             AutomationProperties.AccessibilityView="Raw"/>
 
                         <Button x:Name="SecondaryButton"
-                            Grid.Column="1"
+                            Grid.Column="2"
                             Foreground="{TemplateBinding Foreground}"
                             Background="{TemplateBinding Background}"
                             BorderThickness="{TemplateBinding BorderThickness}"

--- a/dev/SplitButton/SplitButton_rs1.xaml
+++ b/dev/SplitButton/SplitButton_rs1.xaml
@@ -26,14 +26,13 @@
                 <ControlTemplate TargetType="local:SplitButton">
                     <Grid
                         x:Name="RootGrid"
-                        Background="{TemplateBinding Background}"
+                        Background="Transparent"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
 
                         <Grid.Resources>
                             <!-- Override the style of the inner buttons so that they don't affect background/foreground/border colors -->
                             <Style TargetType="Button">
-                                <Setter Property="Background" Value="Transparent" />
                                 <Setter Property="Foreground" Value="{ThemeResource SplitButtonForeground}" />
                                 <Setter Property="BorderBrush" Value="Transparent" />
                                 <Setter Property="BorderThickness" Value="{ThemeResource SplitButtonBorderThemeThickness}" />
@@ -84,8 +83,8 @@
 
                                 <VisualState x:Name="FlyoutOpen">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
-                                        <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
                                     </VisualState.Setters>
@@ -93,8 +92,8 @@
 
                                 <VisualState x:Name="TouchPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
-                                        <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
                                         <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
                                     </VisualState.Setters>
@@ -102,7 +101,6 @@
 
                                 <VisualState x:Name="PrimaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPointerOver}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPointerOver}"/>
@@ -112,7 +110,6 @@
 
                                 <VisualState x:Name="PrimaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundPressed}"/>
@@ -122,7 +119,6 @@
 
                                 <VisualState x:Name="SecondaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackground}"/>
                                         <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPointerOver}"/>
                                         <Setter Target="SecondaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPointerOver}"/>
@@ -132,7 +128,6 @@
 
                                 <VisualState x:Name="SecondaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackground}"/>
                                         <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}"/>
                                         <Setter Target="SecondaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushPressed}"/>
@@ -142,6 +137,8 @@
 
                                 <VisualState x:Name="Checked">
                                     <VisualState.Setters>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
@@ -151,6 +148,8 @@
 
                                 <VisualState x:Name="CheckedFlyoutOpen">
                                     <VisualState.Setters>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedPressed}"/>
@@ -160,6 +159,8 @@
 
                                 <VisualState x:Name="CheckedTouchPressed">
                                     <VisualState.Setters>
+                                        <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
+                                        <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="RootGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPressed}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedPressed}"/>
@@ -169,7 +170,6 @@
 
                                 <VisualState x:Name="CheckedPrimaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPointerOver}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPointerOver}"/>
@@ -181,7 +181,6 @@
 
                                 <VisualState x:Name="CheckedPrimaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedPressed}"/>
                                         <Setter Target="PrimaryButton.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedPressed}"/>
@@ -193,7 +192,6 @@
 
                                 <VisualState x:Name="CheckedSecondaryPointerOver">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
@@ -205,7 +203,6 @@
 
                                 <VisualState x:Name="CheckedSecondaryPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="RootGrid.Background" Value="Transparent"/>
                                         <Setter Target="Border.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushChecked}"/>
                                         <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundChecked}"/>
                                         <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundChecked}"/>
@@ -222,7 +219,7 @@
                                 <VisualState x:Name="SecondaryButtonSpan">
                                     <VisualState.Setters>
                                         <Setter Target="SecondaryButton.(Grid.Column)" Value="0"/>
-                                        <Setter Target="SecondaryButton.(Grid.ColumnSpan)" Value="2"/>
+                                        <Setter Target="SecondaryButton.(Grid.ColumnSpan)" Value="3"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -251,14 +248,15 @@
                         </VisualStateManager.VisualStateGroups>
 
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition x:Name="FirstColumn" Width="*" MinWidth="{ThemeResource SplitButtonPrimaryButtonSize}"/>
-                            <ColumnDefinition x:Name="SecondColumn" Width="{ThemeResource SplitButtonSecondaryButtonSize}"/>
+                            <ColumnDefinition x:Name="PrimaryButtonColumn" Width="*" MinWidth="{ThemeResource SplitButtonPrimaryButtonSize}"/>
+                            <ColumnDefinition x:Name="Separator" Width="1"/>
+                            <ColumnDefinition x:Name="SecondaryButtonColumn" Width="{ThemeResource SplitButtonSecondaryButtonSize}"/>
                         </Grid.ColumnDefinitions>
 
                         <Grid x:Name="PrimaryBackgroundGrid"/>
 
                         <Grid x:Name="SecondaryBackgroundGrid"
-                            Grid.Column="1"/>
+                            Grid.Column="2"/>
 
                         <Grid x:Name="Border"
                             Grid.ColumnSpan="2"
@@ -285,7 +283,7 @@
                             AutomationProperties.AccessibilityView="Raw"/>
 
                         <Button x:Name="SecondaryButton"
-                            Grid.Column="1"
+                            Grid.Column="2"
                             Foreground="{TemplateBinding Foreground}"
                             Background="{TemplateBinding Background}"
                             BorderThickness="{TemplateBinding BorderThickness}"

--- a/dev/SplitButton/SplitButton_rs1.xaml
+++ b/dev/SplitButton/SplitButton_rs1.xaml
@@ -259,7 +259,7 @@
                             Grid.Column="2"/>
 
                         <Grid x:Name="Border"
-                            Grid.ColumnSpan="2"
+                            Grid.ColumnSpan="3"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" />
 


### PR DESCRIPTION
Update the SplitButton to a new visual design, separating the button and drop down.
![Visual Comp](https://user-images.githubusercontent.com/22958680/61009776-b445bf80-a328-11e9-98ed-43d7a366605b.png)
Fix #986 
