### PR TITLE
ItemsRepeater and SelectionModel fix

### DIFF
--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
@@ -69,7 +69,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     ItemsSource = Enumerable.Range(0, numItems),
                     ItemTemplate = elementFactory,
                 };
-
 
                 var context = (ElementFactoryGetArgs)RepeaterTestHooks.CreateRepeaterElementFactoryGetArgs();
                 context.Parent = repeater;
@@ -563,6 +562,39 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 var element = (Button)repeater.TryGetElement(i);
                 Verify.AreEqual(i.ToString(), element.Content);
             }
+        }
+
+        [TestMethod]
+        public void ValidateNullItemTemplateAndContainerInItems()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                const int numItems = 10;
+                ItemsRepeater repeater = null;
+                Content = CreateAndInitializeRepeater
+                (
+                    itemsSource: Enumerable.Range(0, numItems).Select(i => new Button() { Content = i }), // ItemsSource is UIElements
+                    elementFactory: null, // No ItemTemplate
+                    layout: new StackLayout(),
+                    repeater: ref repeater
+                );
+
+                Content.UpdateLayout();
+
+                Verify.AreEqual(numItems, VisualTreeHelper.GetChildrenCount(repeater));
+                
+                for (int i = 0; i < numItems; i++)
+                {
+                    var element = (Button)repeater.TryGetElement(i);
+                    Verify.AreEqual(i, element.Content);
+                }
+
+                Button button0 = (Button)repeater.TryGetElement(0);
+                Verify.IsNotNull(button0.Parent);
+
+                repeater.ItemsSource = null;
+                Verify.IsNull(button0.Parent);
+            });
         }
 
         private ItemsRepeaterScrollHost CreateAndInitializeRepeater(

--- a/dev/Repeater/ItemsRepeater.idl
+++ b/dev/Repeater/ItemsRepeater.idl
@@ -550,6 +550,7 @@ runtimeclass SelectionModelSelectionChangedEventArgs
 runtimeclass SelectionModelChildrenRequestedEventArgs
 {
     Object Source { get; };
+    IndexPath SourceIndex { get; };
     Object Children { get; set; };
 }
 

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -534,6 +534,9 @@ winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data,
 
         m_getChildrenEventSource(*this, m_childrenRequestedEventArgs.get());
         resolved = m_childrenRequestedEventArgs.get().Children();
+
+        // Clear out the values in the args so that it cannot be used after the event handler call.
+        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, nullptr);
     }
     else
     {

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -517,7 +517,7 @@ void SelectionModel::OnSelectionInvalidatedDueToCollectionChange()
     OnSelectionChanged();
 }
 
-winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data)
+winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, SelectionNode* sourceNode)
 {
     winrt::IInspectable resolved = nullptr;
     // Raise ChildrenRequested event if there is a handler
@@ -525,11 +525,11 @@ winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data)
     {
         if (!m_childrenRequestedEventArgs)
         {
-            m_childrenRequestedEventArgs = tracker_ref<winrt::SelectionModelChildrenRequestedEventArgs>(this, winrt::make<SelectionModelChildrenRequestedEventArgs>(data));
+            m_childrenRequestedEventArgs = tracker_ref<winrt::SelectionModelChildrenRequestedEventArgs>(this, winrt::make<SelectionModelChildrenRequestedEventArgs>(data, sourceNode));
         }
         else
         {
-            winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(data);
+            winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(data, sourceNode);
         }
 
         m_getChildrenEventSource(*this, m_childrenRequestedEventArgs.get());

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -517,7 +517,7 @@ void SelectionModel::OnSelectionInvalidatedDueToCollectionChange()
     OnSelectionChanged();
 }
 
-winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, SelectionNode* sourceNode)
+winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, const std::weak_ptr<SelectionNode>& sourceNode)
 {
     winrt::IInspectable resolved = nullptr;
     // Raise ChildrenRequested event if there is a handler
@@ -536,7 +536,7 @@ winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data,
         resolved = m_childrenRequestedEventArgs.get().Children();
 
         // Clear out the values in the args so that it cannot be used after the event handler call.
-        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, nullptr);
+        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, std::weak_ptr<SelectionNode>() /* empty weakptr */);
     }
     else
     {

--- a/dev/Repeater/SelectionModel.h
+++ b/dev/Repeater/SelectionModel.h
@@ -88,7 +88,7 @@ public:
     void OnPropertyChanged(winrt::hstring const& propertyName);
 #pragma endregion
 
-    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, SelectionNode* sourceNode);
+    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, const std::weak_ptr<SelectionNode>& sourceNode);
     void OnSelectionInvalidatedDueToCollectionChange();
     std::shared_ptr<SelectionNode> SharedLeafNode() { return m_leafNode; }
 

