### PR TITLE
Navigation view bottom menu items implementation

### DIFF
--- a/dev/Generated/NavigationView.properties.cpp
+++ b/dev/Generated/NavigationView.properties.cpp
@@ -15,6 +15,7 @@ GlobalDependencyProperty NavigationViewProperties::s_CompactPaneLengthProperty{ 
 GlobalDependencyProperty NavigationViewProperties::s_ContentOverlayProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_DisplayModeProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_ExpandedModeThresholdWidthProperty{ nullptr };
+GlobalDependencyProperty NavigationViewProperties::s_FooterMenuItemsProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_HeaderProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_HeaderTemplateProperty{ nullptr };
 GlobalDependencyProperty NavigationViewProperties::s_IsBackButtonVisibleProperty{ nullptr };
@@ -135,6 +136,17 @@ void NavigationViewProperties::EnsureProperties()
                 false /* isAttached */,
                 ValueHelper<double>::BoxValueIfNecessary(1008.0),
                 winrt::PropertyChangedCallback(&OnExpandedModeThresholdWidthPropertyChanged));
+    }
+    if (!s_FooterMenuItemsProperty)
+    {
+        s_FooterMenuItemsProperty =
+            InitializeDependencyProperty(
+                L"FooterMenuItems",
+                winrt::name_of<winrt::IVector<winrt::IInspectable>>(),
+                winrt::name_of<winrt::NavigationView>(),
+                false /* isAttached */,
+                ValueHelper<winrt::IVector<winrt::IInspectable>>::BoxedDefaultValue(),
+                winrt::PropertyChangedCallback(&OnFooterMenuItemsPropertyChanged));
     }
     if (!s_HeaderProperty)
     {
@@ -455,6 +467,7 @@ void NavigationViewProperties::ClearProperties()
     s_ContentOverlayProperty = nullptr;
     s_DisplayModeProperty = nullptr;
     s_ExpandedModeThresholdWidthProperty = nullptr;
+    s_FooterMenuItemsProperty = nullptr;
     s_HeaderProperty = nullptr;
     s_HeaderTemplateProperty = nullptr;
     s_IsBackButtonVisibleProperty = nullptr;
@@ -560,6 +573,14 @@ void NavigationViewProperties::OnExpandedModeThresholdWidthPropertyChanged(
         return;
     }
 
+    winrt::get_self<NavigationView>(owner)->OnPropertyChanged(args);
+}
+
+void NavigationViewProperties::OnFooterMenuItemsPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::NavigationView>();
     winrt::get_self<NavigationView>(owner)->OnPropertyChanged(args);
 }
 
@@ -847,6 +868,16 @@ void NavigationViewProperties::ExpandedModeThresholdWidth(double value)
 double NavigationViewProperties::ExpandedModeThresholdWidth()
 {
     return ValueHelper<double>::CastOrUnbox(static_cast<NavigationView*>(this)->GetValue(s_ExpandedModeThresholdWidthProperty));
+}
+
+void NavigationViewProperties::FooterMenuItems(winrt::IVector<winrt::IInspectable> const& value)
+{
+    static_cast<NavigationView*>(this)->SetValue(s_FooterMenuItemsProperty, ValueHelper<winrt::IVector<winrt::IInspectable>>::BoxValueIfNecessary(value));
+}
+
+winrt::IVector<winrt::IInspectable> NavigationViewProperties::FooterMenuItems()
+{
+    return ValueHelper<winrt::IVector<winrt::IInspectable>>::CastOrUnbox(static_cast<NavigationView*>(this)->GetValue(s_FooterMenuItemsProperty));
 }
 
 void NavigationViewProperties::Header(winrt::IInspectable const& value)

--- a/dev/Generated/NavigationView.properties.h
+++ b/dev/Generated/NavigationView.properties.h
@@ -30,6 +30,9 @@ public:
     void ExpandedModeThresholdWidth(double value);
     double ExpandedModeThresholdWidth();
 
