### PR TITLE
NumberBox: Add expression calculation

### DIFF
--- a/dev/Generated/NumberBox.properties.cpp
+++ b/dev/Generated/NumberBox.properties.cpp
@@ -8,6 +8,7 @@
 
 CppWinRTActivatableClassWithDPFactory(NumberBox)
 
+GlobalDependencyProperty NumberBoxProperties::s_AcceptsCalculationProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_BasicValidationModeProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HyperScrollEnabledProperty{ nullptr };
@@ -29,6 +30,17 @@ NumberBoxProperties::NumberBoxProperties()
 
 void NumberBoxProperties::EnsureProperties()
 {
+    if (!s_AcceptsCalculationProperty)
+    {
+        s_AcceptsCalculationProperty =
+            InitializeDependencyProperty(
+                L"AcceptsCalculation",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxValueIfNecessary(false),
+                nullptr);
+    }
     if (!s_BasicValidationModeProperty)
     {
         s_BasicValidationModeProperty =
@@ -165,6 +177,7 @@ void NumberBoxProperties::EnsureProperties()
 
 void NumberBoxProperties::ClearProperties()
 {
+    s_AcceptsCalculationProperty = nullptr;
     s_BasicValidationModeProperty = nullptr;
     s_HeaderProperty = nullptr;
     s_HyperScrollEnabledProperty = nullptr;
@@ -243,6 +256,16 @@ void NumberBoxProperties::OnValuePropertyChanged(
 {
     auto owner = sender.as<winrt::NumberBox>();
     winrt::get_self<NumberBox>(owner)->OnValuePropertyChanged(args);
+}
+
+void NumberBoxProperties::AcceptsCalculation(bool value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_AcceptsCalculationProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+}
+
+bool NumberBoxProperties::AcceptsCalculation()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_AcceptsCalculationProperty));
 }
 
 void NumberBoxProperties::BasicValidationMode(winrt::NumberBoxBasicValidationMode const& value)

--- a/dev/Generated/NumberBox.properties.h
+++ b/dev/Generated/NumberBox.properties.h
@@ -9,6 +9,9 @@ class NumberBoxProperties
 public:
     NumberBoxProperties();
 
+    void AcceptsCalculation(bool value);
+    bool AcceptsCalculation();
+
     void BasicValidationMode(winrt::NumberBoxBasicValidationMode const& value);
     winrt::NumberBoxBasicValidationMode BasicValidationMode();
 
@@ -45,6 +48,7 @@ public:
     void WrapEnabled(bool value);
     bool WrapEnabled();
 
+    static winrt::DependencyProperty AcceptsCalculationProperty() { return s_AcceptsCalculationProperty; }
     static winrt::DependencyProperty BasicValidationModeProperty() { return s_BasicValidationModeProperty; }
     static winrt::DependencyProperty HeaderProperty() { return s_HeaderProperty; }
     static winrt::DependencyProperty HyperScrollEnabledProperty() { return s_HyperScrollEnabledProperty; }
@@ -58,6 +62,7 @@ public:
     static winrt::DependencyProperty ValueProperty() { return s_ValueProperty; }
     static winrt::DependencyProperty WrapEnabledProperty() { return s_WrapEnabledProperty; }
 
+    static GlobalDependencyProperty s_AcceptsCalculationProperty;
     static GlobalDependencyProperty s_BasicValidationModeProperty;
     static GlobalDependencyProperty s_HeaderProperty;
     static GlobalDependencyProperty s_HyperScrollEnabledProperty;

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -290,6 +290,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     { "-2 - 5", -7 },       // begins with negative number
                     { "(10)", 10 },         // number in parens
                     { "(-9)", -9 },         // negative number in parens
+                    { "0^0", 1 },           // who knew?
 
                     // These should not parse, which means they will reset back to the previous value.
                     { "5x + 3y", resetValue },        // invalid chars

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -245,13 +245,94 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void BasicCalculationTest()
+        {
+            using (var setup = new TestSetupHelper("NumberBox Tests"))
+            {
+                RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");
+
+                Log.Comment("Verify that calculations don't work if AcceptsCalculations is false");
+                EnterText(numBox, "5 + 3");
+                Verify.AreEqual(0, numBox.Value);
+
+                Check("CalculationCheckBox");
+
+                int numErrors = 0;
+                const double resetValue = 1234;
+                
+                Dictionary<string, double> expressions = new Dictionary<string, double>
+                {
+                    // Valid expressions. None of these should evaluate to the reset value.
+                    { "5", 5 },
+                    { "-358", -358 },
+                    { "12.34", 12.34 },
+                    { "5 + 3", 8 },
+                    { "12345 + 67 + 890", 13302 },
+                    { "000 + 0011", 11 },
+                    { "5 - 3 + 2", 4 },
+                    { "3 + 2 - 5", 0 },
+                    { "9 - 2 * 6 / 4", 6 },
+                    { "9 - -7",  16 },
+                    { "9-3*2", 3 },         // no spaces
+                    { " 10  *   6  ", 60 }, // extra spaces
+                    { "10 /( 2 + 3 )", 2 },
+                    { "5 * -40", -200 },
+                    { "(1 - 4) / (2 + 1)", -1 },
+                    { "3 * ((4 + 8) / 2)", 18 },
+                    { "23 * ((0 - 48) / 8)", -138 },
+                    { "((74-71)*2)^3", 216 },
+                    { "2 - 2 ^ 3", -6 },
+                    { "2 ^ 2 ^ 2 / 2 + 9", 17 },
+                    { "5 ^ -2", 0.04 },
+                    { "5.09 + 14.333", 19.423 },
+                    { "2.5 * 0.35", 0.875 },
+                    { "-2 - 5", -7 },       // begins with negative number
+                    { "(10)", 10 },         // number in parens
+                    { "(-9)", -9 },         // negative number in parens
+
+                    // These should not parse, which means they will reset back to the previous value.
+                    { "5x + 3y", resetValue },        // invalid chars
+                    { "5 + (3", resetValue },         // mismatched parens
+                    { "9 + (2 + 3))", resetValue },
+                    { "(2 + 3)(1 + 5)", resetValue }, // missing operator
+                    { "9 + + 7", resetValue },        // extra operators
+                    { "9 - * 7",  resetValue },
+                    { "9 - - 7",  resetValue },
+                    { "+9", resetValue },
+                    { "1 / 0", resetValue },          // divide by zero
+
+                    // These don't currently work, but maybe should.
+                    { "-(3 + 5)", resetValue }, // negative sign in front of parens -- should be -8
+                };
+                foreach (KeyValuePair<string, double> pair in expressions)
+                {
+                    numBox.SetValue(resetValue);
+                    Wait.ForIdle();
+
+                    EnterText(numBox, pair.Key);
+                    string output = "Expression '" + pair.Key + "' - expected: " + pair.Value + ", actual: " + numBox.Value;
+                    if (Math.Abs(pair.Value - numBox.Value) > 0.00001)
+                    {
+                        numErrors++;
+                        Log.Warning(output);
+                    }
+                    else
+                    {
+                        Log.Comment(output);
+                    }
+                }
+
+                Verify.AreEqual(0, numErrors);
+            }
+        }
+
         Button FindButton(UIObject parent, string buttonName)
         {
             foreach (UIObject elem in parent.Children)
             {
                 if (elem.Name.Equals(buttonName))
                 {
-                    Log.Comment("Found " + buttonName + " button for object " + parent.Name);
                     return new Button(elem);
                 }
             }
@@ -265,7 +346,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 if (elem.ClassName.Equals("TextBox"))
                 {
-                    Log.Comment("Found TextBox for object " + parent.Name);
                     return new Edit(elem);
                 }
             }

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -194,16 +194,9 @@ void NumberBox::ValidateInput()
             // Setting NumberFormatter to something that isn't an INumberParser will throw an exception, so this should be safe
             const auto numberParser = NumberFormatter().as<winrt::INumberParser>();
 
-            winrt::IReference<double> value;
-
-            if (AcceptsCalculation())
-            {
-                value = NumberBoxParser::Compute(textBox.Text(), numberParser);
-            }
-            else
-            {
-                value = numberParser.ParseDouble(text);
-            }
+            const winrt::IReference<double> value = AcceptsCalculation()
+                ? NumberBoxParser::Compute(textBox.Text(), numberParser)
+                : numberParser.ParseDouble(text);
 
             if (!value)
             {

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -9,7 +9,6 @@
 #include "NumberBoxValueChangedEventArgs.g.h"
 #include "NumberBox.properties.h"
 #include "Windows.Globalization.NumberFormatting.h"
-#include <regex>
 
 class NumberBoxValueChangedEventArgs :
     public winrt::implementation::NumberBoxValueChangedEventArgsT<NumberBoxValueChangedEventArgs>
@@ -66,7 +65,6 @@ private:
     void ValidateInput();
     void CoerceValue();
     void UpdateTextToValue();
-    int ComputePrecisionRounderSigDigits(double newVal);
 
     void SetSpinButtonVisualState();
     void StepValue(bool isPositive);
@@ -75,8 +73,7 @@ private:
 
     bool IsInBounds(double value);
 
-    winrt::DecimalFormatter m_stepPrecisionFormatter{};
-    winrt::SignificantDigitsNumberRounder m_stepPrecisionRounder{};
+    winrt::SignificantDigitsNumberRounder m_displayRounder{};
 
     tracker_ref<winrt::TextBox> m_textBox{ this };
 

--- a/dev/NumberBox/NumberBox.idl
+++ b/dev/NumberBox/NumberBox.idl
@@ -66,6 +66,9 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     [MUX_DEFAULT_VALUE("false")]
     Boolean WrapEnabled;
 
+    [MUX_DEFAULT_VALUE("false")]
+    Boolean AcceptsCalculation;
+
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_PROPERTY_VALIDATION_CALLBACK("ValidateNumberFormatter")]
     Windows.Globalization.NumberFormatting.INumberFormatter2 NumberFormatter;
@@ -85,6 +88,7 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty SpinButtonPlacementModeProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty HyperScrollEnabledProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty WrapEnabledProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty AcceptsCalculationProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty NumberFormatterProperty{ get; };
 }

