### PR TITLE
Remove 'Configuration' check from AppxPackageRegistration

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -4,26 +4,12 @@
   <Import Project="$(MSBuildThisFileDirectory)\Common.targets"/>
   <ItemGroup>
     <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Release</Configuration>
-      <Architecture>x86</Architecture>
-      <Version>$(MicrosoftUIXamlAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Debug</Configuration>
       <Architecture>x86</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
     <!-- Some C++/CX projects use Platform=Win32 instead of Platform=x86 -->
     <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Release</Configuration>
-      <Architecture>Win32</Architecture>
-      <Version>$(MicrosoftUIXamlAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Debug</Configuration>
       <Architecture>Win32</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
@@ -31,13 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Release</Configuration>
-      <Architecture>x64</Architecture>
-      <Version>$(MicrosoftUIXamlAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Debug</Configuration>
       <Architecture>x64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
@@ -45,13 +24,6 @@
   </ItemGroup>
   <ItemGroup>
     <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Release</Configuration>
-      <Architecture>arm</Architecture>
-      <Version>$(MicrosoftUIXamlAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Debug</Configuration>
       <Architecture>arm</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
@@ -59,13 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Release</Configuration>
-      <Architecture>arm64</Architecture>
-      <Version>$(MicrosoftUIXamlAppxVersion)</Version>
-      <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
-    </AppxPackageRegistration>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.3.appx">
-      <Configuration>Debug</Configuration>
       <Architecture>arm64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>


### PR DESCRIPTION
If an app uses a set of MSBuild "Configuration" values other than the default of "Debug" and "Release", our framework-packaged-based release nupkg doesn't work. Our .props file adds AppxPackageRegistration conditionally based on the value of 'Configuration'. But this is unnecessary, since we don't use different framework packages based on the value of configuration.

This is related to #1632. There may be an additional issue that needs further investigation.