### PR TITLE
Fix ItemsSource and TreeViewNode syncing

### DIFF
--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -2688,6 +2688,61 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("TestSuite", "B")]
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/1182
+        public void TreeViewWithMultiLevelChildrenExpandCollapseTest()
+        {
+            // TreeView databinding only works on RS5+
+            if (IsLowerThanRS5())
+            {
+                return;
+            }
+
+            using (var setup = new TestSetupHelper("TreeView Tests"))
+            {
+                SetContentMode(true);
+
+                var root = new TreeItem(LabelFirstItem());
+                root.Expand();
+                Wait.ForIdle();
+
+                ClickButton("AddSecondLevelOfNodes");
+                ClickButton("LabelItems");
+
+                var root1 = new TreeItem(FindElement.ByName("Root.1"));
+                root1.Expand();
+                Wait.ForIdle();
+
+                Log.Comment("Drag Root.1.2 into Root.1.1");
+                var root11 = new TreeItem(FindElement.ByName("Root.1.1"));
+                var root12 = new TreeItem(FindElement.ByName("Root.1.2"));
+                InputHelper.DragToTarget(root12, root11);
+
+                var root0 = new TreeItem(FindElement.ByName("Root.0"));
+                Log.Comment("Drag Root.1 into Root.0");
+                InputHelper.DragToTarget(root1, root0);
+
+                root0.Expand();
+                Wait.ForIdle();
+                root1.Expand();
+                Wait.ForIdle();
+                root11.Expand();
+                Wait.ForIdle();
+
+                ClickButton("GetChildrenOrder");
+                Verify.AreEqual("Root | Root.0 | Root.0.0 | Root.1 | Root.1.0 | Root.1.1 | Root.1.2 | Root.2", ReadResult());
+
+                root0.Collapse();
+                Wait.ForIdle();
+                root0.Expand();
+                Wait.ForIdle();
+
+                ClickButton("GetChildrenOrder");
+                Verify.AreEqual("Root | Root.0 | Root.0.0 | Root.1 | Root.1.0 | Root.1.1 | Root.1.2 | Root.2", ReadResult());
+            }
+        }
+
         private void ClickButton(string buttonName)
         {
             var button = new Button(FindElement.ByName(buttonName));

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -236,7 +236,7 @@ void TreeViewNode::SyncChildrenNodesWithItemsSource()
         auto children = winrt::get_self<TreeViewNodeVector>(Children());
         children->Clear(false /* updateItemsSource */);
 
-        auto size = m_itemsDataSource.Count();
+        auto size = m_itemsDataSource ? m_itemsDataSource.Count() : 0;
         for (auto i = 0; i < size; i++)
         {
             auto item = m_itemsDataSource.GetAt(i);

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -250,7 +250,8 @@ void TreeViewNode::SyncChildrenNodesWithItemsSource()
 
 bool TreeViewNode::AreChildrenNodesEqualToItemsSource()
 {
-    UINT32 childrenCount = Children() ? Children().Size() : 0;
+    auto children = Children();
+    UINT32 childrenCount = children ? children.Size() : 0;
     UINT32 itemsSourceCount = m_itemsDataSource ? m_itemsDataSource.Count() : 0;
 
     if (childrenCount != itemsSourceCount)
@@ -259,14 +260,11 @@ bool TreeViewNode::AreChildrenNodesEqualToItemsSource()
     }
 
     // Compare the actual content in collections when counts are equal
-    if (itemsSourceCount > 0)
+    for (UINT32 i = 0; i < itemsSourceCount; i++)
     {
-        for (UINT32 i = 0; i < itemsSourceCount; i++)
+        if (children.GetAt(i).Content() != m_itemsDataSource.GetAt(i))
         {
-            if (Children().GetAt(i).Content() != m_itemsDataSource.GetAt(i))
-            {
-                return false;
-            }
+            return false;
         }
     }
 

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -231,13 +231,13 @@ void TreeViewNode::RemoveFromChildrenNodes(int index, int count)
 
 void TreeViewNode::SyncChildrenNodesWithItemsSource()
 {
-    auto children = winrt::get_self<TreeViewNodeVector>(Children());
-    children->Clear(false /* updateItemsSource */);
-
-    if (m_itemsDataSource)
+    if (!AreChildrenNodesEqualToItemsSource())
     {
-        int size = m_itemsDataSource.Count();
-        for (int i = 0; i < size; i++)
+        auto children = winrt::get_self<TreeViewNodeVector>(Children());
+        children->Clear(false /* updateItemsSource */);
+
+        auto size = m_itemsDataSource.Count();
+        for (auto i = 0; i < size; i++)
         {
             auto item = m_itemsDataSource.GetAt(i);
             auto node = winrt::make_self<TreeViewNode>();
@@ -246,6 +246,31 @@ void TreeViewNode::SyncChildrenNodesWithItemsSource()
             children->Append(*node, false /* updateItemsSource */);
         }
     }
+}
+
+bool TreeViewNode::AreChildrenNodesEqualToItemsSource()
+{
+    UINT32 childrenCount = Children() ? Children().Size() : 0;
+    UINT32 itemsSourceCount = m_itemsDataSource ? m_itemsDataSource.Count() : 0;
+
+    if (childrenCount != itemsSourceCount)
+    {
+        return false;
+    }
+
+    // Compare the actual content in collections when counts are equal
+    if (itemsSourceCount > 0)
+    {
+        for (UINT32 i = 0; i < itemsSourceCount; i++)
+        {
+            if (Children().GetAt(i).Content() != m_itemsDataSource.GetAt(i))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 hstring TreeViewNode::GetContentAsString()

--- a/dev/TreeView/TreeViewNode.h
+++ b/dev/TreeView/TreeViewNode.h
@@ -66,6 +66,7 @@ private:
     winrt::ItemsSourceView m_itemsDataSource{ nullptr };
     void OnItemsSourceChanged(const winrt::IInspectable& sender, const winrt::NotifyCollectionChangedEventArgs& args);
     void SyncChildrenNodesWithItemsSource();
+    bool AreChildrenNodesEqualToItemsSource();
     void AddToChildrenNodes(int index, int count);
     void RemoveFromChildrenNodes(int index, int count);
     bool m_isContentMode{ false };


### PR DESCRIPTION
Fixes #1182 

In expand/collapse scenario, TreeViewNode.Children already contains the right content for ItemsSource, which means we don't need to clear and re-populate ItemsSource into children collection again. Re-populating for every expand can potentially create an infinite loop because updating TreeViewNode.Children collection triggers ListView layout updates, which can trigger ItemsSource update in some cases (when there are multiple levels of children and TreeViewItems got recycled), if we clean and re-populate children collection again it becomes an infinite loop.

Added a check to make sure we only update TreeViewNode children collection when the contents are actually different from ItemsSource.