### PR TITLE
Some ThemeResource fixes

### DIFF
--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -7,8 +7,10 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
-            <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7Present:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+            <contract7NotPresent:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7NotPresent:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
             <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
             <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
         </ResourceDictionary>
@@ -19,8 +21,10 @@
             <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
-            <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7Present:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+            <contract7NotPresent:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7NotPresent:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
             <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
             <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
         </ResourceDictionary>

--- a/dev/ContentDialog/ContentDialog_themeresources.xaml
+++ b/dev/ContentDialog/ContentDialog_themeresources.xaml
@@ -2,6 +2,8 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+    xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
     <ResourceDictionary.ThemeDictionaries>
@@ -264,7 +266,12 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="LayoutRoot" Visibility="Collapsed" Background="{ThemeResource SystemControlPageBackgroundMediumAltMediumBrush}">
+                        <Grid x:Name="LayoutRoot"
+                              contract5Present:Visibility="Collapsed"
+                              Background="{ThemeResource SystemControlPageBackgroundMediumAltMediumBrush}">
+                            <contract5NotPresent:Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                            </contract5NotPresent:Grid.ColumnDefinitions>
                             <Border
                                 x:Name="BackgroundElement"
                                 Background="{TemplateBinding Background}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Found some issues while testing on RS2 for another bug.

FlyoutPresenter: Transient background doesn't work properly on RS2 which makes flyout background transparent. Adding conditional xaml to fallback to previous non-transient colors on older os versions.

ContentDialog: There are quirks in code that makes it only show theme transitions in higher os versions. LayoutRoot is always collapsed in RS2 since the transition doesn't play. Also used conditional xaml to fix that.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually tested on RS2 and RS3.