--- a/dev/NumberBox/NumberBox.vcxitems
+++ b/dev/NumberBox/NumberBox.vcxitems
@@ -17,6 +17,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\NumberBox.properties.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NumberBox.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NumberBoxAutomationPeer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NumberBoxParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)NumberBox.xaml">
@@ -34,6 +35,7 @@
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)NumberBox.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)NumberBoxAutomationPeer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)NumberBoxParser.h" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />

--- a/dev/NumberBox/NumberBox.vcxitems.filters
+++ b/dev/NumberBox/NumberBox.vcxitems.filters
@@ -4,6 +4,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\NumberBox.properties.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NumberBox.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)NumberBoxAutomationPeer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NumberBoxParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="$(MSBuildThisFileDirectory)NumberBox.idl" />
@@ -15,6 +16,7 @@
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)NumberBox.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)NumberBoxAutomationPeer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)NumberBoxParser.h" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />

--- a/dev/NumberBox/NumberBoxParser.cpp
+++ b/dev/NumberBox/NumberBoxParser.cpp
@@ -1,0 +1,301 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "NumberBoxParser.h"
+#include "Utils.h"
+
+static constexpr wstring_view c_numberBoxOperators{ L"+-*/^"sv };
+
+// Returns list of MathTokens from expression input string. If there are any parsing errors, it returns an empty vector.
+std::vector<MathToken> NumberBoxParser::GetTokens(const wchar_t* input, winrt::INumberParser numberParser)
+{
+    auto tokens = std::vector<MathToken>();
+
+    size_t index = 0;
+    bool error = false;
+    bool expectNumber = true;
+    while (input[0] != '\0' && !error)
+    {
+        // Skip spaces
+        auto nextChar = input[0];
+        if (nextChar != L' ')
+        {
+            if (expectNumber)
+            {
+                if (nextChar == '(')
+                {
+                    // Open parens are also acceptable, but don't change the next expected token type.
+                    tokens.push_back(MathToken(MathTokenType::Parenthesis, nextChar));
+                }
+                else
+                {
+                    double value = NAN;
+                    const auto charLength = GetNextNumber(input, numberParser, value);
+
+                    if (charLength > 0)
+                    {
+                        tokens.push_back(MathToken(MathTokenType::Numeric, value));
+                        input += charLength - 1; // advance the end of the token
+                        expectNumber = false; // next token should be an operator
+                    }
+                    else
+                    {
+                        // Error case -- next token is not a number
+                        error = true;
+                    }
+                }
+            }
+            else
+            {
+                if (c_numberBoxOperators.find(nextChar) != std::wstring::npos)
+                {
+                    tokens.push_back(MathToken(MathTokenType::Operator, nextChar));
+                    expectNumber = true; // next token should be a number
+                }
+                else if (nextChar == ')')
+                {
+                    // Closed parens are also acceptable, but don't change the next expected token type.
+                    tokens.push_back(MathToken(MathTokenType::Parenthesis, nextChar));
+                }
+                else
+                {
+                    // Error case -- could not evaluate part of the expression
+                    error = true;
+                }
+            }
+        }
+
+        input++;
+    }
+
+    if (error)
+    {
+        return {};
+    }
+    return tokens;
+}
+
+// Attempts to parse a number from the beginning of the given input string. Returns the character size of the matched string.
+size_t NumberBoxParser::GetNextNumber(std::wstring input, winrt::INumberParser numberParser, double& outValue)
+{
+    size_t charLength = 0;
+
+    // Attempt to parse anything before an operator or space as a number
+    std::wregex regex(L"^-?([^-+/*\\(\\)\\^\\s]+)");
+    std::wsmatch match;
+    if (std::regex_search(input.cbegin(), input.cend(), match, regex))
+    {
+        // Might be a number
+        const auto matchLength = match[0].length();
+        const auto parsedNum = numberParser.ParseDouble(input.substr(0, matchLength));
+
+        if (parsedNum)
+        {
+            // Parsing was successful
+            outValue = parsedNum.Value();
+            charLength = matchLength;
+        }
+    }
+
+    return charLength;
+}
+
+int NumberBoxParser::GetPrecedenceValue(wchar_t c)
+{
+    int opPrecedence = 0;
+    if (c == L'*' || c == L'/')
+    {
+        opPrecedence = 1;
+    }
+    else if (c == L'^')
+    {
+        opPrecedence = 2;
+    }
+
+    return opPrecedence;
+}
+
+// Converts a list of tokens from infix format (e.g. "3 + 5") to postfix (e.g. "3 5 +")
+std::vector<MathToken> NumberBoxParser::ConvertInfixToPostfix(std::vector<MathToken> infixTokens)
+{
+    std::vector<MathToken> postfixTokens;
+    std::stack<MathToken> operatorStack;
+
+    bool error = false;
+
+    for (auto const token : infixTokens)
+    {
+        if (token.Type == MathTokenType::Numeric)
+        {
+            postfixTokens.push_back(token);
+        }
+        else if (token.Type == MathTokenType::Operator)
+        {
+            while (!operatorStack.empty())
+            {
+                const auto top = operatorStack.top();
+                if (top.Type != MathTokenType::Parenthesis && (GetPrecedenceValue(top.Char) >= GetPrecedenceValue(token.Char)))
+                {
+                    postfixTokens.push_back(operatorStack.top());
+                    operatorStack.pop();
+                }
+                else
+                {
+                    break;
+                }
+            }
+            operatorStack.push(token);
+        }
+        else if (token.Type == MathTokenType::Parenthesis)
+        {
+            if (token.Char == L'(')
+            {
+                operatorStack.push(token);
+            }
+            else
+            {
+                while (!operatorStack.empty() && operatorStack.top().Char != L'(')
+                {
+                    // Pop operators onto output until we reach a left paren
+                    postfixTokens.push_back(operatorStack.top());
+                    operatorStack.pop();
+                }
+
+                if (operatorStack.empty())
+                {
+                    // Broken parenthesis
+                    error = true;
+                    break;
+                }
+
+                // Pop left paren and discard
+                operatorStack.pop();
+            }
+        }
+    }
+
+    // Pop all remaining operators.
+    while (!operatorStack.empty())
+    {
+        if (operatorStack.top().Type == MathTokenType::Parenthesis)
+        {
+            // Broken parenthesis
+            error = true;
+            break;
+        }
+
+        postfixTokens.push_back(operatorStack.top());
+        operatorStack.pop();
+    }
+
+    if (error)
+    {
+        return {};
+    }
+    return postfixTokens;
+}
+
+winrt::IReference<double> NumberBoxParser::ComputePostfixExpression(std::vector<MathToken> tokens)
+{
+    winrt::IReference<double> value = nullptr;
+    std::stack<double> stack;
+    bool error = false;
+
+    for (auto const token : tokens)
+    {
+        if (error)
+        {
+            break;
+        }
+
+        if (token.Type == MathTokenType::Operator)
+        {
+            // There has to be at least two values on the stack to apply
+            if (stack.size() < 2)
+            {
+                error = true;
+                break;
+            }
+
+            const auto op1 = stack.top();
+            stack.pop();
+
+            const auto op2 = stack.top();
+            stack.pop();
+
+            double result;
+
+            switch (token.Char)
+            {
+                case L'-':
+                    result = op2 - op1;
+                    break;
+
+                case L'+':
+                    result = op1 + op2;
+                    break;
+
+                case L'*':
+                    result = op1 * op2;
+                    break;
+
+                case L'/':
+                    if (op1 == 0)
+                    {
+                        error = true;
+                        value = NAN;
+                    }
+                    else
+                    {
+                        result = op2 / op1;
+                    }
+                    break;
+
+                case L'^':
+                    result = std::pow(op2, op1);
+                    break;
+
+                default:
+                    error = true;
+                    break;
+            }
+
+            stack.push(result);
+        }
+        else if (token.Type == MathTokenType::Numeric)
+        {
+            stack.push(token.Value);
+        }
+    }
+
+    // If there is more than one number on the stack, we didn't have enough operations, which is also an error.
+    if (!error && stack.size() == 1)
+    {
+        value = stack.top();
+    }
+
+    return value;
+}
+
+winrt::IReference<double> NumberBoxParser::Compute(const std::wstring_view expr, winrt::INumberParser numberParser)
+{
+    winrt::IReference<double> answer = nullptr;
+    auto input = expr.data();
+
+    // Tokenize the input string
+    auto tokens = GetTokens(input, numberParser);
+    if (tokens.size() > 0)
+    {
+        // Rearrange to postfix notation
+        auto postfixTokens = ConvertInfixToPostfix(tokens);
+        if (postfixTokens.size() > 0)
+        {
+            // Compute expression
+            answer = ComputePostfixExpression(postfixTokens);
+        }
+    }
+
+    return answer;
+}

