### PR TITLE
PTR: Fix high contrast list item display, update PTR test page

### DIFF
--- a/dev/PullToRefresh/RefreshContainer/RefreshContainer_themeresources.xaml
+++ b/dev/PullToRefresh/RefreshContainer/RefreshContainer_themeresources.xaml
@@ -13,7 +13,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="RefreshContainerForegroundBrush" Color="{ThemeResource SystemColorHighlightTextColor}"/>
-            <SolidColorBrush x:Key="RefreshContainerBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
+            <SolidColorBrush x:Key="RefreshContainerBackgroundBrush" Color="Transparent"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/dev/PullToRefresh/RefreshContainer/TestUI/RefreshContainerPage.xaml
+++ b/dev/PullToRefresh/RefreshContainer/TestUI/RefreshContainerPage.xaml
@@ -30,7 +30,7 @@
             <Button x:Name="RVRefreshRequestedComboBoxSwitcher" AutomationProperties.Name="RVRefreshRequestedComboBoxSwitcher" Content="switch" Margin="2"/>
         </StackPanel>
         <muxcontrols:RefreshContainer x:Name="RefreshContainer" VerticalAlignment="Center" HorizontalAlignment="Center">
-        <ListView x:Name="listView" Width="400" Height="300" AutomationProperties.Name="listView" Background="Bisque">
+        <ListView x:Name="listView" Width="400" Height="300" AutomationProperties.Name="listView" BorderBrush="Cyan" BorderThickness="2">
             <ListView.Header>
                 <StackPanel Background="Red">
                 <TextBlock Text="ListView header"/>

--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer_themeresources.xaml
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer_themeresources.xaml
@@ -14,7 +14,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="RefreshVisualizerForeground" Color="{ThemeResource SystemColorHighlightTextColor}"/>
-            <SolidColorBrush x:Key="RefreshVisualizerBackground" Color="{ThemeResource SystemColorHighlightColor}"/>
+            <SolidColorBrush x:Key="RefreshVisualizerBackground" Color="Transparent"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>


### PR DESCRIPTION
### Summary
Fixed displaying of PTR in high contrast mode.
Remove background color for PTR in PTR test page and add border to show borders of PTR.

### Motivation
Fixes #1227.

### Testing methodology
Start MUXControlsTestApp and visit PTR -> RefreshContainer.
Ran test suite:
- MUXControls.InteractionTests.RefreshContainerTests
- MUXControls.ApiTests.RefreshVisualizerTests