### PR TITLE
DispatcherHelper constructor throws expected exception, creates developer confusion

### DIFF
--- a/dev/inc/DispatcherHelper.h
+++ b/dev/inc/DispatcherHelper.h
@@ -5,7 +5,7 @@
 #include "SharedHelpers.h"
 
 // To avoid having to call a potentially throwing cppwinrt api, we call directly through the abi.
-// We don't want to include the entirety of the abi headers, so we just reproduce the single interfact
+// We don't want to include the entirety of the abi headers, so we just reproduce the single interface
 // that we need.
 namespace ABI::Windows::ApplicationModel::Core
 {


### PR DESCRIPTION
DispatcherHelper calls winrt::CoreApplication::GetCurrentView, and catches any exceptions that are thrown. This gives the functionally desired behavior, but it results in debugger exception noise. To avoid using exceptions as control flow, we avoid calling the cppwinrt api here and instead call directly into the abi.

See #1414

We also want this change to go into the OS. I will port the change there once this PR has been merged.