--- a/dev/NumberBox/NumberBoxParser.h
+++ b/dev/NumberBox/NumberBoxParser.h
@@ -28,15 +28,15 @@ struct MathToken
 class NumberBoxParser
 {
     public:
-        static winrt::IReference<double> Compute(const std::wstring_view expr, winrt::INumberParser numberParser);
+        static winrt::IReference<double> Compute(const std::wstring_view expr, const winrt::INumberParser& numberParser);
 
     private:
-        static std::vector<MathToken> GetTokens(const wchar_t *input, winrt::INumberParser numberParser);
+        static std::vector<MathToken> GetTokens(const wchar_t *input, const winrt::INumberParser& numberParser);
 
-        static std::tuple<double, size_t> GetNextNumber(std::wstring input, winrt::INumberParser numberParser);
+        static std::tuple<double, size_t> GetNextNumber(const std::wstring& input, const winrt::INumberParser& numberParser);
         static int GetPrecedenceValue(wchar_t c);
 
-        static std::vector<MathToken> ConvertInfixToPostfix(std::vector<MathToken> tokens);
+        static std::vector<MathToken> ConvertInfixToPostfix(const std::vector<MathToken>& tokens);
 
-        static winrt::IReference<double> ComputePostfixExpression(std::vector<MathToken> tokens);
+        static winrt::IReference<double> ComputePostfixExpression(const std::vector<MathToken>& tokens);
 };

