### PR TITLE
Add key names to default control styles

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -369,7 +369,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="AutoSuggestBox">
+    <Style TargetType="AutoSuggestBox" BasedOn="{StaticResource DefaultAutoSuggestBoxStyle}" />
+
+    <Style x:Key="DefaultAutoSuggestBoxStyle" TargetType="AutoSuggestBox">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="TextBoxStyle" Value="{StaticResource AutoSuggestBoxTextBoxStyle}" />

--- a/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
+++ b/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
@@ -73,7 +73,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="CalendarDatePicker">
+    <Style TargetType="CalendarDatePicker" BasedOn="{StaticResource DefaultCalendarDatePicker}" />
+
+    <Style x:Key="DefaultCalendarDatePicker" TargetType="CalendarDatePicker">
         <Setter Property="Foreground" Value="{ThemeResource CalendarDatePickerForeground}" />
         <Setter Property="Background" Value="{ThemeResource CalendarDatePickerBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CalendarDatePickerBorderBrush}" />

--- a/dev/CheckBox/CheckBox_themeresources.xaml
+++ b/dev/CheckBox/CheckBox_themeresources.xaml
@@ -277,7 +277,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="CheckBox">
+    <Style TargetType="CheckBox" BasedOn="{StaticResource DefaultCheckBoxStyle}" />
+    
+    <Style x:Key="DefaultCheckBoxStyle" TargetType="CheckBox">
         <Setter Property="Background" Value="{ThemeResource CheckBoxBackgroundUnchecked}" />
         <Setter Property="Foreground" Value="{ThemeResource CheckBoxForegroundUnchecked}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CheckBoxBorderBrushUnchecked}" />

--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -6,7 +6,10 @@
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
-    <Style TargetType="controls:ColorPicker" >
+
+    <Style TargetType="controls:ColorPicker" BasedOn="{StaticResource DefaultColorPickerStyle}"/>
+    
+    <Style x:Key="DefaultColorPickerStyle" TargetType="controls:ColorPicker">
         <Setter Property="MaxWidth" Value="392" />
         <Setter Property="MinWidth" Value="312" />
         <Setter Property="IsTabStop" Value="False" />

--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -361,7 +361,9 @@
     <Thickness x:Key="ComboBoxEditableTextPadding">11,5,32,6</Thickness>
     <Thickness x:Key="ComboBoxMinHeight">32</Thickness>
 
-    <Style TargetType="ComboBox">
+    <Style TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}"/>
+
+    <Style x:Key="DefaultComboBoxStyle" TargetType="ComboBox">
         <Setter Property="Padding" Value="{ThemeResource ComboBoxPadding}" />
         <Setter Property="MaxDropDownHeight" Value="504" />
         <Setter Property="Foreground" Value="{ThemeResource ComboBoxForeground}" />

--- a/dev/CommandBarFlyout/CommandBarFlyout.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout.xaml
@@ -7,7 +7,9 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:CommandBarFlyoutCommandBar">
+    <Style TargetType="local:CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarStyle}"/>
+
+    <Style x:Key="DefaultCommandBarFlyoutCommandBarStyle" TargetType="local:CommandBarFlyoutCommandBar">
         <Setter Property="Background" Value="{ThemeResource SystemControlAcrylicElementBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransientBorderBrush}" />

--- a/dev/CommandBarFlyout/CommandBarFlyout.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout.xaml
@@ -7,8 +7,6 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarStyle}"/>
-
     <Style x:Key="DefaultCommandBarFlyoutCommandBarStyle" TargetType="local:CommandBarFlyoutCommandBar">
         <Setter Property="Background" Value="{ThemeResource SystemControlAcrylicElementBrush}" />
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
@@ -450,4 +448,6 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarStyle}"/>
 </ResourceDictionary>

--- a/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -98,8 +98,10 @@
     <Thickness x:Key="AppBarButtonTextLabelMargin">2,0,2,8</Thickness>
     <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,11,12,13</Thickness>
 
+    <Style TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />
+
     <!-- LabelOnRightStyle is retired since RS3, We still need it for RS2 or RS3 -->
-    <Style TargetType="AppBarButton">
+    <Style x:Key="DefaultAppBarButtonStyle" TargetType="AppBarButton">
         <Setter Property="Background" Value="{ThemeResource AppBarButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource AppBarButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource AppBarButtonBorderBrush}" />

--- a/dev/CommonStyles/AppBarToggleButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarToggleButton_themeresources.xaml
@@ -204,8 +204,10 @@
     <Thickness x:Key="AppBarToggleButtonTextLabelOnRightMargin">8,11,12,13</Thickness>
     <Thickness x:Key="AppBarToggleButtonOverflowTextLabelPadding">0,5,0,8</Thickness>
 
+    <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}" />
+
     <!-- LabelOnRightStyle is retired since RS3, We still need it for RS2 or RS3 -->
-    <Style TargetType="AppBarToggleButton">
+    <Style x:Key="DefaultAppBarToggleButtonStyle" TargetType="AppBarToggleButton">
         <Setter Property="Background" Value="{ThemeResource AppBarToggleButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource AppBarToggleButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource AppBarToggleButtonBorderBrush}" />