--- a/dev/Repeater/SelectionModel.h
+++ b/dev/Repeater/SelectionModel.h
@@ -88,7 +88,7 @@ public:
     void OnPropertyChanged(winrt::hstring const& propertyName);
 #pragma endregion
 
-    winrt::IInspectable ResolvePath(const winrt::IInspectable& data);
+    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, SelectionNode* sourceNode);
     void OnSelectionInvalidatedDueToCollectionChange();
     std::shared_ptr<SelectionNode> SharedLeafNode() { return m_leafNode; }
 

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
@@ -16,11 +16,21 @@ SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventAr
 
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 {
+    if (!m_sourceNode) // Note that we are checking m_sourceNode since source being nullptr is possibly valid.
+    {
+        throw winrt::hresult_error(E_FAIL, L"Source can only be accesed in the ChildrenRequested event handler.");
+    }
+
     return m_source.get();
 }
 
 winrt::IndexPath SelectionModelChildrenRequestedEventArgs::SourceIndex()
 {
+    if (!m_sourceNode)
+    {
+        throw winrt::hresult_error(E_FAIL, L"SourceIndex can only be accesed in the ChildrenRequested event handler.");
+    }
+
     return m_sourceNode->IndexPath();
 }
 

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
@@ -4,11 +4,12 @@
 #include "pch.h"
 #include "common.h"
 #include "ItemsRepeater.common.h"
+#include "SelectionNode.h"
 #include "SelectionModelChildrenRequestedEventArgs.h"
 
-SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source)
+SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, SelectionNode* sourceNode)
 {
-    Initialize(source);
+    Initialize(source, sourceNode);
 }
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
@@ -16,6 +17,11 @@ SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventAr
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 {
     return m_source.get();
+}
+
+winrt::IndexPath SelectionModelChildrenRequestedEventArgs::SourceIndex()
+{
+    return m_sourceNode->IndexPath();
 }
 
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Children()
@@ -30,8 +36,9 @@ void SelectionModelChildrenRequestedEventArgs::Children(winrt::IInspectable cons
 
 #pragma endregion
 
-void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source)
+void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, SelectionNode* sourceNode)
 {
     m_source.set(source);
+    m_sourceNode = sourceNode;
     m_children.set(nullptr);
 }

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
@@ -7,7 +7,7 @@
 #include "SelectionNode.h"
 #include "SelectionModelChildrenRequestedEventArgs.h"
 
-SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, SelectionNode* sourceNode)
+SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, const std::weak_ptr<SelectionNode>& sourceNode)
 {
     Initialize(source, sourceNode);
 }
@@ -16,7 +16,8 @@ SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventAr
 
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 {
-    if (!m_sourceNode) // Note that we are checking m_sourceNode since source being nullptr is possibly valid.
+    auto node = m_sourceNode.lock();
+    if (!node)
     {
         throw winrt::hresult_error(E_FAIL, L"Source can only be accesed in the ChildrenRequested event handler.");
     }
@@ -26,12 +27,13 @@ winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 
 winrt::IndexPath SelectionModelChildrenRequestedEventArgs::SourceIndex()
 {
-    if (!m_sourceNode)
+    auto node = m_sourceNode.lock();
+    if (!node)
     {
         throw winrt::hresult_error(E_FAIL, L"SourceIndex can only be accesed in the ChildrenRequested event handler.");
     }
 
-    return m_sourceNode->IndexPath();
+    return node->IndexPath();
 }
 
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Children()
@@ -46,7 +48,7 @@ void SelectionModelChildrenRequestedEventArgs::Children(winrt::IInspectable cons
 
 #pragma endregion
 
-void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, SelectionNode* sourceNode)
+void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, const std::weak_ptr<SelectionNode>& sourceNode)
 {
     m_source.set(source);
     m_sourceNode = sourceNode;

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
@@ -22,6 +22,9 @@ public:
 
 private:
     tracker_ref<winrt::IInspectable> m_source{ this };
-    SelectionNode* m_sourceNode{ nullptr };
     tracker_ref<winrt::IInspectable> m_children{ this };
+
+    // Lifetime of sourceNode is owned by the caller and is guaranteed to be alive
+    // during the event handler call.
+    SelectionNode* m_sourceNode{ nullptr };
 };

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
@@ -9,7 +9,7 @@ class SelectionModelChildrenRequestedEventArgs :
     public ReferenceTracker<SelectionModelChildrenRequestedEventArgs, winrt::implementation::SelectionModelChildrenRequestedEventArgsT, winrt::composable, winrt::composing>
 {
 public:
-    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, SelectionNode* sourceNode);
+    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, const std::weak_ptr<SelectionNode>& sourceNode);
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
     winrt::IInspectable Source();
