### PR TITLE
Fix ScrollBar rounded corners

### DIFF
--- a/dev/Common/CornerRadiusFilterConverter.cpp
+++ b/dev/Common/CornerRadiusFilterConverter.cpp
@@ -53,10 +53,13 @@ winrt::IInspectable CornerRadiusFilterConverter::Convert(
     auto cornerRadius = unbox_value<winrt::CornerRadius>(value);
 
     const auto scale = Scale();
-    cornerRadius.TopLeft *= scale;
-    cornerRadius.TopRight *= scale;
-    cornerRadius.BottomRight *= scale;
-    cornerRadius.BottomLeft *= scale;
+    if (!std::isnan(scale))
+    {
+        cornerRadius.TopLeft *= scale;
+        cornerRadius.TopRight *= scale;
+        cornerRadius.BottomRight *= scale;
+        cornerRadius.BottomLeft *= scale;
+    }
 
     const auto filterType = Filter();
     if (filterType == winrt::CornerRadiusFilterKind::TopLeftValue ||

--- a/dev/Common/CornerRadiusFilterConverter.cpp
+++ b/dev/Common/CornerRadiusFilterConverter.cpp
@@ -51,7 +51,14 @@ winrt::IInspectable CornerRadiusFilterConverter::Convert(
     winrt::hstring const& language)
 {
     auto cornerRadius = unbox_value<winrt::CornerRadius>(value);
-    auto filterType = Filter();
+
+    const auto scale = Scale();
+    cornerRadius.TopLeft *= scale;
+    cornerRadius.TopRight *= scale;
+    cornerRadius.BottomRight *= scale;
+    cornerRadius.BottomLeft *= scale;
+
+    const auto filterType = Filter();
     if (filterType == winrt::CornerRadiusFilterKind::TopLeftValue ||
         filterType == winrt::CornerRadiusFilterKind::BottomRightValue)
     {

--- a/dev/Common/CornerRadiusFilterConverters.idl
+++ b/dev/Common/CornerRadiusFilterConverters.idl
@@ -12,6 +12,15 @@ runtimeclass CornerRadiusFilterConverter : Windows.UI.Xaml.DependencyObject, Win
     CornerRadiusFilterKind Filter{ get; set; };
 
     static Windows.UI.Xaml.DependencyProperty FilterProperty{ get; };
+
+    [WUXC_VERSION_MUXONLY]
+    [interface_name("ICornerRadiusFilterConverter2")]
+    {
+        [MUX_DEFAULT_VALUE("1.0")]
+        Double Scale{ get; set; };
+        static Windows.UI.Xaml.DependencyProperty ScaleProperty{ get; };
+    }
+
 };
 
 [WUXC_VERSION_MUXONLY]

--- a/dev/Common/CornerRadiusFilterConverters.idl
+++ b/dev/Common/CornerRadiusFilterConverters.idl
@@ -10,17 +10,11 @@ runtimeclass CornerRadiusFilterConverter : Windows.UI.Xaml.DependencyObject, Win
 
     [MUX_DEFAULT_VALUE("winrt::CornerRadiusFilterKind::None")]
     CornerRadiusFilterKind Filter{ get; set; };
+    [MUX_DEFAULT_VALUE("1.0")]
+    Double Scale{ get; set; };
 
     static Windows.UI.Xaml.DependencyProperty FilterProperty{ get; };
-
-    [WUXC_VERSION_MUXONLY]
-    [interface_name("ICornerRadiusFilterConverter2")]
-    {
-        [MUX_DEFAULT_VALUE("1.0")]
-        Double Scale{ get; set; };
-        static Windows.UI.Xaml.DependencyProperty ScaleProperty{ get; };
-    }
-
+    static Windows.UI.Xaml.DependencyProperty ScaleProperty{ get; };
 };
 
 [WUXC_VERSION_MUXONLY]

--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                              xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
                              xmlns:primitives='using:Microsoft.UI.Xaml.Controls.Primitives'> 
                             <StackPanel.Resources>
-                                <primitives:CornerRadiusFilterConverter x:Key='TopCornerRadiusFilterConverter' Filter='Top'/>
+                                <primitives:CornerRadiusFilterConverter x:Key='TopCornerRadiusFilterConverter' Filter='Top' Scale='2'/>
                                 <primitives:CornerRadiusFilterConverter x:Key='RightCornerRadiusFilterConverter' Filter='Right'/>
                                 <primitives:CornerRadiusFilterConverter x:Key='BottomCornerRadiusFilterConverter' Filter='Bottom'/>
                                 <primitives:CornerRadiusFilterConverter x:Key='LeftCornerRadiusFilterConverter' Filter='Left'/>
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var bottomRadiusGrid = (Grid)root.FindName("BottomRadiusGrid");
                 var leftRadiusGrid = (Grid)root.FindName("LeftRadiusGrid");
 
-                Verify.AreEqual(new CornerRadius(6, 6, 0, 0), topRadiusGrid.CornerRadius);
+                Verify.AreEqual(new CornerRadius(12, 12, 0, 0), topRadiusGrid.CornerRadius);
                 Verify.AreEqual(new CornerRadius(0, 6, 6, 0), rightRadiusGrid.CornerRadius);
                 Verify.AreEqual(new CornerRadius(0, 0, 6, 6), bottomRadiusGrid.CornerRadius);
                 Verify.AreEqual(new CornerRadius(6, 0, 0, 6), leftRadiusGrid.CornerRadius);

--- a/dev/Generated/CornerRadiusFilterConverter.properties.cpp
+++ b/dev/Generated/CornerRadiusFilterConverter.properties.cpp
@@ -9,6 +9,7 @@
 CppWinRTActivatableClassWithDPFactory(CornerRadiusFilterConverter)
 
 GlobalDependencyProperty CornerRadiusFilterConverterProperties::s_FilterProperty{ nullptr };
+GlobalDependencyProperty CornerRadiusFilterConverterProperties::s_ScaleProperty{ nullptr };
 
 CornerRadiusFilterConverterProperties::CornerRadiusFilterConverterProperties()
 {
@@ -28,11 +29,23 @@ void CornerRadiusFilterConverterProperties::EnsureProperties()
                 ValueHelper<winrt::CornerRadiusFilterKind>::BoxValueIfNecessary(winrt::CornerRadiusFilterKind::None),
                 nullptr);
     }
+    if (!s_ScaleProperty)
+    {
+        s_ScaleProperty =
+            InitializeDependencyProperty(
+                L"Scale",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::CornerRadiusFilterConverter>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxValueIfNecessary(1.0),
+                nullptr);
+    }
 }
 
 void CornerRadiusFilterConverterProperties::ClearProperties()
 {
     s_FilterProperty = nullptr;
+    s_ScaleProperty = nullptr;
 }
 
 void CornerRadiusFilterConverterProperties::Filter(winrt::CornerRadiusFilterKind const& value)
