### PR TITLE
Fix bug with TreeView not updating nodes correctly when collection triggers reset event

### DIFF
--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -163,6 +163,43 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 // Put things back
                 MUXControlsTestApp.App.TestContentRoot = null;
+            });
+        }
+
+        [TestMethod]
+        public void TreeViewItemSourceResetRecreateItems()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+
+                ExtendedObservableCollection<TreeViewItemSource> items
+                    = new ExtendedObservableCollection<TreeViewItemSource>();
+                TreeViewItemSource item1 = new TreeViewItemSource() { Content = "item1" };
+                TreeViewItemSource item2 = new TreeViewItemSource() { Content = "item2" };
+                TreeViewItemSource item3 = new TreeViewItemSource() { Content = "item3" };
+                items.Add(item1);
+                items.Add(item2);
+                items.Add(item3);
+
+                var treeView = new TreeView();
+                treeView.ItemsSource = items;
+
+                Verify.AreEqual(treeView.RootNodes.Count, 3);
+                Verify.AreEqual(treeView.RootNodes[0].Content as TreeViewItemSource, items[0]);
+
+                List<TreeViewItemSource> newItems = new List<TreeViewItemSource>();
+                TreeViewItemSource item4 = new TreeViewItemSource() { Content = "item4" };
+                TreeViewItemSource item5 = new TreeViewItemSource() { Content = "item5" };
+
+                newItems.Add(item4);
+                newItems.Add(item5);
+
+                items.ReplaceAll(newItems);
+
+                Verify.AreEqual(treeView.RootNodes.Count, 2);
+                Verify.AreEqual(treeView.RootNodes[0].Content as TreeViewItemSource, items[0]);
+
+
             });
         }
 

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -194,15 +194,7 @@ void TreeViewNode::OnItemsSourceChanged(const winrt::IInspectable& sender, const
 
     case winrt::NotifyCollectionChangedAction::Reset:
     {
-        int count = m_itemsDataSource.Count();
-        int childrenCount = Children().Size();
-
-        if (count > 0) {
-            // Reset was raised as part of massive collection changes!
-            // Add all items to the children
-            AddToChildrenNodes(0, count);
-        }
-        RemoveFromChildrenNodes(count, childrenCount);
+        SyncChildrenNodesWithItemsSource();
         break;
     }
 

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -194,10 +194,15 @@ void TreeViewNode::OnItemsSourceChanged(const winrt::IInspectable& sender, const
 
     case winrt::NotifyCollectionChangedAction::Reset:
     {
-        if (Children().Size() > 0)
-        {
-            Children().Clear();
+        int count = m_itemsDataSource.Count();
+        int childrenCount = Children().Size();
+
+        if (count > 0) {
+            // Reset was raised as part of massive collection changes!
+            // Add all items to the children
+            AddToChildrenNodes(0, count);
         }
+        RemoveFromChildrenNodes(count, childrenCount);
         break;
     }
 

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)\..\..\mux.controls.props" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\mux.controls.props') And $(BuildingWithBuildExe) != 'true'" />
@@ -155,6 +155,7 @@
     <None Include="$(MSBuildThisFileDirectory)\..\..\build\MSTest.pfx" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\ExtendedObservableCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TopLevelTestPageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)VisualTreeTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\LeakTestPage.xaml.cs" Condition="$(SolutionName) != 'MUXControlsInnerLoop'">

--- a/test/MUXControlsTestApp/Utilities/ExtendedObservableCollection.cs
+++ b/test/MUXControlsTestApp/Utilities/ExtendedObservableCollection.cs
@@ -7,8 +7,19 @@ using System.Collections.Specialized;
 
 namespace MUXControlsTestApp.Utilities
 {
+    /// <summary>
+    /// This class aims to add functionality that is present in other collections that can be used as ItemSource for controls,
+    /// e.g. ReplaceAll of the winrt::IVector.
+    /// See https://github.com/microsoft/microsoft-ui-xaml/issues/1379 for additional context as to why this is needed for easy testing.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     class ExtendedObservableCollection<T> : ObservableCollection<T>
     {
+        /// <summary>
+        /// Removes all items of this collection and replaces them with the collection specified.
+        /// Triggers the "Reset" action.
+        /// </summary>
+        /// <param name="items">Collection containing the items that will be replacing the previous content</param>
         public void ReplaceAll(ICollection<T> items)
         {
             this.Items.Clear();

--- a/test/MUXControlsTestApp/Utilities/ExtendedObservableCollection.cs
+++ b/test/MUXControlsTestApp/Utilities/ExtendedObservableCollection.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Text;
 
 namespace MUXControlsTestApp.Utilities
 {

--- a/test/MUXControlsTestApp/Utilities/ExtendedObservableCollection.cs
+++ b/test/MUXControlsTestApp/Utilities/ExtendedObservableCollection.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Text;
+
+namespace MUXControlsTestApp.Utilities
+{
+    class ExtendedObservableCollection<T> : ObservableCollection<T>
+    {
+        public void ReplaceAll(ICollection<T> items)
+        {
+            this.Items.Clear();
+            foreach(T item in items)
+            {
+                this.Items.Add(item);
+            }
+            this.OnCollectionChanged(
+                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset)
+            );
+        }
+
+    }
+}

--- a/test/TestAppCX/MainPage.xaml
+++ b/test/TestAppCX/MainPage.xaml
@@ -14,6 +14,7 @@
             <Button Content="Leak Test Page" Click="GoToLeakTestControlPage"/>
             <Button Content="MenuBar test page" Click="GoToMenuBarTestPage"/>
             <Button Content="CornerRadius test page" Click="GoToCornerRadiusTestPage"/>
+            <Button Content="TreeView test page" Click="GoToTreeViewTestPage"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/test/TestAppCX/MainPage.xaml.cpp
+++ b/test/TestAppCX/MainPage.xaml.cpp
@@ -11,6 +11,7 @@
 #include "LeakCycleTestCX.xaml.h"
 #include "MenuBarTestPage.xaml.h"
 #include "CornerRadiusTestPage.xaml.h"
+#include "TreeViewTestPage.xaml.h"
 
 using namespace TestAppCX;
 
@@ -48,4 +49,10 @@ void TestAppCX::MainPage::GoToCornerRadiusTestPage(Platform::Object^ sender, Win
 {
     auto app = dynamic_cast<App^>(Application::Current);
     app->RootFrame->Navigate(TypeName(CornerRadiusTestPage::typeid), nullptr);
+}
+
+void TestAppCX::MainPage::GoToTreeViewTestPage(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    auto app = dynamic_cast<App^>(Application::Current);
+    app->RootFrame->Navigate(TypeName(TreeViewTestPage::typeid), nullptr);
 }

--- a/test/TestAppCX/MainPage.xaml.h
+++ b/test/TestAppCX/MainPage.xaml.h
@@ -21,5 +21,6 @@ namespace TestAppCX
         void GoToLeakTestControlPage(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void GoToMenuBarTestPage(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void GoToCornerRadiusTestPage(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void GoToTreeViewTestPage(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
     };
 }

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -197,6 +197,9 @@
     <ClInclude Include="LeakCycleTestCX.xaml.h">
       <DependentUpon>LeakCycleTestCX.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="TreeViewTestPage.xaml.h">
+      <DependentUpon>TreeViewTestPage.xaml</DependentUpon>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -212,6 +215,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="MenuBarTestPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="TreeViewTestPage.xaml">
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
@@ -255,6 +261,9 @@
     </ClCompile>
     <ClCompile Include="LeakCycleTestCX.xaml.cpp">
       <DependentUpon>LeakCycleTestCX.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="TreeViewTestPage.xaml.cpp">
+      <DependentUpon>TreeViewTestPage.xaml</DependentUpon>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/test/TestAppCX/TestAppCX.vcxproj.filters
+++ b/test/TestAppCX/TestAppCX.vcxproj.filters
@@ -58,5 +58,6 @@
     <Page Include="LeakCycleTestCX.xaml" />
     <Page Include="MenuBarTestPage.xaml" />
     <Page Include="CornerRadiusTestPage.xaml" />
+    <Page Include="TreeViewTestPage.xaml" />
   </ItemGroup>
 </Project>

--- a/test/TestAppCX/TreeViewTestPage.xaml
+++ b/test/TestAppCX/TreeViewTestPage.xaml
@@ -1,4 +1,5 @@
-﻿<Page
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Page
     x:Class="TestAppCX.TreeViewTestPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/test/TestAppCX/TreeViewTestPage.xaml
+++ b/test/TestAppCX/TreeViewTestPage.xaml
@@ -24,5 +24,6 @@
         </controls:TreeView>
 
         <Button Content="ReplaceAll" Click="ReplaceAll_Click" />
+        <Button Content="Clear" Click="Clear_Click" />
     </StackPanel>
 </Page>

--- a/test/TestAppCX/TreeViewTestPage.xaml
+++ b/test/TestAppCX/TreeViewTestPage.xaml
@@ -1,0 +1,28 @@
+﻿<Page
+    x:Class="TestAppCX.TreeViewTestPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:TestAppCX"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d">
+
+    <StackPanel Padding="20">
+        <controls:TreeView
+            x:Name="TestTreeView"
+            HorizontalAlignment="Left"
+            Width="400" Height="400"
+            ItemsSource="{x:Bind Items}">
+            <controls:TreeView.ItemTemplate>
+                <DataTemplate x:DataType="local:TreeViewData">
+                    <controls:TreeViewItem
+                        ItemsSource="{x:Bind Children}"
+                        Content="{x:Bind Content}" />
+                </DataTemplate>
+            </controls:TreeView.ItemTemplate>
+        </controls:TreeView>
+
+        <Button Content="ReplaceAll" Click="ReplaceAll_Click" />
+    </StackPanel>
+</Page>

--- a/test/TestAppCX/TreeViewTestPage.xaml.cpp
+++ b/test/TestAppCX/TreeViewTestPage.xaml.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "TreeViewTestPage.xaml.h"
 
 using namespace TestAppCX;

--- a/test/TestAppCX/TreeViewTestPage.xaml.cpp
+++ b/test/TestAppCX/TreeViewTestPage.xaml.cpp
@@ -31,6 +31,13 @@ void TestAppCX::TreeViewTestPage::ReplaceAll_Click(Platform::Object^ sender, Win
 {
     auto newItems = ref new Platform::Array<TreeViewData^>(2);
     newItems[0] = ref new TreeViewData("444");
+    newItems[0]->Children->Append(ref new TreeViewData("123"));
     newItems[1] = ref new TreeViewData("555");
     Items->ReplaceAll(newItems);
+}
+
+
+void TestAppCX::TreeViewTestPage::Clear_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    Items->Clear();
 }

--- a/test/TestAppCX/TreeViewTestPage.xaml.cpp
+++ b/test/TestAppCX/TreeViewTestPage.xaml.cpp
@@ -1,0 +1,36 @@
+﻿#include "pch.h"
+#include "TreeViewTestPage.xaml.h"
+
+using namespace TestAppCX;
+
+using namespace Platform;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
+
+TreeViewTestPage::TreeViewTestPage()
+{
+    InitializeComponent();
+
+    TreeViewData^ d1 = ref new TreeViewData("111");
+    TreeViewData^ d2 = ref new TreeViewData("222");
+    TreeViewData^ d3 = ref new TreeViewData("333");
+    Items->Append(d1);
+    Items->Append(d2);
+    Items->Append(d3);
+}
+
+
+void TestAppCX::TreeViewTestPage::ReplaceAll_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    auto newItems = ref new Platform::Array<TreeViewData^>(2);
+    newItems[0] = ref new TreeViewData("444");
+    newItems[1] = ref new TreeViewData("555");
+    Items->ReplaceAll(newItems);
+}

--- a/test/TestAppCX/TreeViewTestPage.xaml.h
+++ b/test/TestAppCX/TreeViewTestPage.xaml.h
@@ -44,6 +44,7 @@ namespace TestAppCX
         TreeViewTestPage();
     private:
         void ReplaceAll_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-    };
+		void Clear_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+	};
 
 }

--- a/test/TestAppCX/TreeViewTestPage.xaml.h
+++ b/test/TestAppCX/TreeViewTestPage.xaml.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "TreeViewTestPage.g.h"
 

--- a/test/TestAppCX/TreeViewTestPage.xaml.h
+++ b/test/TestAppCX/TreeViewTestPage.xaml.h
@@ -1,0 +1,49 @@
+﻿#pragma once
+
+#include "TreeViewTestPage.g.h"
+
+namespace TestAppCX
+{
+    public ref class TreeViewData sealed
+    {
+    private:
+        Platform::String^ m_content;
+        Windows::Foundation::Collections::IObservableVector<TreeViewData^>^ m_children;
+
+    public:
+        TreeViewData(Platform::String^ content) : m_content(content)
+        {
+            m_content = content;
+            m_children = ref new Platform::Collections::Vector<TreeViewData^>();
+        }
+
+        property Platform::String^ Content
+        {
+            Platform::String^ get() { return m_content; }
+        }
+
+        property Windows::Foundation::Collections::IObservableVector<TreeViewData^>^ Children
+        {
+            Windows::Foundation::Collections::IObservableVector<TreeViewData^>^ get() { return m_children; }
+        }
+
+    };
+
+    [Windows::Foundation::Metadata::WebHostHidden]
+    public ref class TreeViewTestPage sealed
+    {
+
+    private:
+        Windows::Foundation::Collections::IObservableVector<TreeViewData^>^ m_items = ref new Platform::Collections::Vector<TreeViewData^>();
+
+    public:
+        property Windows::Foundation::Collections::IObservableVector<TreeViewData^>^ Items
+        {
+            Windows::Foundation::Collections::IObservableVector<TreeViewData^>^ get() { return m_items; }
+        }
+        TreeViewTestPage();
+    private:
+        void ReplaceAll_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+    };
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a bug where the reset event of collection implementin OnCollectionChanged and still having items after reset would result in the TreeView not having any nodes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1379 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new API unit test. Also tested using the great test page created by @kaiguo 
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->