### PR TITLE
conditional Arm64 min version to rs3 for FrameworkPackagePRI project

### DIFF
--- a/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
+++ b/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
@@ -15,7 +15,9 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion Condition=" '$(Platform)' == 'ARM64' ">10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion Condition=" '$(Platform)' != 'ARM64' ">10.0.15063.0</TargetPlatformMinVersion>
+
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
Avoid build error on ARM64 because it requires min version to 16299
##[error]C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VisualStudio\v16.0\AppxPackage\Microsoft.AppXPackage.Targets(6326,5): Error : In order to compile your application for the ARM64 configuration, you must update your project's Minimum Version to the Windows 10 Fall Creators Update (Build 16299) or higher.