### PR TITLE
NumberBox: New features and bug fixes

### DIFF
--- a/dev/Generated/NumberBox.properties.cpp
+++ b/dev/Generated/NumberBox.properties.cpp
@@ -9,19 +9,24 @@
 CppWinRTActivatableClassWithDPFactory(NumberBox)
 
 GlobalDependencyProperty NumberBoxProperties::s_AcceptsCalculationProperty{ nullptr };
-GlobalDependencyProperty NumberBoxProperties::s_BasicValidationModeProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_DescriptionProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderTemplateProperty{ nullptr };
-GlobalDependencyProperty NumberBoxProperties::s_HyperScrollEnabledProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_IsHyperScrollEnabledProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_IsWrapEnabledProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MaximumProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MinimumProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_NumberFormatterProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_PlaceholderTextProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_PreventKeyboardDisplayOnProgrammaticFocusProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_SelectionFlyoutProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_SelectionHighlightColorProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_SpinButtonPlacementModeProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_StepFrequencyProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_TextProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_TextReadingOrderProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_ValidationModeProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_ValueProperty{ nullptr };
-GlobalDependencyProperty NumberBoxProperties::s_WrapEnabledProperty{ nullptr };
 
 NumberBoxProperties::NumberBoxProperties()
     : m_valueChangedEventSource{static_cast<NumberBox*>(this)}
@@ -42,16 +47,16 @@ void NumberBoxProperties::EnsureProperties()
                 ValueHelper<bool>::BoxValueIfNecessary(false),
                 nullptr);
     }
-    if (!s_BasicValidationModeProperty)
+    if (!s_DescriptionProperty)
     {
-        s_BasicValidationModeProperty =
+        s_DescriptionProperty =
             InitializeDependencyProperty(
-                L"BasicValidationMode",
-                winrt::name_of<winrt::NumberBoxBasicValidationMode>(),
+                L"Description",
+                winrt::name_of<winrt::IInspectable>(),
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
-                ValueHelper<winrt::NumberBoxBasicValidationMode>::BoxedDefaultValue(),
-                winrt::PropertyChangedCallback(&OnBasicValidationModePropertyChanged));
+                ValueHelper<winrt::IInspectable>::BoxedDefaultValue(),
+                nullptr);
     }
     if (!s_HeaderProperty)
     {
@@ -75,16 +80,27 @@ void NumberBoxProperties::EnsureProperties()
                 ValueHelper<winrt::DataTemplate>::BoxedDefaultValue(),
                 nullptr);
     }
-    if (!s_HyperScrollEnabledProperty)
+    if (!s_IsHyperScrollEnabledProperty)
     {
-        s_HyperScrollEnabledProperty =
+        s_IsHyperScrollEnabledProperty =
             InitializeDependencyProperty(
-                L"HyperScrollEnabled",
+                L"IsHyperScrollEnabled",
                 winrt::name_of<bool>(),
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
                 ValueHelper<bool>::BoxValueIfNecessary(false),
                 nullptr);
+    }
+    if (!s_IsWrapEnabledProperty)
+    {
+        s_IsWrapEnabledProperty =
+            InitializeDependencyProperty(
+                L"IsWrapEnabled",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxValueIfNecessary(false),
+                winrt::PropertyChangedCallback(&OnIsWrapEnabledPropertyChanged));
     }
     if (!s_MaximumProperty)
     {
@@ -130,6 +146,39 @@ void NumberBoxProperties::EnsureProperties()
                 ValueHelper<winrt::hstring>::BoxedDefaultValue(),
                 nullptr);
     }
+    if (!s_PreventKeyboardDisplayOnProgrammaticFocusProperty)
+    {
+        s_PreventKeyboardDisplayOnProgrammaticFocusProperty =
+            InitializeDependencyProperty(
+                L"PreventKeyboardDisplayOnProgrammaticFocus",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_SelectionFlyoutProperty)
+    {
+        s_SelectionFlyoutProperty =
+            InitializeDependencyProperty(
+                L"SelectionFlyout",
+                winrt::name_of<winrt::FlyoutBase>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<winrt::FlyoutBase>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_SelectionHighlightColorProperty)
+    {
+        s_SelectionHighlightColorProperty =
+            InitializeDependencyProperty(
+                L"SelectionHighlightColor",
+                winrt::name_of<winrt::SolidColorBrush>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<winrt::SolidColorBrush>::BoxedDefaultValue(),
+                nullptr);
+    }
     if (!s_SpinButtonPlacementModeProperty)
     {
         s_SpinButtonPlacementModeProperty =
@@ -150,7 +199,7 @@ void NumberBoxProperties::EnsureProperties()
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
                 ValueHelper<double>::BoxValueIfNecessary(1),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnStepFrequencyPropertyChanged));
     }
     if (!s_TextProperty)
     {
@@ -163,6 +212,28 @@ void NumberBoxProperties::EnsureProperties()
                 ValueHelper<winrt::hstring>::BoxedDefaultValue(),
                 winrt::PropertyChangedCallback(&OnTextPropertyChanged));
     }
+    if (!s_TextReadingOrderProperty)
+    {
+        s_TextReadingOrderProperty =
+            InitializeDependencyProperty(
+                L"TextReadingOrder",
+                winrt::name_of<winrt::TextReadingOrder>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<winrt::TextReadingOrder>::BoxedDefaultValue(),
+                nullptr);
+    }
+    if (!s_ValidationModeProperty)
+    {
+        s_ValidationModeProperty =
+            InitializeDependencyProperty(
+                L"ValidationMode",
+                winrt::name_of<winrt::NumberBoxValidationMode>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<winrt::NumberBoxValidationMode>::BoxedDefaultValue(),
+                winrt::PropertyChangedCallback(&OnValidationModePropertyChanged));
+    }
     if (!s_ValueProperty)
     {
         s_ValueProperty =
@@ -174,43 +245,37 @@ void NumberBoxProperties::EnsureProperties()
                 ValueHelper<double>::BoxValueIfNecessary(0),
                 winrt::PropertyChangedCallback(&OnValuePropertyChanged));
     }
