### PR TITLE
Remove padding of MenuFlyoutItems

### DIFF
--- a/dev/MenuFlyout/MenuFlyout_rs5_themeresources.xaml
+++ b/dev/MenuFlyout/MenuFlyout_rs5_themeresources.xaml
@@ -8,7 +8,6 @@
     <ResourceDictionary.ThemeDictionaries>
 
         <ResourceDictionary x:Key="Default">
-            <Thickness x:Key="MenuFlyoutPresenterThemePadding">1</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePadding">11,9,11,10</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,7</Thickness>
             <StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
@@ -48,7 +47,6 @@
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
-            <Thickness x:Key="MenuFlyoutPresenterThemePadding">1</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePadding">11,9,11,10</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,7</Thickness>
             <!-- Resources for Windows.UI.Xaml.Controls.MenuFlyoutItem -->
@@ -83,7 +81,6 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
-            <Thickness x:Key="MenuFlyoutPresenterThemePadding">1</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePadding">11,9,11,10</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,7</Thickness>
             <StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the internal padding that is used for the MenuItemPresenter so the items are edge to edge with the border of the flyout.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1445 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually using the MUXControlsTestApp
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![menuflyout-spacing-removal](https://user-images.githubusercontent.com/16122379/67012826-5a585100-f0f2-11e9-979c-5ec6700f9eae.png)