@@ -18,13 +18,10 @@ public:
     void Children(winrt::IInspectable const& value);
 #pragma endregion
 
-    void Initialize(const winrt::IInspectable& source, SelectionNode* sourceNode);
+    void Initialize(const winrt::IInspectable& source, const std::weak_ptr<SelectionNode>& sourceNode);
 
 private:
     tracker_ref<winrt::IInspectable> m_source{ this };
     tracker_ref<winrt::IInspectable> m_children{ this };
-
-    // Lifetime of sourceNode is owned by the caller and is guaranteed to be alive
-    // during the event handler call.
-    SelectionNode* m_sourceNode{ nullptr };
+    std::weak_ptr<SelectionNode> m_sourceNode;
 };

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
@@ -9,17 +9,19 @@ class SelectionModelChildrenRequestedEventArgs :
     public ReferenceTracker<SelectionModelChildrenRequestedEventArgs, winrt::implementation::SelectionModelChildrenRequestedEventArgsT, winrt::composable, winrt::composing>
 {
 public:
-    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data);
+    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, SelectionNode* sourceNode);
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
     winrt::IInspectable Source();
+    winrt::IndexPath SourceIndex();
     winrt::IInspectable Children();
     void Children(winrt::IInspectable const& value);
 #pragma endregion
 
-    void Initialize(const winrt::IInspectable& source);
+    void Initialize(const winrt::IInspectable& source, SelectionNode* sourceNode);
 
 private:
     tracker_ref<winrt::IInspectable> m_source{ this };
+    SelectionNode* m_sourceNode{ nullptr };
     tracker_ref<winrt::IInspectable> m_children{ this };
 };

--- a/dev/Repeater/SelectionNode.cpp
+++ b/dev/Repeater/SelectionNode.cpp
@@ -6,6 +6,7 @@
 #include "ItemsRepeater.common.h"
 #include "SelectionNode.h"
 #include "SelectionModel.h"
+#include "IndexPath.h"
 
 SelectionNode::SelectionNode(SelectionModel* manager, SelectionNode* parent) :
     m_manager(manager), m_parent(parent), m_source(manager), m_dataSource(manager)
@@ -77,6 +78,26 @@ void SelectionNode::AnchorIndex(int value)
     m_anchorIndex = value;
 }
 
+winrt::IndexPath SelectionNode::IndexPath()
+{
+    std::vector<int> path;
+    auto parent = m_parent;
+    auto child = this;
+    while (parent != nullptr)
+    {
+        auto childNodes = parent->m_childrenNodes;
+        auto it = std::find_if(childNodes.cbegin(), childNodes.cend(), [&child](const auto& item) {return item.get() == child;});
+        int index = distance(childNodes.cbegin(), it);
+        assert(index >= 0);
+        // we are walking up to the parent, so the path will be backwards
+        path.insert(path.begin(), index);
+        child = parent;
+        parent = parent->m_parent;
+    }
+
+    return winrt::make<::IndexPath>(path);
+}
+
 // For a genuine tree view, we dont know which node is leaf until we 
 // actually walk to it, so currently the tree builds up to the leaf. I don't 
 // create a bunch of leaf node instances - instead i use the same instance m_leafNode to avoid 
