### PR TITLE
Fix bug with focused items not being recycled upon ItemsSource reassignment

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -681,6 +681,7 @@ Global
 		dev\PullToRefresh\RefreshContainer\InteractionTests\RefreshContainer_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\PullToRefresh\ScrollViewerIRefreshInfoProviderAdapter\InteractionTests\ScrollViewerAdapter_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\RadioButtons\InteractionTests\RadioButtons_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
+		dev\Repeater\InteractionTests\Repeater_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\RatingControl\InteractionTests\RatingControl_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\Scroller\InteractionTests\Scroller_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\ScrollViewer\InteractionTests\ScrollViewer_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4

--- a/MUXControlsInnerLoop.sln
+++ b/MUXControlsInnerLoop.sln
@@ -478,6 +478,7 @@ Global
 		dev\PullToRefresh\RefreshContainer\InteractionTests\RefreshContainer_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\PullToRefresh\ScrollViewerIRefreshInfoProviderAdapter\InteractionTests\ScrollViewerAdapter_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\RadioButtons\InteractionTests\RadioButtons_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
+		dev\Repeater\InteractionTests\Repeater_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\RatingControl\InteractionTests\RatingControl_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\Scroller\InteractionTests\Scroller_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4
 		dev\ScrollViewer\InteractionTests\ScrollViewer_InteractionTests.projitems*{4d8c5d1b-f982-44a1-b744-dd0e51651bf2}*SharedItemsImports = 4

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -248,7 +248,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 var template = (DataTemplate)XamlReader.Load(
                         @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'> 
-                            <Button AutomationProperties.Name='{Binding}' Content='{Binding}'/>
+                            <Button Content='{Binding}'/>
                         </DataTemplate>");
 
                 repeater = new ItemsRepeater() {

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -239,8 +239,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         public void FocusedItemGetsRecycledUponCollectionReset()
         {
             List<object> ResettingListItems = new List<object> { "item0", "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
-            ItemsRepeater repeater;
-            RunOnUIThread.Execute(() => {
+            ItemsRepeater repeater = null;
+            int index = 4;
+            string removedText = "item" + index; 
+            
+            RunOnUIThread.Execute(() =>
+            {
 
                 var template = (DataTemplate)XamlReader.Load(
                         @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'> 
@@ -259,23 +263,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         Content = repeater
                     }
                 };
-
                 Content.UpdateLayout();
-                
-                Random r = new Random();
-                int index = r.Next(1, 10);
-                string removedText = "item" + index;
+            });
+            
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() => {
+
 
                 Log.Comment("Focusing a button");
                 Button toFocus = (Button)repeater.TryGetElement(index);
-                Verify.AreEqual(removedText,toFocus.Content as string);
+                Verify.AreEqual(removedText, toFocus.Content as string);
                 toFocus.Focus(FocusState.Programmatic);
-                IdleSynchronizer.Wait();
 
                 Log.Comment("Removing element from collection");
                 ResettingListItems.Remove(removedText);
                 ResettingListItems = new List<object>(ResettingListItems);
-                repeater.ItemsSource = ResettingListItems;
+                repeater.ItemsSource = ResettingListItems
+                ;
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() => { 
+
 
                 Log.Comment("Verify rendered elements");
                 bool[] foundButtons = new bool[10];
@@ -303,6 +313,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         Verify.IsTrue(foundButtons[i]);
                     }
                 }
+
             });
         }
 

--- a/dev/Repeater/InteractionTests/RepeaterTests.cs
+++ b/dev/Repeater/InteractionTests/RepeaterTests.cs
@@ -47,17 +47,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             Button navButton = new Button(FindElement.ByName("ItemsRepeater Tests"));
             navButton.InvokeAndWait();
 
-            Wait.ForMilliseconds(1000);
-
             navButton = new Button(FindElement.ByName("Collection Changes Demo"));
             navButton.InvokeAndWait();
 
-            Wait.ForMilliseconds(1000);
-
-
             Random r = new Random();
             int index = r.Next(1, 10);
-            index = 2;
             string elementToRemove = "item" + index;
             Button someRandomElementToRemove = new Button(FindElement.ByName(elementToRemove));
             someRandomElementToRemove.InvokeAndWait();
@@ -68,7 +62,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             for (int i = 0; i < 10; i++)
             {
                 Button currentButton = new Button(FindElement.ByName("item" + i));
-                int buttonIndex = Int32.Parse(currentButton.Name.Replace("item", ""));
+                int buttonIndex = int.Parse(currentButton.Name.Replace("item", ""));
                 foundButtons[buttonIndex] = true;
             }
 

--- a/dev/Repeater/InteractionTests/RepeaterTests.cs
+++ b/dev/Repeater/InteractionTests/RepeaterTests.cs
@@ -3,13 +3,18 @@
 
 using System;
 
+using Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+
+#if USING_TAEF
 using WEX.TestExecution;
 using WEX.TestExecution.Markup;
 using WEX.Logging.Interop;
-
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
-using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
-using Windows.Foundation.Metadata;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+#endif
 
 using Microsoft.Windows.Apps.Test.Automation;
 using Microsoft.Windows.Apps.Test.Foundation;
@@ -22,6 +27,64 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
     [TestClass]
     public class RepeaterTests
     {
-        // Placeholder for interaction tests
+        [ClassInitialize]
+        [TestProperty("RunAs", "User")]
+        [TestProperty("Classification", "Integration")]
+        [TestProperty("TestPass:IncludeOnlyOn", "Desktop")]
+        public static void ClassInitialize(TestContext testContext)
+        {
+            TestEnvironment.Initialize(testContext);
+        }
+
+        public void TestCleanup()
+        {
+            TestCleanupHelper.Cleanup();
+        }
+
+        [TestMethod]
+        public void FocusedItemGetsRecycledUponCollectionReset()
+        {
+            Button navButton = new Button(FindElement.ByName("ItemsRepeater Tests"));
+            navButton.InvokeAndWait();
+
+            Wait.ForMilliseconds(1000);
+
+            navButton = new Button(FindElement.ByName("Collection Changes Demo"));
+            navButton.InvokeAndWait();
+
+            Wait.ForMilliseconds(1000);
+
+
+            Random r = new Random();
+            int index = r.Next(1, 10);
+            index = 2;
+            string elementToRemove = "item" + index;
+            Button someRandomElementToRemove = new Button(FindElement.ByName(elementToRemove));
+            someRandomElementToRemove.InvokeAndWait();
+
+            bool[] foundButtons = new bool[10];
+
+            // Save all buttons we found
+            for (int i = 0; i < 10; i++)
+            {
+                Button currentButton = new Button(FindElement.ByName("item" + i));
+                int buttonIndex = Int32.Parse(currentButton.Name.Replace("item", ""));
+                foundButtons[buttonIndex] = true;
+            }
+
+            // Check if every button is present EXCEPT the randomly selected and thus removed button
+            for(int i = 0; i < 10; i++)
+            {
+                if(i == index)
+                {
+                    Verify.IsFalse(foundButtons[i]);
+                }
+                else
+                {
+                    Verify.IsTrue(foundButtons[i]);
+                }
+            }
+        }
+
     }
 }

--- a/dev/Repeater/InteractionTests/RepeaterTests.cs
+++ b/dev/Repeater/InteractionTests/RepeaterTests.cs
@@ -40,45 +40,5 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             TestCleanupHelper.Cleanup();
         }
