### PR TITLE
Fix bug where Calender in high contrast would render wrong

### DIFF
--- a/dev/CalendarView/CalendarView_themeresources.xaml
+++ b/dev/CalendarView/CalendarView_themeresources.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary 
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -56,7 +56,7 @@
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundPressed" ResourceKey="SystemControlForegroundBaseMediumBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlTransparentRevealBackgroundBrush" />
+            <StaticResource x:Key="CalendarViewCalendarItemRevealBackground" ResourceKey="SystemControlBackgroundAltHighBrush" />
             <StaticResource x:Key="CalendarViewCalendarItemRevealBorderBrush" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightTransparentBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since the RevealBackgroundBrush is always white in high contrast, we should use a different brush (`SystemControlTransparentRevealBackgroundBrush`) instead.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1436 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually using MUXControlsTestApp
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

### HC1:
![image](https://user-images.githubusercontent.com/16122379/67527518-7db56a00-f6b7-11e9-88d8-879aec81bd4a.png)

### HC2:
![image](https://user-images.githubusercontent.com/16122379/67527594-a3db0a00-f6b7-11e9-8949-1f072cf31103.png)

### HC Black:
![image](https://user-images.githubusercontent.com/16122379/67527692-e43a8800-f6b7-11e9-8925-29ae62a934ad.png)

### HC White:
![image](https://user-images.githubusercontent.com/16122379/67527786-151abd00-f6b8-11e9-8d70-9e6e41576ccb.png)
