### PR TITLE
TabView: Fixed ctrl-click to deselect and tab min/max width.

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -71,6 +71,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Button selectIndexButton = FindElement.ByName<Button>("SelectIndexButton");
                 selectIndexButton.InvokeAndWait();
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
+
+                Log.Comment("Verify that ctrl-click on tab does not deselect.");
+                UIObject selectedTab = FindElement.ByName("LongHeaderTab");
+                KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
+                selectedTab.Click();
+                KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
+                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
             }
         }
 
@@ -120,6 +127,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Log.Comment("Tab with larger content should be wider.");
                 Verify.IsGreaterThan(largerTab.BoundingRectangle.Width, smallerTab.BoundingRectangle.Width);
+
+                Log.Comment("Changing tab header to short/long.");
+                Button shortLongButton = FindElement.ByName<Button>("ShortLongTextButton");
+                shortLongButton.InvokeAndWait();
+                ElementCache.Refresh();
+
+                diff = Math.Abs(smallerTab.BoundingRectangle.Width - 100);
+                Verify.IsLessThanOrEqual(diff, 1, "Smaller text should have min width of 100");
+
+                diff = Math.Abs(largerTab.BoundingRectangle.Width - 240);
+                Verify.IsLessThanOrEqual(diff, 1, "Smaller text should have max width of 240");
 
                 // With largerTab now rendering wider, the scroll buttons should appear:
                 Verify.IsTrue(AreScrollButtonsVisible(), "Scroll buttons should appear");

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Windows.Apps.Test.Foundation.Controls;
 using Microsoft.Windows.Apps.Test.Foundation.Patterns;
 using Microsoft.Windows.Apps.Test.Foundation.Waiters;
 using Windows.UI.Xaml.Media;