-
-        [TestMethod]
-        public void FocusedItemGetsRecycledUponCollectionReset()
-        {
-            Button navButton = new Button(FindElement.ByName("ItemsRepeater Tests"));
-            navButton.InvokeAndWait();
-
-            navButton = new Button(FindElement.ByName("Collection Changes Demo"));
-            navButton.InvokeAndWait();
-
-            Random r = new Random();
-            int index = r.Next(1, 10);
-            string elementToRemove = "item" + index;
-            Button someRandomElementToRemove = new Button(FindElement.ByName(elementToRemove));
-            someRandomElementToRemove.InvokeAndWait();
-
-            bool[] foundButtons = new bool[10];
-
-            // Save all buttons we found
-            for (int i = 0; i < 10; i++)
-            {
-                Button currentButton = new Button(FindElement.ByName("item" + i));
-                int buttonIndex = int.Parse(currentButton.Name.Replace("item", ""));
-                foundButtons[buttonIndex] = true;
-            }
-
-            // Check if every button is present EXCEPT the randomly selected and thus removed button
-            for(int i = 0; i < 10; i++)
-            {
-                if(i == index)
-                {
-                    Verify.IsFalse(foundButtons[i]);
-                }
-                else
-                {
-                    Verify.IsTrue(foundButtons[i]);
-                }
-            }
-        }
-
     }
 }

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include <pch.h>
@@ -525,6 +525,12 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
                 -1 /* newIndex */,
                 -1 /* oldIndex */);
             args.Action();
+            m_processingItemsSourceChange.set(args);
+            auto processingChange = gsl::finally([this]()
+                {
+                    m_processingItemsSourceChange.set(nullptr);
+                });
+
             virtualLayout.OnItemsChangedCore(GetLayoutContext(), newValue, args);
         }
         else if (auto nonVirtualLayout = layout.try_as<winrt::NonVirtualizingLayout>())

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -16,21 +16,21 @@
         </Grid.Resources>
 
         <StackPanel>
