### PR TITLE
Fix bug where empty DataTemplate in DataTemplateSelector would crash

### DIFF
--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
@@ -393,6 +393,52 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 // Asserting render size is zero
                 Verify.IsLessThan(repeater.RenderSize.Width, 0.0001);
                 Verify.IsLessThan(repeater.RenderSize.Height, 0.0001);
+            });
+        }
+
+        [TestMethod]
+        public void ValidateCorrectSizeWhenEmptyDataTemplateInSelector()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var dataTemplateOdd = (DataTemplate)XamlReader.Load(
+                        @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                            <TextBlock Text='{Binding}' Height='30' />
+                        </DataTemplate>");
+                var dataTemplateEven = (DataTemplate)XamlReader.Load(
+                        @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' />");
+                ItemsRepeater repeater = null;
+                const int numItems = 10;
+                var selector = new MySelector() {
+                    TemplateOdd = dataTemplateOdd,
+                    TemplateEven = dataTemplateEven
+                };
+
+                Content = CreateAndInitializeRepeater
+                (
+                   itemsSource: Enumerable.Range(0, numItems),
+                   elementFactory: selector,
+                   layout: new StackLayout(),
+                   repeater: ref repeater
+                );
+
+                Content.UpdateLayout();
+                Verify.AreEqual(numItems, VisualTreeHelper.GetChildrenCount(repeater));
+                for (int i = 0; i < numItems; i++)
+                {
+                    var element = (FrameworkElement)repeater.TryGetElement(i);
+                    if (i % 2 == 0)
+                    {
+                        Verify.AreEqual(element.Height, 0);
+                    }
+                    else
+                    {
+                        Verify.AreEqual(element.Height, 30);
+                    }
+                }
+
+                repeater.ItemsSource = null;
+                Content.UpdateLayout();
             });
         }
 

