### PR TITLE
Fixed NavigationView on launch pane state

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -584,6 +584,7 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
     {
         MUX_FAIL_FAST();
     }
+
     if (!forceSetDisplayMode && m_InitialNonForcedModeUpdate) {
         if (displayMode == winrt::NavigationViewDisplayMode::Minimal ||
             displayMode == winrt::NavigationViewDisplayMode::Compact) {

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -585,7 +585,8 @@ void NavigationView::UpdateAdaptiveLayout(double width, bool forceSetDisplayMode
         MUX_FAIL_FAST();
     }
     if (!forceSetDisplayMode && m_InitialNonForcedModeUpdate) {
-        if (displayMode == winrt::NavigationViewDisplayMode::Minimal && PaneDisplayMode() == winrt::NavigationViewPaneDisplayMode::Auto) {
+        if (displayMode == winrt::NavigationViewDisplayMode::Minimal ||
+            displayMode == winrt::NavigationViewDisplayMode::Compact) {
             ClosePane();
         }
         m_InitialNonForcedModeUpdate = false;

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -319,6 +319,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 navView.IsSettingsVisible = true;
                 navView.IsPaneOpen = true;
+                navView.PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
                 MUXControlsTestApp.App.TestContentRoot = navView;
             });
 

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -445,7 +445,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "A")]
-        public void PaneClosedWhenAutoAndNarrow()
+        public void PaneClosedUponLaunch()
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();
             foreach (var testScenario in testScenarios)
@@ -455,6 +455,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                     CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsAutoPaneOpenCheckBox"));
                     Log.Comment("Checking that a NavigationView with displaymode set to 'Auto' and a narrow width does not display pane");
+                    Wait.ForIdle();
+                    Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
+
+                    isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftMinimalPaneOpenCheckBox"));
+                    Wait.ForIdle();
+                    Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
+
+                    isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftCompactPaneOpenCheckBox"));
                     Wait.ForIdle();
                     Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
                 }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -459,12 +459,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                     Log.Comment("Verify that NavigationView with DisplayMode set to 'LeftMinimal' does not display pane on load.");
                     CheckBox isLeftMinimalPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftMinimalPaneOpenCheckBox"));
-                    Wait.ForIdle();
                     Verify.IsTrue(isLeftMinimalPaneOpenCheckBox.ToggleState == ToggleState.Off);
 
                     Log.Comment("Verify that NavigationView with DisplayMode set to 'LeftCompact' does not display pane on load.");
                     CheckBox isLeftCompactPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftCompactPaneOpenCheckBox"));
-                    Wait.ForIdle();
                     Verify.IsTrue(isLeftCompactPaneOpenCheckBox.ToggleState == ToggleState.Off);
                 }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -452,19 +452,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "Navigation Minimal Test" }))
                 {
-
-                    CheckBox isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsAutoPaneOpenCheckBox"));
-                    Log.Comment("Checking that a NavigationView with displaymode set to 'Auto' and a narrow width does not display pane");
+                    Log.Comment("Verify that NavigationView with DisplayMode set to 'Auto' and a narrow width does not display pane on load.");
+                    CheckBox isAutoPaneOpenCheckBox = new CheckBox(FindElement.ById("IsAutoPaneOpenCheckBox"));
                     Wait.ForIdle();
-                    Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
+                    Verify.IsTrue(isAutoPaneOpenCheckBox.ToggleState == ToggleState.Off);
 
-                    isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftMinimalPaneOpenCheckBox"));
+                    Log.Comment("Verify that NavigationView with DisplayMode set to 'LeftMinimal' does not display pane on load.");
+                    CheckBox isLeftMinimalPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftMinimalPaneOpenCheckBox"));
                     Wait.ForIdle();
-                    Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
+                    Verify.IsTrue(isLeftMinimalPaneOpenCheckBox.ToggleState == ToggleState.Off);
 
-                    isPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftCompactPaneOpenCheckBox"));
+                    Log.Comment("Verify that NavigationView with DisplayMode set to 'LeftCompact' does not display pane on load.");
+                    CheckBox isLeftCompactPaneOpenCheckBox = new CheckBox(FindElement.ById("IsLeftCompactPaneOpenCheckBox"));
                     Wait.ForIdle();
-                    Verify.IsTrue(isPaneOpenCheckBox.ToggleState == ToggleState.Off);
+                    Verify.IsTrue(isLeftCompactPaneOpenCheckBox.ToggleState == ToggleState.Off);
                 }
 
             }