-    if (!s_WrapEnabledProperty)
-    {
-        s_WrapEnabledProperty =
-            InitializeDependencyProperty(
-                L"WrapEnabled",
-                winrt::name_of<bool>(),
-                winrt::name_of<winrt::NumberBox>(),
-                false /* isAttached */,
-                ValueHelper<bool>::BoxValueIfNecessary(false),
-                nullptr);
-    }
 }
 
 void NumberBoxProperties::ClearProperties()
 {
     s_AcceptsCalculationProperty = nullptr;
-    s_BasicValidationModeProperty = nullptr;
+    s_DescriptionProperty = nullptr;
     s_HeaderProperty = nullptr;
     s_HeaderTemplateProperty = nullptr;
-    s_HyperScrollEnabledProperty = nullptr;
+    s_IsHyperScrollEnabledProperty = nullptr;
+    s_IsWrapEnabledProperty = nullptr;
     s_MaximumProperty = nullptr;
     s_MinimumProperty = nullptr;
     s_NumberFormatterProperty = nullptr;
     s_PlaceholderTextProperty = nullptr;
+    s_PreventKeyboardDisplayOnProgrammaticFocusProperty = nullptr;
+    s_SelectionFlyoutProperty = nullptr;
+    s_SelectionHighlightColorProperty = nullptr;
     s_SpinButtonPlacementModeProperty = nullptr;
     s_StepFrequencyProperty = nullptr;
     s_TextProperty = nullptr;
+    s_TextReadingOrderProperty = nullptr;
+    s_ValidationModeProperty = nullptr;
     s_ValueProperty = nullptr;
-    s_WrapEnabledProperty = nullptr;
 }
 
-void NumberBoxProperties::OnBasicValidationModePropertyChanged(
+void NumberBoxProperties::OnIsWrapEnabledPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
     auto owner = sender.as<winrt::NumberBox>();
-    winrt::get_self<NumberBox>(owner)->OnBasicValidationModePropertyChanged(args);
+    winrt::get_self<NumberBox>(owner)->OnIsWrapEnabledPropertyChanged(args);
 }
 
 void NumberBoxProperties::OnMaximumPropertyChanged(
@@ -255,12 +320,28 @@ void NumberBoxProperties::OnSpinButtonPlacementModePropertyChanged(
     winrt::get_self<NumberBox>(owner)->OnSpinButtonPlacementModePropertyChanged(args);
 }
 
+void NumberBoxProperties::OnStepFrequencyPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::NumberBox>();
+    winrt::get_self<NumberBox>(owner)->OnStepFrequencyPropertyChanged(args);
+}
+
 void NumberBoxProperties::OnTextPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
     auto owner = sender.as<winrt::NumberBox>();
     winrt::get_self<NumberBox>(owner)->OnTextPropertyChanged(args);
+}
+
+void NumberBoxProperties::OnValidationModePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::NumberBox>();
+    winrt::get_self<NumberBox>(owner)->OnValidationModePropertyChanged(args);
 }
 
 void NumberBoxProperties::OnValuePropertyChanged(
@@ -281,14 +362,14 @@ bool NumberBoxProperties::AcceptsCalculation()
     return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_AcceptsCalculationProperty));
 }
 
-void NumberBoxProperties::BasicValidationMode(winrt::NumberBoxBasicValidationMode const& value)
+void NumberBoxProperties::Description(winrt::IInspectable const& value)
 {
-    static_cast<NumberBox*>(this)->SetValue(s_BasicValidationModeProperty, ValueHelper<winrt::NumberBoxBasicValidationMode>::BoxValueIfNecessary(value));
+    static_cast<NumberBox*>(this)->SetValue(s_DescriptionProperty, ValueHelper<winrt::IInspectable>::BoxValueIfNecessary(value));
 }
 
-winrt::NumberBoxBasicValidationMode NumberBoxProperties::BasicValidationMode()
+winrt::IInspectable NumberBoxProperties::Description()
 {
-    return ValueHelper<winrt::NumberBoxBasicValidationMode>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_BasicValidationModeProperty));
+    return ValueHelper<winrt::IInspectable>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_DescriptionProperty));
 }
 
 void NumberBoxProperties::Header(winrt::IInspectable const& value)
@@ -311,14 +392,24 @@ winrt::DataTemplate NumberBoxProperties::HeaderTemplate()
     return ValueHelper<winrt::DataTemplate>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_HeaderTemplateProperty));
 }
 
-void NumberBoxProperties::HyperScrollEnabled(bool value)
+void NumberBoxProperties::IsHyperScrollEnabled(bool value)
 {
-    static_cast<NumberBox*>(this)->SetValue(s_HyperScrollEnabledProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+    static_cast<NumberBox*>(this)->SetValue(s_IsHyperScrollEnabledProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
 }
 
-bool NumberBoxProperties::HyperScrollEnabled()
+bool NumberBoxProperties::IsHyperScrollEnabled()
 {
-    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_HyperScrollEnabledProperty));
+    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_IsHyperScrollEnabledProperty));
+}
+
+void NumberBoxProperties::IsWrapEnabled(bool value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_IsWrapEnabledProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+}
+
+bool NumberBoxProperties::IsWrapEnabled()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_IsWrapEnabledProperty));
 }
 
 void NumberBoxProperties::Maximum(double value)
@@ -363,6 +454,36 @@ winrt::hstring NumberBoxProperties::PlaceholderText()
     return ValueHelper<winrt::hstring>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_PlaceholderTextProperty));
 }
 
+void NumberBoxProperties::PreventKeyboardDisplayOnProgrammaticFocus(bool value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_PreventKeyboardDisplayOnProgrammaticFocusProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+}
+
+bool NumberBoxProperties::PreventKeyboardDisplayOnProgrammaticFocus()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_PreventKeyboardDisplayOnProgrammaticFocusProperty));
+}
+
+void NumberBoxProperties::SelectionFlyout(winrt::FlyoutBase const& value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_SelectionFlyoutProperty, ValueHelper<winrt::FlyoutBase>::BoxValueIfNecessary(value));
+}
+
+winrt::FlyoutBase NumberBoxProperties::SelectionFlyout()
+{
+    return ValueHelper<winrt::FlyoutBase>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_SelectionFlyoutProperty));
+}
+
+void NumberBoxProperties::SelectionHighlightColor(winrt::SolidColorBrush const& value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_SelectionHighlightColorProperty, ValueHelper<winrt::SolidColorBrush>::BoxValueIfNecessary(value));
+}
+
+winrt::SolidColorBrush NumberBoxProperties::SelectionHighlightColor()
+{
+    return ValueHelper<winrt::SolidColorBrush>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_SelectionHighlightColorProperty));
+}
+
 void NumberBoxProperties::SpinButtonPlacementMode(winrt::NumberBoxSpinButtonPlacementMode const& value)
 {
     static_cast<NumberBox*>(this)->SetValue(s_SpinButtonPlacementModeProperty, ValueHelper<winrt::NumberBoxSpinButtonPlacementMode>::BoxValueIfNecessary(value));
@@ -393,6 +514,26 @@ winrt::hstring NumberBoxProperties::Text()
     return ValueHelper<winrt::hstring>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_TextProperty));
 }
 
