### PR TITLE
Fix stack layout arrange when items use stretch and final size is more than desired size

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -1335,6 +1335,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        [TestMethod]
+        public void ValidateStackLayoutArrangeWithStretch()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var svWidth = 1000.0;
+                ScrollViewer sv = new ScrollViewer() {
+                    Width = svWidth,
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
+                };
+
+                var repeater = new ItemsRepeater();
+                repeater.ItemsSource = Enumerable.Range(0, 10);
+                repeater.ItemTemplate = GetDataTemplate(@"<TextBlock HorizontalAlignment='Stretch' Text='{Binding}' />");
+
+                sv.Content = repeater;
+
+                Content = sv;
+                Content.UpdateLayout();
+
+                var firstItem = (FrameworkElement)repeater.TryGetElement(0);
+                var bounds = LayoutInformation.GetLayoutSlot(firstItem);
+                Verify.AreEqual(svWidth, bounds.Width);
+
+            });
+        }
+
         #region Private Helpers
 
         private enum LayoutChoice

--- a/dev/Repeater/FlowLayout.cpp
+++ b/dev/Repeater/FlowLayout.cpp
@@ -70,7 +70,8 @@ winrt::Size FlowLayout::ArrangeOverride(
     auto value = GetFlowAlgorithm(context).Arrange(
         finalSize,
         context,
-        static_cast<FlowLayoutAlgorithm::LineAlignment>(m_lineAlignment),
+        true, /* isWrapping */
+        static_cast<FlowLayoutAlgorithm::LineAlignment>(m_lineAlignment),        
         LayoutId());
     return value;
 }

--- a/dev/Repeater/FlowLayoutAlgorithm.h
+++ b/dev/Repeater/FlowLayoutAlgorithm.h
@@ -45,6 +45,7 @@ public:
     winrt::Size Arrange(
         const winrt::Size& finalSize,
         const winrt::VirtualizingLayoutContext& context,
+        bool isWrapping,
         FlowLayoutAlgorithm::LineAlignment lineAlignment,
         const wstring_view& layoutId);
     void OnItemsSourceChanged(
@@ -100,6 +101,7 @@ private:
     void ArrangeVirtualizingLayout(
         const winrt::Size& finalSize,
         FlowLayoutAlgorithm::LineAlignment lineAlignment,
+        bool isWrapping,
         const wstring_view& layoutId);
     void PerformLineAlignment(
         int lineStartIndex,
@@ -108,6 +110,8 @@ private:
         float spaceAtLineEnd,
         float lineSize,
         FlowLayoutAlgorithm::LineAlignment lineAlignment,
+        bool isWrapping,
+        const winrt::Size& finalSize,
         const wstring_view& layoutId);
 #pragma endregion
 

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -76,6 +76,7 @@ winrt::Size StackLayout::ArrangeOverride(
     auto value = GetFlowAlgorithm(context).Arrange(
         finalSize,
         context,
+        false, /* isWraping */
         FlowLayoutAlgorithm::LineAlignment::Start,
         LayoutId());
 

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -85,7 +85,8 @@ winrt::Size UniformGridLayout::ArrangeOverride(
     auto value = GetFlowAlgorithm(context).Arrange(
         finalSize,
         context,
-        static_cast<FlowLayoutAlgorithm::LineAlignment>(m_itemsJustification),
+        true /* isWrapping */,
+        static_cast<FlowLayoutAlgorithm::LineAlignment>(m_itemsJustification),        
         LayoutId());
     return { value.Width, value.Height };
 }


### PR DESCRIPTION
When the final size in the non virtualizing direction for a stack layout is more than the desired size, we should use the final size so that alignments on the items work as expected. 

fixes #1410