### PR TITLE
Fix TreeViewNode content display

### DIFF
--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -284,6 +284,8 @@ hstring TreeViewNode::GetContentAsString()
         {
             return result.ToString();
         }
+
+        return unbox_value<winrt::hstring>(content);
     }
 
     return Type().Name;

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -285,7 +285,7 @@ hstring TreeViewNode::GetContentAsString()
             return result.ToString();
         }
 
-        return unbox_value<winrt::hstring>(content);
+        return winrt::unbox_value_or<hstring>(content, Type().Name);
     }
 
     return Type().Name;

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
@@ -70,5 +70,12 @@ namespace MUXControls.ReleaseTest
             var textBlock = new TextBlock(FindElement.ByName("CheckBoxRectangleCornerRadiusValueTextBlock"));
             Verify.AreEqual("2,2", textBlock.DocumentText);
         }
+
+        [TestMethod]
+        public void TreeViewNodeContentTest()
+        {
+            var node = FindElement.ByName("TreeViewNode1");
+            Verify.IsNotNull(node, "Verify TreeViewNode conteins right content");
+        }
     }
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml
@@ -46,6 +46,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <TextBlock x:Name="TestTextBlock" AutomationProperties.Name="TestTextBlock" Text="Loaded"/>
@@ -54,8 +55,13 @@
                 <Button x:Name="GetCheckBoxRectangleCornerRadiusValue" Content="GetCheckBoxRectangleCornerRadiusValue" AutomationProperties.Name="GetCheckBoxRectangleCornerRadiusValue"  Click="GetCheckBoxRectangleCornerRadiusValue_Click"/>
                 <TextBlock x:Name="CheckBoxRectangleCornerRadiusValueTextBlock" AutomationProperties.Name="CheckBoxRectangleCornerRadiusValueTextBlock"></TextBlock>
             </StackPanel>
-            <Button Grid.Row="2" Click="OnAddItemsButtonClick" Content="Add Items" AutomationProperties.Name="AddItemsButton"  />
-            <ScrollViewer Grid.Row="3">
+            <controls:TreeView Grid.Row="2">
+                <controls:TreeView.RootNodes>
+                    <controls:TreeViewNode Content="TreeViewNode1"/>
+                </controls:TreeView.RootNodes>
+            </controls:TreeView>
+            <Button Grid.Row="3" Click="OnAddItemsButtonClick" Content="Add Items" AutomationProperties.Name="AddItemsButton"  />
+            <ScrollViewer Grid.Row="4">
                 <controls:ItemsRepeater x:Name="Repeater" />
             </ScrollViewer>
         </Grid>


### PR DESCRIPTION
We made TreeViewNode stringable in order to show string content correctly. TreeViewNode checks for ICustomPropertyProvider and IStringable interfaces to convert Content to String. This works in C# app, but in C++, string content is passed in as hstring (neither ICustomPropertyProvider nor IStringable), added "unbox_value" to correctly handle that. Also added a test in NugetPackageTestAppCX.
