### PR TITLE
Ignore MaxHeight&Width in CommandBarOverflowMenu test

### DIFF
--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -140,8 +140,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
-        //Disabling until issue #1455 is resolved.
-        //[TestMethod]
+        [TestMethod]
         public void VerifyVisualTreeForCommandBarOverflowMenu()
         {
             StackPanel root = null;

--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -185,7 +185,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 overflowContent = popup.Child;
             });
 
-            VisualTreeTestHelper.VerifyVisualTree(root: overflowContent, masterFilePrefix: "CommandBarOverflowMenu");
+            var visualTreeDumperFilter = new VisualTreeDumper.DefaultFilter();
+            visualTreeDumperFilter.PropertyNameWhiteList.Remove("MaxWidth");
+            visualTreeDumperFilter.PropertyNameWhiteList.Remove("MaxHeight");
+            VisualTreeTestHelper.VerifyVisualTree(root: overflowContent, masterFilePrefix: "CommandBarOverflowMenu", filter: visualTreeDumperFilter);
         }
 
         private string XamlStringForControl(string controlName)

--- a/test/MUXControlsTestApp/master/CommandBarOverflowMenu-6.xml
+++ b/test/MUXControlsTestApp/master/CommandBarOverflowMenu-6.xml
@@ -6,8 +6,6 @@
     Background=[NULL]
     Name=OverflowContentRoot
     MinWidth=160
-    MaxWidth=480
-    MaxHeight=300
     Margin=0,0,0,0
     FocusVisualSecondaryThickness=1,1,1,1
     FocusVisualSecondaryBrush=#99FFFFFF
@@ -22,7 +20,6 @@
       BorderBrush=#FFCCCCCC
       Background=#FFF2F2F2
       Name=SecondaryItemsControl
-      MaxWidth=480
       Margin=0,0,0,0
       FocusVisualSecondaryThickness=1,1,1,1
       FocusVisualSecondaryBrush=#99FFFFFF

--- a/test/MUXControlsTestApp/master/CommandBarOverflowMenu-7.xml
+++ b/test/MUXControlsTestApp/master/CommandBarOverflowMenu-7.xml
@@ -6,8 +6,6 @@
     Background=[NULL]
     Name=OverflowContentRoot
     MinWidth=160
-    MaxWidth=480
-    MaxHeight=300
     Margin=0,0,0,0
     FocusVisualSecondaryThickness=1,1,1,1
     FocusVisualSecondaryBrush=#99FFFFFF
@@ -23,7 +21,6 @@
       Background=Microsoft.UI.Xaml.Media.AcrylicBrush
       CornerRadius=4,4,4,4
       Name=SecondaryItemsControl
-      MaxWidth=480
       Margin=0,0,0,0
       FocusVisualSecondaryThickness=1,1,1,1
       FocusVisualSecondaryBrush=#99FFFFFF

--- a/test/MUXControlsTestApp/master/CommandBarOverflowMenu-8.xml
+++ b/test/MUXControlsTestApp/master/CommandBarOverflowMenu-8.xml
@@ -6,8 +6,6 @@
     Background=[NULL]
     Name=OverflowContentRoot
     MinWidth=160
-    MaxWidth=480
-    MaxHeight=420
     Margin=0,0,0,0
     FocusVisualSecondaryThickness=1,1,1,1
     FocusVisualSecondaryBrush=#99FFFFFF
@@ -23,7 +21,6 @@
       Background=Microsoft.UI.Xaml.Media.AcrylicBrush
       CornerRadius=4,4,4,4
       Name=SecondaryItemsControl
-      MaxWidth=480
       Margin=0,0,0,0
       FocusVisualSecondaryThickness=1,1,1,1
       FocusVisualSecondaryBrush=#99FFFFFF

--- a/test/MUXControlsTestApp/master/CommandBarOverflowMenu.xml
+++ b/test/MUXControlsTestApp/master/CommandBarOverflowMenu.xml
@@ -6,8 +6,6 @@
     Background=[NULL]
     Name=OverflowContentRoot
     MinWidth=160
-    MaxWidth=480
-    MaxHeight=300
     Margin=0,0,0,0
     FocusVisualSecondaryThickness=1,1,1,1
     FocusVisualSecondaryBrush=#99FFFFFF
@@ -22,7 +20,6 @@
       BorderBrush=#FFCCCCCC
       Background=#FFF2F2F2
       Name=SecondaryItemsControl
-      MaxWidth=480
       Margin=0,0,0,0
       FocusVisualSecondaryThickness=1,1,1,1
       FocusVisualSecondaryBrush=#99FFFFFF

--- a/test/TestAppUtils/VisualTreeDumper.cs
+++ b/test/TestAppUtils/VisualTreeDumper.cs
@@ -142,7 +142,7 @@ namespace MUXControls.TestAppUtils
         public class DefaultFilter : IFilter
         {
             private static readonly string[] _propertyNamePostfixWhiteList = new string[] {"Brush", "Thickness"};
-            private static readonly string[] _propertyNameWhiteList = new string[] {"Background", "Foreground", "Padding", "Margin", "RenderSize", "Visibility", "Name", "CornerRadius",
+            private List<string> _propertyNameWhiteList = new List<string> {"Background", "Foreground", "Padding", "Margin", "RenderSize", "Visibility", "Name", "CornerRadius",
                 "Width", "Height", "MinWidth", "MinHeight", "MaxWidth", "MaxHeight" };
             private static readonly Dictionary<string, string> _ignorePropertyValues = new Dictionary<string, string> {
                 {"MinWidth","0" },
@@ -150,6 +150,13 @@ namespace MUXControls.TestAppUtils
                 {"MaxWidth","∞" },
                 {"MaxHeight","∞" },
             };
+
+            public List<string> PropertyNameWhiteList 
+            {
+                get { return _propertyNameWhiteList; }
+                set { _propertyNameWhiteList = value; }
+            }
+
             public virtual bool ShouldVisitPropertyValuePair(string propertyName, string value)
             {
                 if (_ignorePropertyValues.ContainsKey(propertyName) 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I think popup max width/height is related to screen resolution or window size. Ignoring those properties to get more reliable test result.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1455 