### PR TITLE
Disable codeowners to reduce email notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
+# DISABLED: Turned this off since it's currently generating very noisy notifications to the team and reviewers can't
+# tell the difference between being explicitly added as a reviewer versus by way of this group.
 # Add the code reviews team to all PRs in the repo.
-* @Microsoft/microsoft-ui-xaml-codereviews
+# * @Microsoft/microsoft-ui-xaml-codereviews


### PR DESCRIPTION
Turning off codeowners to see if this improves the email experience for the team. Currently the GitHub behavior for email notifications is that when this group is added then it sends direct email to each member of the group even if the individual isn't directly participating in the code review. 

I'm turning this off to see if the notification experience improves.