+void NumberBoxProperties::TextReadingOrder(winrt::TextReadingOrder const& value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_TextReadingOrderProperty, ValueHelper<winrt::TextReadingOrder>::BoxValueIfNecessary(value));
+}
+
+winrt::TextReadingOrder NumberBoxProperties::TextReadingOrder()
+{
+    return ValueHelper<winrt::TextReadingOrder>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_TextReadingOrderProperty));
+}
+
+void NumberBoxProperties::ValidationMode(winrt::NumberBoxValidationMode const& value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_ValidationModeProperty, ValueHelper<winrt::NumberBoxValidationMode>::BoxValueIfNecessary(value));
+}
+
+winrt::NumberBoxValidationMode NumberBoxProperties::ValidationMode()
+{
+    return ValueHelper<winrt::NumberBoxValidationMode>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_ValidationModeProperty));
+}
+
 void NumberBoxProperties::Value(double value)
 {
     static_cast<NumberBox*>(this)->SetValue(s_ValueProperty, ValueHelper<double>::BoxValueIfNecessary(value));
@@ -401,16 +542,6 @@ void NumberBoxProperties::Value(double value)
 double NumberBoxProperties::Value()
 {
     return ValueHelper<double>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_ValueProperty));
-}
-
-void NumberBoxProperties::WrapEnabled(bool value)
-{
-    static_cast<NumberBox*>(this)->SetValue(s_WrapEnabledProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
-}
-
-bool NumberBoxProperties::WrapEnabled()
-{
-    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_WrapEnabledProperty));
 }
 
 winrt::event_token NumberBoxProperties::ValueChanged(winrt::TypedEventHandler<winrt::NumberBox, winrt::NumberBoxValueChangedEventArgs> const& value)

--- a/dev/Generated/NumberBox.properties.h
+++ b/dev/Generated/NumberBox.properties.h
@@ -12,8 +12,8 @@ public:
     void AcceptsCalculation(bool value);
     bool AcceptsCalculation();
 
-    void BasicValidationMode(winrt::NumberBoxBasicValidationMode const& value);
-    winrt::NumberBoxBasicValidationMode BasicValidationMode();
+    void Description(winrt::IInspectable const& value);
+    winrt::IInspectable Description();
 
     void Header(winrt::IInspectable const& value);
     winrt::IInspectable Header();
@@ -21,8 +21,11 @@ public:
     void HeaderTemplate(winrt::DataTemplate const& value);
     winrt::DataTemplate HeaderTemplate();
 
-    void HyperScrollEnabled(bool value);
-    bool HyperScrollEnabled();
+    void IsHyperScrollEnabled(bool value);
+    bool IsHyperScrollEnabled();
+
+    void IsWrapEnabled(bool value);
+    bool IsWrapEnabled();
 
     void Maximum(double value);
     double Maximum();
@@ -36,6 +39,15 @@ public:
     void PlaceholderText(winrt::hstring const& value);
     winrt::hstring PlaceholderText();
 
+    void PreventKeyboardDisplayOnProgrammaticFocus(bool value);
+    bool PreventKeyboardDisplayOnProgrammaticFocus();
+
+    void SelectionFlyout(winrt::FlyoutBase const& value);
+    winrt::FlyoutBase SelectionFlyout();
+
+    void SelectionHighlightColor(winrt::SolidColorBrush const& value);
+    winrt::SolidColorBrush SelectionHighlightColor();
+
     void SpinButtonPlacementMode(winrt::NumberBoxSpinButtonPlacementMode const& value);
     winrt::NumberBoxSpinButtonPlacementMode SpinButtonPlacementMode();
 
@@ -45,41 +57,54 @@ public:
     void Text(winrt::hstring const& value);
     winrt::hstring Text();
 
+    void TextReadingOrder(winrt::TextReadingOrder const& value);
+    winrt::TextReadingOrder TextReadingOrder();
+
+    void ValidationMode(winrt::NumberBoxValidationMode const& value);
+    winrt::NumberBoxValidationMode ValidationMode();
+
     void Value(double value);
     double Value();
 
-    void WrapEnabled(bool value);
-    bool WrapEnabled();
-
     static winrt::DependencyProperty AcceptsCalculationProperty() { return s_AcceptsCalculationProperty; }
-    static winrt::DependencyProperty BasicValidationModeProperty() { return s_BasicValidationModeProperty; }
+    static winrt::DependencyProperty DescriptionProperty() { return s_DescriptionProperty; }
     static winrt::DependencyProperty HeaderProperty() { return s_HeaderProperty; }
     static winrt::DependencyProperty HeaderTemplateProperty() { return s_HeaderTemplateProperty; }
-    static winrt::DependencyProperty HyperScrollEnabledProperty() { return s_HyperScrollEnabledProperty; }
+    static winrt::DependencyProperty IsHyperScrollEnabledProperty() { return s_IsHyperScrollEnabledProperty; }
+    static winrt::DependencyProperty IsWrapEnabledProperty() { return s_IsWrapEnabledProperty; }
     static winrt::DependencyProperty MaximumProperty() { return s_MaximumProperty; }
     static winrt::DependencyProperty MinimumProperty() { return s_MinimumProperty; }
     static winrt::DependencyProperty NumberFormatterProperty() { return s_NumberFormatterProperty; }
     static winrt::DependencyProperty PlaceholderTextProperty() { return s_PlaceholderTextProperty; }
+    static winrt::DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty() { return s_PreventKeyboardDisplayOnProgrammaticFocusProperty; }
+    static winrt::DependencyProperty SelectionFlyoutProperty() { return s_SelectionFlyoutProperty; }
+    static winrt::DependencyProperty SelectionHighlightColorProperty() { return s_SelectionHighlightColorProperty; }
     static winrt::DependencyProperty SpinButtonPlacementModeProperty() { return s_SpinButtonPlacementModeProperty; }
     static winrt::DependencyProperty StepFrequencyProperty() { return s_StepFrequencyProperty; }
     static winrt::DependencyProperty TextProperty() { return s_TextProperty; }
