### PR TITLE
Disable SDK installation

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -15,8 +15,6 @@ steps:
       echo parameters.buildOutputDir = '${{ parameters.buildOutputDir }}'
     displayName: 'BuildProject: Display parameters'
 
-  - template: MUX-InstallWindowsSDK-Steps.yml
-
   - template: MUX-InstallNuget-Steps.yml
   
   # The environment variable VCToolsInstallDir isn't defined on lab machines, so we need to retrieve it ourselves.


### PR DESCRIPTION
SDK 18362 is already installed in windows-2019 image and we don't need to install it by yourself any more.
