### PR TITLE
Removed MSTestInterop implementation of DisableVerifyFailureExceptions flag

### DIFF
--- a/dev/CommonManaged/MSTestInterop.cs
+++ b/dev/CommonManaged/MSTestInterop.cs
@@ -54,238 +54,104 @@ namespace Common
 
     public static class Verify
     {
+        // TODO: implement
+        // NOTE: At the time of this comment, MUXControlsTestApp is hitting a code path where
+        //       running tests locally will set this flag to true. Hence an implementation of this flag 
+        //       will only log errors and not fail the tests.
         public static bool DisableVerifyFailureExceptions
         {
             get;
             set;
         }
 
-        private static void ThrowOrLogException(Exception e)
-        {
-            if (DisableVerifyFailureExceptions)
-            {
-                Log.Error(e.Message);
-            }
-            else
-            {
-                throw e;
-            }
-        }
-
         public static void AreEqual(object expected, object actual, string message = null)
         {
-            try
-            {
-                Assert.AreEqual(expected, actual, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.AreEqual(expected, actual, message);
         }
 
         public static void AreEqual<T>(T expected, T actual, string message = null)
         {
-            try
-            {
-                Assert.AreEqual(expected, actual, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.AreEqual(expected, actual, message);
         }
 
         public static void AreNotEqual(object notExpected, object actual, string message = null)
         {
-            try
-            { 
-                Assert.AreNotEqual(notExpected, actual, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.AreNotEqual(notExpected, actual, message);
         }
 
         public static void AreNotEqual<T>(T notExpected, T actual, string message = null)
         {
-            try
-            { 
-                Assert.AreNotEqual(notExpected, actual, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.AreNotEqual(notExpected, actual, message);
         }
 
         public static void AreSame(object expected, object actual, string message = null)
         {
-            try
-            {
-                Assert.AreSame(expected, actual, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.AreSame(expected, actual, message);
         }
 
         public static void AreNotSame(object notExpected, object actual, string message = null)
         {
-            try
-            { 
-                Assert.AreNotSame(notExpected, actual, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.AreNotSame(notExpected, actual, message);
         }
 
         public static void IsLessThan(IComparable expectedLess, IComparable expectedGreater, string message = null)
         {
-            try
-            { 
-                Assert.IsTrue(expectedLess.CompareTo(expectedGreater) < 0, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsTrue(expectedLess.CompareTo(expectedGreater) < 0, message);
         }
 
         public static void IsLessThanOrEqual(IComparable expectedLess, IComparable expectedGreater, string message = null)
         {
-            try
-            { 
-                Assert.IsTrue(expectedLess.CompareTo(expectedGreater) <= 0, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsTrue(expectedLess.CompareTo(expectedGreater) <= 0, message);
         }
 
         public static void IsGreaterThan(IComparable expectedGreater, IComparable expectedLess, string message = null)
         {
-            try
-            {
-                Assert.IsTrue(expectedGreater.CompareTo(expectedLess) > 0, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsTrue(expectedGreater.CompareTo(expectedLess) > 0, message);
         }
 
         public static void IsGreaterThanOrEqual(IComparable expectedGreater, IComparable expectedLess, string message = null)
         {
-            try
-            {
-                Assert.IsTrue(expectedGreater.CompareTo(expectedLess) >= 0, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsTrue(expectedGreater.CompareTo(expectedLess) >= 0, message);
         }
 
         public static void IsNull(object value, string message = null)
         {
-            try
-            { 
-                Assert.IsNull(value, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsNull(value, message);
         }
 
         public static void IsNotNull(object value, string message = null)
         {
-            try
-            { 
-                Assert.IsNotNull(value, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsNotNull(value, message);
         }
 
         public static void IsTrue(bool condition, string message = null)
         {
-            try
-            {
-                Assert.IsTrue(condition, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsTrue(condition, message);
         }
 
         public static void IsFalse(bool condition, string message = null)
         {
-            try
-            { 
-                Assert.IsFalse(condition, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.IsFalse(condition, message);
         }
 
         public static void Fail()
         {
-            try 
-            { 
-                Assert.Fail();
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.Fail();
         }
 
         public static void Fail(string message, params object[] args)
         {
-            try
-            { 
-                Assert.Fail(message, args);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.Fail(message, args);
         }
 
         public static void Throws<T>(Action action, string message) where T : Exception
         {
-            try
-            { 
-                Assert.ThrowsException<T>(action, message);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.ThrowsException<T>(action, message);
         }
 
         public static void Throws<T>(Action action) where T : Exception
         {
-            try
-            { 
-                Assert.ThrowsException<T>(action);
-            }
-            catch (AssertFailedException e)
-            {
-                ThrowOrLogException(e);
-            }
+            Assert.ThrowsException<T>(action);
         }
     }
 }

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -169,20 +169,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                     Log.Comment($"Verify visual tree for NavigationViewPaneDisplayMode: {paneDisplayMode}");
                     var navigationView = SetupNavigationView(displayMode);
-                    visualTreeVerifier.VerifyVisualTree(root: navigationView, masterFilePrefix: filePrefix);
+                    visualTreeVerifier.VerifyVisualTreeNoException(root: navigationView, masterFilePrefix: filePrefix);
                 }
 
                 Log.Comment($"Verify visual tree for NavigationViewScrolling");
                 var leftNavViewScrolling = SetupNavigationViewScrolling(NavigationViewPaneDisplayMode.Left);
-                visualTreeVerifier.VerifyVisualTree(root: leftNavViewScrolling, masterFilePrefix: "NavigationViewScrolling");
+                visualTreeVerifier.VerifyVisualTreeNoException(root: leftNavViewScrolling, masterFilePrefix: "NavigationViewScrolling");
                 
                 Log.Comment($"Verify visual tree for NavigationViewLeftPaneContent");
                 var leftNavViewPaneContent = SetupNavigationViewPaneContent(NavigationViewPaneDisplayMode.Left);
-                visualTreeVerifier.VerifyVisualTree(root: leftNavViewPaneContent, masterFilePrefix: "NavigationViewLeftPaneContent");
+                visualTreeVerifier.VerifyVisualTreeNoException(root: leftNavViewPaneContent, masterFilePrefix: "NavigationViewLeftPaneContent");
 
                 Log.Comment($"Verify visual tree for NavigationViewTopPaneContent");
                 var topNavViewPaneContent = SetupNavigationViewPaneContent(NavigationViewPaneDisplayMode.Top);
-                visualTreeVerifier.VerifyVisualTree(root: topNavViewPaneContent, masterFilePrefix: "NavigationViewTopPaneContent");
+                visualTreeVerifier.VerifyVisualTreeNoException(root: topNavViewPaneContent, masterFilePrefix: "NavigationViewTopPaneContent");
             }
         }
 

--- a/test/MUXControlsTestApp/VisualTreeTestHelper.cs
+++ b/test/MUXControlsTestApp/VisualTreeTestHelper.cs
@@ -58,35 +58,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     {
         public bool hasFailed = false;
 
-        public void VerifyVisualTree(string xaml, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
+        public void VerifyVisualTreeNoException(string xaml, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
         {
-            Verify.DisableVerifyFailureExceptions = true;
             try
             {
-                if (!VisualTreeTestHelper.VerifyVisualTree(xaml, masterFilePrefix, theme, translator, filter, logger))
-                {
-                    hasFailed = true;
-                }
+                VisualTreeTestHelper.VerifyVisualTree(xaml, masterFilePrefix, theme, translator, filter, logger);
             }
-            finally
+            catch (Exception e)
             {
-                Verify.DisableVerifyFailureExceptions = false;
+                Log.Error(e.Message);
+                hasFailed = true;
             }
         }
 
-        public void VerifyVisualTree(UIElement root, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
+        public void VerifyVisualTreeNoException(UIElement root, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
         {
-            Verify.DisableVerifyFailureExceptions = true;
             try
             {
-                if (!VisualTreeTestHelper.VerifyVisualTree(root, masterFilePrefix, theme, translator, filter, logger))
-                {
-                    hasFailed = true;
-                }
+                VisualTreeTestHelper.VerifyVisualTree(root, masterFilePrefix, theme, translator, filter, logger);
             }
-            finally
+            catch (Exception e)
             {
-                Verify.DisableVerifyFailureExceptions = false;
+                Log.Error(e.Message);
+                hasFailed = true;
             }
         }
 
@@ -146,13 +140,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             return content;
         }
 
-        public static bool VerifyVisualTree(string xaml, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
+        public static void VerifyVisualTree(string xaml, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
         {
             var root = SetupVisualTree(xaml);
-            return VerifyVisualTree(root, masterFilePrefix, theme, translator, filter, logger);
+            VerifyVisualTree(root, masterFilePrefix, theme, translator, filter, logger);
         }
 
-        public static bool VerifyVisualTree(UIElement root, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
+        public static void VerifyVisualTree(UIElement root, string masterFilePrefix, Theme theme = Theme.None, IPropertyValueTranslator translator = null, IFilter filter = null, IVisualTreeLogger logger = null)
         {
             VisualTreeLog.LogInfo("VerifyVisualTree for theme " + theme.ToString());
             TestExecution helper = new TestExecution(translator, filter, logger, AlwaysLogMasterFile);
@@ -189,9 +183,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             if (helper.HasError())
             {
                 Verify.Fail(helper.GetTestResult(), "Test Failed");
-                return false;
             }
-            return true;
         }
 
         private class TestExecution


### PR DESCRIPTION
Removed the [recently introduced](https://github.com/microsoft/microsoft-ui-xaml/pull/1479) implementation of the DisableVerifyFailureExceptions flag in MSTestInterop.cs. Having this flag implemented causes problems when running tests locally because a codepath is hit (when launching MUXControlsTestApp) where the flag is set to true, causing tests to log the errors, but not fail. 

This flag was introduced in order to be able to run multiple visual tree verification tests at once and only fail the test at the end. For now, moved exception handling to the `VisualTreeVerifier` class so that this behavior can still be achieved.

Verified that now local test runs fail & pass as expected and that using `VisualTreeVerifier` fails at the end of the test run.