--- a/dev/NumberBox/NumberBoxParser.h
+++ b/dev/NumberBox/NumberBoxParser.h
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "pch.h"
+#include "common.h"
+#include <regex>
+#include <stack>
+
+enum MathTokenType
+{
+    Numeric,
+    Operator,
+    Parenthesis,
+};
+
+struct MathToken
+{
+    MathToken(MathTokenType t, wchar_t c) : Type(t), Char(c), Value(std::numeric_limits<double>::quiet_NaN()) {}
+    MathToken(MathTokenType t, double d) : Type(t), Value(d), Char(0) {}
+
+    MathTokenType Type;
+    wchar_t Char;
+    double Value;
+};
+
+class NumberBoxParser
+{
+    public:
+        static winrt::IReference<double> Compute(const std::wstring_view expr, winrt::INumberParser numberParser);
+
+    private:
+        static std::vector<MathToken> GetTokens(const wchar_t *input, winrt::INumberParser numberParser);
+
+        static size_t GetNextNumber(std::wstring input, winrt::INumberParser numberParser, double& outValue);
+        static int GetPrecedenceValue(wchar_t c);
+
+        static std::vector<MathToken> ConvertInfixToPostfix(std::vector<MathToken> tokens);
+
+        static winrt::IReference<double> ComputePostfixExpression(std::vector<MathToken> tokens);
+};

