### PR TITLE
Disable TreeViewItem chevron scaling

### DIFF
--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -163,7 +163,8 @@
                                             FontSize="{TemplateBinding GlyphSize}" Text="{TemplateBinding CollapsedGlyph}"
                                             FontFamily="{StaticResource SymbolThemeFontFamily}"
                                             VerticalAlignment="Center"
-                                            AutomationProperties.AccessibilityView="Raw"/>
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            IsTextScaleFactorEnabled="False" />
                                 <TextBlock Foreground="{TemplateBinding GlyphBrush}"
                                             Width="12" Height="12"
                                             Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.ExpandedGlyphVisibility}" 
@@ -171,7 +172,8 @@
                                             Text="{TemplateBinding ExpandedGlyph}"
                                             FontFamily="{StaticResource SymbolThemeFontFamily}"
                                             VerticalAlignment="Center"
-                                            AutomationProperties.AccessibilityView="Raw"/>
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            IsTextScaleFactorEnabled="False"/>
                             </Grid>
 
                             <ContentPresenter x:Name="ContentPresenter"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
TreeViewItem chevron gets clipped in larger text scales.

Disabling the icon scaling following our design recommendations ([Don’t scale font-based icons or symbols](https://docs.microsoft.com/en-us/windows/uwp/design/input/text-scaling#dont-scale-font-based-icons-or-symbols) ).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
#Fixes #1413

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually tested.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
200% text scale:
![image](https://user-images.githubusercontent.com/4424330/66524706-045b2c00-eaa8-11e9-86ad-334e28fb4732.png)

