### PR TITLE
Fix bug where changing the DisplayMode would raise SelectionChanged with SelectedItem as null

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -398,7 +398,7 @@ void NavigationView::CreateAndHookEventsToSettings(std::wstring_view settingsNam
 
         if (shouldSelectSetting)
         { 
-            SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(selectedItem);
+            SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(nullptr);
         }
 
         m_settingsItemTappedRevoker.revoke();
@@ -425,7 +425,8 @@ void NavigationView::CreateAndHookEventsToSettings(std::wstring_view settingsNam
         SetValue(s_SettingsItemProperty, settingsItem);
 
         if (shouldSelectSetting)
-        { 
+        {
+            m_shouldIgnoreNextSelectionChange = true;
             SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(m_settingsItem.get());
         }
     }
@@ -1980,8 +1981,10 @@ void NavigationView::SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNot
 
         m_indexOfLastSelectedItemInTopNav = m_topDataProvider.IndexOf(item); // for the next time we animate
     }
-
-    SelectedItem(item);
+    // Only select item when it is NOT null
+    if (item) {
+        SelectedItem(item);
+    }
     if (!isChangingSelection)
     {
         m_shouldRaiseInvokeItemInSelectionChange = false;

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -398,7 +398,7 @@ void NavigationView::CreateAndHookEventsToSettings(std::wstring_view settingsNam
 
         if (shouldSelectSetting)
         { 
-            SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(nullptr);
+            SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(selectedItem);
         }
 
         m_settingsItemTappedRevoker.revoke();

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -398,6 +398,10 @@ void NavigationView::CreateAndHookEventsToSettings(std::wstring_view settingsNam
 
         if (shouldSelectSetting)
         {
+            auto scopeGuard = gsl::finally([this]()
+            {
+                m_shouldIgnoreNextSelectionChange = false;
+            });
             m_shouldIgnoreNextSelectionChange = true;
             SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(nullptr);
         }
@@ -427,6 +431,10 @@ void NavigationView::CreateAndHookEventsToSettings(std::wstring_view settingsNam
 
         if (shouldSelectSetting)
         {
+            auto scopeGuard = gsl::finally([this]()
+            {
+                m_shouldIgnoreNextSelectionChange = false;
+            });
             m_shouldIgnoreNextSelectionChange = true;
             SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(m_settingsItem.get());
         }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -397,7 +397,8 @@ void NavigationView::CreateAndHookEventsToSettings(std::wstring_view settingsNam
         bool shouldSelectSetting = selectedItem && IsSettingsItem(selectedItem);
 
         if (shouldSelectSetting)
-        { 
+        {
+            m_shouldIgnoreNextSelectionChange = true;
             SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI(nullptr);
         }
 
@@ -1981,10 +1982,7 @@ void NavigationView::SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNot
 
         m_indexOfLastSelectedItemInTopNav = m_topDataProvider.IndexOf(item); // for the next time we animate
     }
-    // Only select item when it is NOT null
-    if (item) {
-        SelectedItem(item);
-    }
+    SelectedItem(item);
     if (!isChangingSelection)
     {
         m_shouldRaiseInvokeItemInSelectionChange = false;

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -1933,7 +1933,17 @@ void NavigationView::UpdateSingleSelectionFollowsFocusTemplateSetting()
 void NavigationView::OnSelectedItemPropertyChanged(winrt::DependencyPropertyChangedEventArgs const& args)
 {
     auto newItem = args.NewValue();
-    ChangeSelection(args.OldValue(), newItem);
+    auto oldItem = args.OldValue();
+    ChangeSelection(oldItem, newItem);
+
+    // Animate to be sure the selected item is visually higlighted!
+    // See #1395 for additional context
+    if (oldItem != newItem)
+    {
+        ChangeSelectStatusForItem(oldItem, false /*selected*/);
+        ChangeSelectStatusForItem(newItem, true /*selected*/);
+        AnimateSelectionChanged(oldItem, newItem);
+    }
 
     if (m_appliedTemplate && IsTopNavigationView())
     {

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -2937,20 +2937,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         Log.Warning("Test is disabled on RS2 and earlier because SplitView lacks the requisite events.");
                         return;
                     }
+                    Button clearSelectedItem = new Button(FindElement.ById("ClearSelectionChangeIndicatorButton"));
+                    TextBlock selectionRaisedIndicator = new TextBlock(FindElement.ById("SelectionChangedRaised"));
 
                     ComboBox selectedItem = new ComboBox(FindElement.ById("SelectedItemCombobox"));
                     selectedItem.SelectItemByName("Settings");
+                    Verify.AreEqual("True", selectionRaisedIndicator.GetText());
 
                     ComboBox displayMode = new ComboBox(FindElement.ById("PaneDisplayModeCombobox"));
+                    clearSelectedItem.InvokeAndWait();
                     displayMode.SelectItemByName("Top");
+                    Verify.AreEqual("False", selectionRaisedIndicator.GetText());
                     Wait.ForIdle();
 
-                    TextBlock selectedItemWasNull = new TextBlock(FindElement.ById("SelectionChangedItemWasNull"));
-                    Verify.AreEqual("False", selectedItemWasNull.GetText());
 
                     displayMode.SelectItemByName("Left");
                     Wait.ForIdle();
-                    Verify.AreEqual("False", selectedItemWasNull.GetText());
+                    Verify.AreEqual("False", selectionRaisedIndicator.GetText());
                 }
             }
         }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -2925,6 +2925,38 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "C")]
+        public void DisplayModeChangeSelectionEventTest()
+        {
+            var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();
+            foreach (var testScenario in testScenarios)
+            {
+                using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+                {
+                    if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+                    {
+                        Log.Warning("Test is disabled on RS2 and earlier because SplitView lacks the requisite events.");
+                        return;
+                    }
+
+                    ComboBox selectedItem = new ComboBox(FindElement.ById("SelectedItemCombobox"));
+                    selectedItem.SelectItemByName("Settings");
+
+                    ComboBox displayMode = new ComboBox(FindElement.ById("PaneDisplayModeCombobox"));
+                    displayMode.SelectItemByName("Top");
+                    Wait.ForIdle();
+
+                    TextBlock selectedItemWasNull = new TextBlock(FindElement.ById("SelectionChangedItemWasNull"));
+                    Verify.AreEqual("False", selectedItemWasNull.GetText());
+
+                    displayMode.SelectItemByName("Left");
+                    Wait.ForIdle();
+                    Verify.AreEqual("False", selectedItemWasNull.GetText());
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void PaneOpenCloseEventsTest()
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <local:TestPage
     x:Class="MUXControlsTestApp.NavigationViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -177,8 +177,9 @@
                             <ComboBoxItem Content="LeftCompact" Tag="LeftCompact"/>
                             <ComboBoxItem Content="LeftMinimal" Tag="LeftMinimal"/>
                         </ComboBox>
-                        <TextBlock VerticalAlignment="Center">SelectedItem in SelectionChanged event was null: </TextBlock>
-                        <TextBlock VerticalAlignment="Center" x:Name="SelectionChangedItemWasNull" AutomationProperties.Name="SelectionChangedItemWasNull"/>
+                        <Button x:Name="ClearSelectionChangeIndicatorButton" AutomationProperties.Name="ClearSelectionChangeIndicatorButton"  Click="ClearSelectionChangeBlock">Clear selection changed indicator</Button>
+                        <TextBlock VerticalAlignment="Center">Selection was raised:  </TextBlock>
+                        <TextBlock VerticalAlignment="Center" x:Name="SelectionChangedRaised" AutomationProperties.Name="SelectionChangedRaised"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <local:TestPage
     x:Class="MUXControlsTestApp.NavigationViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -177,6 +177,8 @@
                             <ComboBoxItem Content="LeftCompact" Tag="LeftCompact"/>
                             <ComboBoxItem Content="LeftMinimal" Tag="LeftMinimal"/>
                         </ComboBox>
+                        <TextBlock VerticalAlignment="Center">SelectedItem in SelectionChanged event was null: </TextBlock>
+                        <TextBlock VerticalAlignment="Center" x:Name="SelectionChangedItemWasNull" AutomationProperties.Name="SelectionChangedItemWasNull"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
@@ -296,6 +296,7 @@ namespace MUXControlsTestApp
         {
             if (args.SelectedItem != null)
             {
+                SelectionChangedItemWasNull.Text = "False";
                 var itemdata = args.SelectedItem as NavigationViewItem;
                 if (itemdata != null)
                 {
@@ -308,6 +309,10 @@ namespace MUXControlsTestApp
                         NavView.Header = "Settings as header";
                     }
                 }
+            }
+            else
+            {
+                SelectionChangedItemWasNull.Text = "True";
             }
         }
 

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
@@ -294,9 +294,9 @@ namespace MUXControlsTestApp
 
         private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
+            SelectionChangedRaised.Text = "True";
             if (args.SelectedItem != null)
             {
-                SelectionChangedItemWasNull.Text = "False";
                 var itemdata = args.SelectedItem as NavigationViewItem;
                 if (itemdata != null)
                 {
@@ -310,10 +310,11 @@ namespace MUXControlsTestApp
                     }
                 }
             }
-            else
-            {
-                SelectionChangedItemWasNull.Text = "True";
-            }
+        }
+
+        private void ClearSelectionChangeBlock(object sender,RoutedEventArgs e)
+        {
+            SelectionChangedRaised.Text = "False";
         }
 
         private void MoviesEnabledCheckbox_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
~Changed the parameter passed to `SetSelectedItemAndExpectItemInvokeWhenSelectionChangedIfNotInvokedFromAPI` from `nullptr` to the settings item instead.~

Changed code where we update the settings item to set the m_shouldIgnoreNextSelectionChange flag to true, so SelectionChanged ignores that selection change.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #148
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new interaction test, which tests whether the item passed from SelectionChanged event is null or not.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->