### PR TITLE
Fix bug where NavigationView settings button would "lag" behind when rescaling

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -346,12 +346,15 @@
                                         VerticalContentAlignment="Stretch"
                                         HorizontalContentAlignment="Stretch"
                                         Grid.Column="7" />
-
-                                    <local:NavigationViewItem
+                                    <Grid
+                                        Grid.Column="8"
+                                        >
+                                        <local:NavigationViewItem
                                             x:Name="SettingsTopNavPaneItem"
                                             Style="{ThemeResource MUX_NavigationViewSettingsItemStyleWhenOnTopPane}"
-                                            Grid.Column="8"
                                             Icon="Setting"/>
+
+                                    </Grid>
 
                                 </Grid>
                                 <Border
@@ -459,11 +462,13 @@
                                             VerticalContentAlignment="Stretch"
                                             HorizontalContentAlignment="Stretch"
                                             Grid.Row="7" />
-
-                                        <local:NavigationViewItem
+                                        <Grid
+                                            Grid.Row="8">
+                                            <local:NavigationViewItem
                                             x:Name="SettingsNavPaneItem"
-                                            Grid.Row="8"
                                             Icon="Setting"/>
+                                        </Grid>
+
                                     </Grid>
                                 </SplitView.Pane>
 

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -347,8 +347,7 @@
                                         HorizontalContentAlignment="Stretch"
                                         Grid.Column="7" />
                                     <Grid
-                                        Grid.Column="8"
-                                        >
+                                        Grid.Column="8" >
                                         <local:NavigationViewItem
                                             x:Name="SettingsTopNavPaneItem"
                                             Style="{ThemeResource MUX_NavigationViewSettingsItemStyleWhenOnTopPane}"


### PR DESCRIPTION
## Summary
Fix a bug where the settings button would lag behind when the NavigationView gets rescaled.
This was fixed by wrapping the settingsbutton in a grid as the NavigationViewItem seems to be the problem when on "root" level in NavigationView.

## Motivation
Fixes #591 

## Testing methodology
Created NavigationView in both topmode and left mode and resized them to check the delay of reposition.