### PR TITLE
NavigationView: Fixing visibility of close button in Auto PaneDisplayMode and Minimal DisplayMode

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -824,7 +824,15 @@ bool NavigationView::ShouldShowCloseButton()
 {
     if (m_backButton && !ShouldPreserveNavigationViewRS3Behavior() && m_closeButton)
     {
-        if (PaneDisplayMode() != winrt::NavigationViewPaneDisplayMode::LeftMinimal || !IsPaneOpen())
+        if (!IsPaneOpen())
+        {
+            return false;
+        }
+
+        auto paneDisplayMode = PaneDisplayMode();
+
+        if (paneDisplayMode != winrt::NavigationViewPaneDisplayMode::LeftMinimal &&
+            (paneDisplayMode != winrt::NavigationViewPaneDisplayMode::Auto || DisplayMode() != winrt::NavigationViewDisplayMode::Minimal))
         {
             return false;
         }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3502,20 +3502,60 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "D")]
-        [TestProperty("Description", "Verifies the back button is visible when the pane is closed and the close button is visible when the pane is open, in LeftMinimal display mode")]
-        public void VerifyBackAndCloseButtonsVisibility()
+        [TestProperty("Description", "Verifies the back button is visible when the pane is closed and the close button is visible when the pane is open, in LeftMinimal pane display mode")]
+        public void VerifyBackAndCloseButtonsVisibilityInLeftMinimalPaneDisplayMode()
+        {
+            VerifyBackAndCloseButtonsVisibility(inLeftMinimalPanelDisplayMode: true);
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        [TestProperty("Description", "Verifies the close button is visible when the pane is open, in Auto pane display mode and Minimal display mode")]
+        public void VerifyBackAndCloseButtonsVisibilityInAutoPaneDisplayMode()
+        {
+            VerifyBackAndCloseButtonsVisibility(inLeftMinimalPanelDisplayMode: false);
+        }
+
+        private void VerifyBackAndCloseButtonsVisibility(bool inLeftMinimalPanelDisplayMode)
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
             {
+                var displayModeTextBox = new TextBlock(FindElement.ByName("DisplayModeTextBox"));
                 var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
                 var isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
 
-                Log.Comment("Set PaneDisplayMode to LeftMinimal");
-                panelDisplayModeComboBox.SelectItemByName("LeftMinimal");
-                Wait.ForIdle();
+                Verify.AreEqual(expanded, displayModeTextBox.DocumentText, "Original DisplayMode expected to be Expanded");
 
-                Log.Comment("Verify Pane is closed automatically when PaneDisplayMode becomes LeftMinimal");
-                Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be False when PaneDisplayMode becomes LeftMinimal");
+                if (inLeftMinimalPanelDisplayMode)
+                {
+                    Log.Comment("Set PaneDisplayMode to LeftMinimal");
+                    panelDisplayModeComboBox.SelectItemByName("LeftMinimal");
+                    Wait.ForIdle();
+
+                    Log.Comment("Verify Pane is closed automatically when PaneDisplayMode becomes LeftMinimal");
+                    Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be False when PaneDisplayMode becomes LeftMinimal");
+                }
+                else
+                {
+                    Log.Comment("Set PaneDisplayMode to Auto");
+                    panelDisplayModeComboBox.SelectItemByName("Auto");
+                    Wait.ForIdle();
+
+                    Log.Comment("Verify Pane remains open when PaneDisplayMode becomes Auto");
+                    Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to remain True when PaneDisplayMode becomes Auto");
+
+                    Log.Comment("Verify back button is visible when pane is open in Expanded DisplayMode");
+                    VerifyElement.Found("NavigationViewBackButton", FindBy.Id);
+
+                    Log.Comment("Verify close button is not visible when pane is open in Expanded DisplayMode");
+                    VerifyElement.NotFound("NavigationViewCloseButton", FindBy.Id);
+
+                    Log.Comment("Decrease the width of the control from Wide to Narrow and force pane closure");
+                    SetNavViewWidth(ControlWidth.Narrow);
+                    Wait.ForIdle();
+                    Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be False after decreasing width");
+                    Verify.AreEqual(minimal, displayModeTextBox.DocumentText);
+                }
 
                 Log.Comment("Verify toggle-pane button is visible when pane is closed");
                 VerifyElement.Found("TogglePaneButton", FindBy.Id);


### PR DESCRIPTION
Fixes Issue #563.

When the NavigationView pane is open, not only must the new Close button be displayed when PaneDisplayMode is LeftMinimal, it must also appear when the PaneDisplayMode is Auto and the DisplayMode is Minimal.
Only the NavigationView::ShouldShowCloseButton() method had to be tweaked to make that happen.

I added a new VerifyBackAndCloseButtonsVisibilityInAutoPaneDisplayMode test to cover that scenario.