--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -120,7 +120,9 @@
 
     <Thickness x:Key="ButtonPadding">8,5,8,6</Thickness>
 
-    <Style TargetType="Button">
+    <Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}" />
+
+    <Style x:Key="DefaultButtonStyle" TargetType="Button">
         <Setter Property="Background" Value="{ThemeResource ButtonBackground}" />
         <contract7Present:Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -73,7 +73,9 @@
 
     <Thickness x:Key="CommandBarOverflowPresenterMargin">0,4,0,4</Thickness>
 
-    <Style TargetType="CommandBar">
+    <Style TargetType="CommandBar" BasedOn="{StaticResource DefaultCommandBarStyle}" />
+
+    <Style x:Key="DefaultCommandBarStyle" TargetType="CommandBar">
         <Setter Property="Background" Value="{ThemeResource CommandBarBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource CommandBarForeground}" />
         <Setter Property="IsTabStop" Value="False" />
@@ -901,7 +903,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="CommandBarOverflowPresenter">
+    <Style TargetType="CommandBarOverflowPresenter" BasedOn="{StaticResource DefaultCommandBarOverflowPresenterStyle}" />
+
+    <Style x:Key="DefaultCommandBarOverflowPresenterStyle" TargetType="CommandBarOverflowPresenter">
         <Setter Property="Background" Value="{ThemeResource CommandBarOverflowPresenterBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CommandBarOverflowPresenterBorderBrush}" />
         <Setter Property="Padding" Value="{ThemeResource CommandBarOverflowPresenterBorderPadding}" />

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -25,8 +25,10 @@
             <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+
+    <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     
-    <Style TargetType="FlyoutPresenter">
+    <Style x:Key="DefaultFlyoutPresenterStyle" TargetType="FlyoutPresenter">
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="IsTabStop" Value="False" />

--- a/dev/CommonStyles/ListBox_themeresources.xaml
+++ b/dev/CommonStyles/ListBox_themeresources.xaml
@@ -62,7 +62,9 @@
 
     <Thickness x:Key="ListBoxItemPadding">12,9,12,12</Thickness>
 
-     <Style TargetType="ListBoxItem">
+    <Style TargetType="ListBoxItem" BasedOn="{StaticResource DefaultListBoxItemStyle}" />
+
+    <Style x:Key="DefaultListBoxItemStyle" TargetType="ListBoxItem">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="Padding" Value="{StaticResource ListBoxItemPadding}" />
@@ -190,7 +192,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="ListBox">
+    <Style TargetType="ListBox" BasedOn="{StaticResource DefaultListBoxStyle}" />
+
+    <Style x:Key="DefaultListBoxStyle" TargetType="ListBox">
         <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />

--- a/dev/CommonStyles/ListViewItem_themeresources.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources.xaml
@@ -151,7 +151,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ListViewItem">
+    <Style TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}" />
+
+    <Style x:Key="DefaultListViewItemStyle" TargetType="ListViewItem">
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="Background" Value="{ThemeResource ListViewItemBackground}" />

--- a/dev/CommonStyles/MediaTransportControls_themeresources.xaml
+++ b/dev/CommonStyles/MediaTransportControls_themeresources.xaml
@@ -23,7 +23,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-        <Style TargetType="MediaTransportControls">
+    <Style TargetType="MediaTransportControls" BasedOn="{StaticResource DefaultMediaTransportControlsStyle}" />
+
+    <Style x:Key="DefaultMediaTransportControlsStyle" TargetType="MediaTransportControls">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="FlowDirection" Value="LeftToRight" />

--- a/dev/CommonStyles/PasswordBox_themeresources.xaml
+++ b/dev/CommonStyles/PasswordBox_themeresources.xaml
@@ -14,7 +14,9 @@
 
     <Thickness x:Key="PasswordBoxTopHeaderMargin">0,0,0,4</Thickness>
 
-    <Style TargetType="PasswordBox">
+    <Style TargetType="PasswordBox" BasedOn="{StaticResource DefaultPasswordBoxStyle}" />
+
+    <Style x:Key="DefaultPasswordBoxStyle" TargetType="PasswordBox">
         <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
         <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
         <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}" />

--- a/dev/CommonStyles/ProgressBar_themeresources.xaml
+++ b/dev/CommonStyles/ProgressBar_themeresources.xaml
@@ -34,7 +34,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ProgressBar">
+    <Style TargetType="ProgressBar" BasedOn="{StaticResource DefaultProgressBarStyle}" />
+    
+    <Style x:Key="DefaultProgressBarStyle" TargetType="ProgressBar">
         <Setter Property="Foreground" Value="{ThemeResource SystemControlHighlightAccentBrush}" />
         <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource ProgressBarBorderThemeThickness}" />

