### PR TITLE
Fix issue with TabView crashing in a NavigationCacheMode=Required page

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -233,18 +233,17 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
         // Now that ListView exists, we can start using its Items collection.
         auto items = TabItems();
         auto numItemsToCopy = static_cast<int>(items.Size());
-        bool itemsSourceDoesNotExists = listView.ItemsSource() == nullptr;
 
-        if (itemsSourceDoesNotExists)
+        if (!listView.ItemsSource())
         {
-            if (auto lvItems = listView.Items())
+            if (auto const lvItems = listView.Items())
             {
                 // copy the list, because clearing lvItems may also clear items
-                winrt::IVector<winrt::IInspectable> item_list{ winrt::single_threaded_vector<winrt::IInspectable>() };
+                winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
 
-                for (auto itm : items)
+                for (auto const item : items)
                 {
-                    item_list.Append(itm);
+                    itemList.Append(item);
                 }
 
                 lvItems.Clear();
@@ -252,9 +251,8 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
                 for (int i = 0; i < numItemsToCopy; i++)
                 {
                     // App put items in our Items collection; copy them over to ListView.Items
-                    auto itm = item_list.GetAt(i);
-                    if (itm != nullptr)
-                        lvItems.Append(itm);
+                    if (auto const item = itemList.GetAt(i))
+                        lvItems.Append(item);
                 }
                 TabItems(lvItems);
             }
@@ -262,13 +260,13 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
 
         else if (auto itemsSource = listView.ItemsSource().try_as<winrt::IIterable<winrt::IInspectable>>())
         {
-            winrt::IVector<winrt::IInspectable> item_list{ winrt::single_threaded_vector<winrt::IInspectable>() };
+            winrt::IVector<winrt::IInspectable> itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
 
-            for (auto itm : itemsSource)
+            for (auto const item : itemsSource)
             {
-                item_list.Append(itm);
+                itemList.Append(item);
             }
-            TabItems(item_list);
+            TabItems(itemList);
         }
 
         if (ReadLocalValue(s_SelectedItemProperty) != winrt::DependencyProperty::UnsetValue())

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -258,6 +258,18 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
             }
         }
 
+        // if there is an itemsSource, we need to copy the values to TabItems, so that they are also accessible by TabItems property
+        else if (auto itemsSource = listView.ItemsSource().try_as<winrt::IIterable<winrt::IInspectable>>())
+        {
+            winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
+
+            for (auto const item : itemsSource)
+            {
+                itemList.Append(item);
+            }
+            TabItems(itemList);
+        }
+
         if (ReadLocalValue(s_SelectedItemProperty) != winrt::DependencyProperty::UnsetValue())
         {
             UpdateSelectedItem();

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -231,12 +231,11 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
     if (auto listView = m_listView.get())
     {
         // Now that ListView exists, we can start using its Items collection.
-        
-        if (!listView.ItemsSource())
+        if (auto const lvItems = listView.Items())
         {
-            if (auto const lvItems = listView.Items())
+            if (!listView.ItemsSource())
             {
-                // copy the list, because clearing lvItems may also clear items
+                // copy the list, because clearing lvItems may also clear TabItems
                 winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
 
                 for (auto const item : TabItems())
@@ -254,20 +253,8 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
                         lvItems.Append(item);
                     }
                 }
-                TabItems(lvItems);
             }
-        }
-
-        // if there is an itemsSource, we need to copy the values to TabItems, so that they are also accessible by TabItems property
-        else if (auto const itemsSource = listView.ItemsSource().try_as<winrt::IIterable<winrt::IInspectable>>())
-        {
-            winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
-
-            for (auto const item : itemsSource)
-            {
-                itemList.Append(item);
-            }
-            TabItems(itemList);
+            TabItems(lvItems);
         }
 
         if (ReadLocalValue(s_SelectedItemProperty) != winrt::DependencyProperty::UnsetValue())

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -231,13 +231,14 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
     if (auto listView = m_listView.get())
     {
         // Now that ListView exists, we can start using its Items collection.
-        auto items = TabItems();
-        auto numItemsToCopy = static_cast<int>(items.Size());
-
+        
         if (!listView.ItemsSource())
         {
             if (auto const lvItems = listView.Items())
             {
+                auto items = TabItems();
+                auto numItemsToCopy = static_cast<int>(items.Size());
+
                 // copy the list, because clearing lvItems may also clear items
                 winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
 
@@ -248,25 +249,14 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
 
                 lvItems.Clear();
 
-                for (int i = 0; i < numItemsToCopy; i++)
+                for (auto const item : itemList)
                 {
                     // App put items in our Items collection; copy them over to ListView.Items
-                    if (auto const item = itemList.GetAt(i))
+                    if (item)
                         lvItems.Append(item);
                 }
                 TabItems(lvItems);
             }
-        }
-
-        else if (auto itemsSource = listView.ItemsSource().try_as<winrt::IIterable<winrt::IInspectable>>())
-        {
-            winrt::IVector<winrt::IInspectable> itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
-
-            for (auto const item : itemsSource)
-            {
-                itemList.Append(item);
-            }
-            TabItems(itemList);
         }
 
         if (ReadLocalValue(s_SelectedItemProperty) != winrt::DependencyProperty::UnsetValue())

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -259,7 +259,7 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
         }
 
         // if there is an itemsSource, we need to copy the values to TabItems, so that they are also accessible by TabItems property
-        else if (auto itemsSource = listView.ItemsSource().try_as<winrt::IIterable<winrt::IInspectable>>())
+        else if (auto const itemsSource = listView.ItemsSource().try_as<winrt::IIterable<winrt::IInspectable>>())
         {
             winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
 

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -236,13 +236,10 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
         {
             if (auto const lvItems = listView.Items())
             {
-                auto items = TabItems();
-                auto numItemsToCopy = static_cast<int>(items.Size());
-
                 // copy the list, because clearing lvItems may also clear items
                 winrt::IVector<winrt::IInspectable> const itemList{ winrt::single_threaded_vector<winrt::IInspectable>() };
 
-                for (auto const item : items)
+                for (auto const item : TabItems())
                 {
                     itemList.Append(item);
                 }
@@ -253,7 +250,9 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
                 {
                     // App put items in our Items collection; copy them over to ListView.Items
                     if (item)
+                    {
                         lvItems.Append(item);
+                    }
                 }
                 TabItems(lvItems);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When the `TabView` is in a `Page` which has `NavigationCacheMode = "Required"`, it'd cause the app to crash. Because, in the `Loaded`  event of the `ListView`, the previous code would always add the current `TabItems` of the `TabView`, but it is necessary to check whether the `Items` being added have already been added before. As it didn't check that, it would crash in the second loaded event.

Fixes #1245 

## How Has This Been Tested?
I used the MUXControlTestApp to test the changes. I set the `NavigationCacheMode="Required"` of the *TabViewPage* and navigated back and forth to ensure it doesn't crash anymore, as it would before.