+    static winrt::DependencyProperty TextReadingOrderProperty() { return s_TextReadingOrderProperty; }
+    static winrt::DependencyProperty ValidationModeProperty() { return s_ValidationModeProperty; }
     static winrt::DependencyProperty ValueProperty() { return s_ValueProperty; }
-    static winrt::DependencyProperty WrapEnabledProperty() { return s_WrapEnabledProperty; }
 
     static GlobalDependencyProperty s_AcceptsCalculationProperty;
-    static GlobalDependencyProperty s_BasicValidationModeProperty;
+    static GlobalDependencyProperty s_DescriptionProperty;
     static GlobalDependencyProperty s_HeaderProperty;
     static GlobalDependencyProperty s_HeaderTemplateProperty;
-    static GlobalDependencyProperty s_HyperScrollEnabledProperty;
+    static GlobalDependencyProperty s_IsHyperScrollEnabledProperty;
+    static GlobalDependencyProperty s_IsWrapEnabledProperty;
     static GlobalDependencyProperty s_MaximumProperty;
     static GlobalDependencyProperty s_MinimumProperty;
     static GlobalDependencyProperty s_NumberFormatterProperty;
     static GlobalDependencyProperty s_PlaceholderTextProperty;
+    static GlobalDependencyProperty s_PreventKeyboardDisplayOnProgrammaticFocusProperty;
+    static GlobalDependencyProperty s_SelectionFlyoutProperty;
+    static GlobalDependencyProperty s_SelectionHighlightColorProperty;
     static GlobalDependencyProperty s_SpinButtonPlacementModeProperty;
     static GlobalDependencyProperty s_StepFrequencyProperty;
     static GlobalDependencyProperty s_TextProperty;
+    static GlobalDependencyProperty s_TextReadingOrderProperty;
+    static GlobalDependencyProperty s_ValidationModeProperty;
     static GlobalDependencyProperty s_ValueProperty;
-    static GlobalDependencyProperty s_WrapEnabledProperty;
 
     winrt::event_token ValueChanged(winrt::TypedEventHandler<winrt::NumberBox, winrt::NumberBoxValueChangedEventArgs> const& value);
     void ValueChanged(winrt::event_token const& token);
@@ -89,7 +114,7 @@ public:
     static void EnsureProperties();
     static void ClearProperties();
 
-    static void OnBasicValidationModePropertyChanged(
+    static void OnIsWrapEnabledPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
@@ -109,7 +134,15 @@ public:
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
+    static void OnStepFrequencyPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
     static void OnTextPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnValidationModePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -270,15 +270,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        [TestMethod]
+        // [TestMethod] Disabled because GamePad A gets eaten by the TextBox.
         public void GamepadTest()
         {
-            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone4))
-            {
-                Log.Warning("Test is disabled on pre-RS4 because Gamepad interaction is not supported pre-RS4");
-                return;
-            }
-
             using (var setup = new TestSetupHelper("NumberBox Tests"))
             {
                 RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -273,6 +273,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void GamepadTest()
         {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone4))
+            {
+                Log.Warning("Test is disabled on pre-RS4 because Gamepad interaction is not supported pre-RS4");
+                return;
+            }
+
             using (var setup = new TestSetupHelper("NumberBox Tests"))
             {
                 RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -76,29 +76,86 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Check("MinCheckBox");
                 Check("MaxCheckBox");
 
-                numBox.SetValue(98);
-                Wait.ForIdle();
-                Log.Comment("Verify that when wrapping is off, clicking the up button won't go past the max value.");
-                upButton.InvokeAndWait();
-                Verify.AreEqual(100, numBox.Value);
-
+                numBox.SetValue(100);
                 Check("WrapCheckBox");
 
-                Log.Comment("Verify that when wrapping is on, clicking the up button wraps to the min value.");
+                Log.Comment("Verify that when wrapping is on, and value is at max, clicking the up button wraps to the min value.");
                 upButton.InvokeAndWait();
                 Verify.AreEqual(0, numBox.Value);
-
-                Uncheck("WrapCheckBox");
-
-                Log.Comment("Verify that when wrapping is off, clicking the down button won't go past the min value.");
-                downButton.InvokeAndWait();
-                Verify.AreEqual(0, numBox.Value);
-
-                Check("WrapCheckBox");
 
                 Log.Comment("Verify that when wrapping is on, clicking the down button wraps to the max value.");
                 downButton.InvokeAndWait();
                 Verify.AreEqual(100, numBox.Value);
+
+                Log.Comment("Verify that incrementing after typing in a value validates the text first.");
+                EnterText(numBox, "50", false);
+                upButton.InvokeAndWait();
+                Verify.AreEqual(55, numBox.Value);
+            }
+        }
+
+
+        [TestMethod]
+        public void UpDownEnabledTest()
+        {
+            using (var setup = new TestSetupHelper("NumberBox Tests"))
+            {
+                RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");
+
+                ComboBox spinModeComboBox = FindElement.ByName<ComboBox>("SpinModeComboBox");
+                spinModeComboBox.SelectItemByName("Inline");
+                Wait.ForIdle();
+
+                Button upButton = FindButton(numBox, "Increase");
+                Button downButton = FindButton(numBox, "Decrease");
+
+                Check("MinCheckBox");
+                Check("MaxCheckBox");
+
+                Log.Comment("Verify that when Value is at Minimum, the down spin button is disabled.");
+                Verify.IsTrue(upButton.IsEnabled);
+                Verify.IsFalse(downButton.IsEnabled);
+
+                Log.Comment("Verify that when Value is at Maximum, the up spin button is disabled.");
+                numBox.SetValue(100);
+                Wait.ForIdle();
+                Verify.IsFalse(upButton.IsEnabled);
+                Verify.IsTrue(downButton.IsEnabled);
+
+                Log.Comment("Verify that when wrapping is enabled, spin buttons are enabled.");
+                Check("WrapCheckBox");
+                Verify.IsTrue(upButton.IsEnabled);
+                Verify.IsTrue(downButton.IsEnabled);
+                Uncheck("WrapCheckBox");
+
+                Log.Comment("Verify that when Maximum is updated the up button is updated also.");
+                RangeValueSpinner maxBox = FindElement.ByName<RangeValueSpinner>("MaxNumberBox");
+                maxBox.SetValue(200);
+                Wait.ForIdle();
+                Verify.IsTrue(upButton.IsEnabled);
+                Verify.IsTrue(downButton.IsEnabled);
+
+                Log.Comment("Verify that spin buttons are disabled if value is NaN.");
+                numBox.SetValue(double.NaN);
+                Wait.ForIdle();
+                Verify.IsFalse(upButton.IsEnabled);
+                Verify.IsFalse(downButton.IsEnabled);
+
+                ComboBox validationComboBox = FindElement.ByName<ComboBox>("ValidationComboBox");
+                validationComboBox.SelectItemByName("Disabled");
+                Wait.ForIdle();
+
+                Log.Comment("Verify that when validation is off, spin buttons are enabled");
+                numBox.SetValue(0);
+                Wait.ForIdle();
+                Verify.IsTrue(upButton.IsEnabled);
+                Verify.IsTrue(downButton.IsEnabled);
+
+                Log.Comment("...except in the NaN case");
+                numBox.SetValue(double.NaN);
+                Wait.ForIdle();
+                Verify.IsFalse(upButton.IsEnabled);
+                Verify.IsFalse(downButton.IsEnabled);
             }
         }
 
