### PR TITLE
Fix TreeViewItem CheckBox aligment

### DIFF
--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -125,7 +125,7 @@
                                             Width="32"
                                             MinWidth="32"
                                             Margin="12,0,0,0"
-                                            VerticalAlignment="Stretch"
+                                            VerticalAlignment="Center"
                                             Visibility="Collapsed"
                                             IsTabStop="False"
                                             AutomationProperties.AccessibilityView="Raw" />


### PR DESCRIPTION
Fixes #1294 

TreeViewItem CheckBox was not vertically center aligned when item height or font size changes. Changed VerticalAlignment from Stretch to Center.


![Annotation 2019-09-11 165243](https://user-images.githubusercontent.com/4424330/64743409-ac370700-d4b4-11e9-9856-3c38f0e63e41.png) ![Annotation 2019-09-11 165046](https://user-images.githubusercontent.com/4424330/64743411-ad683400-d4b4-11e9-94da-29a393f9b787.png)
