### PR TITLE
Fix the PaneVisible initialziation problem 

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -378,6 +378,7 @@ void NavigationView::OnApplyTemplate()
     UpdateSingleSelectionFollowsFocusTemplateSetting();
     UpdateNavigationViewUseSystemVisual();
     PropagateNavigationViewAsParent();
+    UpdatePaneVisibility();
     UpdateVisualState();
     UpdatePaneTitleMargins();
 }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -697,6 +697,24 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "A")]
+        public void VerifyPaneVisibleOnInit()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Init Test" }))
+            {
+                Log.Comment("Verify PaneIsVisibleItem is invisible");
+                VerifyElement.NotFound("PaneIsVisibleItem", FindBy.Name);
+
+                FindElement.ByName<Button>("ChangePaneVisible").Invoke();
+                Wait.ForIdle();
+
+                Log.Comment("Verify PaneIsVisibleItem is visible");
+                VerifyElement.Found("PaneIsVisibleItem", FindBy.Name);
+
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void VerifyNavigationViewItemResponseToClickAfterBeingMovedBetweenFrames()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Init Test" }))

--- a/dev/NavigationView/TestUI/NavigationViewInitPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewInitPage.xaml
@@ -26,7 +26,7 @@
                     <Button x:Name="RemoveItemButton" AutomationProperties.Name="RemoveItemButton" Content="Remove Item" Click="RemoveButton_Click"/>
                     <Button x:Name="ChangeToIEnumerableButton" AutomationProperties.Name="ChangeToIEnumerableButton" Content="Make it IEnumerable" Click="ChangeToIEnumerableButton_Clicks"/>
                     <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Content="Flip Orientation" Click="FlipOrientation_Click"/>
-                
+
                     <StackPanel>
                         <Button x:Name="SwitchFrame" AutomationProperties.Name="SwitchFrame" Content="SwitchFrame" Click="SwitchFrame_Click" />
                         <TextBlock x:Name="MyLocationResult" AutomationProperties.Name="MyLocationResult" Text="Unknown"/>
@@ -52,6 +52,13 @@
                     <controls:NavigationViewItem Content="Albums" IsSelected="True" />
                     <controls:NavigationViewItem Content="People" IsSelected="True" />
                 </controls:NavigationView.MenuItems>
+            </controls:NavigationView>
+            <controls:NavigationView x:Name="NavView4"
+                IsPaneVisible="False">
+                <controls:NavigationView.MenuItems>
+                    <controls:NavigationViewItem Content="123" AutomationProperties.Name="PaneIsVisibleItem"/>
+                </controls:NavigationView.MenuItems>
+                <Button Content="Change IsPaneVisible Flag" AutomationProperties.Name="ChangePaneVisible" Click="ChangePaneVisibleButton_Click" />
             </controls:NavigationView>
         </StackPanel>
     </Grid>

--- a/dev/NavigationView/TestUI/NavigationViewInitPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewInitPage.xaml.cs
@@ -114,5 +114,10 @@ namespace MUXControlsTestApp
                 MyLocationResult.Text = "Frame2";
             }
         }
+
+        private void ChangePaneVisibleButton_Click(object sender, RoutedEventArgs e)
+        {
+            NavView4.IsPaneVisible = !NavView4.IsPaneVisible;
+        }
     }
 }


### PR DESCRIPTION
Fix #595.
When PaneVisible=false in Xaml, visualstate is not updated to PaneCollapsed correctly.
UpdatePaneVisibility calls VisualStateManager::GoToState.
When PaneVisible = true before OnApplyTemplate, the visualstate change is ignored and didn't take into effect.
This fix just rerun UpdatePaneVisibility in OnApplyTemplate to fix the problem.