### PR TITLE
Modify buttons inside TextBox, PasswordBox and AutoSuggestBox to correctly support rounded corners

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -62,8 +62,9 @@
                                             <Grid x:Name="ButtonLayoutGrid"
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                                Background="{ThemeResource TextControlButtonBackground}">
-
+                                                Background="{ThemeResource TextControlButtonBackground}"
+                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />
@@ -334,6 +335,7 @@
                             Grid.Row="1"
                             Style="{StaticResource DeleteButtonStyle}"
                             BorderThickness="{TemplateBinding BorderThickness}"
+                            contract7Present:CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
                             IsTabStop="False"
                             Grid.Column="1"
                             Visibility="Collapsed"

--- a/dev/CommonStyles/PasswordBox_themeresources.xaml
+++ b/dev/CommonStyles/PasswordBox_themeresources.xaml
@@ -42,8 +42,9 @@
                                             <Grid x:Name="ButtonLayoutGrid"
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                                Background="{ThemeResource TextControlButtonBackground}">
-
+                                                Background="{ThemeResource TextControlButtonBackground}"
+                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />
@@ -277,7 +278,8 @@
                             Grid.Column="1"
                             Style="{StaticResource RevealButtonStyle}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Margin="{ThemeResource HelperButtonThemePadding}"
+                            contract7Present:CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                            Padding="{ThemeResource HelperButtonThemePadding}"
                             IsTabStop="False"
                             Visibility="Collapsed"
                             FontSize="{TemplateBinding FontSize}"

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -105,8 +105,9 @@
                                             <Grid x:Name="ButtonLayoutGrid"
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                                Background="{ThemeResource TextControlButtonBackground}">
-
+                                                Background="{ThemeResource TextControlButtonBackground}"
+                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />
@@ -323,7 +324,8 @@
                             Grid.Column="1"
                             Style="{StaticResource DeleteButtonStyle}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            Margin="{ThemeResource HelperButtonThemePadding}"
+                            contract7Present:CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                            Padding="{ThemeResource HelperButtonThemePadding}"
                             IsTabStop="False"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw"


### PR DESCRIPTION
# Fixes #1268

Modify internal buttons of `TextBox`, `PasswordBox` and `AutoSuggestBox` to correctly manage rounded corners.

# Changes
- Modify templates of `PasswordBox::RevealButtonStyle`, `TextBox::DeleteButtonStyle`, `AutoSuggestBox::DeleteButtonStyle` to support CornerRadius
- Add corner radius to the 3 buttons to the 3 buttons (CornerRadius of the parent control minus the TopLeft and BottomLeft)
- Use `HelperButtonThemePadding` as the Padding instead of the Margin for `PasswordBox::RevealButton`, `TextBox::DeleteButton`
- Support versions < 1809