### PR TITLE
Refine ProgressBar Animation

### DIFF
--- a/dev/Generated/ProgressBarTemplateSettings.properties.cpp
+++ b/dev/Generated/ProgressBarTemplateSettings.properties.cpp
@@ -10,6 +10,7 @@ CppWinRTActivatableClassWithDPFactory(ProgressBarTemplateSettings)
 
 GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_ClipRectProperty{ nullptr };
 GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_ContainerAnimationEndPositionProperty{ nullptr };
+GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_IndicatorLengthDeltaProperty{ nullptr };
 
 ProgressBarTemplateSettingsProperties::ProgressBarTemplateSettingsProperties()
 {
@@ -40,12 +41,24 @@ void ProgressBarTemplateSettingsProperties::EnsureProperties()
                 ValueHelper<double>::BoxedDefaultValue(),
                 nullptr);
     }
+    if (!s_IndicatorLengthDeltaProperty)
+    {
+        s_IndicatorLengthDeltaProperty =
+            InitializeDependencyProperty(
+                L"IndicatorLengthDelta",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::ProgressBarTemplateSettings>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxedDefaultValue(),
+                nullptr);
+    }
 }
 
 void ProgressBarTemplateSettingsProperties::ClearProperties()
 {
     s_ClipRectProperty = nullptr;
     s_ContainerAnimationEndPositionProperty = nullptr;
+    s_IndicatorLengthDeltaProperty = nullptr;
 }
 
 void ProgressBarTemplateSettingsProperties::ClipRect(winrt::RectangleGeometry const& value)
@@ -66,4 +79,14 @@ void ProgressBarTemplateSettingsProperties::ContainerAnimationEndPosition(double
 double ProgressBarTemplateSettingsProperties::ContainerAnimationEndPosition()
 {
     return ValueHelper<double>::CastOrUnbox(static_cast<ProgressBarTemplateSettings*>(this)->GetValue(s_ContainerAnimationEndPositionProperty));
+}
+
+void ProgressBarTemplateSettingsProperties::IndicatorLengthDelta(double value)
+{
+    static_cast<ProgressBarTemplateSettings*>(this)->SetValue(s_IndicatorLengthDeltaProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+}
+
+double ProgressBarTemplateSettingsProperties::IndicatorLengthDelta()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<ProgressBarTemplateSettings*>(this)->GetValue(s_IndicatorLengthDeltaProperty));
 }

--- a/dev/Generated/ProgressBarTemplateSettings.properties.cpp
+++ b/dev/Generated/ProgressBarTemplateSettings.properties.cpp
@@ -10,6 +10,7 @@ CppWinRTActivatableClassWithDPFactory(ProgressBarTemplateSettings)
 
 GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_ClipRectProperty{ nullptr };
 GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_ContainerAnimationEndPositionProperty{ nullptr };
+GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_ContainerAnimationStartPositionProperty{ nullptr };
 GlobalDependencyProperty ProgressBarTemplateSettingsProperties::s_IndicatorLengthDeltaProperty{ nullptr };
 
 ProgressBarTemplateSettingsProperties::ProgressBarTemplateSettingsProperties()
@@ -41,6 +42,17 @@ void ProgressBarTemplateSettingsProperties::EnsureProperties()
                 ValueHelper<double>::BoxedDefaultValue(),
                 nullptr);
     }
