### PR TITLE
Avoid crash when customer set selecteditem to not existing item in datasource.

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -77,6 +77,8 @@ static constexpr float c_paneElevationTranslationZ = 32;
 // so 4 is selected for threshold.
 constexpr int s_measureOnInitStep2CountThreshold{ 4 };
 
+constexpr int s_itemNotFound{ -1 };
+
 static winrt::Size c_infSize{ std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity() };
 
 NavigationView::~NavigationView()
@@ -1855,9 +1857,9 @@ NavigationRecommendedTransitionDirection NavigationView::GetRecommendedTransitio
     if (auto topNavListView = m_topNavListView.get())
     {
         MUX_ASSERT(prev && next);
-        auto prevIndex = topNavListView.IndexFromContainer(prev);
-        auto nextIndex = topNavListView.IndexFromContainer(next);
-        if (prevIndex == -1 || nextIndex == -1)
+        auto prevIndex = prev ? topNavListView.IndexFromContainer(prev) : s_itemNotFound;
+        auto nextIndex = next ? topNavListView.IndexFromContainer(next) : s_itemNotFound;
+        if (prevIndex == s_itemNotFound || nextIndex == s_itemNotFound)
         {
             // One item is settings, so have problem to get the index
             recommendedTransitionDirection = NavigationRecommendedTransitionDirection::Default;
@@ -1927,7 +1929,7 @@ void NavigationView::OnSelectedItemPropertyChanged(winrt::DependencyPropertyChan
         bool measureOverrideDidNothing = m_shouldInvalidateMeasureOnNextLayoutUpdate && !m_layoutUpdatedToken;
             
         if (measureOverrideDidNothing ||
-            (newItem && m_topDataProvider.IndexOf(newItem) != -1 && m_topDataProvider.IndexOf(newItem, PrimaryList) == -1)) // selection is in overflow
+            (newItem && m_topDataProvider.IndexOf(newItem) != s_itemNotFound && m_topDataProvider.IndexOf(newItem, PrimaryList) == s_itemNotFound)) // selection is in overflow
         {
             InvalidateTopNavPrimaryLayout();
         }
@@ -2381,7 +2383,7 @@ void NavigationView::SelectOverflowItem(winrt::IInspectable const& item)
 {
     // Calculate selected overflow item size.
     auto selectedOverflowItemIndex = m_topDataProvider.IndexOf(item);
-    MUX_ASSERT(selectedOverflowItemIndex != -1);
+    MUX_ASSERT(selectedOverflowItemIndex != s_itemNotFound);
     auto selectedOverflowItemWidth = m_topDataProvider.GetWidthForItem(selectedOverflowItemIndex);
  
     bool needInvalidMeasure = !m_topDataProvider.IsValidWidthForItem(selectedOverflowItemIndex);
@@ -2394,12 +2396,12 @@ void NavigationView::SelectOverflowItem(winrt::IInspectable const& item)
         MUX_ASSERT(desiredWidth <= actualWidth);
 
         // Calculate selected item size
-        auto selectedItemIndex = -1;
+        auto selectedItemIndex = s_itemNotFound;
         auto selectedItemWidth = 0.f;
         if (auto selectedItem = SelectedItem())
         {
             selectedItemIndex = m_topDataProvider.IndexOf(selectedItem);
-            if (selectedItemIndex != -1)
+            if (selectedItemIndex != s_itemNotFound)
             {
                 selectedItemWidth = m_topDataProvider.GetWidthForItem(selectedItemIndex);
             }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1856,7 +1856,6 @@ NavigationRecommendedTransitionDirection NavigationView::GetRecommendedTransitio
     auto recommendedTransitionDirection = NavigationRecommendedTransitionDirection::Default;
     if (auto topNavListView = m_topNavListView.get())
     {
-        MUX_ASSERT(prev && next);
         auto prevIndex = prev ? topNavListView.IndexFromContainer(prev) : s_itemNotFound;
         auto nextIndex = next ? topNavListView.IndexFromContainer(next) : s_itemNotFound;
         if (prevIndex == s_itemNotFound || nextIndex == s_itemNotFound)

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1967,7 +1967,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Verify.AreEqual(selectResult.Value, "Apps");
 
-                setInvalidSelectedItemButton.Click();
+                setInvalidSelectedItemButton.Invoke();
                 Wait.ForIdle();
                
                 Verify.AreEqual(selectResult.Value, "Null");

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1961,7 +1961,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Select apps
                 using (var waiter = new ValueChangedEventWaiter(invokeResult))
                 {
-                    apps.Click();
+                    apps.Invoke();
                     waiter.Wait();
                 }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1953,7 +1953,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
               
                 Button setInvalidSelectedItemButton = new Button(FindElement.ById("SetInvalidSelectedItem"));
-                UIObject apps = FindElement.ById("AppsItem");
+                var apps = new Button(FindElement.ById("AppsItem"));
 
                 var invokeResult = new Edit(FindElement.ById("ItemInvokedResult"));
                 var selectResult = new Edit(FindElement.ById("SelectionChangedResult"));

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1947,6 +1947,36 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "B")]
+        public void VerifyNoCrashWhenSelectedItemIsInvalidItem()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Top NavigationView Test" }))
+            {
+              
+                Button setInvalidSelectedItemButton = new Button(FindElement.ById("SetInvalidSelectedItem"));
+                UIObject apps = FindElement.ById("AppsItem");
+
+                var invokeResult = new Edit(FindElement.ById("ItemInvokedResult"));
+                var selectResult = new Edit(FindElement.ById("SelectionChangedResult"));
+
+                // Select apps
+                using (var waiter = new ValueChangedEventWaiter(invokeResult))
+                {
+                    apps.Click();
+                    waiter.Wait();
+                }
+
+                Verify.AreEqual(selectResult.Value, "Apps");
+
+                setInvalidSelectedItemButton.Click();
+                Wait.ForIdle();
+               
+                Verify.AreEqual(selectResult.Value, "Null");
+            }
+        }
+
+
+        [TestMethod]
+        [TestProperty("TestSuite", "B")]
         public void VerifyTopNavigationItemFocusVisualKindRevealTest()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Top NavigationView Store Test" }))

--- a/dev/NavigationView/TestUI/NavigationViewTopNavOnlyPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewTopNavOnlyPage.xaml
@@ -83,6 +83,7 @@
                     <Button x:Name="AddRemoveContentOverlay" AutomationProperties.Name="AddRemoveContentOverlay" Content="Add/Remove Content Overlay (top nav)" Click="AddRemoveContentOverlay_Click" />
                     <Button x:Name="ChangeTopNavVisibility" AutomationProperties.Name="ChangeTopNavVisibility" Content="Change Top Nav Visibility" Click="ChangeTopNavVisibility_Click" />
                     <Button x:Name="ExpectNullSelectedItemInItemInvoke" AutomationProperties.Name="ExpectNullSelectedItemInItemInvoke" Content="Set SelectedItem=null in next ItemInvoke" Click="ExpectNullSelectedItemInItemInvoke_Click" />
+                    <Button x:Name="SetInvalidSelectedItem" AutomationProperties.Name="SetInvalidSelectedItem" Click="SetInvalidSelectedItem_Click" Content="Set Invalid SelectedItem" />
                     <CheckBox x:Name="TestFrameCheckbox" AutomationProperties.Name="TestFrameCheckbox" Content="Show Test Frame" Checked="TestFrameCheckbox_Checked" Unchecked="TestFrameCheckbox_Unchecked" IsChecked="True"  Margin="5" />
                     <CheckBox x:Name="ChangeOverflowLabelVisibility" AutomationProperties.Name="ChangeOverflowLabelVisibility" Content="Show/Hide OverflowButton Label" Checked="ChangeOverflowLabelVisibility_Checked" Unchecked="ChangeOverflowLabelVisibility_Unchecked" IsChecked="True"  Margin="5" />
                     <StackPanel Orientation="Horizontal">

--- a/dev/NavigationView/TestUI/NavigationViewTopNavOnlyPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewTopNavOnlyPage.xaml.cs
@@ -154,7 +154,7 @@ namespace MUXControlsTestApp
             }
             else
             {
-                if (e.SelectedItem != null)
+                if (e.SelectedItem != null && (e.SelectedItem) as NavigationViewItem != null)
                 {
                     var content = ((e.SelectedItem) as NavigationViewItem).Content;
                     SelectionChangedResult.Text = GetAndVerifyTheContainer(content, container);
@@ -278,6 +278,11 @@ namespace MUXControlsTestApp
         private void ChangeTopNavVisibility_Click(object sender, RoutedEventArgs e)
         {
             NavView.IsPaneVisible = !NavView.IsPaneVisible;
+        }
+
+        private void SetInvalidSelectedItem_Click(object sender, RoutedEventArgs e)
+        {
+            NavView.SelectedItem = new CheckBox();
         }
     }
 }

--- a/dev/NavigationView/TestUI/NavigationViewTopNavOnlyPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewTopNavOnlyPage.xaml.cs
@@ -154,10 +154,9 @@ namespace MUXControlsTestApp
             }
             else
             {
-                if (e.SelectedItem != null && (e.SelectedItem) as NavigationViewItem != null)
+                if (e.SelectedItem is NavigationViewItem item)
                 {
-                    var content = ((e.SelectedItem) as NavigationViewItem).Content;
-                    SelectionChangedResult.Text = GetAndVerifyTheContainer(content, container);
+                    SelectionChangedResult.Text = GetAndVerifyTheContainer(item.Content, container);
                 }
                 else
                 {


### PR DESCRIPTION
Fix #1200

1, Avoid crash when set selectedItem which doesn't exist in datasource yet.
2. replace -1 with constexpr s_itemNotFound since it's been used in a lot of places.

I didn't add test case since we already have MUX_ASSERT, and also it's a minor change.