--- a/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewMinimalPage.xaml
@@ -11,21 +11,38 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 <!-- This page contains a NavigationView control that is in LeftMinimal mode on initial load -->
     <StackPanel>
-        <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
-                                    IsBackEnabled="True" Header="Minimal Test Page" PaneDisplayMode="LeftMinimal">
-            <StackPanel>
-                <TextBlock x:Name="NavViewActiveVisualStatesResult" AutomationProperties.Name="NavViewActiveVisualStatesResult"/>
-                <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>
-            </StackPanel>
-        </muxcontrols:NavigationView>
-        <muxcontrols:NavigationView x:Name="NavViewAuto" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
-                                    IsBackEnabled="True" Header="Minimal Test Page" Width="250" Height="300" >
-            <StackPanel>
-            </StackPanel>
-        </muxcontrols:NavigationView>
-        <CheckBox
-            IsChecked="{Binding IsPaneOpen, ElementName=NavViewAuto, Mode=TwoWay}"
-            x:Name="IsAutoPaneOpenCheckBox"
-            AutomationProperties.Name="IsPaneOpenCheckBox" >Toggle auto pane open</CheckBox>
+        <StackPanel Orientation="Horizontal">
+            <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
+                                            IsBackEnabled="True" Header="LeftMinimal" PaneDisplayMode="LeftMinimal">
+                <StackPanel>
+                    <TextBlock x:Name="NavViewActiveVisualStatesResult" AutomationProperties.Name="NavViewActiveVisualStatesResult"/>
+                    <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>
+                </StackPanel>
+            </muxcontrols:NavigationView>
+            <muxcontrols:NavigationView x:Name="NavViewLeftCompact" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavViewLeftCompact"
+                                            IsBackEnabled="True" Header="LeftCompact" PaneDisplayMode="LeftCompact">
+                <StackPanel>
+                </StackPanel>
+            </muxcontrols:NavigationView>
+            <muxcontrols:NavigationView x:Name="NavViewAuto" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
+                                        IsBackEnabled="True" Header="Auto" Width="250" Height="300" >
+                <StackPanel>
+                </StackPanel>
+            </muxcontrols:NavigationView>
+        </StackPanel>
+        <StackPanel>
+            <CheckBox
+                IsChecked="{Binding IsPaneOpen, ElementName=NavView, Mode=TwoWay}"
+                x:Name="IsLeftMinimalPaneOpenCheckBox"
+                AutomationProperties.Name="IsLeftMinimalPaneOpenCheckBox" >Toggle LeftMinimal pane open</CheckBox>
+            <CheckBox
+                IsChecked="{Binding IsPaneOpen, ElementName=NavViewLeftCompact, Mode=TwoWay}"
+                x:Name="IsLeftCompactPaneOpenCheckBox"
+                AutomationProperties.Name="IsLeftCompactPaneOpenCheckBox" >Toggle LeftCompact pane open</CheckBox>
+            <CheckBox
+                IsChecked="{Binding IsPaneOpen, ElementName=NavViewAuto, Mode=TwoWay}"
+                x:Name="IsAutoPaneOpenCheckBox"
+                AutomationProperties.Name="IsPaneOpenCheckBox" >Toggle auto pane open</CheckBox>
+        </StackPanel>
     </StackPanel>
 </local:TestPage>


### PR DESCRIPTION
## Description
When an app with NavigationView launches straight into LeftCompact and LeftMinimal mode, the pane is open by default. The expected behavior is for it to be initially closed, made changes to reflect this.

## Motivation and Context
Fixes #1430 

## How Has This Been Tested?
Added validation for LeftCompact and LeftMinimal scenarios to an existing relevant test.
Verified that an app launching into these pane states no longer have the pane open by default.