--- a/dev/CommonStyles/RepeatButton_themeresources.xaml
+++ b/dev/CommonStyles/RepeatButton_themeresources.xaml
@@ -80,7 +80,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="RepeatButton">
+    <Style TargetType="RepeatButton" BasedOn="{StaticResource DefaultRepeatButtonStyle}" />
+
+    <Style x:Key="DefaultRepeatButtonStyle" TargetType="RepeatButton">
         <Setter Property="Background" Value="{ThemeResource RepeatButtonBackground}" />
         <contract7Present:Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
         <Setter Property="Foreground" Value="{ThemeResource RepeatButtonForeground}" />

--- a/dev/CommonStyles/RichEditBox_themeresources.xaml
+++ b/dev/CommonStyles/RichEditBox_themeresources.xaml
@@ -7,7 +7,9 @@
 
     <Thickness x:Key="RichEditBoxTopHeaderMargin">0,0,0,4</Thickness>
 
-    <Style TargetType="RichEditBox">
+    <Style TargetType="RichEditBox" BasedOn="{StaticResource DefaultRichEditBoxStyle}" />
+
+    <Style x:Key="DefaultRichEditBoxStyle" TargetType="RichEditBox">
         <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
         <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
         <contract7Present:Setter Property="ContentLinkForegroundColor" Value="{ThemeResource ContentLinkForegroundColor}" />

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -74,7 +74,9 @@
 
     <Thickness x:Key="TextBoxTopHeaderMargin">0,0,0,4</Thickness>
 
-    <Style TargetType="TextBox">
+    <Style TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}" />
+
+    <Style x:Key="DefaultTextBoxStyle" TargetType="TextBox">
         <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
         <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}" />

--- a/dev/CommonStyles/ToggleButton_themeresources.xaml
+++ b/dev/CommonStyles/ToggleButton_themeresources.xaml
@@ -178,7 +178,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ToggleButton">
+    <Style TargetType="ToggleButton" BasedOn="{StaticResource DefaultToggleButtonStyle}" />
+
+    <Style x:Key="DefaultToggleButtonStyle" TargetType="ToggleButton">
         <Setter Property="Background" Value="{ThemeResource ToggleButtonBackground}" />
         <contract7Present:Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
         <Setter Property="Foreground" Value="{ThemeResource ToggleButtonForeground}" />

--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -194,7 +194,9 @@
     
     <x:Double x:Key="ToggleSwitchThemeMinWidth">154</x:Double>
 
-    <Style TargetType="ToggleSwitch">
+    <Style TargetType="ToggleSwitch" BasedOn="{StaticResource DefaultToggleSwitchStyle}" />
+
+    <Style x:Key="DefaultToggleSwitchStyle" TargetType="ToggleSwitch">
         <Setter Property="Foreground" Value="{ThemeResource ToggleSwitchContentForeground}" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Center" />

--- a/dev/ContentDialog/ContentDialog_themeresources.xaml
+++ b/dev/ContentDialog/ContentDialog_themeresources.xaml
@@ -88,7 +88,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ContentDialog">
+    <Style TargetType="ContentDialog" BasedOn="{StaticResource DefaultContentDialogStyle}" />
+
+    <Style x:Key="DefaultContentDialogStyle" TargetType="ContentDialog">
         <Setter Property="Foreground" Value="{ThemeResource ContentDialogForeground}" />
         <Setter Property="Background" Value="{ThemeResource ContentDialogBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ContentDialogBorderBrush}" />

--- a/dev/DatePicker/DatePicker_themeresources.xaml
+++ b/dev/DatePicker/DatePicker_themeresources.xaml
@@ -129,7 +129,9 @@
     <Thickness x:Key="DatePickerHostPadding">0,3,0,6</Thickness>
     <Thickness x:Key="DatePickerHostMonthPadding">9,3,0,6</Thickness>
 
-    <Style TargetType="DatePicker">
+    <Style TargetType="DatePicker" BasedOn="{StaticResource DefaultDatePickerStyle}" />
+
+    <Style x:Key="DefaultDatePickerStyle" TargetType="DatePicker">
         <Setter Property="Orientation" Value="Horizontal" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
@@ -350,7 +352,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="DatePickerFlyoutPresenter">
+    <Style TargetType="DatePickerFlyoutPresenter" BasedOn="{StaticResource DefaultDatePickerFlyoutPresenterStyle}" />
+
+    <Style x:Key="DefaultDatePickerFlyoutPresenterStyle" TargetType="DatePickerFlyoutPresenter">
         <Setter Property="Width" Value="296" />
         <Setter Property="MinWidth" Value="296" />
         <Setter Property="MaxHeight" Value="398" />

--- a/dev/DropDownButton/DropDownButton.xaml
+++ b/dev/DropDownButton/DropDownButton.xaml
@@ -6,7 +6,9 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:DropDownButton">
+    <Style TargetType="local:DropDownButton" BasedOn="{StaticResource DefaultDropDownButtonStyle}" />
+
+    <Style x:Key="DefaultDropDownButtonStyle" TargetType="local:DropDownButton">
         <Setter Property="Background" Value="{ThemeResource ButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}" />

