### PR TITLE
Update ConverterFilterKind enum to be flags

### DIFF
--- a/dev/Common/CornerRadiusFilterConverter.cpp
+++ b/dev/Common/CornerRadiusFilterConverter.cpp
@@ -5,28 +5,30 @@
 #include <common.h>
 #include "CornerRadiusFilterConverter.h"
 
+using FilterKind = winrt::CornerRadiusFilterKind;
+
 winrt::CornerRadius CornerRadiusFilterConverter::Convert(winrt::CornerRadius const& radius, winrt::CornerRadiusFilterKind const& filterKind)
 {
-    winrt::CornerRadius result = radius;
+    winrt::CornerRadius result { 0,0,0,0 };
 
-    switch (filterKind)
+    if ((filterKind & FilterKind::TopLeft) == FilterKind::TopLeft)
     {
-    case winrt::CornerRadiusFilterKind::Top:
-        result.BottomLeft = 0;
-        result.BottomRight = 0;
-        break;
-    case winrt::CornerRadiusFilterKind::Right:
-        result.TopLeft = 0;
-        result.BottomLeft = 0;
-        break;
-    case winrt::CornerRadiusFilterKind::Bottom:
-        result.TopLeft = 0;
-        result.TopRight = 0;
-        break;
-    case winrt::CornerRadiusFilterKind::Left:
-        result.TopRight = 0;
-        result.BottomRight = 0;
-        break;
+        result.TopLeft = radius.TopLeft;
+    }
+
+    if ((filterKind & FilterKind::TopRight) == FilterKind::TopRight)
+    {
+        result.TopRight = radius.TopRight;
+    }
+
+    if ((filterKind & FilterKind::BottomLeft) == FilterKind::BottomLeft)
+    {
+        result.BottomLeft = radius.BottomLeft;
+    }
+
+    if ((filterKind & FilterKind::BottomRight) == FilterKind::BottomRight)
+    {
+        result.BottomRight = radius.BottomRight;
     }
 
     return result;
@@ -34,13 +36,26 @@ winrt::CornerRadius CornerRadiusFilterConverter::Convert(winrt::CornerRadius con
 
 double CornerRadiusFilterConverter::GetDoubleValue(winrt::CornerRadius const& radius, winrt::CornerRadiusFilterKind const& filterKind)
 {
-    switch (filterKind)
+    if ((filterKind & FilterKind::TopLeft) == FilterKind::TopLeft)
     {
-    case winrt::CornerRadiusFilterKind::TopLeftValue:
         return radius.TopLeft;
-    case winrt::CornerRadiusFilterKind::BottomRightValue:
+    }
+
+    if ((filterKind & FilterKind::TopRight) == FilterKind::TopRight)
+    {
+        return radius.TopRight;
+    }
+
+    if ((filterKind & FilterKind::BottomLeft) == FilterKind::BottomLeft)
+    {
+        return radius.BottomLeft;
+    }
+
+    if ((filterKind & FilterKind::BottomRight) == FilterKind::BottomRight)
+    {
         return radius.BottomRight;
     }
+
     return 0;
 }
 
@@ -52,8 +67,7 @@ winrt::IInspectable CornerRadiusFilterConverter::Convert(
 {
     auto cornerRadius = unbox_value<winrt::CornerRadius>(value);
     auto filterType = Filter();
-    if (filterType == winrt::CornerRadiusFilterKind::TopLeftValue ||
-        filterType == winrt::CornerRadiusFilterKind::BottomRightValue)
+    if ((filterType & FilterKind::ValueOnly) == FilterKind::ValueOnly)
     {
         return box_value(GetDoubleValue(cornerRadius, Filter()));
     }

--- a/dev/Common/CornerRadiusFilterConverter.cpp
+++ b/dev/Common/CornerRadiusFilterConverter.cpp
@@ -36,26 +36,20 @@ winrt::CornerRadius CornerRadiusFilterConverter::Convert(winrt::CornerRadius con
 
 double CornerRadiusFilterConverter::GetDoubleValue(winrt::CornerRadius const& radius, winrt::CornerRadiusFilterKind const& filterKind)
 {
-    if ((filterKind & FilterKind::TopLeft) == FilterKind::TopLeft)
+    switch (filterKind)
     {
+    case FilterKind::TopLeft:
         return radius.TopLeft;
-    }
 
-    if ((filterKind & FilterKind::TopRight) == FilterKind::TopRight)
-    {
+    case FilterKind::TopRight:
         return radius.TopRight;
-    }
 
-    if ((filterKind & FilterKind::BottomLeft) == FilterKind::BottomLeft)
-    {
+    case FilterKind::BottomLeft:
         return radius.BottomLeft;
-    }
 
-    if ((filterKind & FilterKind::BottomRight) == FilterKind::BottomRight)
-    {
+    case FilterKind::BottomRight:
         return radius.BottomRight;
     }
-
     return 0;
 }
 

--- a/dev/Common/CornerRadiusFilterConverters.idl
+++ b/dev/Common/CornerRadiusFilterConverters.idl
@@ -16,15 +16,19 @@ runtimeclass CornerRadiusFilterConverter : Windows.UI.Xaml.DependencyObject, Win
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
+[flags]
 enum CornerRadiusFilterKind
 {
-    None,
-    Top,
-    Right,
-    Bottom,
-    Left,
-    TopLeftValue,
-    BottomRightValue
+    None = 0x0000,
+    TopLeft = 0x0001,
+    TopRight = 0x0002,
+    BottomLeft = 0x0004,
+    BottomRight = 0x0008,
+    Top = TopLeft | TopRight,
+    Left = TopLeft | BottomLeft,
+    Bottom = BottomLeft | BottomRight,
+    Right = TopRight | BottomRight,
+    ValueOnly = 0x0010,
 };
 
 }

--- a/dev/CommonStyles/CornerRadius_themeresources.xaml
+++ b/dev/CommonStyles/CornerRadius_themeresources.xaml
@@ -22,7 +22,7 @@
     <primitives:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right"/>
     <primitives:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="Bottom"/>
     <primitives:CornerRadiusFilterConverter x:Key="LeftCornerRadiusFilterConverter" Filter="Left"/>
-    <primitives:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter" Filter="TopLeftValue"/>
-    <primitives:CornerRadiusFilterConverter x:Key="BottomRightCornerRadiusDoubleValueConverter" Filter="BottomRightValue"/>
+    <primitives:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter" Filter="TopLeft, ValueOnly"/>
+    <primitives:CornerRadiusFilterConverter x:Key="BottomRightCornerRadiusDoubleValueConverter" Filter="BottomRight, ValueOnly" />
     
 </ResourceDictionary>


### PR DESCRIPTION
Idea comes from this API review comment https://github.com/microsoft/microsoft-ui-xaml-specs/pull/48/files#r317833889.

ConverterFilterKind is now a flag, that enables us to combine values like below

```xml
<CornerRadiusFilterConverter Filter="TopLeft,BottomRight" />
```