### PR TITLE
Fix bug with textbox clipping under small width and height

### DIFF
--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -292,8 +292,8 @@
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                             contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                             Control.IsTemplateFocusTarget="True"
-                            MinWidth="{ThemeResource TextControlThemeMinWidth}"
-                            MinHeight="{ThemeResource TextControlThemeMinHeight}" />
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MinHeight="{TemplateBinding MinHeight}" />
                         <ScrollViewer x:Name="ContentElement"
                             Grid.Row="1"
                             Grid.Column="0"

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -89,6 +89,8 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
+        <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
         <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}" />
         <contract6Present:Setter Property="UseSystemFocusVisuals" Value="{ThemeResource IsApplicationFocusVisualKindReveal}" />
         <contract7Present:Setter Property="ContextFlyout" Value="{StaticResource TextControlCommandBarContextFlyout}" />


### PR DESCRIPTION
## Summary
Fix a bug with the TextBox component where it would start clipping when width and height is set to small values.

## Motivation
Fixes #641.

## Screenshots
![image](https://user-images.githubusercontent.com/16122379/65034945-5052ff00-d948-11e9-8fda-ae553a8e3ad9.png)