--- a/dev/NumberBox/NumberBoxParser.h
+++ b/dev/NumberBox/NumberBoxParser.h
@@ -33,7 +33,7 @@ class NumberBoxParser
     private:
         static std::vector<MathToken> GetTokens(const wchar_t *input, winrt::INumberParser numberParser);
 
-        static size_t GetNextNumber(std::wstring input, winrt::INumberParser numberParser, double& outValue);
+        static std::tuple<double, size_t> GetNextNumber(std::wstring input, winrt::INumberParser numberParser);
         static int GetPrecedenceValue(wchar_t c);
 
         static std::vector<MathToken> ConvertInfixToPostfix(std::vector<MathToken> tokens);

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -30,6 +30,8 @@
                 <ComboBoxItem Content="Inline"/>
             </ComboBox>
 
+            <CheckBox x:Name="CalculationCheckBox" AutomationProperties.Name="CalculationCheckBox" IsChecked="False" Content="Accepts Calculations"/>
+
             <CheckBox x:Name="HyperScrollCheckBox" AutomationProperties.Name="HyperScrollCheckBox" IsChecked="False" Content="HyperScroll Enabled"/>
 
             <CheckBox x:Name="WrapCheckBox" AutomationProperties.Name="WrapCheckBox" IsChecked="False" Content="Wrap Enabled"/>
@@ -58,6 +60,7 @@
                     Header="NumberBox"
                     ValueChanged="NumberBoxValueChanged"
                     StepFrequency="{x:Bind StepNumberBox.Value, Mode=OneWay}"
+                    AcceptsCalculation="{x:Bind CalculationCheckBox.IsChecked.Value, Mode=OneWay}"
                     HyperScrollEnabled="{x:Bind HyperScrollCheckBox.IsChecked.Value, Mode=OneWay}"
                     WrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"/>
 


### PR DESCRIPTION
This changes add the AcceptsCalculations property back to NumberBox, as well as the parser for parsing expressions. Essentially, the parser takes an input string, tokenizes it into alternating numerical and operator tokens, rearranges the tokens into postfix notation, and then computes the value from there.

The only issue I'm currently aware of is that "-(2 + 3)" doesn't evaluate -- a negative indicator before parenthesis isn't handled. It's on the list of bugs.

In addition, I discovered that .NET's default double-to-string parser truncates doubles at 12 significant digits, so I simplified our parser to do the same.