+    if (!s_ContainerAnimationStartPositionProperty)
+    {
+        s_ContainerAnimationStartPositionProperty =
+            InitializeDependencyProperty(
+                L"ContainerAnimationStartPosition",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::ProgressBarTemplateSettings>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxedDefaultValue(),
+                nullptr);
+    }
     if (!s_IndicatorLengthDeltaProperty)
     {
         s_IndicatorLengthDeltaProperty =
@@ -58,6 +70,7 @@ void ProgressBarTemplateSettingsProperties::ClearProperties()
 {
     s_ClipRectProperty = nullptr;
     s_ContainerAnimationEndPositionProperty = nullptr;
+    s_ContainerAnimationStartPositionProperty = nullptr;
     s_IndicatorLengthDeltaProperty = nullptr;
 }
 
@@ -79,6 +92,16 @@ void ProgressBarTemplateSettingsProperties::ContainerAnimationEndPosition(double
 double ProgressBarTemplateSettingsProperties::ContainerAnimationEndPosition()
 {
     return ValueHelper<double>::CastOrUnbox(static_cast<ProgressBarTemplateSettings*>(this)->GetValue(s_ContainerAnimationEndPositionProperty));
+}
+
+void ProgressBarTemplateSettingsProperties::ContainerAnimationStartPosition(double value)
+{
+    static_cast<ProgressBarTemplateSettings*>(this)->SetValue(s_ContainerAnimationStartPositionProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+}
+
+double ProgressBarTemplateSettingsProperties::ContainerAnimationStartPosition()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<ProgressBarTemplateSettings*>(this)->GetValue(s_ContainerAnimationStartPositionProperty));
 }
 
 void ProgressBarTemplateSettingsProperties::IndicatorLengthDelta(double value)

--- a/dev/Generated/ProgressBarTemplateSettings.properties.h
+++ b/dev/Generated/ProgressBarTemplateSettings.properties.h
@@ -15,11 +15,16 @@ public:
     void ContainerAnimationEndPosition(double value);
     double ContainerAnimationEndPosition();
 
+    void IndicatorLengthDelta(double value);
+    double IndicatorLengthDelta();
+
     static winrt::DependencyProperty ClipRectProperty() { return s_ClipRectProperty; }
     static winrt::DependencyProperty ContainerAnimationEndPositionProperty() { return s_ContainerAnimationEndPositionProperty; }
+    static winrt::DependencyProperty IndicatorLengthDeltaProperty() { return s_IndicatorLengthDeltaProperty; }
 
     static GlobalDependencyProperty s_ClipRectProperty;
     static GlobalDependencyProperty s_ContainerAnimationEndPositionProperty;
+    static GlobalDependencyProperty s_IndicatorLengthDeltaProperty;
 
     static void EnsureProperties();
     static void ClearProperties();

--- a/dev/Generated/ProgressBarTemplateSettings.properties.h
+++ b/dev/Generated/ProgressBarTemplateSettings.properties.h
@@ -15,15 +15,20 @@ public:
     void ContainerAnimationEndPosition(double value);
     double ContainerAnimationEndPosition();
 
+    void ContainerAnimationStartPosition(double value);
+    double ContainerAnimationStartPosition();
+
     void IndicatorLengthDelta(double value);
     double IndicatorLengthDelta();
 
     static winrt::DependencyProperty ClipRectProperty() { return s_ClipRectProperty; }
     static winrt::DependencyProperty ContainerAnimationEndPositionProperty() { return s_ContainerAnimationEndPositionProperty; }
+    static winrt::DependencyProperty ContainerAnimationStartPositionProperty() { return s_ContainerAnimationStartPositionProperty; }
     static winrt::DependencyProperty IndicatorLengthDeltaProperty() { return s_IndicatorLengthDeltaProperty; }
 
     static GlobalDependencyProperty s_ClipRectProperty;
     static GlobalDependencyProperty s_ContainerAnimationEndPositionProperty;
+    static GlobalDependencyProperty s_ContainerAnimationStartPositionProperty;
     static GlobalDependencyProperty s_IndicatorLengthDeltaProperty;
 
     static void EnsureProperties();

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -70,11 +70,7 @@ void ProgressBar::UpdateStates()
 {
     m_shouldUpdateWidthBasedTemplateSettings = false;
 
-    if (m_isUpdating)
-    {
-        winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true);
-    }
-    else if (ShowError())
+    if (ShowError())
     {
         winrt::VisualStateManager::GoToState(*this, s_ErrorStateName, true);
     }
@@ -112,8 +108,7 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             const double minimum = Minimum();
             const auto padding = Padding();
 
-            m_isUpdating = true; // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition in ProgressBar.xaml when reverting back to previous state
-            UpdateStates();
+            winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true); // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition in ProgressBar.xaml when reverting back to previous state
 
             if (IsIndeterminate())
             {
@@ -132,9 +127,8 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             {
                 progressBarIndicator.Width(0); // Error
             }
-
-            m_isUpdating = false; // Reverts back to previous state
-            UpdateStates();
+           
+            UpdateStates(); // Reverts back to previous state
         }
     }
 }

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -40,11 +40,7 @@ void ProgressBar::OnApplyTemplate()
 void ProgressBar::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&)
 {
     SetProgressBarIndicatorWidth();
-
-    if (m_shouldUpdateWidthBasedTemplateSettings)
-    {
-        UpdateWidthBasedTemplateSettings();
-    }
+    UpdateWidthBasedTemplateSettings();
 }
 
 void ProgressBar::OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
@@ -116,7 +112,11 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             m_isUpdating = true; // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition in ProgressBar.xaml when reverting back to previous state
             UpdateStates();
 