--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -372,6 +372,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
+        public void ValidateNoSizeWhenEmptyDataTemplate()
+        {
+            ItemsRepeater repeater = null;
+            RunOnUIThread.Execute(() =>
+            {
+                var elementFactory = new RecyclingElementFactory();
+                elementFactory.RecyclePool = new RecyclePool();
+                elementFactory.Templates["Item"] = (DataTemplate)XamlReader.Load(
+                    @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' />");
+
+                repeater = new ItemsRepeater() {
+                    ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
+                    ItemTemplate = elementFactory,
+                    // Default is StackLayout, so do not have to explicitly set.
+                    // Layout = new StackLayout(),
+                };
+                repeater.UpdateLayout();
+
+                // Asserting render size is zero
+                Verify.IsLessThan(repeater.RenderSize.Width, 0.0001);
+                Verify.IsLessThan(repeater.RenderSize.Height, 0.0001);
+            });
+        }
+
+        [TestMethod]
         public void ValidateReyclingElementFactoryWithNoTemplate()
         {
             RunOnUIThread.Execute(() =>

--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -402,8 +402,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             RunOnUIThread.Execute(() =>
             {
                 var dataTemplateOdd = (DataTemplate)XamlReader.Load(
-                        @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
-                            <TextBlock Text='{Binding}' Height='30' />
+                        @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                            <TextBlock Text='{Binding}' Height='30' Width='50' />
                         </DataTemplate>");
                 var dataTemplateEven = (DataTemplate)XamlReader.Load(
                         @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' />");
@@ -414,13 +414,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     TemplateEven = dataTemplateEven
                 };
 
-                Content = CreateAndInitializeRepeater
-                (
-                   itemsSource: Enumerable.Range(0, numItems),
-                   elementFactory: selector,
-                   layout: new StackLayout(),
-                   repeater: ref repeater
-                );
+                repeater = new ItemsRepeater() {
+                    ItemTemplate = selector,
+                    Layout = new StackLayout(),
+                    ItemsSource = Enumerable.Range(0, numItems)
+                };
+
+                repeater.VerticalAlignment = VerticalAlignment.Top;
+                repeater.HorizontalAlignment = HorizontalAlignment.Left;
+                Content = repeater;
 
                 Content.UpdateLayout();
                 Verify.AreEqual(numItems, VisualTreeHelper.GetChildrenCount(repeater));
@@ -436,6 +438,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         Verify.AreEqual(element.Height, 30);
                     }
                 }
+
+                Verify.AreEqual(5 * 30, repeater.ActualHeight);
+
+                // ItemsRepeater stretches page, so actual width is width of page and not 50
+                //Verify.AreEqual(50, repeater.ActualWidth);
+
 
                 repeater.ItemsSource = null;
                 Content.UpdateLayout();

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -142,32 +142,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.SetValue(ItemsRepeater.ItemsSourceProperty, dataSource);
                 Verify.AreSame(dataSource, repeater.GetValue(ItemsRepeater.ItemsSourceProperty) as ItemsSourceView);
                 Verify.AreSame(dataSource, repeater.ItemsSourceView);
-            });
-        }
-
-        [TestMethod]
-        public void ValidateNoSizeWhenEmptyDataTemplate()
-        {
-
-            ItemsRepeater repeater = null;
-            RunOnUIThread.Execute(() =>
-            {
-                var elementFactory = new RecyclingElementFactory();
-                elementFactory.RecyclePool = new RecyclePool();
-                elementFactory.Templates["Item"] = (DataTemplate)XamlReader.Load(
-                    @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' />");
-
-                repeater = new ItemsRepeater() {
-                    ItemsSource = Enumerable.Range(0, 10).Select(i => string.Format("Item #{0}", i)),
-                    ItemTemplate = elementFactory,
-                    // Default is StackLayout, so do not have to explicitly set.
-                    // Layout = new StackLayout(),
-                };
-                repeater.UpdateLayout();
-
-                // Asserting render size is zero
-                Verify.IsLessThan(repeater.RenderSize.Width , 0.0001);
-                Verify.IsLessThan(repeater.RenderSize.Height , 0.0001);
             });
         }
 

--- a/dev/Repeater/ItemTemplateWrapper.cpp
+++ b/dev/Repeater/ItemTemplateWrapper.cpp
@@ -57,9 +57,10 @@ winrt::UIElement ItemTemplateWrapper::GetElement(winrt::ElementFactoryGetArgs co
 
         // Template returned null, so insert empty element to render nothing
         if (!element) {
-            element = winrt::Rectangle();
-            element.as<winrt::Rectangle>().Width(0);
-            element.as<winrt::Rectangle>().Height(0);
+            auto rectangle = winrt::Rectangle();
+            rectangle.Width(0);
+            rectangle.Height(0);
+            element = rectangle;
         }
 
         // Associate template with element

--- a/dev/Repeater/ItemTemplateWrapper.cpp
+++ b/dev/Repeater/ItemTemplateWrapper.cpp
@@ -57,10 +57,9 @@ winrt::UIElement ItemTemplateWrapper::GetElement(winrt::ElementFactoryGetArgs co
 
         // Template returned null, so insert empty element to render nothing
         if (!element) {
-            winrt::Rectangle rectangle = winrt::Rectangle();
-            rectangle.Width(0);
-            rectangle.Height(0);
-            element = rectangle;
+            element = winrt::Rectangle();
+            element.as<winrt::Rectangle>().Width(0);
+            element.as<winrt::Rectangle>().Height(0);
         }
 
         // Associate template with element

--- a/dev/Repeater/ItemTemplateWrapper.cpp
+++ b/dev/Repeater/ItemTemplateWrapper.cpp
@@ -55,6 +55,11 @@ winrt::UIElement ItemTemplateWrapper::GetElement(winrt::ElementFactoryGetArgs co
         // no element was found in recycle pool, create a new element
         element = selectedTemplate.LoadContent().as<winrt::FrameworkElement>();
 
+        // Template returned null, so insert empty element to render nothing
+        if (!element) {
+            element = winrt::XamlReader::Load(L"<Rectangle xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' Height='0' Width='0' />").as<winrt::Rectangle>();
+        }
+
         // Associate template with element
         element.SetValue(RecyclePool::GetOriginTemplateProperty(), selectedTemplate);
     }

--- a/dev/Repeater/ItemTemplateWrapper.cpp
+++ b/dev/Repeater/ItemTemplateWrapper.cpp
@@ -57,7 +57,10 @@ winrt::UIElement ItemTemplateWrapper::GetElement(winrt::ElementFactoryGetArgs co
 
         // Template returned null, so insert empty element to render nothing
         if (!element) {
-            element = winrt::XamlReader::Load(L"<Rectangle xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' Height='0' Width='0' />").as<winrt::Rectangle>();
+            winrt::Rectangle rectangle = winrt::Rectangle();
+            rectangle.Width(0);
+            rectangle.Height(0);
+            element = rectangle;
         }
 
         // Associate template with element


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Instead of forcefully trying to use the empty DataTemplate which returns null as content, we now return a Rectangle of height and width 0.

Also the test added by #1358 was moved to the correct file.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1385
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new api test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->