### PR TITLE
Make TextCommandBarFlyout resilient against clipboard error HRESULTs

### DIFF
--- a/test/MUXControls.Test/MSTest/BuildAppX.cmd
+++ b/test/MUXControls.Test/MSTest/BuildAppX.cmd
@@ -1,14 +1,14 @@
 @echo off
 
 if "%DevEnvDir%" == "" (
-    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise" (
-        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
+    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" (
+        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
     ) else (
-        call "%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Enterprise\Common7\Tools\VsDevCmd.bat"
+        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
     )
 )
 
-set Command="%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe" %1 /p:platform="%2" /p:configuration="%3" /p:VisualStudioVersion="15.0" /flp:Verbosity=Diagnostic /fl /verbosity:Minimal
+set Command=MSBuild.exe %1 /p:platform="%2" /p:configuration="%3" /p:VisualStudioVersion="%VisualStudioVersion%" /flp:Verbosity=Diagnostic /fl /verbosity:Minimal
 
 echo.
 echo Calling "%Command%"

--- a/test/MUXControls.Test/MSTest/BuildAppX.cmd
+++ b/test/MUXControls.Test/MSTest/BuildAppX.cmd
@@ -1,12 +1,9 @@
 @echo off
+setlocal
 
-if "%DevEnvDir%" == "" (
-    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" (
-        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-    ) else (
-        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat"
-    )
-)
+"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -Latest -requires Microsoft.Component.MSBuild -property InstallationPath > %TEMP%\vsinstalldir.txt
+set /p _VsInstallDir=<%TEMP%\vsinstalldir.txt
+call "%_VsInstallDir%\Common7\Tools\VsDevCmd.bat"
 
 set Command=MSBuild.exe %1 /p:platform="%2" /p:configuration="%3" /p:VisualStudioVersion="%VisualStudioVersion%" /flp:Verbosity=Diagnostic /fl /verbosity:Minimal
 

--- a/tools/NugetWrapper.cmd
+++ b/tools/NugetWrapper.cmd
@@ -1,7 +1,7 @@
 @echo OFF
 setlocal
 
-set VisualStudioVersion=15.0
+if "%VisualStudioVersion%" == "" set VisualStudioVersion=15.0
 
 if defined NUGETEXETOOLPATH goto :AzurePipelines
 


### PR DESCRIPTION
Clipboard operations can return clipboard specific HRESULT values, which will cause us to crash if uncaught.  These aren't unrecoverable error states, so we'll be resilient against them by catching them - it's better to do a no-op than to crash.

I did what I could to get a local repro of this issue that would enable the creation of a test case, but everything I tried didn't work.  If I minimized the test app or opened another app (e.g., Calculator), the flyout immediately closed (as it should, by design), invalidating the buttons' UIA objects.  If I tried copying the button out of the flyout to keep it around, the Target property on the flyout was unset, causing the operation to be a no-op since it no longer knows what text control it should operate on.  I unfortunately don't know what circumstances led to the sequence of events allowing this to happen.

While I was testing, I ran into a couple issues where local tests didn't play nicely with VS 2019, since we had assumed 2017 in a couple places.  I fixed those up to work with 2019 as well.