-            if (std::abs(maximum - minimum) > DBL_EPSILON)
+            if (IsIndeterminate())
+            {
+                progressBarIndicator.Width(progressBarWidth * 0.4);
+            }
+            else if (std::abs(maximum - minimum) > DBL_EPSILON)
             {
                 const double maxIndicatorWidth = progressBarWidth - (padding.Left + padding.Right);
                 const double increment = maxIndicatorWidth / (maximum - minimum);
@@ -149,8 +149,6 @@ void ProgressBar::UpdateWidthBasedTemplateSettings()
             }
             return std::make_tuple(0.0f, 0.0f);
         }();
-
-        progressBarIndicator.Width(width / 3);
 
         templateSettings->ContainerAnimationEndPosition(width);
 

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -39,34 +39,24 @@ void ProgressBar::OnApplyTemplate()
 
 void ProgressBar::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&)
 {
-    m_isUpdating = true;
-    UpdateStates();
     SetProgressBarIndicatorWidth();
 
     if (m_shouldUpdateWidthBasedTemplateSettings)
     {
         UpdateWidthBasedTemplateSettings();
     }
-
-    m_isUpdating = false;
-    UpdateStates();
 }
 
 void ProgressBar::OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
 {
     // NOTE: This hits when the Value property changes, because we called RegisterPropertyChangedCallback.
-    m_isUpdating = true;
-    UpdateStates();
     SetProgressBarIndicatorWidth();
-
-    m_isUpdating = false;
-    UpdateStates();
 }
 
 void ProgressBar::OnIsIndeterminatePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
     // NOTE: This hits when IsIndeterminate changes because we set MUX_PROPERTY_CHANGED_CALLBACK to true in the idl.
-
+    SetProgressBarIndicatorWidth();
     UpdateStates();
 }
 
@@ -108,12 +98,7 @@ void ProgressBar::UpdateStates()
     }
     else if (!IsIndeterminate())
     {
-        m_isUpdating = true;
-        UpdateStates();
-        SetProgressBarIndicatorWidth();
         winrt::VisualStateManager::GoToState(*this, s_DeterminateStateName, true);
-
-        m_isUpdating = false;
     }
 }
 
@@ -128,6 +113,9 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             const double minimum = Minimum();
             const auto padding = Padding();
 
+            m_isUpdating = true; // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition in ProgressBar.xaml when reverting back to previous state
+            UpdateStates();
+
             if (std::abs(maximum - minimum) > DBL_EPSILON)
             {
                 const double maxIndicatorWidth = progressBarWidth - (padding.Left + padding.Right);
@@ -138,6 +126,9 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             {
                 progressBarIndicator.Width(0); // Error
             }
+
+            m_isUpdating = false; // Reverts back to previous state
+            UpdateStates();
         }
     }
 }

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -39,18 +39,28 @@ void ProgressBar::OnApplyTemplate()
 
 void ProgressBar::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&)
 {
+    m_isUpdating = true;
+    UpdateStates();
     SetProgressBarIndicatorWidth();
+
     if (m_shouldUpdateWidthBasedTemplateSettings)
     {
         UpdateWidthBasedTemplateSettings();
     }
+
+    m_isUpdating = false;
+    UpdateStates();
 }
 
 void ProgressBar::OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
 {
     // NOTE: This hits when the Value property changes, because we called RegisterPropertyChangedCallback.
-
+    m_isUpdating = true;
+    UpdateStates();
     SetProgressBarIndicatorWidth();
+
+    m_isUpdating = false;
+    UpdateStates();
 }
 
 void ProgressBar::OnIsIndeterminatePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -73,7 +83,12 @@ void ProgressBar::OnShowErrorPropertyChanged(const winrt::DependencyPropertyChan
 void ProgressBar::UpdateStates()
 {
     m_shouldUpdateWidthBasedTemplateSettings = false;
-    if (ShowError())
+
+    if (m_isUpdating)
+    {
+        winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true);
+    }
+    else if (ShowError())
     {
         winrt::VisualStateManager::GoToState(*this, s_ErrorStateName, true);
     }
@@ -93,8 +108,12 @@ void ProgressBar::UpdateStates()
     }
     else if (!IsIndeterminate())
     {
+        m_isUpdating = true;
+        UpdateStates();
         SetProgressBarIndicatorWidth();
         winrt::VisualStateManager::GoToState(*this, s_DeterminateStateName, true);
+
+        m_isUpdating = false;
     }
 }
 

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -39,8 +39,8 @@ void ProgressBar::OnApplyTemplate()
 
 void ProgressBar::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&)
 {
-    SetProgressBarIndicatorWidth();
     UpdateWidthBasedTemplateSettings();
+    SetProgressBarIndicatorWidth();
 }
 
 void ProgressBar::OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