--- a/dev/DropDownButton/DropDownButton.xaml
+++ b/dev/DropDownButton/DropDownButton.xaml
@@ -6,8 +6,6 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:DropDownButton" BasedOn="{StaticResource DefaultDropDownButtonStyle}" />
-
     <Style x:Key="DefaultDropDownButtonStyle" TargetType="local:DropDownButton">
         <Setter Property="Background" Value="{ThemeResource ButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
@@ -120,5 +118,7 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:DropDownButton" BasedOn="{StaticResource DefaultDropDownButtonStyle}" />
 
 </ResourceDictionary>

--- a/dev/DropDownButton/DropDownButton_rs1.xaml
+++ b/dev/DropDownButton/DropDownButton_rs1.xaml
@@ -6,6 +6,8 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
+    <Style TargetType="local:DropDownButton" BasedOn="{StaticResource DefaultDropDownButtonStyle}" />
+
     <Style TargetType="local:DropDownButton">
         <Setter Property="Background" Value="{ThemeResource ButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />

--- a/dev/DropDownButton/DropDownButton_rs1.xaml
+++ b/dev/DropDownButton/DropDownButton_rs1.xaml
@@ -6,9 +6,7 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:DropDownButton" BasedOn="{StaticResource DefaultDropDownButtonStyle}" />
-
-    <Style TargetType="local:DropDownButton">
+    <Style x:Key="DefaultDropDownButtonStyle" TargetType="local:DropDownButton">
         <Setter Property="Background" Value="{ThemeResource ButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ButtonBorderBrush}" />
@@ -119,5 +117,7 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:DropDownButton" BasedOn="{StaticResource DefaultDropDownButtonStyle}" />
 
 </ResourceDictionary>

--- a/dev/FlipView/FlipViewItem_themeresources.xaml
+++ b/dev/FlipView/FlipViewItem_themeresources.xaml
@@ -16,7 +16,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="FlipViewItem">
+    <Style TargetType="FlipViewItem" BasedOn="{StaticResource DefaultFlipViewItemStyle}" />
+
+    <Style x:Key="DefaultFlipViewItemStyle" TargetType="FlipViewItem">
         <Setter Property="Background" Value="{ThemeResource FlipViewItemBackground}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />

--- a/dev/FlipView/FlipView_themeresources.xaml
+++ b/dev/FlipView/FlipView_themeresources.xaml
@@ -5,7 +5,8 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <ResourceDictionary x:Key="Default">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
         <Thickness x:Key="FlipViewButtonBorderThemeThickness">0</Thickness>
         <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
         <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
@@ -28,7 +29,7 @@
         <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="#BD292929" />
         <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
     </ResourceDictionary>
-    <ResourceDictionary x:Key="HighContrast">
+        <ResourceDictionary x:Key="HighContrast">
         <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
         <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
         <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
@@ -51,7 +52,7 @@
         <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
         <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
     </ResourceDictionary>
-    <ResourceDictionary x:Key="Light">
+        <ResourceDictionary x:Key="Light">
         <Thickness x:Key="FlipViewButtonBorderThemeThickness">0</Thickness>
         <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
         <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
@@ -74,8 +75,11 @@
         <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="#BD292929" />
         <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
     </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="FlipView">
+    <Style TargetType="FlipView" BasedOn="{StaticResource DefaultFlipViewStyle}" />
+
+    <Style x:Key="DefaultFlipViewStyle" TargetType="FlipView">
         <Setter Property="Background" Value="{ThemeResource FlipViewBackground}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="TabNavigation" Value="Once" />

