### PR TITLE
NumberBox: Heaps of bug fixes

### DIFF
--- a/dev/Generated/NumberBox.properties.cpp
+++ b/dev/Generated/NumberBox.properties.cpp
@@ -11,6 +11,7 @@ CppWinRTActivatableClassWithDPFactory(NumberBox)
 GlobalDependencyProperty NumberBoxProperties::s_AcceptsCalculationProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_BasicValidationModeProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_HeaderTemplateProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HyperScrollEnabledProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MaximumProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MinimumProperty{ nullptr };
@@ -57,10 +58,21 @@ void NumberBoxProperties::EnsureProperties()
         s_HeaderProperty =
             InitializeDependencyProperty(
                 L"Header",
-                winrt::name_of<winrt::hstring>(),
+                winrt::name_of<winrt::IInspectable>(),
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
-                ValueHelper<winrt::hstring>::BoxedDefaultValue(),
+                ValueHelper<winrt::IInspectable>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_HeaderTemplateProperty)
+    {
+        s_HeaderTemplateProperty =
+            InitializeDependencyProperty(
+                L"HeaderTemplate",
+                winrt::name_of<winrt::DataTemplate>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<winrt::DataTemplate>::BoxedDefaultValue(),
                 nullptr);
     }
     if (!s_HyperScrollEnabledProperty)
@@ -180,6 +192,7 @@ void NumberBoxProperties::ClearProperties()
     s_AcceptsCalculationProperty = nullptr;
     s_BasicValidationModeProperty = nullptr;
     s_HeaderProperty = nullptr;
+    s_HeaderTemplateProperty = nullptr;
     s_HyperScrollEnabledProperty = nullptr;
     s_MaximumProperty = nullptr;
     s_MinimumProperty = nullptr;
@@ -278,14 +291,24 @@ winrt::NumberBoxBasicValidationMode NumberBoxProperties::BasicValidationMode()
     return ValueHelper<winrt::NumberBoxBasicValidationMode>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_BasicValidationModeProperty));
 }
 
-void NumberBoxProperties::Header(winrt::hstring const& value)
+void NumberBoxProperties::Header(winrt::IInspectable const& value)
 {
-    static_cast<NumberBox*>(this)->SetValue(s_HeaderProperty, ValueHelper<winrt::hstring>::BoxValueIfNecessary(value));
+    static_cast<NumberBox*>(this)->SetValue(s_HeaderProperty, ValueHelper<winrt::IInspectable>::BoxValueIfNecessary(value));
 }
 
-winrt::hstring NumberBoxProperties::Header()
+winrt::IInspectable NumberBoxProperties::Header()
 {
-    return ValueHelper<winrt::hstring>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_HeaderProperty));
+    return ValueHelper<winrt::IInspectable>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_HeaderProperty));
+}
+
+void NumberBoxProperties::HeaderTemplate(winrt::DataTemplate const& value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_HeaderTemplateProperty, ValueHelper<winrt::DataTemplate>::BoxValueIfNecessary(value));
+}
+
+winrt::DataTemplate NumberBoxProperties::HeaderTemplate()
+{
+    return ValueHelper<winrt::DataTemplate>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_HeaderTemplateProperty));
 }
 
 void NumberBoxProperties::HyperScrollEnabled(bool value)

--- a/dev/Generated/NumberBox.properties.h
+++ b/dev/Generated/NumberBox.properties.h
@@ -15,8 +15,11 @@ public:
     void BasicValidationMode(winrt::NumberBoxBasicValidationMode const& value);
     winrt::NumberBoxBasicValidationMode BasicValidationMode();
 
-    void Header(winrt::hstring const& value);
-    winrt::hstring Header();
+    void Header(winrt::IInspectable const& value);
+    winrt::IInspectable Header();
+
+    void HeaderTemplate(winrt::DataTemplate const& value);
+    winrt::DataTemplate HeaderTemplate();
 
     void HyperScrollEnabled(bool value);
     bool HyperScrollEnabled();
@@ -51,6 +54,7 @@ public:
     static winrt::DependencyProperty AcceptsCalculationProperty() { return s_AcceptsCalculationProperty; }
     static winrt::DependencyProperty BasicValidationModeProperty() { return s_BasicValidationModeProperty; }
     static winrt::DependencyProperty HeaderProperty() { return s_HeaderProperty; }
