### PR TITLE
Make TreeView ItemSource binding synchronous

### DIFF
--- a/dev/TreeView/TreeViewItem.cpp
+++ b/dev/TreeView/TreeViewItem.cpp
@@ -321,20 +321,14 @@ void TreeViewItem::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
         {
             winrt::IInspectable value = args.NewValue();
 
-            // ItemsSource change happens during measuring.
-            // Adding itemsSource to node's children triggers another layout change, so it has to be done async.
-            m_dispatcherHelper.RunAsync(
-                [this, node, value]()
+            auto treeViewNode = winrt::get_self<TreeViewNode>(node);
+            treeViewNode->ItemsSource(value);
+            if (IsInContentMode())
             {
-                auto treeViewNode = winrt::get_self<TreeViewNode>(node);
-                treeViewNode->ItemsSource(value);
-                if (IsInContentMode())
-                {
-                    // The children have changed, validate and update GlyphOpacity
-                    bool hasChildren = HasUnrealizedChildren() || treeViewNode->HasChildren();
-                    GlyphOpacity(hasChildren ? 1.0 : 0.0);
-                }
-            });
+                // The children have changed, validate and update GlyphOpacity
+                bool hasChildren = HasUnrealizedChildren() || treeViewNode->HasChildren();
+                GlyphOpacity(hasChildren ? 1.0 : 0.0);
+            }
         }
         else if (property == s_HasUnrealizedChildrenProperty)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
TreeView ItemsSource binding used to be done asynchronously because of the reasons in the code comment, this seems to be a non-issue now, removing async code to make the behavior more predicable.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1489.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
There should be plenty of existing tests exercising this ItemsSource binding code path.