### PR TITLE
Fix RefreshVisualizer crash in release builds

### DIFF
--- a/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
+++ b/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
@@ -131,7 +131,7 @@
       <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.2.190830001</Version>
+      <Version>2.1.190606001</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -152,3 +152,5 @@
   </Target>
   -->
 </Project>
+
+

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -171,7 +171,7 @@
       <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.2.190830001</Version>
+      <Version>2.1.190606001</Version>
     </PackageReference>
     <PackageReference Include="MUXCustomBuildTasks">
       <Version>1.0.38</Version>

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
@@ -223,15 +223,15 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NETCore.UniversalWindowsPlatform.6.2.8\build\Microsoft.NETCore.UniversalWindowsPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETCore.UniversalWindowsPlatform.6.2.8\build\Microsoft.NETCore.UniversalWindowsPlatform.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.NETCore.UniversalWindowsPlatform.6.2.8\build\Microsoft.NetCore.UniversalWindowsPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NETCore.UniversalWindowsPlatform.6.2.8\build\Microsoft.NetCore.UniversalWindowsPlatform.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.2.190830001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.2.190830001\build\native\Microsoft.UI.Xaml.targets'))" />
   </Target>
   <Import Project="$(MSBuildProjectDirectory)\..\..\..\CustomInlineTasks.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\packages\MUXCustomBuildTasks.1.0.38\build\native\MUXCustomBuildTasks.targets')" />
+    <Import Project="..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" />
     <Import Project="..\packages\Microsoft.NETCore.UniversalWindowsPlatform.6.2.8\build\Microsoft.NetCore.UniversalWindowsPlatform.targets" Condition="Exists('..\packages\Microsoft.NETCore.UniversalWindowsPlatform.6.2.8\build\Microsoft.NetCore.UniversalWindowsPlatform.targets')" />
-    <Import Project="..\packages\Microsoft.UI.Xaml.2.2.190830001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.2.190830001\build\native\Microsoft.UI.Xaml.targets')" />
   </ImportGroup>
   <Target Name="AfterBuild">
     <RunPowershellScript Path="$(SolutionDir)\tools\ExtractPackageDependencies_ReleaseTest.ps1" Parameters="-sourceFile $(OutDir)\$(AppxPackageName).build.appxrecipe -platform $(ConvertedPlatformName) -outputFile $(AppxPackageTestDir)\$(AppxPackageName).dependencies.txt" FilesWritten="$(AppxPackageTestDir)\$(AppxPackageName).dependencies.txt" />

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/packages.config
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.8" targetFramework="native" />
-  <package id="Microsoft.UI.Xaml" version="2.2.190830001" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.1.190606001" targetFramework="native" />
   <package id="MUXCustomBuildTasks" version="1.0.38" targetFramework="native" />
 </packages>


### PR DESCRIPTION
In release builds we take preview features and set their feature stage to "AlwaysDisabled". This caused CppWinRT to stop emitting implementations for the interfaces of those types. Luckily there's a command line option -ignore_velocity we can pass to make them stop doing that and behave the same as in our prerelease builds where the stage is "DisabledByDefault".

I added a nuget package test which repros the bug before this fix, and retargeted the nuget test apps to latest just to facilitate local testing.

Fixes #1277 