+    static winrt::DependencyProperty HeaderTemplateProperty() { return s_HeaderTemplateProperty; }
     static winrt::DependencyProperty HyperScrollEnabledProperty() { return s_HyperScrollEnabledProperty; }
     static winrt::DependencyProperty MaximumProperty() { return s_MaximumProperty; }
     static winrt::DependencyProperty MinimumProperty() { return s_MinimumProperty; }
@@ -65,6 +69,7 @@ public:
     static GlobalDependencyProperty s_AcceptsCalculationProperty;
     static GlobalDependencyProperty s_BasicValidationModeProperty;
     static GlobalDependencyProperty s_HeaderProperty;
+    static GlobalDependencyProperty s_HeaderTemplateProperty;
     static GlobalDependencyProperty s_HyperScrollEnabledProperty;
     static GlobalDependencyProperty s_MaximumProperty;
     static GlobalDependencyProperty s_MinimumProperty;

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -169,11 +169,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(200, numBox.Maximum);
                 Verify.AreEqual(200, numBox.Value);
 
-                Log.Comment("Verify that setting the maximum below the minimum changes the maximum");
+                Log.Comment("Verify that setting the maximum below the minimum changes the minimum");
                 EnterText(maxBox, "150");
-                Verify.AreEqual(200, numBox.Minimum);
-                Verify.AreEqual(200, numBox.Maximum);
-                Verify.AreEqual(200, numBox.Value);
+                Verify.AreEqual(150, numBox.Minimum);
+                Verify.AreEqual(150, numBox.Maximum);
+                Verify.AreEqual(150, numBox.Value);
             }
         }
 

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -168,12 +168,11 @@ void NumberBox::OnSpinButtonPlacementModePropertyChanged(const winrt::Dependency
 
 void NumberBox::OnTextPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
-    if (auto&& textBox = m_textBox.get())
+    if (!m_textUpdating)
     {
-        const auto text = Text();
-        if (std::wcscmp(textBox.Text().data(), text.data()) != 0)
+        if (auto && textBox = m_textBox.get())
         {
-            textBox.Text(text);
+            textBox.Text(Text());
             ValidateInput();
         }
     }
@@ -363,6 +362,12 @@ void NumberBox::UpdateTextToValue()
 
         const auto formattedValue = NumberFormatter().FormatDouble(roundedValue);
         textBox.Text(formattedValue);
+
+        auto scopeGuard = gsl::finally([this]()
+        {
+            m_textUpdating = false;
+        });
+        m_textUpdating = true;
         Text(formattedValue);
 
         // This places the caret at the end of the text.

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -133,16 +133,13 @@ void NumberBox::OnValuePropertyChanged(const winrt::DependencyPropertyChangedEve
 
 void NumberBox::OnMinimumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
-    // We only coerce the maximum to be above the minimum, not the other way around.
-    // This way, as long as the user always sets the minimum first and then the maximum,
-    // they will always get what they expect (if the values are valid).
     CoerceMaximum();
     CoerceValue();
 }
 
 void NumberBox::OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
-    CoerceMaximum();
+    CoerceMinimum();
     CoerceValue();
 }
 