+    void FooterMenuItems(winrt::IVector<winrt::IInspectable> const& value);
+    winrt::IVector<winrt::IInspectable> FooterMenuItems();
+
     void Header(winrt::IInspectable const& value);
     winrt::IInspectable Header();
 
@@ -121,6 +124,7 @@ public:
     static winrt::DependencyProperty ContentOverlayProperty() { return s_ContentOverlayProperty; }
     static winrt::DependencyProperty DisplayModeProperty() { return s_DisplayModeProperty; }
     static winrt::DependencyProperty ExpandedModeThresholdWidthProperty() { return s_ExpandedModeThresholdWidthProperty; }
+    static winrt::DependencyProperty FooterMenuItemsProperty() { return s_FooterMenuItemsProperty; }
     static winrt::DependencyProperty HeaderProperty() { return s_HeaderProperty; }
     static winrt::DependencyProperty HeaderTemplateProperty() { return s_HeaderTemplateProperty; }
     static winrt::DependencyProperty IsBackButtonVisibleProperty() { return s_IsBackButtonVisibleProperty; }
@@ -157,6 +161,7 @@ public:
     static GlobalDependencyProperty s_ContentOverlayProperty;
     static GlobalDependencyProperty s_DisplayModeProperty;
     static GlobalDependencyProperty s_ExpandedModeThresholdWidthProperty;
+    static GlobalDependencyProperty s_FooterMenuItemsProperty;
     static GlobalDependencyProperty s_HeaderProperty;
     static GlobalDependencyProperty s_HeaderTemplateProperty;
     static GlobalDependencyProperty s_IsBackButtonVisibleProperty;
@@ -236,6 +241,10 @@ public:
         winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnExpandedModeThresholdWidthPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnFooterMenuItemsPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -95,6 +95,7 @@ private:
     bool DoesSelectedItemContainContent(winrt::IInspectable const& item, winrt::NavigationViewItemBase const& itemContainer);
     void ChangeSelectStatusForItem(winrt::IInspectable const& item, bool selected);
     bool IsSettingsItem(winrt::IInspectable const& item);
+    bool IsFooterMenuItem(winrt::IInspectable const& item);
     void UnselectPrevItem(winrt::IInspectable const& prevItem, winrt::IInspectable const& nextItem);
     void UndoSelectionAndRevertSelectionTo(winrt::IInspectable const& prevSelectedItem, winrt::IInspectable const& nextItem);
     void CloseTopNavigationViewFlyout();
@@ -143,7 +144,7 @@ private:
     bool IsTopNavigationView();
     bool IsTopPrimaryListVisible();
 
-    void CreateAndHookEventsToSettings(std::wstring_view settingsName);
+    void CreateAndHookEventsToSettings();
     void OnIsPaneOpenChanged();
     void UpdateHeaderVisibility();
     void UpdateHeaderVisibility(winrt::NavigationViewDisplayMode displayMode);
@@ -161,6 +162,7 @@ private:
     void UpdateTopNavListViewItemSource(const winrt::IInspectable& items);
     void UpdateListViewItemsSource(const winrt::ListView& listView, const winrt::IInspectable& itemsSource);
     void UpdateListViewItemSource();
+    void UpdateFooterListViewItemSource();
     void UpdateSelectionForMenuItems();
     bool m_InitialNonForcedModeUpdate{ true };
 
@@ -230,6 +232,14 @@ private:
             }
         }
 
