### PR TITLE
Calculator Swipe Crash

### DIFF
--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -719,18 +719,19 @@ void SwipeControl::DetachDismissingHandlers()
     {
         if (auto xamlRoot = uiElement10.XamlRoot())
         {
-            auto xamlRootContent = xamlRoot.Content();
-
-            if (m_onXamlRootPointerPressedEventHandler)
+            if (auto xamlRootContent = xamlRoot.Content())
             {
-                xamlRootContent.RemoveHandler(winrt::UIElement::PointerPressedEvent(), m_onXamlRootPointerPressedEventHandler.get());
-                m_onXamlRootPointerPressedEventHandler.set(nullptr);
-            }
+                if (m_onXamlRootPointerPressedEventHandler)
+                {
+                    xamlRootContent.RemoveHandler(winrt::UIElement::PointerPressedEvent(), m_onXamlRootPointerPressedEventHandler.get());
+                    m_onXamlRootPointerPressedEventHandler.set(nullptr);
+                }
 
-            if (m_onXamlRootKeyDownEventHandler)
-            {
-                xamlRootContent.RemoveHandler(winrt::UIElement::KeyDownEvent(), m_onXamlRootKeyDownEventHandler.get());
-                m_onXamlRootKeyDownEventHandler.set(nullptr);
+                if (m_onXamlRootKeyDownEventHandler)
+                {
+                    xamlRootContent.RemoveHandler(winrt::UIElement::KeyDownEvent(), m_onXamlRootKeyDownEventHandler.get());
+                    m_onXamlRootKeyDownEventHandler.set(nullptr);
+                }
             }
         }
     }

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -677,22 +677,24 @@ void SwipeControl::AttachDismissingHandlers()
     {
         if (auto xamlRoot = uiElement10.XamlRoot())
         {
-            auto xamlRootContent = xamlRoot.Content();
-            m_onXamlRootPointerPressedEventHandler = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
-                xamlRootContent,
-                [this](auto const&, auto const& args)
-                {
-                    DismissSwipeOnAnExternalTap(args.GetCurrentPoint(nullptr).Position());
-                },
-                true /*handledEventsToo*/);
+            if (auto&& xamlRootContent = xamlRoot.Content())
+            {
+                m_xamlRootPointerPressedEventHandler = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
+                    xamlRootContent,
+                    [this](auto const&, auto const& args)
+                    {
+                        DismissSwipeOnAnExternalTap(args.GetCurrentPoint(nullptr).Position());
+                    },
+                    true /*handledEventsToo*/);
 
-            m_onXamlRootKeyDownEventHandler = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
-                xamlRootContent,
-                [this](auto const&, auto const& args)
-                {
-                    CloseIfNotRemainOpenExecuteItem();
-                },
-                true /*handledEventsToo*/);
+                m_xamlRootKeyDownEventHandler = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
+                    xamlRootContent,
+                    [this](auto const&, auto const& args)
+                    {
+                        CloseIfNotRemainOpenExecuteItem();
+                    },
+                    true /*handledEventsToo*/);
+            }
 
             m_xamlRootChangedRevoker = xamlRoot.Changed(winrt::auto_revoke, { this, &SwipeControl::CurrentXamlRootChanged });
         }
@@ -724,8 +726,8 @@ void SwipeControl::DetachDismissingHandlers()
 {
     SWIPECONTROL_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
 
-    m_onXamlRootPointerPressedEventHandler.revoke();
-    m_onXamlRootKeyDownEventHandler.revoke();
+    m_xamlRootPointerPressedEventHandler.revoke();
+    m_xamlRootKeyDownEventHandler.revoke();
     m_xamlRootChangedRevoker.revoke();
 
     m_acceleratorKeyActivatedRevoker.revoke();

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -687,7 +687,7 @@ void SwipeControl::AttachDismissingHandlers()
                     },
                     true /*handledEventsToo*/);
 
