### PR TITLE
Fix visual bug where chevron would clip with text scaling ~200%

### DIFF
--- a/dev/DropDownButton/DropDownButton.xaml
+++ b/dev/DropDownButton/DropDownButton.xaml
@@ -113,6 +113,7 @@
                                 Text="&#xE70D;"
                                 VerticalAlignment="Center"
                                 Margin="6,0,0,0"
+                                IsTextScaleFactorEnabled="False"
                                 AutomationProperties.AccessibilityView="Raw"/>
                         </Grid>
 

--- a/dev/SplitButton/SplitButton.xaml
+++ b/dev/SplitButton/SplitButton.xaml
@@ -285,6 +285,7 @@
                                     Text="&#xE70D;"
                                     VerticalAlignment="Center"
                                     HorizontalAlignment="Right"
+                                    IsTextScaleFactorEnabled="False"
                                     AutomationProperties.AccessibilityView="Raw"/>
                             </Button.Content>
                         </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `IsTextScaleFactorEnabled="False"` to the chevron textblock of the (toggle)splitbutton.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1519 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually using MUXControlsTestApp.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
Before:
![SplitButtonBefore](https://user-images.githubusercontent.com/16122379/67993946-3abd3e80-fc43-11e9-9d1c-38777ea99d6d.png)
![image](https://user-images.githubusercontent.com/16122379/67993660-262c7680-fc42-11e9-9043-0a1d3de99523.png)

After:
![image](https://user-images.githubusercontent.com/16122379/67993971-59233a00-fc43-11e9-8c1b-359f3c32fc2e.png)
![image](https://user-images.githubusercontent.com/16122379/68025399-ea7ac680-fcac-11e9-9590-9eb2abf4f13f.png)
