### PR TITLE
Update MUX-CI pipeline to not publish the nuget package if run manually

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -93,7 +93,7 @@ jobs:
 # To publish the package to vsts feed, set queue time variable NuGetFeed = d62f8eac-f05c-4c25-bccb-21f98b95c95f
 # This is the magic GUID from the pipeline visual designer for this feed: https://dev.azure.com/ms/microsoft-ui-xaml/_packaging?_a=feed&feed=MUX-CI
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    condition: ne(variables['NuGetFeed'], '')
+    condition: and(ne(variables['NuGetFeed'], ''), ne(variables['Build.Reason'], 'Manual'))
     displayName: 'NuGet push to $(NuGetFeed)'
     inputs:
       command: push


### PR DESCRIPTION
We have two pipelines MUX-CI and MUX-CI experiments to avoid sending email and publishing the nuget when running manually, but it is easy to mistake and do a manual run on the MUX-CI pipeline. We can get rid of the experiments pipeline if we don't publish the nuget package or send email when MUX-CI is run manually. The email was a settings that Keith updated. This change fixes it so that the nuget package does not get published when the pipeline is run manually. 

We can remove the experiments pipeline after this change.