### PR TITLE
Update use of weak_ref in SwipeControl to avoid potential race condition

### DIFF
--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -30,12 +30,15 @@ SwipeControl::~SwipeControl()
 {
     DetachEventHandlers();
 
-    if (s_lastInteractedWithSwipeControl && s_lastInteractedWithSwipeControl.get() && s_lastInteractedWithSwipeControl.get().get() == this)
+    if (auto lastInteractedWithSwipeControl = s_lastInteractedWithSwipeControl.get())
     {
-        s_lastInteractedWithSwipeControl = nullptr;
-        if (auto globalTestHooks = SwipeTestHooks::GetGlobalTestHooks())
+        if (lastInteractedWithSwipeControl.get() == this)
         {
-            globalTestHooks->NotifyLastInteractedWithSwipeControlChanged();
+            s_lastInteractedWithSwipeControl = nullptr;
+            if (auto globalTestHooks = SwipeTestHooks::GetGlobalTestHooks())
+            {
+                globalTestHooks->NotifyLastInteractedWithSwipeControlChanged();
+            }
         }
     }
 }
@@ -325,11 +328,12 @@ void SwipeControl::ValuesChanged(
 {
     SWIPECONTROL_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
 
-    if (m_isInteracting && (!s_lastInteractedWithSwipeControl.get() || s_lastInteractedWithSwipeControl.get().get() != this))
+    auto lastInteractedWithSwipeControl = s_lastInteractedWithSwipeControl.get();
+    if (m_isInteracting && (!lastInteractedWithSwipeControl || lastInteractedWithSwipeControl.get() != this))
     {
-        if (s_lastInteractedWithSwipeControl.get())
+        if (lastInteractedWithSwipeControl)
         {
-            s_lastInteractedWithSwipeControl.get()->CloseIfNotRemainOpenExecuteItem();
+            lastInteractedWithSwipeControl->CloseIfNotRemainOpenExecuteItem();
         }
         s_lastInteractedWithSwipeControl = get_weak();
 
@@ -372,9 +376,9 @@ void SwipeControl::ValuesChanged(
 #pragma region TestHookHelpers
 winrt::SwipeControl SwipeControl::GetLastInteractedWithSwipeControl()
 {
-    if (s_lastInteractedWithSwipeControl.get())
+    if (auto lastInteractedWithSwipeControl = s_lastInteractedWithSwipeControl.get())
     {
-        return s_lastInteractedWithSwipeControl.get()->GetThis();
+        return *lastInteractedWithSwipeControl;
     }
     return nullptr;
 }


### PR DESCRIPTION
A speculative fix for: #890 

The issue is that we are attempting to resolve a weak ref to a managed object (sub-class of SwipeControl) that has already been garbage collected.

I have never been able to reproduce the crash from #890, so I cannot confirm that this change resolves the issue. But this change removes a potential race condition in SwipeControl. Before checking a weak_ref for equality, we first take a strong ref to ensure that the object does not get destroyed between the time we check the weak ref and the time we use it.