+        if (auto flv = IsTopNavigationView() ? m_topFooterNavListView.get() : m_leftFooterNavListView.get())
+        {
+            if (auto itemContainer = flv.ContainerFromItem(data))
+            {
+                return itemContainer.try_as<T>();
+            }
+        }
+
         if (auto settingsItem = m_settingsItem.get())
         {
             if (settingsItem == data || settingsItem.Content() == data)
@@ -284,6 +294,8 @@ private:
     tracker_ref<winrt::Button> m_closeButton{ this };
     tracker_ref<winrt::ListView> m_leftNavListView{ this };
     tracker_ref<winrt::ListView> m_topNavListView{ this };
+    tracker_ref<winrt::ListView> m_leftFooterNavListView{ this };
+    tracker_ref<winrt::ListView> m_topFooterNavListView{ this };
     tracker_ref<winrt::Button> m_topNavOverflowButton{ this };
     tracker_ref<winrt::ListView> m_topNavListOverflowView{ this };
     tracker_ref<winrt::Grid> m_topNavGrid{ this };
@@ -321,9 +333,6 @@ private:
 
     // Event Tokens
     winrt::Button::Click_revoker m_paneToggleButtonClickRevoker{};
-    winrt::UIElement::Tapped_revoker m_settingsItemTappedRevoker{};
-    winrt::UIElement::KeyDown_revoker m_settingsItemKeyDownRevoker{};
-    winrt::UIElement::KeyUp_revoker m_settingsItemKeyUpRevoker{};
     winrt::Button::Click_revoker m_paneSearchButtonClickRevoker{};
     winrt::CoreApplicationViewTitleBar::LayoutMetricsChanged_revoker m_titleBarMetricsChangedRevoker{};
     winrt::CoreApplicationViewTitleBar::IsVisibleChanged_revoker m_titleBarIsVisibleChangedRevoker{};
@@ -332,9 +341,15 @@ private:
     winrt::ListView::ItemClick_revoker m_leftNavListViewItemClickRevoker{};
     winrt::ListView::Loaded_revoker m_leftNavListViewLoadedRevoker{};
     winrt::ListView::SelectionChanged_revoker m_leftNavListViewSelectionChangedRevoker{};
+    winrt::ListView::ItemClick_revoker m_leftFooterNavListViewItemClickRevoker{};
+    winrt::ListView::Loaded_revoker m_leftFooterNavListViewLoadedRevoker{};
+    winrt::ListView::SelectionChanged_revoker m_leftFooterNavListViewSelectionChangedRevoker{};
     winrt::ListView::ItemClick_revoker m_topNavListViewItemClickRevoker{};
     winrt::ListView::Loaded_revoker m_topNavListViewLoadedRevoker{};
     winrt::ListView::SelectionChanged_revoker m_topNavListViewSelectionChangedRevoker{};
+    winrt::ListView::ItemClick_revoker m_topFooterNavListViewItemClickRevoker{};
+    winrt::ListView::Loaded_revoker m_topFooterNavListViewLoadedRevoker{};
+    winrt::ListView::SelectionChanged_revoker m_topFooterNavListViewSelectionChangedRevoker{};
     winrt::ListView::SelectionChanged_revoker m_topNavListOverflowViewSelectionChangedRevoker{};
     PropertyChanged_revoker m_splitViewIsPaneOpenChangedRevoker{};
     PropertyChanged_revoker m_splitViewDisplayModeChangedRevoker{};

--- a/dev/NavigationView/NavigationView.idl
+++ b/dev/NavigationView/NavigationView.idl
@@ -159,6 +159,7 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
     [MUX_DEFAULT_VALUE("1008.0")]
     [MUX_PROPERTY_VALIDATION_CALLBACK("CoerceToGreaterThanZero")]
     Double ExpandedModeThresholdWidth { get; set; };
+    Windows.Foundation.Collections.IVector<Object> FooterMenuItems{ get; };
     Windows.UI.Xaml.UIElement PaneFooter { get; set; };
     Object Header { get; set; };
     Windows.UI.Xaml.DataTemplate HeaderTemplate { get; set; };
@@ -195,6 +196,7 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
     static Windows.UI.Xaml.DependencyProperty IsPaneOpenProperty { get; };
     static Windows.UI.Xaml.DependencyProperty CompactModeThresholdWidthProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ExpandedModeThresholdWidthProperty { get; };
+    static Windows.UI.Xaml.DependencyProperty FooterMenuItemsProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty PaneFooterProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HeaderProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; };

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -55,15 +55,6 @@
                                 </VisualState>
                             </VisualStateGroup>
 