-            <Button x:Name="defaultDemo" >Default Demo</Button>
-            <Button x:Name="basicDemo" >Basic Demo</Button>
-            <Button x:Name="itemsSourceDemo" >ItemsSource Demo</Button>
-            <Button x:Name="itemTemplateDemo" >ItemTemplate Demo</Button>
-            <Button x:Name="collectionChangeDemo" >Collection Changes Demo</Button>
-            <Button x:Name="animationsDemo" >Animations Demo</Button>
-            <Button x:Name="circleLayoutDemo">Circle Layout Demo</Button>
-            <Button x:Name="activityFeedLayoutDemo">Xbox Activity Feed Layout Demo</Button>
-            <Button x:Name="nonVirtualStackLayoutDemo">Non Virtual Stack Layout Demo</Button>
-            <Button x:Name="virtualFixedStackLayoutDemo">Virtual Fixed Stack Layout Demo</Button>
-            <Button x:Name="virtualStackLayoutDemo">Virtual Variable Stack Layout Demo (Estimated)</Button>
-            <Button x:Name="pinterestLayoutDemo">Pinterest Layout Demo</Button>
-            <Button x:Name="flowLayoutDemo">Flow Layout Demo</Button>
-            <Button x:Name="storeDemo">Store demo</Button>
-            <Button x:Name="animatedScrollDemo">Animated scroll demo</Button>
+            <Button x:Name="defaultDemo" AutomationProperties.Name="Default Demo" >Default Demo</Button>
+            <Button x:Name="basicDemo" AutomationProperties.Name="Basic Demo">Basic Demo</Button>
+            <Button x:Name="itemsSourceDemo" AutomationProperties.Name="ItemsSource Demo">ItemsSource Demo</Button>
+            <Button x:Name="itemTemplateDemo" AutomationProperties.Name="ItemTemplate Demo">ItemTemplate Demo</Button>
+            <Button x:Name="collectionChangeDemo" AutomationProperties.Name="Collection Changes Demo" >Collection Changes Demo</Button>
+            <Button x:Name="animationsDemo" AutomationProperties.Name="Animations Demo">Animations Demo</Button>
+            <Button x:Name="circleLayoutDemo" AutomationProperties.Name="Circle Layout Demo">Circle Layout Demo</Button>
+            <Button x:Name="activityFeedLayoutDemo" AutomationProperties.Name="Xbox Activity Feed Layout Demo">Xbox Activity Feed Layout Demo</Button>
+            <Button x:Name="nonVirtualStackLayoutDemo" AutomationProperties.Name="Non virtual Stack Layout Demo">Non Virtual Stack Layout Demo</Button>
+            <Button x:Name="virtualFixedStackLayoutDemo" AutomationProperties.Name="Virtual Fixed Stack Layout Demo">Virtual Fixed Stack Layout Demo</Button>
+            <Button x:Name="virtualStackLayoutDemo" AutomationProperties.Name="Virtual Variable Stack Layout Demo (Estimated)">Virtual Variable Stack Layout Demo (Estimated)</Button>
+            <Button x:Name="pinterestLayoutDemo" AutomationProperties.Name="Pinterest Layout Demo">Pinterest Layout Demo</Button>
+            <Button x:Name="flowLayoutDemo" AutomationProperties.Name="Flow Layout Demo">Flow Layout Demo</Button>
+            <Button x:Name="storeDemo" AutomationProperties.Name="Store demo">Store demo</Button>
+            <Button x:Name="animatedScrollDemo" AutomationProperties.Name="Animated scroll demo">Animated scroll demo</Button>
             <TextBlock>Selection Demo</TextBlock>
             <StackPanel Orientation="Horizontal">
                 <Button x:Name="flatSelectionDemo">Flat</Button>

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
@@ -66,8 +66,7 @@
             <controls:ItemsRepeater.ItemTemplate>
                 <DataTemplate>
                     <Grid Width="300" HorizontalAlignment="Left">
-                        <TextBlock Text="{Binding}"/>
-                        <Button Width="40" Height="40" HorizontalAlignment="Right" AutomationProperties.Name="{Binding}"
+                        <Button Width="140" Height="40" HorizontalAlignment="Right" AutomationProperties.Name="{Binding}"
                                 Click="ResettingCollectionRemoveItemButton_ItemClick" Content="{Binding}"/>
                     </Grid>
                 </DataTemplate>

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
@@ -23,6 +23,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+
         </Grid.RowDefinitions>
         <StackPanel Orientation="Vertical">
             <StackPanel Orientation="Horizontal">
@@ -59,5 +61,17 @@
                 </controls:ItemsRepeater>
             </ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