@@ -243,6 +300,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Check("HyperScrollCheckBox");
 
+                Log.Comment("Verify that scroll doesn't work when the control doesn't have focus.");
+                InputHelper.RotateWheel(numBox, 1);
+                Wait.ForIdle();
+                Verify.AreEqual(0, numBox.Value);
+
+                FindTextBox(numBox).SetFocus();
+
                 InputHelper.RotateWheel(numBox, 1);
                 InputHelper.RotateWheel(numBox, 1);
                 Wait.ForIdle();
@@ -341,19 +405,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual("100", newValueTextBlock.GetText());
                 Verify.AreEqual("0", oldValueTextBlock.GetText());
 
-                Log.Comment("Verify that setting value to NaN is invalid and does not fire an event.");
+                Log.Comment("Verify that setting text to an empty string sets value to NaN.");
+                EnterText(numBox, "");
+                Verify.AreEqual("", textTextBlock.GetText());
+                Verify.AreEqual("NaN", newValueTextBlock.GetText());
+                Verify.AreEqual("100", oldValueTextBlock.GetText());
+
+                Log.Comment("Verify that setting value to NaN doesn't have any effect");
                 Button nanbutton = FindElement.ByName<Button>("SetValueNaNButton");
                 nanbutton.InvokeAndWait();
-                Verify.AreEqual("100", textTextBlock.GetText());
-                Verify.AreEqual("100", newValueTextBlock.GetText());
-                Verify.AreEqual("0", oldValueTextBlock.GetText());
-
-                Log.Comment("Verify that setting value to NaN is valid when validation is disabled.");
-                ComboBox validationComboBox = FindElement.ByName<ComboBox>("ValidationComboBox");
-                validationComboBox.SelectItemByName("Disabled");
-                Wait.ForIdle();
-                nanbutton.InvokeAndWait();
-                Verify.AreEqual("NaN", textTextBlock.GetText());
+                Verify.AreEqual("", textTextBlock.GetText());
                 Verify.AreEqual("NaN", newValueTextBlock.GetText());
                 Verify.AreEqual("100", oldValueTextBlock.GetText());
             }

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -39,37 +39,38 @@ public:
     // IFrameworkElement
     void OnApplyTemplate();
 
-    void OnHeaderPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnSpinButtonPlacementModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnPlaceholderTextPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnTextPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
-    void OnBasicValidationModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnHyperScrollEnabledPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnValidationModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
     void OnValuePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMinimumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnStepFrequencyPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnIsWrapEnabledPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
     void OnNumberFormatterPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void ValidateNumberFormatter(winrt::INumberFormatter2 value);
 
 private:
 
-    void OnTextBoxLostFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnSpinDownClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnSpinUpClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
-    void OnNumberBoxKeyUp(winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args);
+    void OnNumberBoxKeyDown(winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args);
     void OnNumberBoxGotFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
-    void OnScroll(winrt::IInspectable const& sender, winrt::PointerRoutedEventArgs const& args);
+    void OnNumberBoxLostFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
+    void OnNumberBoxScroll(winrt::IInspectable const& sender, winrt::PointerRoutedEventArgs const& args);
 
     void ValidateInput();
     void CoerceMinimum();
     void CoerceMaximum();
     void CoerceValue();
     void UpdateTextToValue();
+    void UpdateValueToText();
 
-    void SetSpinButtonVisualState();
+    void UpdateSpinButtonPlacement();
+    void UpdateSpinButtonEnabled();
     void StepValue(bool isPositive);
     void StepValueUp() { StepValue(true); }
     void StepValueDown() { StepValue(false); }
@@ -82,9 +83,11 @@ private:
     winrt::SignificantDigitsNumberRounder m_displayRounder{};
 
     tracker_ref<winrt::TextBox> m_textBox{ this };
+    tracker_ref<winrt::Popup> m_popup{ this };
 
     winrt::RepeatButton::Click_revoker m_upButtonClickRevoker{};
     winrt::RepeatButton::Click_revoker m_downButtonClickRevoker{};
-    winrt::TextBox::LostFocus_revoker m_textBoxLostFocusRevoker{};
-    winrt::TextBox::KeyUp_revoker m_textBoxKeyUpRevoker{};
+    winrt::TextBox::KeyDown_revoker m_textBoxKeyDownRevoker{};
+    winrt::RepeatButton::Click_revoker m_popupUpButtonClickRevoker{};
+    winrt::RepeatButton::Click_revoker m_popupDownButtonClickRevoker{};
 };

--- a/dev/NumberBox/NumberBox.idl
+++ b/dev/NumberBox/NumberBox.idl
@@ -6,12 +6,13 @@
 enum NumberBoxSpinButtonPlacementMode
 {
     Hidden,
+    Compact,
     Inline
 };
 
 [WUXC_VERSION_PREVIEW]
 [webhosthidden]
