### PR TITLE
fixed the closed button displaying bug

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -495,6 +495,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void CloseButtonDoesNotShowWhenVisibilityIsToggled()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                // Wait for the test page's timer to set visibility to the close button to visible
+                Wait.ForMilliseconds(2);
+                Wait.ForIdle();
+
+                UIObject notCloseableTab = FindElement.ByName("NotCloseableTab");
+                var closeButton = FindCloseButton(notCloseableTab);
+                Verify.IsNull(closeButton);
+            }
+        }
+
         public void PressButtonAndVerifyText(String buttonName, String textBlockName, String expectedText)
         {
             Button button = FindElement.ByName<Button>(buttonName);

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -67,6 +67,8 @@ void TabViewItem::OnApplyTemplate()
         m_tabDragStartingRevoker = tabView.TabDragStarting(winrt::auto_revoke, { this, &TabViewItem::OnTabDragStarting });
         m_tabDragCompletedRevoker = tabView.TabDragCompleted(winrt::auto_revoke, { this, &TabViewItem::OnTabDragCompleted });
     }
+
+    UpdateCloseButton();
 }
 
 void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -18,8 +18,6 @@ TabViewItem::TabViewItem()
     SetValue(s_TabViewTemplateSettingsProperty, winrt::make<TabViewItemTemplateSettings>());
 
     RegisterPropertyChangedCallback(winrt::SelectorItem::IsSelectedProperty(), { this, &TabViewItem::OnIsSelectedPropertyChanged });
-
-    Loaded({ this, &TabViewItem::OnLoaded });
 }
 
 void TabViewItem::OnApplyTemplate()
@@ -108,10 +106,6 @@ winrt::AutomationPeer TabViewItem::OnCreateAutomationPeer()
     return winrt::make<TabViewItemAutomationPeer>(*this);
 }
 
-void TabViewItem::OnLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args)
-{
-    UpdateCloseButton();
-}
 
 void TabViewItem::UpdateCloseButton()
 {

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -53,7 +53,6 @@ public:
     winrt::TabView::TabDragStarting_revoker m_tabDragStartingRevoker{};
     winrt::TabView::TabDragCompleted_revoker m_tabDragCompletedRevoker{};
 
-    void OnLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnCloseButtonClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
 
     void OnIsSelectedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -21,6 +21,7 @@ using System.Collections.ObjectModel;
 using Windows.Devices.PointOfService;
 using Windows.ApplicationModel.DataTransfer;
 using MUXControlsTestApp.Utilities;
+using System.Threading.Tasks;
 
 namespace MUXControlsTestApp
 {
@@ -54,6 +55,13 @@ namespace MUXControlsTestApp
                 itemSource.Add(item);
             }
             DataBindingTabView.TabItemsSource = itemSource;
+        }
+
+        protected async override void OnNavigatedTo(Windows.UI.Xaml.Navigation.NavigationEventArgs args) 
+        {
+            NotCloseableTab.Visibility = Visibility.Collapsed;
+            await Task.Delay(1);
+            NotCloseableTab.Visibility = Visibility.Visible;
         }
 
         public void IsClosableCheckBox_CheckChanged(object sender, RoutedEventArgs e)

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -60,7 +60,7 @@ namespace MUXControlsTestApp
         protected async override void OnNavigatedTo(Windows.UI.Xaml.Navigation.NavigationEventArgs args) 
         {
             NotCloseableTab.Visibility = Visibility.Collapsed;
-            await Task.Delay(1);
+            await Task.Delay(TimeSpan.FromMilliseconds(1));
             NotCloseableTab.Visibility = Visibility.Visible;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added `UpdateCloseButton()` under `TabViewItem::OnApplyTemplate()`

## Motivation and Context

fixes the issue of the close button showing up on the video tab because the TabViewItem was depending on the onloaded event handler to set the close button visibility but this would fail if the template hasn't been applied yet. Fixes #1416  


## How Has This Been Tested?
Manually 
## Screenshots (if appropriate):
