### PR TITLE
Replace nuget.org feed with MUX-Dependencies feed

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -64,7 +64,7 @@ jobs:
         <configuration>
           <packageSources>
             <clear />
-            <add key='NuGet official package source' value='https://api.nuget.org/v3/index.json' />
+            <add key='MUX-Dependencies' value='https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json' />
             <add key='dotnetfeed' value='https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json' />
             <add key='local' value='${{parameters.pkgArtifactPath}}'/>
           </packageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,11 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+
+    <!-- do not add new sources to this file. If new packages are required, push them to one of these feeds. -->
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
+
     <add key="localpackages" value="localpackages" />
   </packageSources>
 </configuration>

--- a/test/MUXControlsReleaseTest/nuget.config
+++ b/test/MUXControlsReleaseTest/nuget.config
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    <clear />
+
+    <!-- do not add new sources to this file. If new packages are required, push them to one of these feeds. -->
     <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
+    
     <add key="local" value="localpackages" />
   </packageSources>
 </configuration>

--- a/tools/PublishPackageToArcade/nuget.config
+++ b/tools/PublishPackageToArcade/nuget.config
@@ -1,8 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <clear />
+    
+    <!-- do not add new sources to this file. If new packages are required, push them to one of these feeds. -->
+    <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
     <add key="MUXControls" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/DEPControls/nuget/v3/index.json" />
+    <add key="dotnetfeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    
   </packageSources>
 </configuration>


### PR DESCRIPTION
It is preferable to not depend on nuget.org directly for build time dependencies. I have created a MUX-Dependencies feed that we can use instead.