@@ -196,12 +193,19 @@ void NumberBox::OnTextBoxLostFocus(winrt::IInspectable const& sender, winrt::Rou
 {
     ValidateInput();
 }
+void NumberBox::CoerceMinimum()
+{
+    const auto max = Maximum();
+    if (Minimum() > max)
+    {
+        Minimum(max);
+    }
+}
 
 void NumberBox::CoerceMaximum()
 {
-    const auto max = Maximum();
     const auto min = Minimum();
-    if (max < min)
+    if (Maximum() < min)
     {
         Maximum(min);
     }

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -76,6 +76,7 @@ private:
     bool IsInBounds(double value);
 
     bool m_valueUpdating{ false };
+    bool m_textUpdating{ false };
 
     winrt::SignificantDigitsNumberRounder m_displayRounder{};
 

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -60,9 +60,11 @@ private:
     void OnSpinDownClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnSpinUpClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnNumberBoxKeyUp(winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args);
+    void OnNumberBoxGotFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnScroll(winrt::IInspectable const& sender, winrt::PointerRoutedEventArgs const& args);
 
     void ValidateInput();
+    void CoerceMaximum();
     void CoerceValue();
     void UpdateTextToValue();
 
@@ -72,6 +74,8 @@ private:
     void StepValueDown() { StepValue(false); }
 
     bool IsInBounds(double value);
+
+    bool m_valueUpdating{ false };
 
     winrt::SignificantDigitsNumberRounder m_displayRounder{};
 

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -64,6 +64,7 @@ private:
     void OnScroll(winrt::IInspectable const& sender, winrt::PointerRoutedEventArgs const& args);
 
     void ValidateInput();
+    void CoerceMinimum();
     void CoerceMaximum();
     void CoerceValue();
     void UpdateTextToValue();

--- a/dev/NumberBox/NumberBox.idl
+++ b/dev/NumberBox/NumberBox.idl
@@ -46,7 +46,8 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     [MUX_DEFAULT_VALUE("1")]
     Double StepFrequency;
 
-    String Header;
+    Object Header;
+    Windows.UI.Xaml.DataTemplate HeaderTemplate;
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     String Text;
@@ -81,6 +82,7 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty StepFrequencyProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty HeaderProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty TextProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty{ get; };
 

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -24,46 +24,54 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-                        <StackPanel Orientation="Horizontal">
-                            <StackPanel.Resources>
-                                <ResourceDictionary>
-                                    <ResourceDictionary.ThemeDictionaries>
-                                        <ResourceDictionary x:Key="Light">
-                                            <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlBorderBrush"/>
-                                            <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlBorderBrush"/>
-                                        </ResourceDictionary>
+                        <Grid.Resources>
+                            <ResourceDictionary>
+                                <ResourceDictionary.ThemeDictionaries>
+                                    <ResourceDictionary x:Key="Light">
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlBorderBrush"/>
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlBorderBrush"/>
+                                    </ResourceDictionary>
 
-                                        <ResourceDictionary x:Key="Dark">
-                                            <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlBorderBrush"/>
-                                            <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlBorderBrush"/>
-                                        </ResourceDictionary>
+                                    <ResourceDictionary x:Key="Dark">
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlBorderBrush"/>
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlBorderBrush"/>
+                                    </ResourceDictionary>
 
-                                        <ResourceDictionary x:Key="HighContrast">
-                                            <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
-                                            <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
-                                        </ResourceDictionary>
-                                    </ResourceDictionary.ThemeDictionaries>
-                                </ResourceDictionary>
-                            </StackPanel.Resources>
+                                    <ResourceDictionary x:Key="HighContrast">
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
+                                    </ResourceDictionary>
+                                </ResourceDictionary.ThemeDictionaries>
+                            </ResourceDictionary>
+                        </Grid.Resources>
 
-                            <TextBox x:Name="InputBox"
-                                Header="{TemplateBinding Header}"
-                                PlaceholderText="{TemplateBinding PlaceholderText}"/>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
 
-                            <RepeatButton x:Name="UpSpinButton"
-                                Visibility="Collapsed"
-                                FontSize="{TemplateBinding FontSize}"
-                                Content="&#xE70E;"
-                                Style="{StaticResource NumberBoxSpinButtonStyle}"
-                                contract7Present:CornerRadius="0"/>
+                        <TextBox x:Name="InputBox"
+                            Grid.Column="0"
+                            Header="{TemplateBinding Header}"
+                            HeaderTemplate="{TemplateBinding HeaderTemplate}"
+                            PlaceholderText="{TemplateBinding PlaceholderText}"/>
 
-                            <RepeatButton x:Name="DownSpinButton"
-                                Visibility="Collapsed"
-                                FontSize="{TemplateBinding FontSize}"
-                                Content="&#xE70D;"
-                                Style="{StaticResource NumberBoxSpinButtonStyle}"
-                                contract7Present:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
-                        </StackPanel>
+                        <RepeatButton x:Name="UpSpinButton"
+                            Grid.Column="1"
+                            Visibility="Collapsed"
+                            FontSize="{TemplateBinding FontSize}"
+                            Content="&#xE70E;"
+                            Style="{StaticResource NumberBoxSpinButtonStyle}"
+                            contract7Present:CornerRadius="0"/>
+
+                        <RepeatButton x:Name="DownSpinButton"
+                            Grid.Column="2"
+                            Visibility="Collapsed"
+                            FontSize="{TemplateBinding FontSize}"
+                            Content="&#xE70D;"
+                            Style="{StaticResource NumberBoxSpinButtonStyle}"
+                            contract7Present:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -49,6 +49,12 @@
             </StackPanel>
 
             <Button x:Name="CustomFormatterButton" AutomationProperties.Name="CustomFormatterButton" Content="Custom Formatter" Click="CustomFormatterButton_Click" Margin="0,4,0,0"/>
+
+            <Button x:Name="SetTextButton" AutomationProperties.Name="SetTextButton" Content="Set text to 15" Click="SetTextButton_Click" Margin="0,4,0,0"/>
+
+            <Button x:Name="SetValueButton" AutomationProperties.Name="SetValueButton" Content="Set value to 42" Click="SetValueButton_Click" Margin="0,4,0,0"/>
+            
+            <Button x:Name="SetValueNaNButton" AutomationProperties.Name="SetValueNaNButton" Content="Set value to NaN" Click="SetNaNButton_Click" Margin="0,4,0,0"/>
         </StackPanel>
 
         <Grid Grid.Column="1">
@@ -66,12 +72,17 @@
 
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="Value:" Margin="0,0,5,0" />
-                    <TextBlock x:Name="CurrentValueTextBox" Text="0" />
+                    <TextBlock x:Name="NewValueTextBox" AutomationProperties.Name="NewValueTextBox" Text="0" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="Old Value:" Margin="0,0,5,0" />
-                    <TextBlock x:Name="OldValueTextBox"/>
+                    <TextBlock x:Name="OldValueTextBox" AutomationProperties.Name="OldValueTextBox"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Text:" Margin="0,0,5,0" />
+                    <TextBlock x:Name="TextTextBox" AutomationProperties.Name="TextTextBox" Text="0"/>
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml.cs
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml.cs
@@ -6,6 +6,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls;
 using Windows.Globalization.NumberFormatting;
+using System.Collections.Generic;
 
 namespace MUXControlsTestApp
 {
@@ -15,6 +16,8 @@ namespace MUXControlsTestApp
         public NumberBoxPage()
         {
             this.InitializeComponent();
+
+            TestNumberBox.RegisterPropertyChangedCallback(NumberBox.TextProperty, new DependencyPropertyChangedCallback(TextPropertyChanged));
         }
 
         private void SpinMode_Changed(object sender, RoutedEventArgs e)
@@ -80,16 +83,38 @@ namespace MUXControlsTestApp
         {
             if (TestNumberBox != null)
             {
-                CurrentValueTextBox.Text = e.NewValue.ToString();
+                NewValueTextBox.Text = e.NewValue.ToString();
                 OldValueTextBox.Text = e.OldValue.ToString();
             }
         }
+
         private void CustomFormatterButton_Click(object sender, RoutedEventArgs e)
         {
-            DecimalFormatter formatter = new DecimalFormatter();
+            List<string> languages = new List<string>() { "fr-FR" };
+            DecimalFormatter formatter = new DecimalFormatter(languages, "FR");
             formatter.IntegerDigits = 1;
             formatter.FractionDigits = 2;
             TestNumberBox.NumberFormatter = formatter;
+        }
+
+        private void SetTextButton_Click(object sender, RoutedEventArgs e)
+        {
+            TestNumberBox.Text = "15";
+        }
+
+        private void SetValueButton_Click(object sender, RoutedEventArgs e)
+        {
+            TestNumberBox.Value = 42;
+        }
+
+        private void SetNaNButton_Click(object sender, RoutedEventArgs e)
+        {
+            TestNumberBox.Value = Double.NaN;
+        }
+
+        private void TextPropertyChanged(DependencyObject o, DependencyProperty p)
+        {
+            TextTextBox.Text = TestNumberBox.Text;
         }
     }
 }


### PR DESCRIPTION
- Now validates input when the Text() property changes. Also, the Text() property is now updated in SetTextToValue().
- Maximum is now coerced to be >= Minimum.
- Trims whitespace from input strings so that " 5 " now evaluates to 5 instead of an error.
- Only sends ValueChanged once instead of twice if input is invalid.
- Replaces the text even if Value hasn't changed (e.g. if Value is 5, user types "2+3", text should still be replaced with "5")
- Header is now an object instead of a string. Also added HeaderTemplate as a property.
- When the control gets focus, it selects the text in the textbox. On evaluation, the caret moves to the end of the string.

Added tests for all of the above, as well as a better test for custom NumberFormatter that proves alternate decimal characters work.