@@ -43,4 +56,14 @@ void CornerRadiusFilterConverterProperties::Filter(winrt::CornerRadiusFilterKind
 winrt::CornerRadiusFilterKind CornerRadiusFilterConverterProperties::Filter()
 {
     return ValueHelper<winrt::CornerRadiusFilterKind>::CastOrUnbox(static_cast<CornerRadiusFilterConverter*>(this)->GetValue(s_FilterProperty));
+}
+
+void CornerRadiusFilterConverterProperties::Scale(double value)
+{
+    static_cast<CornerRadiusFilterConverter*>(this)->SetValue(s_ScaleProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+}
+
+double CornerRadiusFilterConverterProperties::Scale()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<CornerRadiusFilterConverter*>(this)->GetValue(s_ScaleProperty));
 }

--- a/dev/Generated/CornerRadiusFilterConverter.properties.h
+++ b/dev/Generated/CornerRadiusFilterConverter.properties.h
@@ -12,9 +12,14 @@ public:
     void Filter(winrt::CornerRadiusFilterKind const& value);
     winrt::CornerRadiusFilterKind Filter();
 
+    void Scale(double value);
+    double Scale();
+
     static winrt::DependencyProperty FilterProperty() { return s_FilterProperty; }
+    static winrt::DependencyProperty ScaleProperty() { return s_ScaleProperty; }
 
     static GlobalDependencyProperty s_FilterProperty;
