### PR TITLE
Fix crash in RefreshVisualizer when not wrapping a ScrollViewer

### DIFF
--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.cpp
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.cpp
@@ -298,7 +298,13 @@ void RefreshVisualizer::UpdateContent()
             contentVisual.Opacity(1.0f);
             if (m_root)
             {
-                float translationRatio = (1.0f - (float)(m_refreshInfoProvider.get().ExecutionRatio())) * PARALLAX_POSITION_RATIO;
+                float translationRatio = [this]() {
+                    if (auto&& refreshInfoProvider = m_refreshInfoProvider.get())
+                    {
+                        return (1.0f - (float)(refreshInfoProvider.ExecutionRatio())) * PARALLAX_POSITION_RATIO;
+                    }
+                    return 0.0f;
+                }();
                 translationRatio = IsPullDirectionFar() ? -1.0f * translationRatio : translationRatio;
                 //On RS2 and above we achieve the parallax animation using the Translation property, so we set the appropriate field here.
                 if (SharedHelpers::IsRS2OrHigher())

--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.cpp
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.cpp
@@ -303,7 +303,7 @@ void RefreshVisualizer::UpdateContent()
                     {
                         return (1.0f - (float)(refreshInfoProvider.ExecutionRatio())) * PARALLAX_POSITION_RATIO;
                     }
-                    return 0.0f;
+                    return 1.0f;
                 }();
                 translationRatio = IsPullDirectionFar() ? -1.0f * translationRatio : translationRatio;
                 //On RS2 and above we achieve the parallax animation using the Translation property, so we set the appropriate field here.


### PR DESCRIPTION
The last change I made here added a test -- that test is crashing because the RefreshVisualizer doesn't actually wrap a ScrollViewer or something that can be "adapted". We shouldn't crash in this case, however. Adding an if check to fix that failing test.

Fixes #1277