### PR TITLE
Update vpack creation script to include info about source nupkg

### DIFF
--- a/build/FrameworkPackage/CreateVpackFromNupkg.ps1
+++ b/build/FrameworkPackage/CreateVpackFromNupkg.ps1
@@ -93,6 +93,9 @@ if($LASTEXITCODE)
     exit
 }
 
+$infoTextFilePath = Join-Path $outputPath "info.txt"
+Out-File -FilePath $infoTextFilePath -InputObject "Vpack created from nuget package: $nupkgFileNameWithoutExtension"
+
 if($isPrerelease)
 {
     $flavors = @("x86", "x64", "arm", "arm64")


### PR DESCRIPTION
Create a txt file containing the full name of the nupkg used to create a vpack. This is useful for cross referencing versions of vpacks and nupkgs, since the versions aren't guaranteed to exactly match (e.g. in the case where we need to update an existing vpack, without having to update the nupkg version).