+    static GlobalDependencyProperty s_ScaleProperty;
 
     static void EnsureProperties();
     static void ClearProperties();

--- a/dev/ScrollBar/ScrollBar_themeresources.xaml
+++ b/dev/ScrollBar/ScrollBar_themeresources.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
@@ -197,6 +198,9 @@
             <x:String x:Key="ScrollBarContractBeginTime">00:00:02.00</x:String>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+
+    <primitives:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter8x" Filter="TopLeftValue" Scale="8"/>
+    <primitives:CornerRadiusFilterConverter x:Key="BottomRightCornerRadiusDoubleValueConverter8x" Filter="BottomRightValue" Scale="8"/>
 
     <Style TargetType="ScrollBar" BasedOn="{StaticResource DefaultScrollBarStyle}" />
 
@@ -420,9 +424,9 @@
                             </ControlTemplate>
                             <ControlTemplate x:Key="VerticalThumbTemplate" TargetType="Thumb">
                                 <Rectangle x:Name="ThumbVisual" Fill="{TemplateBinding Background}"
-                                           contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                           contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter8x}}"
                                            contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
-                                           contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                           contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter8x}}"
                                            contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
                                     <VisualStateManager.VisualStateGroups>
                                         <VisualStateGroup x:Name="CommonStates">
@@ -456,9 +460,9 @@
                             <ControlTemplate x:Key="HorizontalThumbTemplate" TargetType="Thumb">
                                 <Rectangle x:Name="ThumbVisual" Fill="{TemplateBinding Background}"
                                            contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                           contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
+                                           contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter8x}}"
                                            contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                           contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
+                                           contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter8x}}">
                                     <VisualStateManager.VisualStateGroups>
                                         <VisualStateGroup x:Name="CommonStates">
                                             <VisualState x:Name="Normal" />
@@ -621,8 +625,6 @@
                                         <Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
                                         <Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
                                         <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
-                                        <contract7Present:Setter Target="HorizontalThumb.CornerRadius" Value="0" />
-                                        <contract7Present:Setter Target="VerticalThumb.CornerRadius" Value="0" />
                                     </VisualState.Setters>
 
                                     <Storyboard>
@@ -642,6 +644,12 @@
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalLargeDecrease" Storyboard.TargetProperty="Opacity" To="1" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalSmallDecrease" Storyboard.TargetProperty="Opacity" To="1" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="1" />
+                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="CornerRadius">
+                                            <DiscreteObjectKeyFrame KeyTime="{ThemeResource ScrollBarExpandBeginTime}" Value="0" />
+                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="CornerRadius">
+                                            <DiscreteObjectKeyFrame KeyTime="{ThemeResource ScrollBarExpandBeginTime}" Value="0" />
+                                        </contract7Present:ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="ExpandedWithoutAnimation">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ScrollBar's width/height (depends on the orientation) is scaled down to 1/8 in rest state, which makes CornerRadius value much smaller than it should be.

Added a "Scale" property in CornerRadiusFilterConverter to scale up the values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

Fixes #1432.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Updated API test, manually verified ScrollBar visual.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
ScrollBar 200%:
![Annotation 2019-10-23 114352](https://user-images.githubusercontent.com/4424330/67425350-ab51c480-f58c-11e9-9b6b-9be725b5a0f7.png)
