### PR TITLE
Add binding to name of NavigationView for menu lists, Closes #564

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -262,6 +262,7 @@
                                     <!-- Top nav list -->
                                     <local:NavigationViewList
                                         AutomationProperties.LandmarkType="Navigation"
+                                        AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                         x:Name="TopNavMenuItemsHost"
                                         Grid.Column="3"
                                         SelectionMode="Single"
@@ -439,6 +440,7 @@
                                         <!-- Left nav list -->
                                         <local:NavigationViewList
                                             x:Name="MenuItemsHost"
+                                            AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                             Grid.Row="6"
                                             Margin="0,0,0,20"
                                             SelectionMode="Single"


### PR DESCRIPTION
### Summary
Added template binding to the UIA name of the lists of the navigation items.

### Motivation
Closes #564

### Testing methodology
Tested by creating a NavigationView in top and in left display mode and navigating through it with Narrator(controls+windows key+enter) enabled 