### PR TITLE
Fix glyph opacity issue when recycling elements in treeview.

### DIFF
--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -366,16 +366,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void ValidateTreeViewItemSourceChangeUpdatesChevronOpacity()
         {
+            var collection = new ObservableCollection<int>();
+            collection.Add(5);
+            TreeViewItem tvi = null;
+            TreeView treeView = null;
+
             RunOnUIThread.Execute(() =>
             {
-                TreeViewItem tvi = new TreeViewItem();
-                var emptyCollection = new ObservableCollection<int>();
-                tvi.ItemsSource = emptyCollection;
+                treeView = new TreeView();
+                treeView.ItemsSource = collection;
+                MUXControlsTestApp.App.TestContentRoot = treeView;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                tvi = (TreeViewItem)treeView.ContainerFromItem(5);
                 Verify.AreEqual(tvi.GlyphOpacity, 0.0);
-                var collection = new ObservableCollection<int>();
-                collection.Add(5);
                 tvi.ItemsSource = collection;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
                 Verify.AreEqual(tvi.GlyphOpacity, 1.0);
+                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -364,6 +364,22 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        public void ValidateTreeViewItemSourceChangeUpdatesChevronOpacity()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                TreeViewItem tvi = new TreeViewItem();
+                var emptyCollection = new ObservableCollection<int>();
+                tvi.ItemsSource = emptyCollection;
+                Verify.AreEqual(tvi.GlyphOpacity, 0.0);
+                var collection = new ObservableCollection<int>();
+                collection.Add(5);
+                tvi.ItemsSource = collection;
+                Verify.AreEqual(tvi.GlyphOpacity, 1.0);
+            });
+        }
+
+        [TestMethod]
         public void TreeViewItemContainerStyleTest()
         {
             RunOnUIThread.Execute(() =>

--- a/dev/TreeView/TreeViewItem.cpp
+++ b/dev/TreeView/TreeViewItem.cpp
@@ -324,9 +324,16 @@ void TreeViewItem::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
             // ItemsSource change happens during measuring.
             // Adding itemsSource to node's children triggers another layout change, so it has to be done async.
             m_dispatcherHelper.RunAsync(
-                [node, value]()
+                [this, node, value]()
             {
-                winrt::get_self<TreeViewNode>(node)->ItemsSource(value);
+                auto treeViewNode = winrt::get_self<TreeViewNode>(node);
+                treeViewNode->ItemsSource(value);
+                if (IsInContentMode())
+                {
+                    // The children have changed, validate and update GlyphOpacity
+                    bool hasChildren = HasUnrealizedChildren() || treeViewNode->HasChildren();
+                    GlyphOpacity(hasChildren ? 1.0 : 0.0);
+                }
             });
         }
         else if (property == s_HasUnrealizedChildrenProperty)


### PR DESCRIPTION
With data bound TreeView items, we were not updating the glyph opacity when recycling across elements. This ends up manifesting with the glyph showing up sometimes where it should not and vice versa. When recycling, we don't have the children collection bound yet - that happens only when measuring at which point the template expands and the bindings fire. Unfortunately that was too late and the opacity was already set before that. This fixes the issue by updating the opacity once the children are updated.  Verified that the repro app works as expected. Do not have a test yet.

Fixes #1249