--- a/dev/FlipView/FlipView_themeresources.xaml
+++ b/dev/FlipView/FlipView_themeresources.xaml
@@ -7,74 +7,74 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-        <Thickness x:Key="FlipViewButtonBorderThemeThickness">0</Thickness>
-        <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPressed" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForeground" ResourceKey="SystemControlForegroundAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPointerOver" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPressed" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPressed" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
-        <SolidColorBrush x:Key="FlipViewButtonBackgroundThemeBrush" Color="#59D5D5D5" />
-        <SolidColorBrush x:Key="FlipViewButtonBorderThemeBrush" Color="#59D5D5D5" />
-        <SolidColorBrush x:Key="FlipViewButtonForegroundThemeBrush" Color="#99000000" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverBackgroundThemeBrush" Color="#F0D7D7D7" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverBorderThemeBrush" Color="#9EC1C1C1" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverForegroundThemeBrush" Color="#FF000000" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedBackgroundThemeBrush" Color="#BD292929" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="#BD292929" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
-    </ResourceDictionary>
+            <Thickness x:Key="FlipViewButtonBorderThemeThickness">0</Thickness>
+            <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPressed" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForeground" ResourceKey="SystemControlForegroundAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPointerOver" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPressed" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPressed" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <SolidColorBrush x:Key="FlipViewButtonBackgroundThemeBrush" Color="#59D5D5D5" />
+            <SolidColorBrush x:Key="FlipViewButtonBorderThemeBrush" Color="#59D5D5D5" />
+            <SolidColorBrush x:Key="FlipViewButtonForegroundThemeBrush" Color="#99000000" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverBackgroundThemeBrush" Color="#F0D7D7D7" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverBorderThemeBrush" Color="#9EC1C1C1" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverForegroundThemeBrush" Color="#FF000000" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedBackgroundThemeBrush" Color="#BD292929" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="#BD292929" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
+        </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-        <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPressed" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForeground" ResourceKey="SystemControlForegroundAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPointerOver" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPressed" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPressed" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
-        <Thickness x:Key="FlipViewButtonBorderThemeThickness">1</Thickness>
-        <SolidColorBrush x:Key="FlipViewButtonBackgroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverBackgroundThemeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverForegroundThemeBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedBackgroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
-    </ResourceDictionary>
+            <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPressed" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForeground" ResourceKey="SystemControlForegroundAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPointerOver" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPressed" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPressed" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <Thickness x:Key="FlipViewButtonBorderThemeThickness">1</Thickness>
+            <SolidColorBrush x:Key="FlipViewButtonBackgroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverBackgroundThemeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverForegroundThemeBrush" Color="{ThemeResource SystemColorHighlightTextColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedBackgroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+        </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-        <Thickness x:Key="FlipViewButtonBorderThemeThickness">0</Thickness>
-        <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPressed" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForeground" ResourceKey="SystemControlForegroundAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPointerOver" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPressed" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPressed" ResourceKey="SystemControlForegroundTransparentBrush" />
-        <StaticResource x:Key="FlipViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
-        <SolidColorBrush x:Key="FlipViewButtonBackgroundThemeBrush" Color="#59D5D5D5" />
-        <SolidColorBrush x:Key="FlipViewButtonBorderThemeBrush" Color="#59D5D5D5" />
-        <SolidColorBrush x:Key="FlipViewButtonForegroundThemeBrush" Color="#99000000" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverBackgroundThemeBrush" Color="#F0D7D7D7" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverBorderThemeBrush" Color="#9EC1C1C1" />
-        <SolidColorBrush x:Key="FlipViewButtonPointerOverForegroundThemeBrush" Color="#FF000000" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedBackgroundThemeBrush" Color="#BD292929" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="#BD292929" />
-        <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
-    </ResourceDictionary>
+            <Thickness x:Key="FlipViewButtonBorderThemeThickness">0</Thickness>
+            <StaticResource x:Key="FlipViewBackground" ResourceKey="SystemControlPageBackgroundListLowBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackground" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightBaseMediumBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBackgroundPressed" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForeground" ResourceKey="SystemControlForegroundAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPointerOver" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousArrowForegroundPressed" ResourceKey="SystemControlHighlightAltAltMediumHighBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewNextPreviousButtonBorderBrushPressed" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="FlipViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
+            <SolidColorBrush x:Key="FlipViewButtonBackgroundThemeBrush" Color="#59D5D5D5" />
+            <SolidColorBrush x:Key="FlipViewButtonBorderThemeBrush" Color="#59D5D5D5" />
+            <SolidColorBrush x:Key="FlipViewButtonForegroundThemeBrush" Color="#99000000" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverBackgroundThemeBrush" Color="#F0D7D7D7" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverBorderThemeBrush" Color="#9EC1C1C1" />
+            <SolidColorBrush x:Key="FlipViewButtonPointerOverForegroundThemeBrush" Color="#FF000000" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedBackgroundThemeBrush" Color="#BD292929" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedBorderThemeBrush" Color="#BD292929" />
+            <SolidColorBrush x:Key="FlipViewButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
+        </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
     <Style TargetType="FlipView" BasedOn="{StaticResource DefaultFlipViewStyle}" />

--- a/dev/MenuBar/MenuBar.xaml
+++ b/dev/MenuBar/MenuBar.xaml
@@ -4,7 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
-    <Style TargetType="local:MenuBar">
+    <Style TargetType="local:MenuBar" BasedOn="{StaticResource DefaultMenuBarStyle}" />
+
+    <Style x:Key="DefaultMenuBarStyle" TargetType="local:MenuBar">
         <Setter Property="Background" Value="{ThemeResource MenuBarBackground}"/>
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Height" Value="{StaticResource MenuBarHeight}"/>

--- a/dev/PersonPicture/PersonPicture.xaml
+++ b/dev/PersonPicture/PersonPicture.xaml
@@ -4,7 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
-    <Style TargetType="local:PersonPicture">
+    <Style TargetType="local:PersonPicture" BasedOn="{StaticResource DefaultPersonPictureStyle}" />
+
+    <Style x:Key="DefaultPersonPictureStyle" TargetType="local:PersonPicture">
         <Setter Property="Foreground" Value="{ThemeResource PersonPictureForegroundThemeBrush}" />
         <Setter Property="Width" Value="100" />
         <Setter Property="Height" Value="100" />

--- a/dev/Pivot/Pivot_themeresources.xaml
+++ b/dev/Pivot/Pivot_themeresources.xaml
@@ -496,7 +496,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource DefaultPivotHeaderItem}" />
+    <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource DefaultPivotHeaderItemStyle}" />
 
     <Style x:Key="DefaultPivotHeaderItem" TargetType="PivotHeaderItem">
         <Setter Property="FontSize" Value="{ThemeResource PivotHeaderItemFontSize}" />

