### PR TITLE
Fix bug where pane was open when app would start minimal with NavigationView

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -134,8 +134,6 @@ void NavigationView::UnhookEventsAndClearFields(bool isFromDestructor)
 
 NavigationView::NavigationView()
 {
-    // Used for correct displaying of initial display mode when DisplayMode is "Auto"
-    m_InitialNonForcedModeUpdate = false;
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_NavigationView);
     SetValue(s_TemplateSettingsProperty, winrt::make<::NavigationViewTemplateSettings>());
     SetDefaultStyleKey(this);
@@ -591,10 +589,6 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
             ClosePane();
         }
         m_InitialNonForcedModeUpdate = false;
-    }
-
-    if (forceSetDisplayMode) {
-        m_InitialNonForcedModeUpdate = true;
     }
 
     auto previousMode = DisplayMode();

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -584,7 +584,12 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
     {
         MUX_FAIL_FAST();
     }
-
+    if (displayMode == winrt::NavigationViewDisplayMode::Minimal) {
+        IsPaneOpen(false);
+    }
+    if (displayMode == winrt::NavigationViewDisplayMode::Expanded) {
+        IsPaneOpen(true);
+    }
     auto previousMode = DisplayMode();
     SetDisplayMode(displayMode, forceSetDisplayMode);
 

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -81,8 +81,6 @@ constexpr int s_itemNotFound{ -1 };
 
 static winrt::Size c_infSize{ std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity() };
 
-bool isInitialLoading = false;
-
 NavigationView::~NavigationView()
 {
     // Used for correct displaying of initial display mode when DisplayMode is "Auto"

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -83,8 +83,6 @@ static winrt::Size c_infSize{ std::numeric_limits<float>::infinity(), std::numer
 
 NavigationView::~NavigationView()
 {
-    // Used for correct displaying of initial display mode when DisplayMode is "Auto"
-    m_InitialNonForcedModeUpdate = false;
     UnhookEventsAndClearFields(true);
 }
 
@@ -136,6 +134,8 @@ void NavigationView::UnhookEventsAndClearFields(bool isFromDestructor)
 
 NavigationView::NavigationView()
 {
+    // Used for correct displaying of initial display mode when DisplayMode is "Auto"
+    m_InitialNonForcedModeUpdate = false;
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_NavigationView);
     SetValue(s_TemplateSettingsProperty, winrt::make<::NavigationViewTemplateSettings>());
     SetDefaultStyleKey(this);

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -81,8 +81,12 @@ constexpr int s_itemNotFound{ -1 };
 
 static winrt::Size c_infSize{ std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity() };
 
+bool isInitialLoading = false;
+
 NavigationView::~NavigationView()
 {
+    // Used for correct displaying of initial display mode when DisplayMode is "Auto"
+    m_InitialNonForcedModeUpdate = false;
     UnhookEventsAndClearFields(true);
 }
 
@@ -584,12 +588,17 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
     {
         MUX_FAIL_FAST();
     }
-    if (displayMode == winrt::NavigationViewDisplayMode::Minimal) {
-        IsPaneOpen(false);
+    if (!forceSetDisplayMode && m_InitialNonForcedModeUpdate) {
+        if (displayMode == winrt::NavigationViewDisplayMode::Minimal && PaneDisplayMode() == winrt::NavigationViewPaneDisplayMode::Auto) {
+            ClosePane();
+        }
+        m_InitialNonForcedModeUpdate = false;
     }
-    if (displayMode == winrt::NavigationViewDisplayMode::Expanded) {
-        IsPaneOpen(true);
+
+    if (forceSetDisplayMode) {
+        m_InitialNonForcedModeUpdate = true;
     }
+
     auto previousMode = DisplayMode();
     SetDisplayMode(displayMode, forceSetDisplayMode);
 

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -162,6 +162,7 @@ private:
     void UpdateListViewItemsSource(const winrt::ListView& listView, const winrt::IInspectable& itemsSource);
     void UpdateListViewItemSource();
     void UpdateSelectionForMenuItems();
+    bool m_InitialNonForcedModeUpdate;
 
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
     void OnLayoutUpdated(const winrt::IInspectable& sender, const winrt::IInspectable& e);

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -162,7 +162,7 @@ private:
     void UpdateListViewItemsSource(const winrt::ListView& listView, const winrt::IInspectable& itemsSource);
     void UpdateListViewItemSource();
     void UpdateSelectionForMenuItems();
-    bool m_InitialNonForcedModeUpdate;
+    bool m_InitialNonForcedModeUpdate{ true };
 
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
     void OnLayoutUpdated(const winrt::IInspectable& sender, const winrt::IInspectable& e);

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
@@ -383,6 +383,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 {
                     CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
 
+                    if (isPaneOpenCheckBox.ToggleState == ToggleState.Off)
+                    {
+                        isPaneOpenCheckBox.Toggle();
+                        Wait.ForIdle();
+                    }
+
                     Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be True");
 
                     Button navButton = new Button(FindElement.ById("TogglePaneButton"));
@@ -412,6 +418,26 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     Verify.AreEqual(ToggleState.Off, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be False after increasing the width of the control from compact to expanded");
                     Verify.AreEqual(expanded, displayModeTextBox.DocumentText);
                 }
+            }
+        }
+
+
+        [TestMethod]
+        [TestProperty("TestSuite", "A")]
+        public void PaneClosedWhenAutoAndNarrow()
+        {
+            var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();
+            foreach (var testScenario in testScenarios)
+            {
+                using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Navigation Minimal Test" }))
+                {
+
+                    CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsAutoPaneOpenCheckBox"));
+                    Log.Comment("Checking that a NavigationView with displaymode set to 'Auto' and a narrow width does not display pane");
+                    Wait.ForIdle();
+                    Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
+                }
+
             }
         }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
@@ -382,12 +382,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", testScenario.TestPageName }))
                 {
                     CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsPaneOpenCheckBox"));
-
-                    if (isPaneOpenCheckBox.ToggleState == ToggleState.Off)
-                    {
-                        isPaneOpenCheckBox.Toggle();
-                        Wait.ForIdle();
-                    }
 
                     Verify.AreEqual(ToggleState.On, isPaneOpenCheckBox.ToggleState, "IsPaneOpen expected to be True");
 

--- a/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 <!-- This page contains a NavigationView control that is in LeftMinimal mode on initial load -->
-    <Grid>
+    <StackPanel>
         <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
                                     IsBackEnabled="True" Header="Minimal Test Page" PaneDisplayMode="LeftMinimal">
             <StackPanel>
@@ -18,5 +18,14 @@
                 <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>
             </StackPanel>
         </muxcontrols:NavigationView>
-    </Grid>
+        <muxcontrols:NavigationView x:Name="NavViewAuto" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
+                                    IsBackEnabled="True" Header="Minimal Test Page" Width="250" Height="300" >
+            <StackPanel>
+            </StackPanel>
+        </muxcontrols:NavigationView>
+        <CheckBox
+            IsChecked="{Binding IsPaneOpen, ElementName=NavViewAuto, Mode=TwoWay}"
+            x:Name="IsAutoPaneOpenCheckBox"
+            AutomationProperties.Name="IsPaneOpenCheckBox" >Toggle auto pane open</CheckBox>
+    </StackPanel>
 </local:TestPage>


### PR DESCRIPTION
### Summary
Fixed a bug where opening an App with NavigationView in minimal size would still show pane instead of hiding it.

### Motivation
Closes #1186

### Testing methodology
Started an app with NavigationView in various sizes and checked that it would show pane correctly