-                            <VisualStateGroup x:Name="SettingsGroup">
-                                <VisualState x:Name="SettingsVisible" />
-                                <VisualState x:Name="SettingsCollapsed">
-                                    <VisualState.Setters>
-                                        <Setter Target="SettingsNavPaneItem.Visibility" Value="Collapsed" />
-                                        <Setter Target="SettingsTopNavPaneItem.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
 
                             <VisualStateGroup x:Name="AutoSuggestGroup">
                                 <VisualState x:Name="AutoSuggestBoxVisible" />
@@ -90,10 +81,12 @@
                                 <VisualState x:Name="ListSizeCompact">
                                     <VisualState.Setters>
                                         <Setter Target="MenuItemsHost.HorizontalAlignment" Value="Left"/>
+                                        <Setter Target="FooterMenuItemsHost.HorizontalAlignment" Value="Left"/>
                                         <!-- This is essentially a TemplateBinding: -->
                                         <Setter Target="MenuItemsHost.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>
-                                        <Setter Target="SettingsNavPaneItem.HorizontalAlignment" Value="Left"/>
-                                        <Setter Target="SettingsNavPaneItem.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>
+                                        <Setter Target="FooterMenuItemsHost.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>
+                                        <!--<Setter Target="SettingsNavPaneItem.HorizontalAlignment" Value="Left"/>
+                                        <Setter Target="SettingsNavPaneItem.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>-->
                                         <Setter Target="PaneTitleTextBlock.Visibility" Value="Collapsed" />
                                         <Setter Target="PaneHeaderContentBorder.Visibility" Value="Collapsed" />
                                         <Setter Target="PaneCustomContentBorder.HorizontalAlignment" Value="Left"/>
@@ -144,7 +137,6 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-
                         <Grid
                             x:Name="PaneToggleButtonGrid"
                             Margin="0,0,0,8"
@@ -217,7 +209,7 @@
                                 Background="{ThemeResource NavigationViewTopPaneBackground}"
                                 Grid.Row="0"
                                 HorizontalAlignment="Stretch"
-                                VerticalAlignment="Top"                                
+                                VerticalAlignment="Top"
                                 Canvas.ZIndex="1"
                                 contract4Present:XYFocusKeyboardNavigation="Enabled">
 
@@ -346,15 +338,32 @@
                                         VerticalContentAlignment="Stretch"
                                         HorizontalContentAlignment="Stretch"
                                         Grid.Column="7" />
-                                    <Grid
-                                        Grid.Column="8" >
-                                        <local:NavigationViewItem
-                                            x:Name="SettingsTopNavPaneItem"
-                                            Style="{ThemeResource MUX_NavigationViewSettingsItemStyleWhenOnTopPane}"
-                                            Icon="Setting"/>
 
-                                    </Grid>
-
+                                    <!-- Top footer nav list -->
+                                    <local:NavigationViewList
+                                        AutomationProperties.LandmarkType="Navigation"
+                                        x:Name="TopNavFooterMenuItemsHost"
+                                        Grid.Column="8"
+                                        SelectionMode="Single"
+                                        IsItemClickEnabled="True"
+                                        ItemTemplate="{TemplateBinding MenuItemTemplate}"
+                                        ItemTemplateSelector="{TemplateBinding MenuItemTemplateSelector}"
+                                        ItemContainerStyle="{TemplateBinding MenuItemContainerStyle}"
+                                        ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
+                                        ScrollViewer.HorizontalScrollMode="Disabled"
+                                        ScrollViewer.HorizontalScrollBarVisibility="Hidden"
+                                        ScrollViewer.VerticalScrollMode="Disabled"
+                                        ScrollViewer.VerticalScrollBarVisibility="Hidden"
+                                        SingleSelectionFollowsFocus="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SingleSelectionFollowsFocus}">
+                                        <ListView.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <ItemsStackPanel Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </ListView.ItemsPanel>
+                                        <ListView.ItemContainerTransitions>
+                                            <TransitionCollection />
+                                        </ListView.ItemContainerTransitions>
+                                    </local:NavigationViewList>
                                 </Grid>
                                 <Border
                                     x:Name="TopNavContentOverlayAreaGrid"