--- a/dev/Pivot/Pivot_themeresources.xaml
+++ b/dev/Pivot/Pivot_themeresources.xaml
@@ -209,7 +209,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="Pivot">
+    <Style TargetType="Pivot" BasedOn="{StaticResource DefaultPivotStyle}" />
+
+    <Style x:Key="DefaultPivotStyle" TargetType="Pivot">
         <Setter Property="Margin" Value="0" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Background" Value="{ThemeResource PivotBackground}" />
@@ -467,7 +469,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="PivotItem">
+    <Style TargetType="PivotItem" BasedOn="{StaticResource DefaultPivotItemStyle}" />
+
+    <Style x:Key="DefaultPivotItemStyle" TargetType="PivotItem">
         <Setter Property="Background" Value="{ThemeResource PivotItemBackground}" />
         <Setter Property="Margin" Value="{ThemeResource PivotItemMargin}" />
         <Setter Property="Padding" Value="0" />
@@ -492,7 +496,9 @@
         </Setter>
     </Style>
 
-    <Style TargetType="PivotHeaderItem">
+    <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource DefaultPivotHeaderItem}" />
+
+    <Style x:Key="DefaultPivotHeaderItem" TargetType="PivotHeaderItem">
         <Setter Property="FontSize" Value="{ThemeResource PivotHeaderItemFontSize}" />
         <Setter Property="FontFamily" Value="{ThemeResource PivotHeaderItemFontFamily}" />
         <Setter Property="FontWeight" Value="{ThemeResource PivotHeaderItemThemeFontWeight}" />

--- a/dev/Pivot/Pivot_themeresources.xaml
+++ b/dev/Pivot/Pivot_themeresources.xaml
@@ -498,7 +498,7 @@
 
     <Style TargetType="PivotHeaderItem" BasedOn="{StaticResource DefaultPivotHeaderItemStyle}" />
 
-    <Style x:Key="DefaultPivotHeaderItem" TargetType="PivotHeaderItem">
+    <Style x:Key="DefaultPivotHeaderItemStyle" TargetType="PivotHeaderItem">
         <Setter Property="FontSize" Value="{ThemeResource PivotHeaderItemFontSize}" />
         <Setter Property="FontFamily" Value="{ThemeResource PivotHeaderItemFontFamily}" />
         <Setter Property="FontWeight" Value="{ThemeResource PivotHeaderItemThemeFontWeight}" />

--- a/dev/PullToRefresh/RefreshContainer/RefreshContainer.xaml
+++ b/dev/PullToRefresh/RefreshContainer/RefreshContainer.xaml
@@ -4,7 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
-  <Style TargetType="local:RefreshContainer">
+  <Style TargetType="local:RefreshContainer" BasedOn="{StaticResource DefaultRefreshContainerStyle}" />
+
+  <Style x:Key="DefaultRefreshContainerStyle" TargetType="local:RefreshContainer">
     <Setter Property="Foreground" Value="{ThemeResource RefreshContainerForegroundBrush}"/>
     <Setter Property="Background" Value="{ThemeResource RefreshContainerBackgroundBrush}"/>
     <Setter Property="IsTabStop" Value="False" />

--- a/dev/RadioButtons/RadioButton.xaml
+++ b/dev/RadioButtons/RadioButton.xaml
@@ -3,7 +3,9 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style TargetType="RadioButton">
+    <Style TargetType="RadioButton" BasedOn="{StaticResource DefaultRadioButtonStyle}" />
+
+    <Style x:Key="DefaultRadioButtonStyle" TargetType="RadioButton">
         <Setter Property="Background" Value="{ThemeResource RadioButtonBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource RadioButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource RadioButtonBorderBrush}" />

--- a/dev/RadioButtons/RadioButtons.xaml
+++ b/dev/RadioButtons/RadioButtons.xaml
@@ -5,7 +5,9 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
 
-    <Style TargetType="local:RadioButtons">
+    <Style TargetType="local:RadioButtons" BasedOn="{StaticResource DefaultRadioButtonsStyle}" />
+
+    <Style x:Key="DefaultRadioButtonsStyle" TargetType="local:RadioButtons">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="TabNavigation" Value="Once" />
         <Setter Property="Template">

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs1_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs1_themeresources.xaml
@@ -4,8 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
+    <Style TargetType="local:RadioMenuFlyoutItem" BasedOn="{StaticResource DefaultRadioMenuFlyoutItemStyle}" />
+
     <!-- Same as default rs1 style for ToggleMenuFlyoutItem -->
-    <Style TargetType="local:RadioMenuFlyoutItem">
+    <Style x:Key="DefaultRadioMenuFlyoutItemStyle" TargetType="local:RadioMenuFlyoutItem">
         <Setter Property="Background" Value="{ThemeResource ToggleMenuFlyoutItemBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ToggleMenuFlyoutItemForeground}" />
         <Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs2_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs2_themeresources.xaml
