### PR TITLE
Fix bug with empty DataTemplate

### DIFF
--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -142,6 +142,32 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.SetValue(ItemsRepeater.ItemsSourceProperty, dataSource);
                 Verify.AreSame(dataSource, repeater.GetValue(ItemsRepeater.ItemsSourceProperty) as ItemsSourceView);
                 Verify.AreSame(dataSource, repeater.ItemsSourceView);
+            });
+        }
+
+        [TestMethod]
+        public void ValidateNoSizeWhenEmptyDataTemplate()
+        {
+
+            ItemsRepeater repeater = null;
+            RunOnUIThread.Execute(() =>
+            {
+                var elementFactory = new RecyclingElementFactory();
+                elementFactory.RecyclePool = new RecyclePool();
+                elementFactory.Templates["Item"] = (DataTemplate)XamlReader.Load(
+                    @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' />");
+
+                repeater = new ItemsRepeater() {
+                    ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
+                    ItemTemplate = elementFactory,
+                    // Default is StackLayout, so do not have to explicitly set.
+                    // Layout = new StackLayout(),
+                };
+                repeater.UpdateLayout();
+
+                // Asserting render size is zero
+                Verify.IsLessThan(repeater.RenderSize.Width , 0.0001);
+                Verify.IsLessThan(repeater.RenderSize.Height , 0.0001);
             });
         }
 

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
@@ -175,4 +175,9 @@ private:
     winrt::IElementFactory m_itemTemplate{ nullptr };
     winrt::Layout m_layout{ nullptr };
     winrt::ElementAnimator m_animator{ nullptr };
+
+    // Bug where DataTemplate with no content causes a crash.
+    // See: https://github.com/microsoft/microsoft-ui-xaml/issues/776
+    // Solution: Have reference to DataTemplate and check if content is not null
+    winrt::DataTemplate m_dataTemplateReference{ nullptr };
 };

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -178,6 +178,6 @@ private:
 
     // Bug where DataTemplate with no content causes a crash.
     // See: https://github.com/microsoft/microsoft-ui-xaml/issues/776
-    // Solution: Have flag that is only true when DataTemplate is existend and empty!
+    // Solution: Have flag that is only true when DataTemplate exists but it is empty.
     bool m_isItemTemplateEmpty{ false };
 };

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
@@ -178,6 +178,6 @@ private:
 
     // Bug where DataTemplate with no content causes a crash.
     // See: https://github.com/microsoft/microsoft-ui-xaml/issues/776
-    // Solution: Have reference to DataTemplate and check if content is not null
-    winrt::DataTemplate m_dataTemplateReference{ nullptr };
+    // Solution: Have flag that is only true when DataTemplate is existend and empty!
+    bool m_isItemTemplateEmpty{ false };
 };

--- a/dev/Repeater/TestUI/Samples/Defaults.xaml
+++ b/dev/Repeater/TestUI/Samples/Defaults.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Page
     x:Class="MUXControlsTestApp.Samples.Defaults"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -7,6 +7,7 @@
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
@@ -20,5 +21,10 @@
                 <controls:ItemsRepeater ItemsSource="{x:Bind Data}" />
             </ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
+        <controls:ItemsRepeater x:Name="emptyDataTemplateRepeater" ItemsSource="{x:Bind Data}">
+            <controls:ItemsRepeater.ItemTemplate>
+                <DataTemplate />
+            </controls:ItemsRepeater.ItemTemplate>
+        </controls:ItemsRepeater>
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
Fixed a bug where an ItemRepeater with an empty DataTemplate as ItemTemplate would result in a crash.

## Motivation
Fixes #776 

## Testing methodology
Added a test where we create an ItemRepeater with an empty DataTemplate and assert the size being zero. Also an ItemRepeater with empty DataTemplate was added to the test UI.