@@ -379,12 +388,13 @@
                                         Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.LeftPaneVisibility}">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="0"/> <!-- above button margin + back button space -->                                            
+                                            <RowDefinition Height="0"/> <!-- above button margin + back button space -->
                                             <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" MinHeight="{StaticResource NavigationViewPaneHeaderRowMinHeight}"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="8"/> <!-- above list margin -->
                                             <RowDefinition Height="*"/>
+                                            <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="8"/>
@@ -461,13 +471,20 @@
                                             VerticalContentAlignment="Stretch"
                                             HorizontalContentAlignment="Stretch"
                                             Grid.Row="7" />
-                                        <Grid
-                                            Grid.Row="8">
-                                            <local:NavigationViewItem
-                                            x:Name="SettingsNavPaneItem"
-                                            Icon="Setting"/>
-                                        </Grid>
-
+                                        <!--bottom left nav list-->
+                                        <local:NavigationViewList
+                                            x:Name="FooterMenuItemsHost"
+                                            Grid.Row="8"
+                                            SelectionMode="Single"
+                                            IsItemClickEnabled="True"
+                                            HorizontalAlignment="Stretch"
+                                            SelectedItem="{TemplateBinding SelectedItem}"
+                                            ItemTemplate="{TemplateBinding MenuItemTemplate}"
+                                            ItemTemplateSelector="{TemplateBinding MenuItemTemplateSelector}"
+                                            ItemContainerStyle="{TemplateBinding MenuItemContainerStyle}"
+                                            ItemContainerStyleSelector="{TemplateBinding MenuItemContainerStyleSelector}"
+                                            SingleSelectionFollowsFocus="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SingleSelectionFollowsFocus}">
+                                        </local:NavigationViewList>
                                     </Grid>
                                 </SplitView.Pane>
 

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -85,8 +85,6 @@
                                         <!-- This is essentially a TemplateBinding: -->
                                         <Setter Target="MenuItemsHost.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>
                                         <Setter Target="FooterMenuItemsHost.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>
-                                        <!--<Setter Target="SettingsNavPaneItem.HorizontalAlignment" Value="Left"/>
-                                        <Setter Target="SettingsNavPaneItem.Width" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CompactPaneLength}"/>-->
                                         <Setter Target="PaneTitleTextBlock.Visibility" Value="Collapsed" />
                                         <Setter Target="PaneHeaderContentBorder.Visibility" Value="Collapsed" />
                                         <Setter Target="PaneCustomContentBorder.HorizontalAlignment" Value="Left"/>

--- a/dev/NavigationView/NavigationViewHelper.h
+++ b/dev/NavigationView/NavigationViewHelper.h
@@ -23,6 +23,8 @@ enum class NavigationViewPropagateTarget
     LeftListView,
     TopListView,
     OverflowListView,
+    LeftFooterListView,
+    TopFooterListView,
     All
 };
 
@@ -55,3 +57,4 @@ static constexpr wstring_view c_OnLeftNavigation = L"OnLeftNavigation"sv;
 static constexpr wstring_view c_OnTopNavigationPrimary = L"OnTopNavigationPrimary"sv;
 static constexpr wstring_view c_OnTopNavigationPrimaryReveal = L"OnTopNavigationPrimaryReveal"sv;
 static constexpr wstring_view c_OnTopNavigationOverflow = L"OnTopNavigationOverflow"sv;
+

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -729,7 +729,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="local:NavigationViewItem" x:Key="MUX_NavigationViewSettingsItemStyleWhenOnTopPane">
+    <Style TargetType="local:NavigationViewItem" x:Key="MUX_NavigationViewFooterItemStyleWhenOnTopPane">
         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource NavigationViewItemBorderBrush}" />
@@ -800,11 +800,11 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Rectangle 
-                            x:Name="PointerRectangle" 
+                            x:Name="PointerRectangle"
                             Fill="Transparent" />