+        
+        <controls:ItemsRepeater ItemsSource="{x:Bind ResettingListItems, Mode=OneWay}" Grid.Row="2" x:Name="ResettingCollectionRepeater">
+            <controls:ItemsRepeater.ItemTemplate>
+                <DataTemplate>
+                    <Grid Width="300" HorizontalAlignment="Left">
+                        <TextBlock Text="{Binding}"/>
+                        <Button Width="40" Height="40" HorizontalAlignment="Right" AutomationProperties.Name="{Binding}"
+                                Click="ResettingCollectionRemoveItemButton_ItemClick" Content="{Binding}"/>
+                    </Grid>
+                </DataTemplate>
+            </controls:ItemsRepeater.ItemTemplate>
+        </controls:ItemsRepeater>
     </Grid>
 </Page>

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml.cs
@@ -18,7 +18,7 @@ namespace MUXControlsTestApp.Samples
     public sealed partial class CollectionChangeDemo : Page
     {
         MyDataSource _dataSource = new MyDataSource(Enumerable.Range(0, 10).Select(i => i.ToString()).ToList());
-        public List<object> ResettingListItems { get; set; } = new List<object> { "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9", "item10" };
+        public List<object> ResettingListItems { get; set; } = new List<object> { "item0","item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
         public CollectionChangeDemo()
         {
             this.InitializeComponent();

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml.cs
@@ -18,6 +18,7 @@ namespace MUXControlsTestApp.Samples
     public sealed partial class CollectionChangeDemo : Page
     {
         MyDataSource _dataSource = new MyDataSource(Enumerable.Range(0, 10).Select(i => i.ToString()).ToList());
+        public List<object> ResettingListItems { get; set; } = new List<object> { "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9", "item10" };
         public CollectionChangeDemo()
         {
             this.InitializeComponent();
@@ -36,6 +37,12 @@ namespace MUXControlsTestApp.Samples
             args.TemplateKey = (int.Parse(args.DataContext.ToString()) % 2 == 0) ? "even" : "odd";
         }
 
+        private void ResettingCollectionRemoveItemButton_ItemClick(object sender, RoutedEventArgs e)
+        {
+            ResettingListItems.Remove((sender as Button).Content);
+            ResettingListItems = new List<object>(ResettingListItems);
+            ResettingCollectionRepeater.ItemsSource = ResettingListItems;
+        }
         private void OnItemClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             int index = repeater.GetElementIndex(sender as UIElement);

--- a/test/MUXControls.Test/MUXControls.Test.Shared.targets
+++ b/test/MUXControls.Test/MUXControls.Test.Shared.targets
@@ -24,6 +24,7 @@
   <Import Project="..\..\dev\CommandBarFlyout\InteractionTests\CommandBarFlyout_InteractionTests.projitems" Label="Shared" Condition="$(FeatureCommandBarFlyoutEnabled) == 'true'" />
   <Import Project="..\..\dev\CommonStyles\InteractionTests\CommonStyles_InteractionTests.projitems" Label="Shared" Condition="$(FeatureCommonStylesEnabled) == 'true'" />  
   <Import Project="..\..\dev\RadioButtons\InteractionTests\RadioButtons_InteractionTests.projitems" Label="Shared" Condition="$(FeatureRadioButtonsEnabled) == 'true'" />
+  <Import Project="..\..\dev\Repeater\InteractionTests\Repeater_InteractionTests.projitems" Label="Shared" Condition="$(FeatureRadioButtonsEnabled) == 'true'" />
   <Import Project="..\..\dev\RadioMenuFlyoutItem\InteractionTests\RadioMenuFlyoutItem_InteractionTests.projitems" Label="Shared" Condition="$(FeatureRadioMenuFlyoutItemEnabled) == 'true'" />
   <Import Project="..\..\dev\TeachingTip\InteractionTests\TeachingTip_InteractionTests.projitems" Label="Shared" Condition="$(FeatureTeachingTipEnabled) == 'true'" />
   <Import Project="..\..\dev\AnimatedVisualPlayer\InteractionTests\AnimatedVisualPlayer_InteractionTests.projitems" Label="Shared" Condition="$(FeatureAnimatedVisualPlayerEnabled) == 'true'" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added call of m_processingItemsChange to OnDataSourcePropertyChanged.
Also added some test UI for this bug and added an interaction test (that is why a bit more files were modified).

I did not use TestSetupHelper, because somehow I was not able to navigate to the correct page with it. The solution with the buttons works however. I also made the test select an element at random to prevent any "hardcoded" fix (e.g. only update the x-th item).

Thank you @ad1Dima for pointing out what to fix!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1447.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually and through newly added unit test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->