### PR TITLE
Collect crash dumps from Helix test passes

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-ProcessTestResults-Job.yml
@@ -3,6 +3,7 @@ parameters:
   rerunPassesRequiredToAvoidFailure: 5
   minimumExpectedTestsExecutedCount: 3000
   checkJobAttempt: false
+  
 
 jobs:
 - job: ProcessTestResults
@@ -11,6 +12,8 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 120
+  variables:
+    crashDumpsListFilePath: $(Build.SourcesDirectory)\crashdumps.html
 
   steps:
   - task: powershell@2
@@ -32,3 +35,20 @@ jobs:
       targetType: filePath
       filePath: build\Helix\OutputTestResults.ps1
       arguments: -MinimumExpectedTestsExecutedCount '${{ parameters.minimumExpectedTestsExecutedCount }}' -CheckJobAttempt $${{ parameters.checkJobAttempt }}
+
+  - task: powershell@2
+    displayName: 'CreateListOfCrashDumpsFromTestPass.ps1'
+    condition: succeededOrFailed()
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    inputs:
+      targetType: filePath
+      filePath: build\Helix\CreateListOfCrashDumpsFromTestPass.ps1
+      arguments: -OutputFilePath '$(crashDumpsListFilePath)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Crash Dump List'
+    condition: succeededOrFailed()
+    inputs:
+      PathtoPublish: $(crashDumpsListFilePath)
+      artifactName: drop

--- a/build/Helix/CreateListOfCrashDumpsFromTestPass.ps1
+++ b/build/Helix/CreateListOfCrashDumpsFromTestPass.ps1
@@ -1,0 +1,63 @@
+Param(
+    [string]$AccessToken = $env:SYSTEM_ACCESSTOKEN,
+    [string]$CollectionUri = $env:SYSTEM_COLLECTIONURI,
+    [string]$TeamProject = $env:SYSTEM_TEAMPROJECT,
+    [string]$BuildUri = $env:BUILD_BUILDURI,
+    [string]$OutputFilePath = "dumplinks.html"
+)
+
+$azureDevOpsRestApiHeaders = @{
+    "Accept"="application/json"
+    "Authorization"="Basic $([System.Convert]::ToBase64String([System.Text.ASCIIEncoding]::ASCII.GetBytes(":$AccessToken")))"
+}
+
+. "$PSScriptRoot/AzurePipelinesHelperScripts.ps1"
+
+$queryUri = GetQueryTestRunsUri -CollectionUri $CollectionUri -TeamProject $TeamProject -BuildUri $BuildUri -IncludeRunDetails
+Write-Host "queryUri = $queryUri"
+
+$testRuns = Invoke-RestMethod -Uri $queryUri -Method Get -Headers $azureDevOpsRestApiHeaders
+
+[System.Collections.Generic.List[string]]$workItems = @()
+
+Out-File -FilePath $outputFilePath -InputObject "<h1>Dumps</h1>"
+
+foreach ($testRun in $testRuns.value)
+{
+    $testRunResultsUri = "$($testRun.url)/results?api-version=5.0"
+    $testResults = Invoke-RestMethod -Uri "$($testRun.url)/results?api-version=5.0" -Method Get -Headers $azureDevOpsRestApiHeaders
+
+    Out-File -FilePath $outputFilePath -Append -InputObject "<h2>$($testRun.name)</h2>"
+        
+    foreach ($testResult in $testResults.value)
+    {
+        $info = ConvertFrom-Json $testResult.comment
+        $helixJobId = $info.HelixJobId
+        $helixWorkItemName = $info.HelixWorkItemName
+
+        $workItem = "$helixJobId-$helixWorkItemName"
+
+        if (-not $workItems.Contains($workItem))
+        {
+            $workItems.Add($workItem)
+
+            Out-File -FilePath $outputFilePath -Append -InputObject "<h3>$helixWorkItemName</h3>"
+
+            $filesQueryUri = "https://helix.dot.net/api/2019-06-17/jobs/$helixJobId/workitems/$helixWorkItemName/files"
+
+            $files = Invoke-RestMethod -Uri $filesQueryUri -Method Get
+
+            $dumps = $files | where { $_.Name.EndsWith(".dmp") }
+
+            if($dumps.Count -gt 0)
+            {
+                Out-File -FilePath $outputFilePath -Append -InputObject "<ul>"
+                foreach($file in $dumps)
+                {
+                    Out-File -FilePath $outputFilePath -Append -InputObject "<li><a href=$($file.Link)>$($file.Name)</a></li>"
+                }
+                Out-File -FilePath $outputFilePath -Append -InputObject "</ul>"
+            }
+        }        
+    }
+}

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -310,8 +310,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // TODO: fix broken test
-        //[TestMethod]
+        [TestMethod]
         public void KeyboardTest()
         {
             using (var setup = new TestSetupHelper("TabView Tests"))

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -379,6 +379,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Wait.ForIdle();
 
                 VerifyElement.NotFound("FirstTab", FindBy.Name);
+
+                // Move focus to the second tab content
+                secondTabButton.SetFocus();
+                Wait.ForIdle();
             }
         }
 


### PR DESCRIPTION
If one of our test apps crashes during test pass execution in Helix, we would like to be able to get access to the crash dumps in order to debug the problem. This is particularly important where a test is crashing in Helix, but the crash cannot be reproduced locally.

First we need to have Windows create the crash dumps for our apps. This is controlled by WER registry settings. See here for more info: https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps
We set the appropriate registry key corresponding to each of our test processes. Note: our runtests.cmd script is run from a 32-bit cmd.exe, but we need to set the native 64-bit reg keys for WER. If we invoke reg.exe directly, we will be updating the virtualized syswow64 reg hive. So instead we indirectly invoke reg via %systemroot%\sysnative.

Helix will automatically upload any dumps that it finds in the %HELIX_DUMP_FOLDER% (c:\cores) directory. So we set the WER registry keys to create dumps there.

After the dumps are uploaded, the next step is to make it easy to find them from Azure DevOps. I created a script CreateListOfCrashDumpsFromTestPass.ps1 that produces a crashdumps.html file with links to the dumps. It consumes the [WorkItem_ListFiles](https://helix.dot.net/swagger/ui/index#!/WorkItem/WorkItem_ListFiles) Helix API. The generated html file gets uploaded to the Pipeline artifacts.

At the moment, this crashdumps.html file is pretty bare bones. But I could imagine us expanding on it in the future to create a more comprehensive test pass report (e.g. including direct links to screenshots and logs, etc.). 

This PR also re-enables TabViewTests.KeyboardTest which was disabled due to intermittent crashing. With this crash dump collection enabled, we should be able to get more info on this test failure.

Fixes: #216