-enum NumberBoxBasicValidationMode
+enum NumberBoxValidationMode
 {
     InvalidInputOverwritten,
     Disabled
@@ -44,28 +45,35 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     Double Value;
 
     [MUX_DEFAULT_VALUE("1")]
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Double StepFrequency;
-
-    Object Header;
-    Windows.UI.Xaml.DataTemplate HeaderTemplate;
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     String Text;
 
+    // TextBox properties
+    Object Header;
+    Windows.UI.Xaml.DataTemplate HeaderTemplate;
     String PlaceholderText;
+    Windows.UI.Xaml.Controls.Primitives.FlyoutBase SelectionFlyout;
+    Windows.UI.Xaml.Media.SolidColorBrush SelectionHighlightColor;
+    Windows.UI.Xaml.TextReadingOrder TextReadingOrder;
+    Boolean PreventKeyboardDisplayOnProgrammaticFocus;
+    Object Description;
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
-    NumberBoxBasicValidationMode BasicValidationMode;
+    NumberBoxValidationMode ValidationMode;
 
     [MUX_DEFAULT_VALUE("winrt::NumberBoxSpinButtonPlacementMode::Hidden")]
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     NumberBoxSpinButtonPlacementMode SpinButtonPlacementMode{ get; set; };
 
     [MUX_DEFAULT_VALUE("false")]
-    Boolean HyperScrollEnabled;
+    Boolean IsHyperScrollEnabled;
 
     [MUX_DEFAULT_VALUE("false")]
-    Boolean WrapEnabled;
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Boolean IsWrapEnabled;
 
     [MUX_DEFAULT_VALUE("false")]
     Boolean AcceptsCalculation;
@@ -80,16 +88,21 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty MaximumProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty ValueProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty StepFrequencyProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty TextProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty HeaderProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty TextProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty SelectionHighlightColorProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty DescriptionProperty{ get; };
 
-    static Windows.UI.Xaml.DependencyProperty BasicValidationModeProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty ValidationModeProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty SpinButtonPlacementModeProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty HyperScrollEnabledProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty WrapEnabledProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty IsHyperScrollEnabledProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty IsWrapEnabledProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty AcceptsCalculationProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty NumberFormatterProperty{ get; };

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -3,9 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
-<Style TargetType="local:NumberBox">
+    <Style TargetType="local:NumberBox">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:NumberBox">
@@ -19,6 +20,32 @@
                                         <Setter Target="DownSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="UpSpinButton.Visibility" Value="Visible" />
                                         <contract7Present:Setter Target="InputBox.CornerRadius" Value="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource LeftCornerRadiusFilterConverter}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="SpinButtonsPopup">
+                                    <VisualState.Setters>
+                                        <Setter Target="InputBox.Style" Value="{StaticResource NumberBoxTextBoxStyle}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="UpSpinButtonEnabledStates">
+                                <VisualState x:Name="UpSpinButtonEnabled" />
+                                <VisualState x:Name="UpSpinButtonDisabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="UpSpinButton.IsEnabled" Value="False" />
+                                        <Setter Target="PopupUpSpinButton.IsEnabled" Value="False" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                            <VisualStateGroup x:Name="DownSpinButtonEnabledStates">
+                                <VisualState x:Name="DownSpinButtonEnabled" />
+                                <VisualState x:Name="DownSpinButtonDisabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="DownSpinButton.IsEnabled" Value="False" />
+                                        <Setter Target="PopupDownSpinButton.IsEnabled" Value="False" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -55,7 +82,39 @@
                             Grid.Column="0"
                             Header="{TemplateBinding Header}"
                             HeaderTemplate="{TemplateBinding HeaderTemplate}"
-                            PlaceholderText="{TemplateBinding PlaceholderText}"/>
+                            PlaceholderText="{TemplateBinding PlaceholderText}"
+                            contract7Present:SelectionFlyout="{TemplateBinding SelectionFlyout}"
+                            SelectionHighlightColor="{TemplateBinding SelectionHighlightColor}"
+                            TextReadingOrder="{TemplateBinding TextReadingOrder}"
+                            PreventKeyboardDisplayOnProgrammaticFocus="{TemplateBinding PreventKeyboardDisplayOnProgrammaticFocus}"
+                            contract7Present:Description="{TemplateBinding Description}"/>
+
+                        <Popup x:Name="UpDownPopup"
+                            Grid.Column="1"
+                            VerticalOffset="{ThemeResource NumberBoxPopupVerticalOffset}"
+                            HorizontalOffset="{ThemeResource NumberBoxPopupHorizonalOffset}"
+                            HorizontalAlignment="Left">
+
+                            <Grid x:Name="PopupContentRoot"
+                                    Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
+                                    contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}">
+
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+
+                                <RepeatButton x:Name="PopupUpSpinButton"
+                                    Style="{StaticResource NumberBoxPopupSpinButtonStyle}"
+                                    Grid.Row="0"
+                                    Content="&#xE70E;"/>
+
+                                <RepeatButton x:Name="PopupDownSpinButton"
+                                    Style="{StaticResource NumberBoxPopupSpinButtonStyle}"
+                                    Grid.Row="1"
+                                    Content="&#xE70D;"/>
+                            </Grid>
+                        </Popup>
 
                         <RepeatButton x:Name="UpSpinButton"
                             Grid.Column="1"
@@ -89,5 +148,292 @@
             <Setter Property="BorderThickness" Value="{ThemeResource NumberBoxSpinButtonBorderThickness}"/>
             <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
         </Style.Setters>