+using Windows.Devices.Input;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {
@@ -72,12 +73,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 selectIndexButton.InvokeAndWait();
                 Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
 
-                Log.Comment("Verify that ctrl-click on tab does not deselect.");
-                UIObject selectedTab = FindElement.ByName("LongHeaderTab");
+                Log.Comment("Verify that ctrl-click on tab selects it.");
+                UIObject firstTab = FindElement.ByName("FirstTab");
                 KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
-                selectedTab.Click();
+                firstTab.Click();
                 KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
+                Wait.ForIdle();
+                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
+
+                Log.Comment("Verify that ctrl-click on tab does not deselect.");
+                KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
+                firstTab.Click();
+                KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
+                Wait.ForIdle();
+                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
             }
         }
 

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -513,6 +513,9 @@ void TabView::UpdateTabWidths()
 {
     double tabWidth = std::numeric_limits<double>::quiet_NaN();
 
+    double minTabWidth = unbox_value<double>(SharedHelpers::FindResource(c_tabViewItemMinWidthName, winrt::Application::Current().Resources(), box_value(c_tabMinimumWidth)));
+    double maxTabWidth = unbox_value<double>(SharedHelpers::FindResource(c_tabViewItemMaxWidthName, winrt::Application::Current().Resources(), box_value(c_tabMaximumWidth)));
+
     if (auto tabGrid = m_tabContainerGrid.get())
     {
         // Add up width taken by custom content and + button
@@ -555,10 +558,6 @@ void TabView::UpdateTabWidths()
                 }
                 else if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
                 {
-                    // Tabs should all be the same size, proportional to the amount of space.
-                    double minTabWidth = unbox_value<double>(SharedHelpers::FindResource(c_tabViewItemMinWidthName, winrt::Application::Current().Resources(), box_value(c_tabMinimumWidth)));
-                    double maxTabWidth = unbox_value<double>(SharedHelpers::FindResource(c_tabViewItemMaxWidthName, winrt::Application::Current().Resources(), box_value(c_tabMaximumWidth)));
-
                     // Calculate the proportional width of each tab given the width of the ScrollViewer.
                     auto padding = Padding();
                     double tabWidthForScroller = (availableWidth - (padding.Left + padding.Right)) / (double)(TabItems().Size());
@@ -601,6 +600,8 @@ void TabView::UpdateTabWidths()
         if (tvi)
         {
             tvi.Width(tabWidth);
+            tvi.MaxWidth(maxTabWidth);
+            tvi.MinWidth(minTabWidth);
         }
     }
 }

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -176,7 +176,7 @@ void TabViewItem::OnHeaderPropertyChanged(const winrt::DependencyPropertyChanged
 
 void TabViewItem::OnPointerPressed(winrt::PointerRoutedEventArgs const& args)
 {
-    if (args.Pointer().PointerDeviceType() == winrt::PointerDeviceType::Mouse)
+    if (IsSelected() && args.Pointer().PointerDeviceType() == winrt::PointerDeviceType::Mouse)
     {
         auto pointerPoint = args.GetCurrentPoint(*this);
         if (pointerPoint.Properties().IsLeftButtonPressed())

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -176,6 +176,20 @@ void TabViewItem::OnHeaderPropertyChanged(const winrt::DependencyPropertyChanged
 
 void TabViewItem::OnPointerPressed(winrt::PointerRoutedEventArgs const& args)
 {
+    if (args.Pointer().PointerDeviceType() == winrt::PointerDeviceType::Mouse)
+    {
+        auto pointerPoint = args.GetCurrentPoint(*this);
+        if (pointerPoint.Properties().IsLeftButtonPressed())
+        {
+            auto isCtrlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+            if (isCtrlDown)
+            {
+                // Return here so the base class will not pick it up, but let it remain unhandled so someone else could handle it.
+                return;
+            }
+        }
+    }
+
     __super::OnPointerPressed(args);
 
     if (args.GetCurrentPoint(nullptr).Properties().PointerUpdateKind() == winrt::PointerUpdateKind::MiddleButtonPressed)

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -30,6 +30,8 @@
                 <Button x:Name="CustomTooltipButton" AutomationProperties.Name="CustomTooltipButton" Content="Custom Tooltip" Margin="0,0,0,8" Click="CustomTooltipButton_Click"/>
                 <Button x:Name="SetTabViewWidth" AutomationProperties.Name="SetTabViewWidth" Content="Set Width" Margin="0,0,0,8" Click="SetTabViewWidth_Click" />
 
+                <Button x:Name="ShortLongTextButton" AutomationProperties.Name="ShortLongTextButton" Content="Short/Long Text" Margin="0,0,0,8" Click="ShortLongTextButton_Click" />
+
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                     <TextBlock Text="Scroll buttons visible: " />
                     <TextBlock x:Name="ScrollButtonsVisible" AutomationProperties.Name="ScrollButtonsVisible" Text="False" />
@@ -108,8 +110,8 @@
                             </controls:TabViewItem.IconSource>
 
                             <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
-                                <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
-                                <Button x:Name="TabViewSizingPageButtton" AutomationProperties.Name="TabViewSizingPageButtton" Margin="8" FontSize="20" Click="TabViewSizingPageButtton_Click" >TabView Sizing Page</Button>
+                                <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8">Home Button</Button>
+                                <Button x:Name="TabViewSizingPageButtton" AutomationProperties.Name="TabViewSizingPageButtton" Margin="8" Click="TabViewSizingPageButtton_Click" >TabView Sizing Page</Button>
                             </StackPanel>
                         </controls:TabViewItem>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -110,8 +110,8 @@
                             </controls:TabViewItem.IconSource>
 
                             <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
-                                <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8">Home Button</Button>
-                                <Button x:Name="TabViewSizingPageButtton" AutomationProperties.Name="TabViewSizingPageButtton" Margin="8" Click="TabViewSizingPageButtton_Click" >TabView Sizing Page</Button>
+                                <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
+                                <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
                             </StackPanel>
                         </controls:TabViewItem>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -323,5 +323,11 @@ namespace MUXControlsTestApp
         {
             this.Frame.Navigate(typeof(TabViewSizingPage));
         }
+
+        private void ShortLongTextButton_Click(object sender, RoutedEventArgs e)
+        {
+            FirstTab.Header = "s";
+            LongHeaderTab.Header = "long long long long long long long long";
+        }
     }
 }

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -319,7 +319,7 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void TabViewSizingPageButtton_Click(object sender, RoutedEventArgs e)
+        private void TabViewSizingPageButton_Click(object sender, RoutedEventArgs e)
         {
             this.Frame.Navigate(typeof(TabViewSizingPage));
         }


### PR DESCRIPTION
Fixes the following:
#1307 - ListView deselects items on ctrl-click; we don't want that.
#1309 - Applies min/max width to tabs.
Also added tests for both fixes.