@@ -4,8 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
+    <Style TargetType="local:RadioMenuFlyoutItem" BasedOn="{StaticResource DefaultRadioMenuFlyoutItemStyle}" />
+
     <!-- Same as default rs2 style for ToggleMenuFlyoutItem -->
-    <Style TargetType="local:RadioMenuFlyoutItem">
+    <Style x:Key="DefaultRadioMenuFlyoutItemStyle" TargetType="local:RadioMenuFlyoutItem">
         <Setter Property="Background" Value="{ThemeResource ToggleMenuFlyoutItemBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ToggleMenuFlyoutItemForeground}" />
         <Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources.xaml
@@ -4,8 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
+    <Style TargetType="local:RadioMenuFlyoutItem" BasedOn="{StaticResource DefaultRadioMenuFlyoutItemStyle}" />
+
     <!-- Same as default rs4 style for ToggleMenuFlyoutItem -->
-    <Style TargetType="local:RadioMenuFlyoutItem">
+    <Style x:Key="DefaultRadioMenuFlyoutItemStyle" TargetType="local:RadioMenuFlyoutItem">
         <Setter Property="Background" Value="{ThemeResource ToggleMenuFlyoutItemBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource ToggleMenuFlyoutItemForeground}" />
         <Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources.xaml
@@ -4,8 +4,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
+    <Style TargetType="local:RadioMenuFlyoutItem" BasedOn="{StaticResource DefaultRadioMenuFlyoutItemStyle}" />
+
     <!-- Same as rs5 ToggleMenuFlyoutItemRevealStyle -->
-    <Style TargetType="local:RadioMenuFlyoutItem">
+    <Style x:Key="DefaultRadioMenuFlyoutItemStyle" TargetType="local:RadioMenuFlyoutItem">
         <Setter Property="Background" Value="{ThemeResource ToggleMenuFlyoutItemRevealBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ToggleMenuFlyoutItemRevealBorderBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource ToggleMenuFlyoutItemRevealBorderThickness}" />

--- a/dev/ScrollBar/ScrollBar_themeresources.xaml
+++ b/dev/ScrollBar/ScrollBar_themeresources.xaml
@@ -198,7 +198,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ScrollBar">
+    <Style TargetType="ScrollBar" BasedOn="{StaticResource DefaultScrollBarStyle}" />
+
+    <Style x:Key="DefaultScrollBarStyle" TargetType="ScrollBar">
         <Setter Property="MinWidth" Value="{ThemeResource ScrollBarSize}" />
         <Setter Property="MinHeight" Value="{ThemeResource ScrollBarSize}" />
         <Setter Property="Background" Value="{ThemeResource ScrollBarBackground}" />

--- a/dev/ScrollViewer/ScrollViewer.xaml
+++ b/dev/ScrollViewer/ScrollViewer.xaml
@@ -6,7 +6,9 @@
     xmlns:localPrimitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:ScrollViewer">
+    <Style TargetType="local:ScrollViewer" BasedOn="{StaticResource DefaultScrollViewerStyle}" />
+
+    <Style x:Key="DefaultScrollViewerStyle" TargetType="local:ScrollViewer">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}"/>

--- a/dev/Slider/Slider_themeresources.xaml
+++ b/dev/Slider/Slider_themeresources.xaml
@@ -172,8 +172,10 @@
     <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
     <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
     <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+
+    <Style TargetType="Slider" BasedOn="{StaticResource DefaultSliderStyle}" />
     
-    <Style TargetType="Slider">
+    <Style x:Key="DefaultSliderStyle" TargetType="Slider">
         <Setter Property="Background" Value="{ThemeResource SliderTrackFill}" />
         <Setter Property="BorderThickness" Value="{ThemeResource SliderBorderThemeThickness}" />
         <Setter Property="Foreground" Value="{ThemeResource SliderTrackValueFill}" />

--- a/dev/SplitView/SplitView_themeresources.xaml
+++ b/dev/SplitView/SplitView_themeresources.xaml
@@ -36,7 +36,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="SplitView">
+    <Style TargetType="SplitView" BasedOn="{StaticResource DefaultSplitViewStyle}" />
+
+    <Style x:Key="DefaultSplitViewStyle" TargetType="SplitView">
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="OpenPaneLength" Value="{ThemeResource SplitViewOpenPaneThemeLength}" />

--- a/dev/SwipeControl/SwipeControl.xaml
+++ b/dev/SwipeControl/SwipeControl.xaml
@@ -5,7 +5,9 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:SwipeControl">
+    <Style TargetType="local:SwipeControl" BasedOn="{StaticResource DefaultSwipeControlStyle}" />
+
+    <Style x:Key="DefaultSwipeControlStyle" TargetType="local:SwipeControl">
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}"/>

--- a/dev/SwipeControl/SwipeControl.xaml
+++ b/dev/SwipeControl/SwipeControl.xaml
@@ -5,8 +5,6 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:SwipeControl" BasedOn="{StaticResource DefaultSwipeControlStyle}" />
-
     <Style x:Key="DefaultSwipeControlStyle" TargetType="local:SwipeControl">
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Background" Value="Transparent"/>
@@ -39,4 +37,6 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:SwipeControl" BasedOn="{StaticResource DefaultSwipeControlStyle}" />
 </ResourceDictionary>

