### PR TITLE
Fix bug with chevron not having right color when disabled

### DIFF
--- a/dev/DropDownButton/DropDownButton.xaml
+++ b/dev/DropDownButton/DropDownButton.xaml
@@ -77,6 +77,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ChevronTextBlock" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/Materials/Reveal/RevealBrush_rs2_themeresources.xaml
+++ b/dev/Materials/Reveal/RevealBrush_rs2_themeresources.xaml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -2682,6 +2682,9 @@
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonRevealBorderBrushDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ChevronTextBlock" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>


### PR DESCRIPTION
## Summary
Added the correct foreground setter in the VisualStateManager for the chevron when the DropDownButton is disabled.

## Motivation
See [this comment/bug report](https://github.com/microsoft/microsoft-ui-xaml/issues/70#issuecomment-534187471)

## Screenshots
![image](https://user-images.githubusercontent.com/16122379/65457433-d5a84900-de4b-11e9-9f7d-9018e6d571d8.png)