-                m_xamlRootKeyDownEventHandler = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
+                m_xamlRootKeyDownEventHandler = AddRoutedEventHandler<RoutedEventType::KeyDown>(
                     xamlRootContent,
                     [this](auto const&, auto const& args)
                     {

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -679,7 +679,7 @@ void SwipeControl::AttachDismissingHandlers()
         {
             if (auto&& xamlRootContent = xamlRoot.Content())
             {
-                m_xamlRootPointerPressedEventHandler = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
+                m_xamlRootPointerPressedEventRevoker = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
                     xamlRootContent,
                     [this](auto const&, auto const& args)
                     {
@@ -687,7 +687,7 @@ void SwipeControl::AttachDismissingHandlers()
                     },
                     true /*handledEventsToo*/);
 
-                m_xamlRootKeyDownEventHandler = AddRoutedEventHandler<RoutedEventType::KeyDown>(
+                m_xamlRootKeyDownEventRevoker = AddRoutedEventHandler<RoutedEventType::KeyDown>(
                     xamlRootContent,
                     [this](auto const&, auto const& args)
                     {
@@ -726,8 +726,8 @@ void SwipeControl::DetachDismissingHandlers()
 {
     SWIPECONTROL_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
 
-    m_xamlRootPointerPressedEventHandler.revoke();
-    m_xamlRootKeyDownEventHandler.revoke();
+    m_xamlRootPointerPressedEventRevoker.revoke();
+    m_xamlRootKeyDownEventRevoker.revoke();
     m_xamlRootChangedRevoker.revoke();
 
     m_acceleratorKeyActivatedRevoker.revoke();

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -719,19 +719,24 @@ void SwipeControl::DetachDismissingHandlers()
     {
         if (auto xamlRoot = uiElement10.XamlRoot())
         {
-            if (auto xamlRootContent = xamlRoot.Content())
-            {
-                if (m_onXamlRootPointerPressedEventHandler)
-                {
-                    xamlRootContent.RemoveHandler(winrt::UIElement::PointerPressedEvent(), m_onXamlRootPointerPressedEventHandler.get());
-                    m_onXamlRootPointerPressedEventHandler.set(nullptr);
-                }
+            auto xamlRootContent = xamlRoot.Content();
 
-                if (m_onXamlRootKeyDownEventHandler)
+            if (auto&& handler = m_onXamlRootPointerPressedEventHandler.get())
+            {
+                if (xamlRootContent)
                 {
-                    xamlRootContent.RemoveHandler(winrt::UIElement::KeyDownEvent(), m_onXamlRootKeyDownEventHandler.get());
-                    m_onXamlRootKeyDownEventHandler.set(nullptr);
+                    xamlRootContent.RemoveHandler(winrt::UIElement::PointerPressedEvent(), handler);
                 }
+                m_onXamlRootPointerPressedEventHandler.set(nullptr);
+            }
+
+            if (auto&& handler = m_onXamlRootKeyDownEventHandler.get())
+            {
+                if (xamlRootContent)
+                {
+                    xamlRootContent.RemoveHandler(winrt::UIElement::KeyDownEvent(), handler);
+                }
+                m_onXamlRootKeyDownEventHandler.set(nullptr);
             }
         }
     }

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -177,8 +177,8 @@ private:
     tracker_ref<winrt::IInspectable> m_onPointerPressedEventHandler{ this };
 
     // Used on platforms where we have XamlRoot.
-    RoutedEventHandler_revoker m_onXamlRootPointerPressedEventHandler{};
-    RoutedEventHandler_revoker m_onXamlRootKeyDownEventHandler{};
+    RoutedEventHandler_revoker m_xamlRootPointerPressedEventHandler{};
+    RoutedEventHandler_revoker m_xamlRootKeyDownEventHandler{};
     winrt::IXamlRoot::Changed_revoker m_xamlRootChangedRevoker;
 
 

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -177,9 +177,9 @@ private:
     tracker_ref<winrt::IInspectable> m_onPointerPressedEventHandler{ this };
 
     // Used on platforms where we have XamlRoot.
-    RoutedEventHandler_revoker m_xamlRootPointerPressedEventHandler{};
-    RoutedEventHandler_revoker m_xamlRootKeyDownEventHandler{};
-    winrt::IXamlRoot::Changed_revoker m_xamlRootChangedRevoker;
+    RoutedEventHandler_revoker m_xamlRootPointerPressedEventRevoker{};
+    RoutedEventHandler_revoker m_xamlRootKeyDownEventRevoker{};
+    winrt::IXamlRoot::Changed_revoker m_xamlRootChangedRevoker{};
 
 
     // Used on platforms where we don't have XamlRoot.

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -85,10 +85,8 @@ private:
     void DismissSwipeOnAcceleratorKeyActivator(const winrt::Windows::UI::Core::CoreDispatcher & sender, const winrt::AcceleratorKeyEventArgs & args);
 
     // Used on platforms where we have XamlRoot.
-    void DismissSwipeOnXamlRootKeyDown(const winrt::IInspectable & sender, const winrt::KeyRoutedEventArgs & args);
     void CurrentXamlRootChanged(const winrt::XamlRoot & sender, const winrt::XamlRootChangedEventArgs & args);
-    void DismissSwipeOnAnExternalXamlRootTap(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-
+    
 
     // Used on platforms where we don't have XamlRoot.
     void DismissSwipeOnCoreWindowKeyDown(const winrt::CoreWindow & sender, const winrt::KeyEventArgs & args);
@@ -179,8 +177,8 @@ private:
     tracker_ref<winrt::IInspectable> m_onPointerPressedEventHandler{ this };
 
     // Used on platforms where we have XamlRoot.
-    tracker_ref<winrt::IInspectable> m_onXamlRootPointerPressedEventHandler{ this };
-    tracker_ref<winrt::IInspectable> m_onXamlRootKeyDownEventHandler{ this };
+    RoutedEventHandler_revoker m_onXamlRootPointerPressedEventHandler{};
+    RoutedEventHandler_revoker m_onXamlRootKeyDownEventHandler{};
     winrt::IXamlRoot::Changed_revoker m_xamlRootChangedRevoker;
 
 

--- a/dev/inc/RoutedEventHelpers.h
+++ b/dev/inc/RoutedEventHelpers.h
@@ -81,6 +81,7 @@ enum class RoutedEventType
     GettingFocus,
     LosingFocus,
     KeyDown,
+    PointerPressed
 };
 
 template<RoutedEventType eventType>
@@ -107,6 +108,13 @@ struct RoutedEventTraits<RoutedEventType::KeyDown>
 {
     static winrt::RoutedEvent Event() { return winrt::UIElement::KeyDownEvent(); }
     using HandlerT = winrt::KeyEventHandler;
+};
+
+template <>
+struct RoutedEventTraits<RoutedEventType::PointerPressed>
+{
+    static winrt::RoutedEvent Event() { return winrt::UIElement::PointerPressedEvent(); }
+    using HandlerT = winrt::PointerEventHandler;
 };
 
 template<RoutedEventType eventType, typename traits = RoutedEventTraits<eventType>>


### PR DESCRIPTION
Swipe is crashing in the calculator app, I believe it it because we are not checking for the existence of the xaml root's content before detaching our event handlers from it during clean up.