@@ -105,7 +126,7 @@ std::shared_ptr<SelectionNode> SelectionNode::GetAt(int index, bool realizeChild
             auto childData = m_dataSource.get().GetAt(index);
             if (childData != nullptr)
             {
-                auto resolvedChild = m_manager->ResolvePath(childData);
+                auto resolvedChild = m_manager->ResolvePath(childData, this);
                 if (resolvedChild != nullptr)
                 {
                     child = std::make_shared<SelectionNode>(m_manager, this /* parent */);

--- a/dev/Repeater/SelectionNode.cpp
+++ b/dev/Repeater/SelectionNode.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<SelectionNode> SelectionNode::GetAt(int index, bool realizeChild
             auto childData = m_dataSource.get().GetAt(index);
             if (childData != nullptr)
             {
-                auto resolvedChild = m_manager->ResolvePath(childData, this);
+                auto resolvedChild = m_manager->ResolvePath(childData, weak_from_this());
                 if (resolvedChild != nullptr)
                 {
                     child = std::make_shared<SelectionNode>(m_manager, this /* parent */);

--- a/dev/Repeater/SelectionNode.cpp
+++ b/dev/Repeater/SelectionNode.cpp
@@ -87,7 +87,7 @@ winrt::IndexPath SelectionNode::IndexPath()
     {
         auto childNodes = parent->m_childrenNodes;
         auto it = std::find_if(childNodes.cbegin(), childNodes.cend(), [&child](const auto& item) {return item.get() == child;});
-        int index = distance(childNodes.cbegin(), it);
+        const auto index = static_cast<int>(distance(childNodes.cbegin(), it));
         assert(index >= 0);
         // we are walking up to the parent, so the path will be backwards
         path.insert(path.begin(), index);

--- a/dev/Repeater/SelectionNode.h
+++ b/dev/Repeater/SelectionNode.h
@@ -17,7 +17,7 @@ enum SelectionState
 // a nested scenario. This would map to one ItemsSourceView/Collection. This node reacts
 // to collection changes and keeps the selected indices up to date.
 // This can either be a leaf node or a non leaf node.
-class SelectionNode final
+class SelectionNode final: public std::enable_shared_from_this<SelectionNode>
 {
 public:
     SelectionNode(SelectionModel* manager, SelectionNode* parent);

--- a/dev/Repeater/SelectionNode.h
+++ b/dev/Repeater/SelectionNode.h
@@ -48,6 +48,7 @@ public:
     bool SelectRange(const IndexRange& range, bool select);
     SelectionState EvaluateIsSelectedBasedOnChildrenNodes();
     static winrt::IReference<bool> ConvertToNullableBool(SelectionState isSelected);
+    winrt::IndexPath IndexPath();
 
 private:
     void HookupCollectionChangedHandler();

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -118,6 +118,19 @@ void ViewManager::ClearElementToElementFactory(const winrt::UIElement& element)
         context.Element(nullptr);
         context.Parent(nullptr);
     }
+    else
+    {
+        // No ItemTemplate to recycle to, remove the element from the children collection.
+        auto children = m_owner->Children();
+        unsigned int childIndex = 0;
+        bool found = children.IndexOf(element, childIndex);
+        if (!found)
+        {
+            throw winrt::hresult_error(E_FAIL, L"ItemsRepeater's child not found in its Children collection.");
+        }
+
+        children.RemoveAt(childIndex);
+    }
 
     auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);    
     virtInfo->MoveOwnershipToElementFactory();


### PR DESCRIPTION
If ItemTemplate is null and the objects in the ItemsSource are UIElements, we use them as is to show in the ItemsRepeater. When they do get recycled, those elements have to be removed from the repeater which was not happening before. 

Also Adding SourceIndex to ChildrenRequestedEventArgs to allow treeview scenarios with ItemsRepeater where the collection might be of custom type and the consumer need to provide the children collection. If the children collection is hooked up via data templates, then it is not possible to figure that out from just the data object. With this change, we also pass the IndexPath of the source, so that a control can walk the hierarchy based on the IndexPath to get the correct Container and then  get to the children from its property (like ItemsSource).

Added a couple of tests to validate the changes as well.