-                        <Border		
-                            x:Name="RevealBorder"		
-                            BorderBrush="{TemplateBinding BorderBrush}"		
+                        <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" >
                         </Border>
                         <Grid x:Name="ContentGrid">
@@ -817,7 +817,7 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <Viewbox 
-                                x:Name="IconBox" 
+                                x:Name="IconBox"
                                 Grid.Row="1"
                                 Grid.Column="1"
                                 Height="16"
@@ -836,7 +836,9 @@
             </Setter.Value>
         </Setter>
     </Style>
-    
+
+    <!--<Style TargetType="local:NavigationViewItem" x:Key="MUX_NavigationViewSettingsItemStyleWhenOnTopPane" BasedOn="{StaticResource MUX_NavigationViewFooterItemStyleWhenOnTopPane}"/>-->
+
     <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnTopPane">
         <Setter Property="Template">
             <Setter.Value>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -837,8 +837,6 @@
         </Setter>
     </Style>
 
-    <!--<Style TargetType="local:NavigationViewItem" x:Key="MUX_NavigationViewSettingsItemStyleWhenOnTopPane" BasedOn="{StaticResource MUX_NavigationViewFooterItemStyleWhenOnTopPane}"/>-->
-
     <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnTopPane">
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
Fix #375
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added `FooterMenuItems` property to `NavigationView`. My goal also was not to break current behavior of `NavigationView`.
So i kept both `PaneFooter` and `IsSettingsVisible` propertes. However `SettingsItem` itself now adds to end of `FooterItems` list if `IsSettingsVisible` is true

Only braking change is that SettingsItem now have selection when `PaneDisplayMode` is set to `Top`.
but you can use `SelectsOnInvoked` property to avoid this

## Motivation and Context
Fix #375

## How Has This Been Tested?
manually.
Checked switching between Top and Left PaneMode
SettingsItem Visibility changing
Dynamically updating of FooterMenuItems
SelectedItem Property and ItemInvoked event

## Usege example and screenshots:
``` xml

<muxc:NavigationView x:Name="NavigationView" ItemInvoked="NavigationView_ItemInvoked" IsSettingsVisible="{x:Bind SettingsCheckbox.IsChecked.Value, Mode=OneWay}">
        <muxc:NavigationView.MenuItems>
            <muxc:NavigationViewItem Icon="Audio" Content="Audio"/>
            <muxc:NavigationViewItem Icon="Video" Content="Video"/>
            <muxc:NavigationViewItem Icon="View" Content="View"/>
        </muxc:NavigationView.MenuItems>
        <muxc:NavigationView.FooterMenuItems>
            <muxc:NavigationViewItem Icon="Account" Content="Account" />
        </muxc:NavigationView.FooterMenuItems>
        <muxc:NavigationView.PaneFooter>
            <Grid Background="Red">
                <TextBlock Text="PaneFooter"/>
            </Grid>
        </muxc:NavigationView.PaneFooter>
        <Grid>
            <StackPanel Margin="12">
                <Button Click="Button_Click">
                    Left/Top switch
                </Button>
                <CheckBox x:Name="SettingsCheckbox" Content="IsSettingsVisible" IsChecked="True"/>
                <TextBlock Text="{x:Bind ((muxc:NavigationViewItem)NavigationView.SelectedItem).Content.ToString(), Mode=OneWay}"/>
            </StackPanel>
        </Grid>
    </muxc:NavigationView>

```

![image](https://user-images.githubusercontent.com/3244664/67738855-cddb5600-fa42-11e9-92b9-87adc9fbdd38.png)
![image](https://user-images.githubusercontent.com/3244664/67738897-f06d6f00-fa42-11e9-8d36-8250000f426b.png)
![image](https://user-images.githubusercontent.com/3244664/67738868-daf84500-fa42-11e9-8a90-97b06c7a210b.png)
![image](https://user-images.githubusercontent.com/3244664/67738881-e3e91680-fa42-11e9-8d9d-1002777f04a3.png)