+    </Style>
+
+    <Style x:Name="NumberBoxPopupSpinButtonStyle" TargetType="RepeatButton">
+        <Style.Setters>
+            <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
+            <Setter Property="IsTabStop" Value="False"/>
+            <Setter Property="Width" Value="40"/>
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="Background" Value="{ThemeResource TextControlBackground}"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
+        </Style.Setters>
+    </Style>
+    
+    <Style x:Name="NumberBoxTextBoxStyle" TargetType="TextBox">
+        <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+        <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}" />
+        <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}" />
+        <Setter Property="UseSystemFocusVisuals" Value="{ThemeResource IsApplicationFocusVisualKindReveal}" />
+        <Setter Property="ContextFlyout" Value="{StaticResource TextControlCommandBarContextFlyout}" />
+        <contract7Present:Setter Property="SelectionFlyout" Value="{StaticResource TextControlCommandBarSelectionFlyout}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Grid>
+
+                        <Grid.Resources>
+                            <Style x:Name="DeleteButtonStyle" TargetType="Button">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                            <Grid x:Name="ButtonLayoutGrid"
+                                                BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                Background="{ThemeResource TextControlButtonBackground}">
+
+                                                <VisualStateManager.VisualStateGroups>
+                                                    <VisualStateGroup x:Name="CommonStates">
+                                                        <VisualState x:Name="Normal" />
+
+                                                        <VisualState x:Name="PointerOver">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Pressed">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Disabled">
+                                                            <Storyboard>
+                                                                <DoubleAnimation Storyboard.TargetName="ButtonLayoutGrid"
+                                                                    Storyboard.TargetProperty="Opacity"
+                                                                    To="0"
+                                                                    Duration="0" />
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                    </VisualStateGroup>
+                                                </VisualStateManager.VisualStateGroups>
+                                                <TextBlock x:Name="GlyphElement"
+                                                    Foreground="{ThemeResource TextControlButtonForeground}"
+                                                    VerticalAlignment="Center"
+                                                    HorizontalAlignment="Center"
+                                                    FontStyle="Normal"
+                                                    FontSize="12"
+                                                    Text="&#xE10A;"
+                                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    AutomationProperties.AccessibilityView="Raw" />
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Grid.Resources>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+
+                                <VisualState x:Name="Disabled">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlHeaderForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <contract5Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForegroundDisabled}}" />
+                                        </contract5Present:ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="PointerOver">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <contract5Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForegroundPointerOver}}" />
+                                        </contract5Present:ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Focused">
+
+                                    <Storyboard>
+                                        <contract5Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForegroundFocused}}" />
+                                        </contract5Present:ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="RequestedTheme">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Light" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ButtonStates">
+                                <VisualState x:Name="ButtonVisible">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton" Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Visible</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="ButtonCollapsed" />
+
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <ContentPresenter x:Name="HeaderContentPresenter"
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            Content="{TemplateBinding Header}"
+                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                            FontWeight="Normal"
+                            Foreground="{ThemeResource TextControlHeaderForeground}"
+                            Margin="{ThemeResource TextBoxTopHeaderMargin}"
+                            TextWrapping="Wrap"
+                            VerticalAlignment="Top"
+                            Visibility="Collapsed"
+                            x:DeferLoadStrategy="Lazy" />
+                        <Border x:Name="BorderElement"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Grid.RowSpan="1"
+                            Grid.ColumnSpan="3"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Control.IsTemplateFocusTarget="True"
+                            MinWidth="{ThemeResource TextControlThemeMinWidth}"
+                            MinHeight="{ThemeResource TextControlThemeMinHeight}" />
+                        <ScrollViewer x:Name="ContentElement"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                            IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                            IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                            IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                            Margin="{TemplateBinding BorderThickness}"
+                            Padding="{TemplateBinding Padding}"
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw"
+                            ZoomMode="Disabled" />
+                        <TextBlock x:Name="PlaceholderTextContentPresenter"
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            Margin="{TemplateBinding BorderThickness}"
+                            Padding="{TemplateBinding Padding}"
+                            Text="{TemplateBinding PlaceholderText}"
+                            TextAlignment="{TemplateBinding TextAlignment}"
+                            TextWrapping="{TemplateBinding TextWrapping}"
+                            IsHitTestVisible="False" />
+                        <Button x:Name="DeleteButton"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Style="{StaticResource DeleteButtonStyle}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Margin="{ThemeResource HelperButtonThemePadding}"
+                            IsTabStop="False"
+                            Visibility="Collapsed"
+                            AutomationProperties.AccessibilityView="Raw"
+                            FontSize="{TemplateBinding FontSize}"
+                            MinWidth="34"
+                            VerticalAlignment="Stretch" />
+                        <ContentPresenter x:Name="DescriptionPresenter"
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            Content="{TemplateBinding Description}"
+                            Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
+                            AutomationProperties.AccessibilityView="Raw"
+                            x:Load="False"/>
+                        
+                        <TextBlock
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            Margin="{StaticResource NumberBoxPopupIndicatorMargin}"
+                            Foreground="{ThemeResource NumberBoxPopupIndicatorForeground}"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
+                            FontSize="12"
+                            Text="&#xEC8F;"
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            AutomationProperties.AccessibilityView="Raw" />
+
+                    </Grid>
+
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
     xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+    xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <Style TargetType="local:NumberBox">
@@ -178,8 +179,8 @@
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
         <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}" />
-        <Setter Property="UseSystemFocusVisuals" Value="{ThemeResource IsApplicationFocusVisualKindReveal}" />
-        <Setter Property="ContextFlyout" Value="{StaticResource TextControlCommandBarContextFlyout}" />
+        <contract6Present:Setter Property="UseSystemFocusVisuals" Value="{ThemeResource IsApplicationFocusVisualKindReveal}" />
+        <contract7Present:Setter Property="ContextFlyout" Value="{StaticResource TextControlCommandBarContextFlyout}" />
         <contract7Present:Setter Property="SelectionFlyout" Value="{StaticResource TextControlCommandBarSelectionFlyout}" />
         <Setter Property="Template">
             <Setter.Value>

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -7,6 +7,8 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <Style TargetType="local:NumberBox">
+        <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}" />
+        <contract7Present:Setter Property="SelectionFlyout" Value="{StaticResource TextControlCommandBarSelectionFlyout}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:NumberBox">

--- a/dev/NumberBox/NumberBox_themeresources.xaml
+++ b/dev/NumberBox/NumberBox_themeresources.xaml
@@ -2,8 +2,28 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Dark">
+            <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
     
     <Thickness x:Key="NumberBoxSpinButtonBorderThickness">0,1,1,1</Thickness>
     <Thickness x:Key="NumberBoxIconMargin">10,0,0,0</Thickness>
+
+    <x:Double x:Key="NumberBoxPopupHorizonalOffset">-20</x:Double>
+    <x:Double x:Key="NumberBoxPopupVerticalOffset">8</x:Double>
+    <x:Double x:Key="NumberBoxPopupShadowDepth">16</x:Double>
+
+    <Thickness x:Key="NumberBoxPopupIndicatorMargin">0,0,8,0</Thickness>
 
 </ResourceDictionary>

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -27,16 +27,20 @@
 
             <ComboBox x:Name="SpinModeComboBox" AutomationProperties.Name="SpinModeComboBox" SelectedIndex="0" SelectionChanged="SpinMode_Changed" Header="SpinButtonMode">
                 <ComboBoxItem Content="Hidden"/>
