### PR TITLE
Allow user to page injection for compact.xaml by flag DisableWinUIXamlPageInjection

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -132,7 +132,7 @@
   
   <!-- Make this URI works in framework package "ms-appx:///Microsoft.UI.Xaml/DensityStyles/Compact.xaml" -->
   <ItemGroup>
-    <Page Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml" Condition="'$(DisableWinUIXamlPageInjection)' != 'true'">
       <SubType>Designer</SubType>
       <Link>Microsoft.UI.Xaml\DensityStyles\Compact.xaml</Link>
     </Page>


### PR DESCRIPTION
Allow user to disable inject in C++/CX UWP DLL project. Fix #1512
Example to disable the injection in the project:
```
  <PropertyGroup Label="Globals">
...
    <DisableWinUIXamlPageInjection>true</DisableWinUIXamlPageInjection>
  </PropertyGroup>
```