--- a/dev/SwipeControl/SwipeControl_rs1.xaml
+++ b/dev/SwipeControl/SwipeControl_rs1.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
-    <Style TargetType="local:SwipeControl">
+    <Style x:Key="DefaultSwipeControlStyle" TargetType="local:SwipeControl">
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Template">
@@ -30,4 +30,6 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:SwipeControl" BasedOn="{StaticResource DefaultSwipeControlStyle}" />
 </ResourceDictionary>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -8,7 +8,9 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
 
-    <Style TargetType="local:TabView">
+    <Style TargetType="local:TabView" BasedOn="{StaticResource DefaultTabViewStyle}" />
+
+    <Style x:Key="DefaultTabViewStyle" TargetType="local:TabView">
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Padding" Value="{ThemeResource TabViewHeaderPadding}" />
         <Setter Property="IsTabStop" Value="False" />

--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -5,7 +5,9 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:TeachingTip">
+    <Style TargetType="local:TeachingTip" BasedOn="{StaticResource DefaultTeachingTipStyle}" />
+
+    <Style x:Key="DefaultTeachingTipStyle" TargetType="local:TeachingTip">
         <Setter Property="Background" Value="{ThemeResource TeachingTipBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{ThemeResource TeachingTipForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource TeachingTipBorderBrush}"/>

--- a/dev/ToolTip/ToolTip_rs1_themeresources.xaml
+++ b/dev/ToolTip/ToolTip_rs1_themeresources.xaml
@@ -40,7 +40,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ToolTip">
+    <Style TargetType="ToolTip" BasedOn="{StaticResource DefaultToolTipStyle}" />
+
+    <Style x:Key="DefaultToolTipStyle" TargetType="ToolTip">
         <Setter Property="Foreground" Value="{ThemeResource ToolTipForeground}" />
         <Setter Property="Background" Value="{ThemeResource ToolTipBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ToolTipBorderBrush}" />

--- a/dev/ToolTip/ToolTip_rs5_themeresources.xaml
+++ b/dev/ToolTip/ToolTip_rs5_themeresources.xaml
@@ -21,7 +21,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="ToolTip">
+    <Style TargetType="ToolTip" BasedOn="{StaticResource DefaultToolTipStyle}" />
+
+    <Style x:Key="DefaultToolTipStyle" TargetType="ToolTip">
         <Setter Property="Foreground" Value="{ThemeResource ToolTipForeground}" />
         <Setter Property="Background" Value="{ThemeResource ToolTipBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ToolTipBorderBrush}" />

--- a/dev/TreeView/TreeView.xaml
+++ b/dev/TreeView/TreeView.xaml
@@ -15,7 +15,9 @@
         </Grid>
     </DataTemplate>
 
-    <Style TargetType="local:TreeView">
+    <Style TargetType="local:TreeView" BasedOn="{StaticResource DefaultTreeViewStyle}" />
+
+    <Style x:Key="DefaultTreeViewStyle" TargetType="local:TreeView">
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="CanDragItems" Value="True"/>
         <Setter Property="CanReorderItems" Value="True"/>

--- a/dev/TwoPaneView/TwoPaneView.xaml
+++ b/dev/TwoPaneView/TwoPaneView.xaml
@@ -6,7 +6,9 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:TwoPaneView">
+    <Style TargetType="local:TwoPaneView" BasedOn="{StaticResource DefaultTwoPaneViewStyle}" />
+
+    <Style x:Key="DefaultTwoPaneViewStyle" TargetType="local:TwoPaneView">
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="MinWideModeWidth" Value="641"/>

--- a/dev/TwoPaneView/TwoPaneView.xaml
+++ b/dev/TwoPaneView/TwoPaneView.xaml
@@ -6,8 +6,6 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
-    <Style TargetType="local:TwoPaneView" BasedOn="{StaticResource DefaultTwoPaneViewStyle}" />
-
     <Style x:Key="DefaultTwoPaneViewStyle" TargetType="local:TwoPaneView">
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
@@ -124,5 +122,7 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:TwoPaneView" BasedOn="{StaticResource DefaultTwoPaneViewStyle}" />
 
 </ResourceDictionary>

--- a/dev/TwoPaneView/TwoPaneView_rs1.xaml
+++ b/dev/TwoPaneView/TwoPaneView_rs1.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
-    <Style TargetType="local:TwoPaneView">
+    <Style x:Key="DefaultTwoPaneViewStyle" TargetType="local:TwoPaneView">
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="MinWideModeWidth" Value="641"/>
@@ -85,5 +85,7 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style TargetType="local:TwoPaneView" BasedOn="{StaticResource DefaultTwoPaneViewStyle}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
Fixes #1260.

Added key names to default control styles so they can support `BasedOn` styles like below.

```xml
<Style x:Key="MyComboBoxStyle" TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
    ...
</Style>
```