@@ -100,6 +100,8 @@ void ProgressBar::UpdateStates()
 
 void ProgressBar::SetProgressBarIndicatorWidth()
 {
+    const auto templateSettings = winrt::get_self<::ProgressBarTemplateSettings>(TemplateSettings());
+
     if (auto&& progressBar = m_layoutRoot.get())
     {
         if (auto&& progressBarIndicator = m_progressBarIndicator.get())
@@ -118,9 +120,16 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             }
             else if (std::abs(maximum - minimum) > DBL_EPSILON)
             {
+                const double prevIndicatorWidth = progressBarIndicator.ActualWidth();
+
                 const double maxIndicatorWidth = progressBarWidth - (padding.Left + padding.Right);
                 const double increment = maxIndicatorWidth / (maximum - minimum);
-                progressBarIndicator.Width(increment * (Value() - minimum));
+                const double indicatorWidth = increment * (Value() - minimum);
+
+                const double widthDelta = (indicatorWidth - prevIndicatorWidth);
+                templateSettings->IndicatorLengthDelta(-widthDelta);
+
+                progressBarIndicator.Width(indicatorWidth);
             }
             else
             {
@@ -139,7 +148,7 @@ void ProgressBar::UpdateWidthBasedTemplateSettings()
 
     if (auto&& progressBarIndicator = m_progressBarIndicator.get())
     {
-        auto const [width, height] = [progressBar = m_layoutRoot.get()]()
+        const auto [width, height] = [ progressBar = m_layoutRoot.get()]()
         {
             if (progressBar)
             {

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -39,8 +39,8 @@ void ProgressBar::OnApplyTemplate()
 
 void ProgressBar::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&)
 {
-    UpdateWidthBasedTemplateSettings();
     SetProgressBarIndicatorWidth();
+    UpdateWidthBasedTemplateSettings();
 }
 
 void ProgressBar::OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
@@ -53,7 +53,7 @@ void ProgressBar::OnIsIndeterminatePropertyChanged(const winrt::DependencyProper
 {
     // NOTE: This hits when IsIndeterminate changes because we set MUX_PROPERTY_CHANGED_CALLBACK to true in the idl.
     SetProgressBarIndicatorWidth();
-    UpdateStates();
+    UpdateStates(); 
 }
 
 void ProgressBar::OnShowPausedPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -124,7 +124,7 @@ void ProgressBar::SetProgressBarIndicatorWidth()
                 const double maxIndicatorWidth = progressBarWidth - (padding.Left + padding.Right);
                 const double increment = maxIndicatorWidth / (maximum - minimum);
                 const double indicatorWidth = increment * (Value() - minimum);
-                const double widthDelta = (indicatorWidth - prevIndicatorWidth);
+                const double widthDelta = indicatorWidth - prevIndicatorWidth;
                 templateSettings->IndicatorLengthDelta(-widthDelta);
                 progressBarIndicator.Width(indicatorWidth);
             }
@@ -145,20 +145,19 @@ void ProgressBar::UpdateWidthBasedTemplateSettings()
 
     if (auto&& progressBarIndicator = m_progressBarIndicator.get())
     {
-        const auto [width, height, indicatorWidth] = [progressBarIndicator, progressBar = m_layoutRoot.get()]()
+        const auto [width, height] = [progressBar = m_layoutRoot.get()]()
         {
             if (progressBar)
             {
                 const float width = static_cast<float>(progressBar.ActualWidth());
                 const float height = static_cast<float>(progressBar.ActualHeight());
-                const float indicatorWidth = static_cast<float>(progressBarIndicator.ActualHeight());
-                return std::make_tuple(width, height, indicatorWidth);
+                return std::make_tuple(width, height);
             }
-            return std::make_tuple(0.0f, 0.0f, 0.0f);
+            return std::make_tuple(0.0f, 0.0f);
         }();
 
-        templateSettings->ContainerAnimationStartPosition(-indicatorWidth);
-        templateSettings->ContainerAnimationEndPosition(width + indicatorWidth);
+        templateSettings->ContainerAnimationStartPosition(width * -0.4);
+        templateSettings->ContainerAnimationEndPosition(width);
 
         const auto rectangle = [width, height, padding = Padding()]()
         {

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -108,7 +108,9 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             const double minimum = Minimum();
             const auto padding = Padding();
 
-            winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true); // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition in ProgressBar.xaml when reverting back to previous state
+            // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition
+            // in ProgressBar.xaml when reverting back to previous state
+            winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true); 
 
             if (IsIndeterminate())
             {
@@ -150,7 +152,9 @@ void ProgressBar::UpdateWidthBasedTemplateSettings()
             return std::make_tuple(0.0f, 0.0f);
         }();
 
-        templateSettings->ContainerAnimationStartPosition(width * -0.4);
+        const double indicatorWidthMultiplier = -0.4;
+
+        templateSettings->ContainerAnimationStartPosition(width * indicatorWidthMultiplier);
         templateSettings->ContainerAnimationEndPosition(width);
 
         const auto rectangle = [width, height, padding = Padding()]()

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -107,6 +107,7 @@ void ProgressBar::SetProgressBarIndicatorWidth()
         if (auto&& progressBarIndicator = m_progressBarIndicator.get())
         {
             const double progressBarWidth = progressBar.ActualWidth();
+            const double prevIndicatorWidth = progressBarIndicator.ActualWidth();
             const double maximum = Maximum();
             const double minimum = Minimum();
             const auto padding = Padding();
@@ -120,15 +121,11 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             }
             else if (std::abs(maximum - minimum) > DBL_EPSILON)
             {
-                const double prevIndicatorWidth = progressBarIndicator.ActualWidth();
-
                 const double maxIndicatorWidth = progressBarWidth - (padding.Left + padding.Right);
                 const double increment = maxIndicatorWidth / (maximum - minimum);
                 const double indicatorWidth = increment * (Value() - minimum);
-
                 const double widthDelta = (indicatorWidth - prevIndicatorWidth);
                 templateSettings->IndicatorLengthDelta(-widthDelta);
-
                 progressBarIndicator.Width(indicatorWidth);
             }
             else
@@ -148,18 +145,20 @@ void ProgressBar::UpdateWidthBasedTemplateSettings()
 
     if (auto&& progressBarIndicator = m_progressBarIndicator.get())
     {
-        const auto [width, height] = [ progressBar = m_layoutRoot.get()]()
+        const auto [width, height, indicatorWidth] = [progressBarIndicator, progressBar = m_layoutRoot.get()]()
         {
             if (progressBar)
             {
                 const float width = static_cast<float>(progressBar.ActualWidth());
                 const float height = static_cast<float>(progressBar.ActualHeight());
-                return std::make_tuple(width, height);
+                const float indicatorWidth = static_cast<float>(progressBarIndicator.ActualHeight());
+                return std::make_tuple(width, height, indicatorWidth);
             }
-            return std::make_tuple(0.0f, 0.0f);
+            return std::make_tuple(0.0f, 0.0f, 0.0f);
         }();
 
-        templateSettings->ContainerAnimationEndPosition(width);
+        templateSettings->ContainerAnimationStartPosition(-indicatorWidth);
+        templateSettings->ContainerAnimationEndPosition(width + indicatorWidth);
 
         const auto rectangle = [width, height, padding = Padding()]()
         {

--- a/dev/ProgressBar/ProgressBar.h
+++ b/dev/ProgressBar/ProgressBar.h
@@ -42,6 +42,7 @@ private:
     tracker_ref<winrt::Rectangle> m_progressBarIndicator{ this };
 
     bool m_shouldUpdateWidthBasedTemplateSettings = false;
+    bool m_isUpdating = true;
 
     static constexpr wstring_view s_LayoutRootName{ L"LayoutRoot" };
     static constexpr wstring_view s_ProgressBarIndicatorName{ L"ProgressBarIndicator" };
@@ -49,4 +50,5 @@ private:
     static constexpr wstring_view s_PausedStateName{ L"Paused" };
     static constexpr wstring_view s_IndeterminateStateName{ L"Indeterminate" };
     static constexpr wstring_view s_DeterminateStateName{ L"Determinate" };
+    static constexpr wstring_view s_UpdatingStateName{ L"Updating" };
 };

--- a/dev/ProgressBar/ProgressBar.h
+++ b/dev/ProgressBar/ProgressBar.h
@@ -42,7 +42,6 @@ private:
     tracker_ref<winrt::Rectangle> m_progressBarIndicator{ this };
 
     bool m_shouldUpdateWidthBasedTemplateSettings = false;
-    bool m_isUpdating = true;
 
     static constexpr wstring_view s_LayoutRootName{ L"LayoutRoot" };
     static constexpr wstring_view s_ProgressBarIndicatorName{ L"ProgressBarIndicator" };

--- a/dev/ProgressBar/ProgressBar.idl
+++ b/dev/ProgressBar/ProgressBar.idl
@@ -7,6 +7,9 @@ unsealed runtimeclass ProgressBarTemplateSettings : Windows.UI.Xaml.DependencyOb
 {
     ProgressBarTemplateSettings();
 
+    Double ContainerAnimationStartPosition;
+    static Windows.UI.Xaml.DependencyProperty ContainerAnimationStartPositionProperty{ get; };
+
     Double ContainerAnimationEndPosition;
     static Windows.UI.Xaml.DependencyProperty ContainerAnimationEndPositionProperty{ get; };
 

--- a/dev/ProgressBar/ProgressBar.idl
+++ b/dev/ProgressBar/ProgressBar.idl
@@ -10,6 +10,9 @@ unsealed runtimeclass ProgressBarTemplateSettings : Windows.UI.Xaml.DependencyOb
     Double ContainerAnimationEndPosition;
     static Windows.UI.Xaml.DependencyProperty ContainerAnimationEndPositionProperty{ get; };
 
+    Double IndicatorLengthDelta;
+    static Windows.UI.Xaml.DependencyProperty IndicatorLengthDeltaProperty{ get; };
+
     Windows.UI.Xaml.Media.RectangleGeometry ClipRect;
     static Windows.UI.Xaml.DependencyProperty ClipRectProperty{ get; };
 }

--- a/dev/ProgressBar/ProgressBar.xaml
+++ b/dev/ProgressBar/ProgressBar.xaml
@@ -28,7 +28,7 @@
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="Updating" To="Determinate">
                                         <Storyboard>
-                                            <RepositionThemeAnimation TargetName="ProgressBarIndicator" FromHorizontalOffset="-50" />
+                                            <RepositionThemeAnimation TargetName="ProgressBarIndicator" FromHorizontalOffset="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorLengthDelta}" />
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition From="Paused" To="Determinate">

--- a/dev/ProgressBar/ProgressBar.xaml
+++ b/dev/ProgressBar/ProgressBar.xaml
@@ -27,7 +27,6 @@
 
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="Updating" To="Determinate">
-
                                         <Storyboard>
                                             <RepositionThemeAnimation TargetName="ProgressBarIndicator" FromHorizontalOffset="-50" />
                                         </Storyboard>

--- a/dev/ProgressBar/ProgressBar.xaml
+++ b/dev/ProgressBar/ProgressBar.xaml
@@ -51,7 +51,7 @@
                                             Storyboard.TargetName="ProgressBarIndicator"
                                             Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)"
                                             Duration="0:0:1">
-                                            <EasingDoubleKeyFrame KeyTime="0" Value="0">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationStartPosition}">
                                                 <EasingDoubleKeyFrame.EasingFunction>
                                                     <CubicEase/>
                                                 </EasingDoubleKeyFrame.EasingFunction>

--- a/dev/ProgressBar/ProgressBar.xaml
+++ b/dev/ProgressBar/ProgressBar.xaml
@@ -26,6 +26,12 @@
                             <VisualStateGroup x:Name="CommonStates">
 
                                 <VisualStateGroup.Transitions>
+                                    <VisualTransition From="Updating" To="Determinate">
+
+                                        <Storyboard>
+                                            <RepositionThemeAnimation TargetName="ProgressBarIndicator" FromHorizontalOffset="-50" />
+                                        </Storyboard>
+                                    </VisualTransition>
                                     <VisualTransition From="Paused" To="Determinate">
                                         <Storyboard>
                                             <DoubleAnimation
@@ -39,6 +45,7 @@
                                 
                                 <VisualState x:Name="Normal" />
                                 <VisualState x:Name="Determinate" />
+                                <VisualState x:Name="Updating" />
                                 <VisualState x:Name="Indeterminate">
                                     <Storyboard RepeatBehavior="Forever">
                                         <DoubleAnimationUsingKeyFrames


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refine animation of ProgressBar:
- Animate transitions between changes in ProgressBarIndicator Width
- Refine Indeterminate animation by offsetting initial start position

Fix Bug:
- Update ClipRect template settings on ProgressBar Width change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Existing interaction tests