+                <ComboBoxItem Content="Compact"/>
                 <ComboBoxItem Content="Inline"/>
             </ComboBox>
 
+            <CheckBox x:Name="EnabledCheckBox" AutomationProperties.Name="EnabledCheckBox" IsChecked="True" Content="Enabled"/>
+            
             <CheckBox x:Name="CalculationCheckBox" AutomationProperties.Name="CalculationCheckBox" IsChecked="False" Content="Accepts Calculations"/>
 
             <CheckBox x:Name="HyperScrollCheckBox" AutomationProperties.Name="HyperScrollCheckBox" IsChecked="False" Content="HyperScroll Enabled"/>
 
             <CheckBox x:Name="WrapCheckBox" AutomationProperties.Name="WrapCheckBox" IsChecked="False" Content="Wrap Enabled"/>
 
-            <controls:NumberBox x:Name="StepNumberBox" AutomationProperties.Name="StepNumberBox" Value="1" Header="Step"/>
+            <!-- Set Text instead of Value to verify that it works -->
+            <controls:NumberBox x:Name="StepNumberBox" AutomationProperties.Name="StepNumberBox" Text="1" Header="Step"/>
 
             <StackPanel Orientation="Horizontal">
                 <CheckBox x:Name="MinCheckBox" AutomationProperties.Name="MinCheckBox" IsChecked="False" Checked="MinCheckBox_CheckChanged" Unchecked="MinCheckBox_CheckChanged" MinWidth="32" VerticalAlignment="Bottom"/>
@@ -45,7 +49,8 @@
 
             <StackPanel Orientation="Horizontal">
                 <CheckBox x:Name="MaxCheckBox" AutomationProperties.Name="MaxCheckBox" IsChecked="False" Checked="MaxCheckBox_CheckChanged" Unchecked="MaxCheckBox_CheckChanged" MinWidth="32" VerticalAlignment="Bottom"/>
-                <controls:NumberBox x:Name="MaxNumberBox" AutomationProperties.Name="MaxNumberBox" Header="Maximum" Value="100" IsEnabled="False" ValueChanged="MaxValueChanged"/>
+                <!-- Verify that setting Value overrides setting Text -->
+                <controls:NumberBox x:Name="MaxNumberBox" AutomationProperties.Name="MaxNumberBox" Header="Maximum" Value="100" Text="50" IsEnabled="False" ValueChanged="MaxValueChanged"/>
             </StackPanel>
 
             <Button x:Name="CustomFormatterButton" AutomationProperties.Name="CustomFormatterButton" Content="Custom Formatter" Click="CustomFormatterButton_Click" Margin="0,4,0,0"/>
@@ -64,11 +69,13 @@
                     x:Name="TestNumberBox"
                     AutomationProperties.Name="TestNumberBox"
                     Header="NumberBox"
+                    PlaceholderText="Text"
                     ValueChanged="NumberBoxValueChanged"
                     StepFrequency="{x:Bind StepNumberBox.Value, Mode=OneWay}"
                     AcceptsCalculation="{x:Bind CalculationCheckBox.IsChecked.Value, Mode=OneWay}"
-                    HyperScrollEnabled="{x:Bind HyperScrollCheckBox.IsChecked.Value, Mode=OneWay}"
-                    WrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"/>
+                    IsHyperScrollEnabled="{x:Bind HyperScrollCheckBox.IsChecked.Value, Mode=OneWay}"
+                    IsWrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"
+                    IsEnabled="{x:Bind EnabledCheckBox.IsChecked.Value, Mode=OneWay}"/>
 
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="Value:" Margin="0,0,5,0" />

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml.cs
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml.cs
@@ -30,11 +30,14 @@ namespace MUXControlsTestApp
                 }
                 else if (SpinModeComboBox.SelectedIndex == 1)
                 {
+                    TestNumberBox.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Compact;
+                }
+                else if (SpinModeComboBox.SelectedIndex == 2)
+                {
                     TestNumberBox.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline;
                 }
             }
         }
-
 
         private void Validation_Changed(object sender, RoutedEventArgs e)
         {
@@ -42,11 +45,11 @@ namespace MUXControlsTestApp
             {
                 if (ValidationComboBox.SelectedIndex == 0)
                 {
-                    TestNumberBox.BasicValidationMode = NumberBoxBasicValidationMode.InvalidInputOverwritten;
+                    TestNumberBox.ValidationMode = NumberBoxValidationMode.InvalidInputOverwritten;
                 }
                 else if (ValidationComboBox.SelectedIndex == 1)
                 {
-                    TestNumberBox.BasicValidationMode = NumberBoxBasicValidationMode.Disabled;
+                    TestNumberBox.ValidationMode = NumberBoxValidationMode.Disabled;
                 }
             }
         }
@@ -81,7 +84,7 @@ namespace MUXControlsTestApp
 
         private void NumberBoxValueChanged(object sender, NumberBoxValueChangedEventArgs e)
         {
-            if (TestNumberBox != null)
+            if (TestNumberBox != null && NewValueTextBox != null && OldValueTextBox != null)
             {
                 NewValueTextBox.Text = e.NewValue.ToString();
                 OldValueTextBox.Text = e.OldValue.ToString();


### PR DESCRIPTION
- Added Compact mode for the spin buttons. This meant retemplating the TextBox style in order to add an up/down icon inside indicating that a popup will appear if the control is focused. Added the popup inline to the control, which is shown on focus and hidden on loss of focus.
- NaN is now displayed as an empty string. It is no longer ever considered out of bounds.
- Scrolling only works when the control has focus.
- Stepping the value now validates the contents of the textbox before altering the value. So if Value is 0, you enter "8", press the up button/key, the result will be 9, not 1.
- Setting Text if Value is not set now validates Text and updates Value. Previously, initially setting Text was being ignored. If Value and Text are both set, Value should "win".
- Spin buttons are disabled if the Value is NaN or has hit Minimum/Maximum.
- Up/Down keys now trigger on key down.
- API changes based on spec changes:
    - BasicValidationMode -> ValidationMode
    - HyperScrollEnabled -> IsHyperScrollEnabled
    - WrapEnabled -> IsWrapEnabled
    - Added several TextBox properties to pass along to the inner TextBox