### PR TITLE
Fix bug where shadow on NavigationView pane is missing

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3595,8 +3595,11 @@ void NavigationView::UpdatePaneShadow()
             {
                 contentGrid.SetRowSpan(shadowReceiver, contentGrid.RowDefinitions().Size());
                 contentGrid.SetRow(shadowReceiver, 0);
-                contentGrid.SetColumn(shadowReceiver, 0);
-                contentGrid.SetColumnSpan(shadowReceiver, contentGrid.ColumnDefinitions().Size());
+                // Only register to columns if those are actually defined
+                if (contentGrid.ColumnDefinitions().Size() > 0) {
+                    contentGrid.SetColumn(shadowReceiver, 0);
+                    contentGrid.SetColumnSpan(shadowReceiver, contentGrid.ColumnDefinitions().Size());
+                }
                 contentGrid.Children().Append(shadowReceiver);
 
                 winrt::ThemeShadow shadow;

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3594,6 +3594,9 @@ void NavigationView::UpdatePaneShadow()
             if (auto contentGrid = GetTemplateChildT<winrt::Grid>(c_contentGridName, *this))
             {
                 contentGrid.SetRowSpan(shadowReceiver, contentGrid.RowDefinitions().Size());
+                contentGrid.SetRow(shadowReceiver, 0);
+                contentGrid.SetColumn(shadowReceiver, 0);
+                contentGrid.SetColumnSpan(shadowReceiver, 2);
                 contentGrid.Children().Append(shadowReceiver);
 
                 winrt::ThemeShadow shadow;
@@ -3611,9 +3614,16 @@ void NavigationView::UpdatePaneShadow()
             }
         }
 
+
         // Shadow will get clipped if casting on the splitView.Content directly
         // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
         winrt::Thickness shadowReceiverMargin = { -CompactPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
+
+        // Ensuring shadow is aligned to the left
+        shadowReceiver.HorizontalAlignment(winrt::HorizontalAlignment::Left);
+
+        // Ensure shadow is as wide as the pane when it is open
+        shadowReceiver.Width(OpenPaneLength() + c_paneElevationTranslationZ);
         shadowReceiver.Margin(shadowReceiverMargin);
     }
 }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3617,13 +3617,13 @@ void NavigationView::UpdatePaneShadow()
 
         // Shadow will get clipped if casting on the splitView.Content directly
         // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
-        winrt::Thickness shadowReceiverMargin = { -CompactPaneLength(), -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
+        winrt::Thickness shadowReceiverMargin = { 0, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
 
         // Ensuring shadow is aligned to the left
         shadowReceiver.HorizontalAlignment(winrt::HorizontalAlignment::Left);
 
         // Ensure shadow is as wide as the pane when it is open
-        shadowReceiver.Width(OpenPaneLength() + c_paneElevationTranslationZ);
+        shadowReceiver.Width(OpenPaneLength());
         shadowReceiver.Margin(shadowReceiverMargin);
     }
 }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3596,7 +3596,7 @@ void NavigationView::UpdatePaneShadow()
                 contentGrid.SetRowSpan(shadowReceiver, contentGrid.RowDefinitions().Size());
                 contentGrid.SetRow(shadowReceiver, 0);
                 contentGrid.SetColumn(shadowReceiver, 0);
-                contentGrid.SetColumnSpan(shadowReceiver, 2);
+                contentGrid.SetColumnSpan(shadowReceiver, contentGrid.ColumnDefinitions().Size());
                 contentGrid.Children().Append(shadowReceiver);
 
                 winrt::ThemeShadow shadow;

--- a/test/MUXControlsTestApp/master/NavigationView-8.xml
+++ b/test/MUXControlsTestApp/master/NavigationView-8.xml
@@ -2124,14 +2124,15 @@
                       RenderSize=120,19
                 [Windows.UI.Xaml.Controls.Canvas]
                     Background=[NULL]
+                    Width=120
                     Name=PaneShadowReceiver
-                    Margin=-40,-32,-32,-32
+                    Margin=0,-32,-32,-32
                     FocusVisualSecondaryThickness=1,1,1,1
                     FocusVisualSecondaryBrush=#99FFFFFF
                     FocusVisualPrimaryThickness=2,2,2,2
                     FocusVisualPrimaryBrush=#FF000000
                     Visibility=Visible
-                    RenderSize=72,664
+                    RenderSize=120,664
             [Windows.UI.Xaml.Shapes.Rectangle]
                 StrokeThickness=1
                 Name=LightDismissLayer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added missing size and alignment properties for the shadow canvas and added the correct row and column properties.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1394. 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Test manually by starting MUX test app.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![navigationview-missing-shadow](https://user-images.githubusercontent.com/16122379/66053939-7f19c980-e533-11e9-88ac-50fb51708a45.gif)
