### PR TITLE
Fix ADAL nuget version in release helper script

### DIFF
--- a/tools/BuildMachineUtils.psm1
+++ b/tools/BuildMachineUtils.psm1
@@ -8,8 +8,8 @@
         $installLocation = Get-Package Microsoft.IdentityModel.Clients.ActiveDirectory -MaximumVersion $adalVersion -MinimumVersion $adalVersion -ErrorAction Ignore
         if (!$installLocation)
         {
-            Install-package Microsoft.IdentityModel.Clients.ActiveDirectory -Source https://nuget.org/api/v2/ -ProviderName nuget -MaximumVersion $adalMaxVersion -Scope CurrentUser
-            $installLocation = Get-Package Microsoft.IdentityModel.Clients.ActiveDirectory -MaximumVersion $adalMaxVersion
+            Install-package Microsoft.IdentityModel.Clients.ActiveDirectory -Source https://nuget.org/api/v2/ -ProviderName nuget -MaximumVersion $adalVersion -Scope CurrentUser
+            $installLocation = Get-Package Microsoft.IdentityModel.Clients.ActiveDirectory -MaximumVersion $adalVersion
         }
 
         $adalPath = Split-Path $installLocation.Source


### PR DESCRIPTION
Fix a simple typo that was making this script not work on machines where the "right" version of ADAL hadn't been nuget restored.