### PR TITLE
Fix SplitButton reveal style, Closes #1310

### DIFF
--- a/dev/Materials/Reveal/RevealBrush_rs2_themeresources.xaml
+++ b/dev/Materials/Reveal/RevealBrush_rs2_themeresources.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -2651,7 +2651,11 @@
 
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
-                                                        <VisualState x:Name="Normal"/>
+                                                        <VisualState x:Name="Normal">
+                                                            <Storyboard>
+                                                                <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
+                                                            </Storyboard>
+                                                        </VisualState>
 
                                                         <VisualState x:Name="PointerOver">
                                                             <VisualState.Setters>


### PR DESCRIPTION
### Summary
Fixed a bug with the SplitButton Reveal style where closing the flyout would remove the reveal style from the chevron button.

Side note: Clicking the left button had the same effect on the left button.

### Motivation
Closes #1310 .

### Screenshot
![splitbutton reveal new](https://user-images.githubusercontent.com/16122379/64735843-a90a3e00-d4e9-11e9-83af-18e0ffdd402e.gif)
