### PR TITLE
Update ComboBox dropdown button margin

### DIFF
--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -640,7 +640,7 @@
                             Grid.Row="1"
                             Grid.Column="1"
                             Background="Transparent"
-                            Margin="0,2,2,2"
+                            Margin="0,1,1,1"
                             Visibility="Collapsed"
                             Width="30"
                             HorizontalAlignment="Right"


### PR DESCRIPTION
We updated ComboBox border thickness to 1px but dropdown button margin is still 2px, so there is gap around the button. Updated margin to 1 to fix it.

Before:
![image](https://user-images.githubusercontent.com/7389110/63364633-e9085600-c36d-11e9-92c5-7972311cefb5.png)

After fix (with rounded corners turned on):
![{9BBE1976-9C15-43ED-9238-C932BCE1A62B}](https://user-images.githubusercontent.com/4424330/63375716-260a2380-c341-11e9-878e-396e1d7d7c49.png)

![{81DFE3A0-7BEC-4019-A745-E1C2F3D63349}](https://user-images.githubusercontent.com/4424330/63388145-498e9780-c35c-11e9-9230-5b173a9db453.png)
![{1BCF1975-05CD-408B-A8B0-7E6A983CB8AE}](https://user-images.githubusercontent.com/4424330/63388154-4eebe200-c35c-11e9-987e-f32d7da8a07b.png)



