### PR TITLE
Re-enable code analysis and fix some CppCoreGuidelines checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,9 +85,9 @@ dotnet_style_predefined_type_for_member_access = true:suggestion
 #Style - implicit and explicit types
 
 #prefer explicit type over var to declare variables with built-in system types such as int
-csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_for_built_in_types = false:none
 #prefer explicit type over var when the type is already mentioned on the right-hand side of a declaration
-csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
 
 #Style - language keyword and framework type options
 
@@ -104,6 +104,9 @@ dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 #prefer properties not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_property = false:suggestion
+
+# IDE0008: Use explicit type
+csharp_style_var_elsewhere = false:none
 
 [**.{cpp,h,idl}]
 indent_style = space

--- a/build/PrefastWarnings.ruleset
+++ b/build/PrefastWarnings.ruleset
@@ -1,104 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Controls Custom Ruleset" Description="This is the default VS ruleset plus rules that Windows likes too" ToolsVersion="15.0">
+<RuleSet Name="Controls Custom Ruleset" Description="This is the default VS ruleset plus rules that Windows likes too" ToolsVersion="16.0">
   <Include Path="nativerecommendedrules.ruleset" Action="Default" />
-
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
-    <Rule Id="C6014" Action="Warning" />
-    <Rule Id="C6029" Action="Warning" />
-    <Rule Id="C6053" Action="Warning" />
-    <Rule Id="C6059" Action="Warning" />
-    <Rule Id="C6063" Action="Warning" />
-    <Rule Id="C6064" Action="Warning" />
-    <Rule Id="C6066" Action="Warning" />
-    <Rule Id="C6067" Action="Warning" />
-    <Rule Id="C6201" Action="Warning" />
-    <Rule Id="C6214" Action="Warning" />
-    <Rule Id="C6215" Action="Warning" />
-    <Rule Id="C6216" Action="Warning" />
-    <Rule Id="C6217" Action="Warning" />
-    <Rule Id="C6220" Action="Warning" />
-    <Rule Id="C6225" Action="Warning" />
-    <Rule Id="C6226" Action="Warning" />
-    <Rule Id="C6230" Action="Warning" />
-    <Rule Id="C6235" Action="Warning" />
-    <Rule Id="C6236" Action="Warning" />
-    <Rule Id="C6237" Action="Warning" />
-    <Rule Id="C6248" Action="Warning" />
-    <Rule Id="C6250" Action="Warning" />
-    <Rule Id="C6259" Action="Warning" />
-    <Rule Id="C6260" Action="Warning" />
-    <Rule Id="C6262" Action="Warning" />
-    <Rule Id="C6268" Action="Warning" />
-    <Rule Id="C6270" Action="Warning" />
-    <Rule Id="C6271" Action="Warning" />
-    <Rule Id="C6272" Action="Warning" />
-    <Rule Id="C6273" Action="Warning" />
-    <Rule Id="C6276" Action="Warning" />
-    <Rule Id="C6277" Action="Warning" />
-    <Rule Id="C6278" Action="Warning" />
-    <Rule Id="C6279" Action="Warning" />
-    <Rule Id="C6280" Action="Warning" />
-    <Rule Id="C6281" Action="Warning" />
-    <Rule Id="C6282" Action="Warning" />
-    <Rule Id="C6283" Action="Warning" />
-    <Rule Id="C6284" Action="Warning" />
-    <Rule Id="C6285" Action="Warning" />
-    <Rule Id="C6286" Action="Warning" />
-    <Rule Id="C6287" Action="Warning" />
-    <Rule Id="C6288" Action="Warning" />
-    <Rule Id="C6289" Action="Warning" />
-    <Rule Id="C6290" Action="Warning" />
-    <Rule Id="C6291" Action="Warning" />
-    <Rule Id="C6292" Action="Warning" />
-    <Rule Id="C6293" Action="Warning" />
-    <Rule Id="C6294" Action="Warning" />
-    <Rule Id="C6295" Action="Warning" />
-    <Rule Id="C6296" Action="Warning" />
-    <Rule Id="C6297" Action="Warning" />
-    <Rule Id="C6299" Action="Warning" />
-    <Rule Id="C6302" Action="Warning" />
-    <Rule Id="C6303" Action="Warning" />
-    <Rule Id="C6305" Action="Warning" />
-    <Rule Id="C6306" Action="Warning" />
-    <Rule Id="C6308" Action="Warning" />
-    <Rule Id="C6312" Action="Warning" />
-    <Rule Id="C6314" Action="Warning" />
-    <Rule Id="C6318" Action="Warning" />
-    <Rule Id="C6328" Action="Warning" />
-    <Rule Id="C6333" Action="Warning" />
-    <Rule Id="C6334" Action="Warning" />
-    <Rule Id="C6335" Action="Warning" />
-    <Rule Id="C6381" Action="Warning" />
-    <Rule Id="C6383" Action="Warning" />
-    <Rule Id="C6384" Action="Warning" />
-    <Rule Id="C6500" Action="Warning" />
-    <Rule Id="C6503" Action="Warning" />
-    <Rule Id="C6504" Action="Warning" />
-    <Rule Id="C6505" Action="Warning" />
-    <Rule Id="C6506" Action="Warning" />
-    <Rule Id="C6508" Action="Warning" />
-    <Rule Id="C6510" Action="Warning" />
-    <Rule Id="C6511" Action="Warning" />
-    <Rule Id="C6513" Action="Warning" />
-    <Rule Id="C6514" Action="Warning" />
-    <Rule Id="C6515" Action="Warning" />
-    <Rule Id="C6516" Action="Warning" />
-    <Rule Id="C6517" Action="Warning" />
-    <Rule Id="C6518" Action="Warning" />
-    <Rule Id="C6522" Action="Warning" />
-    <Rule Id="C6530" Action="Warning" />
-    <Rule Id="C6540" Action="Warning" />
-    <Rule Id="C6551" Action="Warning" />
-    <Rule Id="C6552" Action="Warning" />
-    <Rule Id="C6701" Action="Warning" />
-    <Rule Id="C6702" Action="Warning" />
-    <Rule Id="C6703" Action="Warning" />
-    <Rule Id="C6704" Action="Warning" />
-    <Rule Id="C6705" Action="Warning" />
-    <Rule Id="C6706" Action="Warning" />
-    <Rule Id="C6707" Action="Warning" />
-    <Rule Id="C6993" Action="Warning" />
-    <Rule Id="C6997" Action="Warning" />
     <Rule Id="C13001" Action="Warning" />
     <Rule Id="C13008" Action="Warning" />
     <Rule Id="C16001" Action="Warning" />
@@ -137,6 +40,13 @@
     <Rule Id="C26200" Action="Warning" />
     <Rule Id="C26201" Action="Warning" />
     <Rule Id="C26202" Action="Warning" />
+    <Rule Id="C26400" Action="Warning" />
+    <Rule Id="C26401" Action="Warning" />
+    <Rule Id="C26402" Action="Warning" />
+    <Rule Id="C26408" Action="Warning" />
+    <Rule Id="C26409" Action="Warning" />
+    <Rule Id="C26451" Action="None" />
+    <Rule Id="C26465" Action="Warning" />
     <Rule Id="C26500" Action="Warning" />
     <Rule Id="C26501" Action="Warning" />
     <Rule Id="C26505" Action="Warning" />
@@ -320,6 +230,14 @@
     <Rule Id="C38041" Action="Warning" />
     <Rule Id="C38042" Action="Warning" />
     <Rule Id="C38043" Action="Warning" />
+    <Rule Id="C6014" Action="Warning" />
+    <Rule Id="C6029" Action="Warning" />
+    <Rule Id="C6053" Action="Warning" />
+    <Rule Id="C6059" Action="Warning" />
+    <Rule Id="C6063" Action="Warning" />
+    <Rule Id="C6064" Action="Warning" />
+    <Rule Id="C6066" Action="Warning" />
+    <Rule Id="C6067" Action="Warning" />
     <Rule Id="C60903" Action="Warning" />
     <Rule Id="C60904" Action="Warning" />
     <Rule Id="C61008" Action="Warning" />
@@ -389,6 +307,7 @@
     <Rule Id="C62002" Action="Warning" />
     <Rule Id="C62004" Action="Warning" />
     <Rule Id="C62006" Action="Warning" />
+    <Rule Id="C6201" Action="Warning" />
     <Rule Id="C62101" Action="Warning" />
     <Rule Id="C62103" Action="Warning" />
     <Rule Id="C62104" Action="Warning" />
@@ -411,6 +330,11 @@
     <Rule Id="C62127" Action="Warning" />
     <Rule Id="C62128" Action="Warning" />
     <Rule Id="C62129" Action="Warning" />
+    <Rule Id="C6214" Action="Warning" />
+    <Rule Id="C6215" Action="Warning" />
+    <Rule Id="C6216" Action="Warning" />
+    <Rule Id="C6217" Action="Warning" />
+    <Rule Id="C6220" Action="Warning" />
     <Rule Id="C62207" Action="Warning" />
     <Rule Id="C62208" Action="Warning" />
     <Rule Id="C62211" Action="Warning" />
@@ -433,6 +357,87 @@
     <Rule Id="C62236" Action="Warning" />
     <Rule Id="C62237" Action="Warning" />
     <Rule Id="C62240" Action="Warning" />
-
+    <Rule Id="C6225" Action="Warning" />
+    <Rule Id="C6226" Action="Warning" />
+    <Rule Id="C6230" Action="Warning" />
+    <Rule Id="C6235" Action="Warning" />
+    <Rule Id="C6236" Action="Warning" />
+    <Rule Id="C6237" Action="Warning" />
+    <Rule Id="C6248" Action="Warning" />
+    <Rule Id="C6250" Action="Warning" />
+    <Rule Id="C6259" Action="Warning" />
+    <Rule Id="C6260" Action="Warning" />
+    <Rule Id="C6262" Action="Warning" />
+    <Rule Id="C6268" Action="Warning" />
+    <Rule Id="C6270" Action="Warning" />
+    <Rule Id="C6271" Action="Warning" />
+    <Rule Id="C6272" Action="Warning" />
+    <Rule Id="C6273" Action="Warning" />
+    <Rule Id="C6276" Action="Warning" />
+    <Rule Id="C6277" Action="Warning" />
+    <Rule Id="C6278" Action="Warning" />
+    <Rule Id="C6279" Action="Warning" />
+    <Rule Id="C6280" Action="Warning" />
+    <Rule Id="C6281" Action="Warning" />
+    <Rule Id="C6282" Action="Warning" />
+    <Rule Id="C6283" Action="Warning" />
+    <Rule Id="C6284" Action="Warning" />
+    <Rule Id="C6285" Action="Warning" />
+    <Rule Id="C6286" Action="Warning" />
+    <Rule Id="C6287" Action="Warning" />
+    <Rule Id="C6288" Action="Warning" />
+    <Rule Id="C6289" Action="Warning" />
+    <Rule Id="C6290" Action="Warning" />
+    <Rule Id="C6291" Action="Warning" />
+    <Rule Id="C6292" Action="Warning" />
+    <Rule Id="C6293" Action="Warning" />
+    <Rule Id="C6294" Action="Warning" />
+    <Rule Id="C6295" Action="Warning" />
+    <Rule Id="C6296" Action="Warning" />
+    <Rule Id="C6297" Action="Warning" />
+    <Rule Id="C6299" Action="Warning" />
+    <Rule Id="C6302" Action="Warning" />
+    <Rule Id="C6303" Action="Warning" />
+    <Rule Id="C6305" Action="Warning" />
+    <Rule Id="C6306" Action="Warning" />
+    <Rule Id="C6308" Action="Warning" />
+    <Rule Id="C6312" Action="Warning" />
+    <Rule Id="C6314" Action="Warning" />
+    <Rule Id="C6318" Action="Warning" />
+    <Rule Id="C6328" Action="Warning" />
+    <Rule Id="C6333" Action="Warning" />
+    <Rule Id="C6334" Action="Warning" />
+    <Rule Id="C6335" Action="Warning" />
+    <Rule Id="C6381" Action="Warning" />
+    <Rule Id="C6383" Action="Warning" />
+    <Rule Id="C6384" Action="Warning" />
+    <Rule Id="C6500" Action="Warning" />
+    <Rule Id="C6503" Action="Warning" />
+    <Rule Id="C6504" Action="Warning" />
+    <Rule Id="C6505" Action="Warning" />
+    <Rule Id="C6506" Action="Warning" />
+    <Rule Id="C6508" Action="Warning" />
+    <Rule Id="C6510" Action="Warning" />
+    <Rule Id="C6511" Action="Warning" />
+    <Rule Id="C6513" Action="Warning" />
+    <Rule Id="C6514" Action="Warning" />
+    <Rule Id="C6515" Action="Warning" />
+    <Rule Id="C6516" Action="Warning" />
+    <Rule Id="C6517" Action="Warning" />
+    <Rule Id="C6518" Action="Warning" />
+    <Rule Id="C6522" Action="Warning" />
+    <Rule Id="C6530" Action="Warning" />
+    <Rule Id="C6540" Action="Warning" />
+    <Rule Id="C6551" Action="Warning" />
+    <Rule Id="C6552" Action="Warning" />
+    <Rule Id="C6701" Action="Warning" />
+    <Rule Id="C6702" Action="Warning" />
+    <Rule Id="C6703" Action="Warning" />
+    <Rule Id="C6704" Action="Warning" />
+    <Rule Id="C6705" Action="Warning" />
+    <Rule Id="C6706" Action="Warning" />
+    <Rule Id="C6707" Action="Warning" />
+    <Rule Id="C6993" Action="Warning" />
+    <Rule Id="C6997" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -732,7 +732,7 @@ void AnimatedVisualPlayer::OnAutoPlayPropertyChanged(
         auto from = 0;
         auto to = 1;
         auto looped = true;
-        PlayAsync(from, to, looped);
+        auto ignore = PlayAsync(from, to, looped);
     }
 }
 
@@ -911,7 +911,7 @@ void AnimatedVisualPlayer::UpdateContent()
         auto to = 1;
         auto looped = true;
         // NOTE: If !IsAnimatedVisualLoaded() then this is a no-op.
-        PlayAsync(from, to, looped);
+        auto ignore = PlayAsync(from, to, looped);
     }
 }
 

--- a/dev/ColorPicker/ColorChangedEventArgs.h
+++ b/dev/ColorPicker/ColorChangedEventArgs.h
@@ -17,6 +17,6 @@ public:
     void NewColor(winrt::Color const& value);
 
 private:
-    winrt::Color m_oldColor;
-    winrt::Color m_newColor;
+    winrt::Color m_oldColor{};
+    winrt::Color m_newColor{};
 };

--- a/dev/Effects/microsoft.ui.composition.effects_impl.h
+++ b/dev/Effects/microsoft.ui.composition.effects_impl.h
@@ -12,7 +12,7 @@
 #include <d2d1effects_2.h>
 
 #pragma warning(push)
-#pragma warning(disable : 28285 28196 6387 6319)
+#pragma warning(disable : 28285 28196 6387 6319 26812)
 
 #include "AlphaMaskEffect.g.h"
 #include "ArithmeticCompositeEffect.g.h"

--- a/dev/Lights/MaterialHelper.cpp
+++ b/dev/Lights/MaterialHelper.cpp
@@ -931,7 +931,7 @@ void MaterialHelper::UpdatePolicyStatus(bool onUIThread)
             }
             else
             {
-                m_dispatcher.RunAsync(winrt::CoreDispatcherPriority::Normal, callback);
+                auto ignore = m_dispatcher.RunAsync(winrt::CoreDispatcherPriority::Normal, callback);
             }
         }
     }

--- a/dev/Lights/RevealHoverLight.h
+++ b/dev/Lights/RevealHoverLight.h
@@ -112,6 +112,6 @@ private:
     // For mouse and touch we will set this to false and have our light follow the pointer position.
     bool m_centerLight{ true };
 
-    const RevealHoverSpotlightStateDesc* m_spotLightStates;
+    const RevealHoverSpotlightStateDesc* m_spotLightStates{};
     winrt::IInspectable m_elementPointerPressedEventHandler{};
 };

--- a/dev/MenuBar/MenuBarItem.h
+++ b/dev/MenuBar/MenuBarItem.h
@@ -6,7 +6,7 @@
 #include "MenuBarItem.g.h"
 #include "MenuBarItem.properties.h"
 
-enum FlyoutLocation
+enum class FlyoutLocation
 {
     Left,
     Right

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1674,7 +1674,7 @@ bool NavigationView::BumperNavigation(int offset)
     {
         if (auto nvi = NavigationViewItemOrSettingsContentFromData(item))
         {
-            auto index = m_topDataProvider.IndexOf(item, PrimaryList);
+            auto index = m_topDataProvider.IndexOf(item, NavigationViewSplitVectorID::PrimaryList);
 
             if (index >= 0)
             {
@@ -1938,7 +1938,7 @@ void NavigationView::OnSelectedItemPropertyChanged(winrt::DependencyPropertyChan
         bool measureOverrideDidNothing = m_shouldInvalidateMeasureOnNextLayoutUpdate && !m_layoutUpdatedToken;
             
         if (measureOverrideDidNothing ||
-            (newItem && m_topDataProvider.IndexOf(newItem) != s_itemNotFound && m_topDataProvider.IndexOf(newItem, PrimaryList) == s_itemNotFound)) // selection is in overflow
+            (newItem && m_topDataProvider.IndexOf(newItem) != s_itemNotFound && m_topDataProvider.IndexOf(newItem, NavigationViewSplitVectorID::PrimaryList) == s_itemNotFound)) // selection is in overflow
         {
             InvalidateTopNavPrimaryLayout();
         }
@@ -2568,7 +2568,7 @@ std::vector<int> NavigationView::FindMovableItemsBeyondAvailableWidth(float avai
     std::vector<int> toBeMoved;
     if (auto listView = m_topNavListView.get())
     {
-        int selectedItemIndexInPrimary = m_topDataProvider.IndexOf(SelectedItem(), PrimaryList);
+        int selectedItemIndexInPrimary = m_topDataProvider.IndexOf(SelectedItem(), NavigationViewSplitVectorID::PrimaryList);
         int size = m_topDataProvider.GetPrimaryListSize();
 
         float requiredWidth = 0;

--- a/dev/NavigationView/NavigationViewDisplayModeChangedEventArgs.h
+++ b/dev/NavigationView/NavigationViewDisplayModeChangedEventArgs.h
@@ -16,7 +16,7 @@ public:
     void DisplayMode(winrt::NavigationViewDisplayMode value);
 
 private:
-    winrt::NavigationViewDisplayMode m_DisplayMode;
+    winrt::NavigationViewDisplayMode m_DisplayMode{};
 };
 
 //CppWinRTActivatableClassWithBasicFactory(NavigationViewDisplayModeChangedEventArgs);

--- a/dev/NavigationView/SplitDataSourceBase.h
+++ b/dev/NavigationView/SplitDataSourceBase.h
@@ -175,7 +175,7 @@ public:
     {
         if (index >= 0 && index < RawDataSize())
         {
-            return m_splitVectors[m_flags[index]];
+            return m_splitVectors[static_cast<int>(m_flags[index])];
         }
         return nullptr;
     }
@@ -210,7 +210,7 @@ public:
             m_flags[index] = newVectorID;
 
             // insert item to vector which matches with the newVectorID
-            if (auto &toVector = m_splitVectors[newVectorID])
+            if (auto &toVector = m_splitVectors[static_cast<int>(newVectorID)])
             {
                 int pos = GetPreferIndex(index, newVectorID);
 
@@ -246,13 +246,13 @@ protected:
     {
         for (auto &vector: vectors)
         {
-            m_splitVectors[vector->GetVectorIDForItem()] = vector;
+            m_splitVectors[static_cast<int>(vector->GetVectorIDForItem())] = vector;
         }
     }
 
     std::shared_ptr<SplitVectorType> GetVector(SplitVectorID vectorID)
     {
-        return m_splitVectors[vectorID];
+        return m_splitVectors[static_cast<int>(vectorID)];
     }
 
 

--- a/dev/NavigationView/TopNavigationViewDataProvider.cpp
+++ b/dev/NavigationView/TopNavigationViewDataProvider.cpp
@@ -19,8 +19,8 @@ TopNavigationViewDataProvider::TopNavigationViewDataProvider(const ITrackerHandl
         return IndexOf(value);
     };
 
-    auto primaryVector = std::make_shared<SplitVectorT>(m_owner, PrimaryList, lambda);
-    auto overflowVector = std::make_shared<SplitVectorT>(m_owner, OverflowList, lambda);
+    auto primaryVector = std::make_shared<SplitVectorT>(m_owner, NavigationViewSplitVectorID::PrimaryList, lambda);
+    auto overflowVector = std::make_shared<SplitVectorT>(m_owner, NavigationViewSplitVectorID::OverflowList, lambda);
     
     InitializeSplitVectors({ primaryVector, overflowVector });
 }
@@ -28,12 +28,12 @@ TopNavigationViewDataProvider::TopNavigationViewDataProvider(const ITrackerHandl
 
 winrt::IVector<winrt::IInspectable> TopNavigationViewDataProvider::GetPrimaryItems()
 {
-    return GetVector(PrimaryList)->GetVector();
+    return GetVector(NavigationViewSplitVectorID::PrimaryList)->GetVector();
 }
 
 winrt::IVector<winrt::IInspectable> TopNavigationViewDataProvider::GetOverflowItems()
 {
-    return GetVector(OverflowList)->GetVector();
+    return GetVector(NavigationViewSplitVectorID::OverflowList)->GetVector();
 }
 
 // The raw data is from MenuItems or MenuItemsSource
@@ -96,7 +96,7 @@ int TopNavigationViewDataProvider::Size()
 
 NavigationViewSplitVectorID TopNavigationViewDataProvider::DefaultVectorIDOnInsert()
 {
-    return NotInitialized;
+    return NavigationViewSplitVectorID::NotInitialized;
 }
 
 float TopNavigationViewDataProvider::DefaultAttachedData()
@@ -108,7 +108,7 @@ void TopNavigationViewDataProvider::MoveAllItemsToPrimaryList()
 {
     for (int i = 0; i < Size(); i++)
     {
-        MoveItemToVector(i, PrimaryList);
+        MoveItemToVector(i, NavigationViewSplitVectorID::PrimaryList);
     }
 }
 
@@ -117,7 +117,7 @@ std::vector<int> TopNavigationViewDataProvider::ConvertPrimaryIndexToIndex(std::
     std::vector<int> indexes;
     if (!indexesInPrimary.empty())
     {
-        auto vector = GetVector(PrimaryList);
+        auto vector = GetVector(NavigationViewSplitVectorID::PrimaryList);
         if (vector)
         {
             // transform PrimaryList index to OrignalVector index
@@ -133,12 +133,12 @@ std::vector<int> TopNavigationViewDataProvider::ConvertPrimaryIndexToIndex(std::
 
 void TopNavigationViewDataProvider::MoveItemsOutOfPrimaryList(std::vector<int> const& indexes)
 {
-    MoveItemsToList(indexes, OverflowList);
+    MoveItemsToList(indexes, NavigationViewSplitVectorID::OverflowList);
 }
 
 void TopNavigationViewDataProvider::MoveItemsToPrimaryList(std::vector<int> const& indexes)
 {
-    MoveItemsToList(indexes, PrimaryList);
+    MoveItemsToList(indexes, NavigationViewSplitVectorID::PrimaryList);
 }
 
 void TopNavigationViewDataProvider::MoveItemsToList(std::vector<int> const& indexes, NavigationViewSplitVectorID vectorID)
@@ -182,7 +182,7 @@ int TopNavigationViewDataProvider::GetNavigationViewItemCountInTopNav()
 
 void TopNavigationViewDataProvider::UpdateWidthForPrimaryItem(int indexInPrimary, float width)
 {
-    auto vector = GetVector(PrimaryList);
+    auto vector = GetVector(NavigationViewSplitVectorID::PrimaryList);
     if (vector)
     {
         auto index = vector->IndexToIndexInOriginalVector(indexInPrimary);
@@ -358,7 +358,7 @@ void TopNavigationViewDataProvider::ChangeDataSource(winrt::ItemsSourceView newV
         Clear();
 
         m_dataSource.set(newValue);
-        SyncAndInitVectorFlagsWithID(NotInitialized, DefaultAttachedData());
+        SyncAndInitVectorFlagsWithID(NavigationViewSplitVectorID::NotInitialized, DefaultAttachedData());
 
         if (newValue)
         {
@@ -367,12 +367,12 @@ void TopNavigationViewDataProvider::ChangeDataSource(winrt::ItemsSourceView newV
     }
 
     // Move all to primary list
-    MoveItemsToVector(NotInitialized);
+    MoveItemsToVector(NavigationViewSplitVectorID::NotInitialized);
 }
 
 bool TopNavigationViewDataProvider::IsItemInPrimaryList(int index)
 {
-    return GetVectorIDForItem(index) == PrimaryList;
+    return GetVectorIDForItem(index) == NavigationViewSplitVectorID::PrimaryList;
 }
 
 bool TopNavigationViewDataProvider::IsContainerNavigationViewItem(int index)

--- a/dev/NavigationView/TopNavigationViewDataProvider.h
+++ b/dev/NavigationView/TopNavigationViewDataProvider.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "SplitDataSourceBase.h"
-enum NavigationViewSplitVectorID
+enum class NavigationViewSplitVectorID
 {
     NotInitialized = 0,
     PrimaryList = 1,

--- a/dev/NumberBox/NumberBoxParser.h
+++ b/dev/NumberBox/NumberBoxParser.h
@@ -8,7 +8,7 @@
 #include <regex>
 #include <stack>
 
-enum MathTokenType
+enum class MathTokenType
 {
     Numeric,
     Operator,

--- a/dev/PersonPicture/InitialsGenerator.h
+++ b/dev/PersonPicture/InitialsGenerator.h
@@ -6,7 +6,7 @@
     /// <summary>
     /// Value indicating the general character set for a given character.
     /// </summary>
-enum CharacterType
+enum class CharacterType
 {
     /// <summary>
     /// Indicates we could not match the character set.

--- a/dev/RadioButtons/RadioButtons.vcxitems.filters
+++ b/dev/RadioButtons/RadioButtons.vcxitems.filters
@@ -10,10 +10,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)RadioButtons.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)RadioButtonsElementFactory.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)ColumnMajorUniformToLargestGridLayout.h" />
-    <ClInclude Include="$(MSBuildThisFileDirectory)RadioButtonsTestHooks.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Generated\ColumnMajorUniformToLargestGridLayout.properties.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)ColumnMajorUniformToLargestGridLayout.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)RadioButtonsElementFactory.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)RadioButtonsTestHooks.h" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)RadioButtons.xaml" />

--- a/dev/RatingControl/RatingControl.h
+++ b/dev/RatingControl/RatingControl.h
@@ -9,7 +9,7 @@
 #include "RatingControl.properties.h"
 #include "DispatcherHelper.h"
 
-enum RatingControlStates
+enum class RatingControlStates
 {
     Disabled = 0,
     Set = 1,
@@ -20,7 +20,7 @@ enum RatingControlStates
     Null = 6
 };
 
-enum RatingInfoType
+enum class RatingInfoType
 {
     None,
     Font,

--- a/dev/Repeater/Phaser.h
+++ b/dev/Repeater/Phaser.h
@@ -8,7 +8,7 @@ class ItemsRepeater;
 struct ElementInfo
 {
     ElementInfo(const winrt::UIElement&  element, const winrt::com_ptr<VirtualizationInfo>& virtInfo) :
-        m_element(std::move(element)),
+        m_element(element),
         m_virtInfo(virtInfo)
     {}
 

--- a/dev/Repeater/SelectionNode.h
+++ b/dev/Repeater/SelectionNode.h
@@ -6,7 +6,7 @@
 
 class SelectionModel;
 
-enum SelectionState
+enum class SelectionState
 {
     Selected,
     NotSelected,

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -474,7 +474,7 @@ void ViewManager::EnsureFirstLastRealizedIndices()
     if (m_firstRealizedElementIndexHeldByLayout == FirstRealizedElementIndexDefault)
     {
         // This will ensure that the indexes are updated.
-        GetElementIfAlreadyHeldByLayout(0);
+        auto element = GetElementIfAlreadyHeldByLayout(0);
     }
 }
 

--- a/dev/Telemetry/RuntimeProfiler.cpp
+++ b/dev/Telemetry/RuntimeProfiler.cpp
@@ -5,6 +5,9 @@
 #include "RuntimeProfiler.h"
 #include "TraceLogging.h"
 
+#pragma warning(push)
+#pragma warning(disable : 26812)
+
 #define DEFINE_PROFILEGROUP(name, group, size) \
     CMethodProfileGroup<size>        name(group)
 
@@ -15,8 +18,8 @@ namespace RuntimeProfiler {
     struct FunctionTelemetryCount
     {
         volatile LONG      *pInstanceCount{ nullptr };
-        volatile UINT16     uTypeIndex;
-        volatile UINT16     uMethodIndex;
+        volatile UINT16     uTypeIndex{};
+        volatile UINT16     uMethodIndex{};
     };
 
     class CMethodProfileGroupBase
@@ -283,3 +286,5 @@ STDAPI_(void) SendTelemetryOnSuspend() noexcept
 {
     RuntimeProfiler::FireEvent(true);
 }
+
+#pragma warning(pop)

--- a/dev/TreeView/TreeViewItem.cpp
+++ b/dev/TreeView/TreeViewItem.cpp
@@ -756,7 +756,7 @@ winrt::TreeViewNode TreeViewItem::TreeNode()
 void TreeViewItem::UpdateNodeIsExpandedAsync(winrt::TreeViewNode const& node, bool isExpanded)
 {
     auto dispatcher = winrt::Window::Current().Dispatcher();
-    dispatcher.RunAsync(
+    auto ignore = dispatcher.RunAsync(
         winrt::CoreDispatcherPriority::Normal,
         winrt::DispatchedHandler([node, isExpanded]()
     {

--- a/dev/TwoPaneView/DisplayRegionHelper.h
+++ b/dev/TwoPaneView/DisplayRegionHelper.h
@@ -8,7 +8,7 @@ const uint32_t c_maxRegions = 2;
 struct DisplayRegionHelperInfo
 {
     winrt::TwoPaneViewMode Mode{ winrt::TwoPaneViewMode::SinglePane };
-    std::array<winrt::Rect, c_maxRegions> Regions;
+    std::array<winrt::Rect, c_maxRegions> Regions{};
     uint32_t RegionCount{ 0 };
 };
 

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -243,12 +243,6 @@
       <PreprocessorDefinitions>DISABLE_WINRT_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization Condition="'$(Configuration)'=='Release'">MinSpace</Optimization>
       <ConformanceMode>true</ConformanceMode>
-      <!-- Pipelines agents are low-memory configurations that struggle to compile code analysis in parallel. See 
-          https://developercommunity.visualstudio.com/content/problem/831568/cl-analyze-runs-out-of-memory.html
-          for more details. While we get that resolved (either with a fix in VS or better agents), we need
-          to disable MultiProc compile. Use NUMBER_OF_PROCESSORS==2 to check if it's one of the underpowered Azure
-          Pipelines VMs -->
-      <MultiProcessorCompilation Condition="'$(RunCodeAnalysis)'=='true' AND '$(NUMBER_OF_PROCESSORS)'=='2'">false</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -133,7 +133,7 @@
     <Import Project="..\SplitView\SplitView.vcxitems" Label="Shared" Condition="$(FeatureScrollBarEnabled) == 'true' Or $(FeatureScrollBarEnabled) == 'productOnly'" />
     <Import Project="..\ContentDialog\ContentDialog.vcxitems" Label="Shared" Condition="$(FeatureContentDialogEnabled) == 'true' Or $(FeatureContentDialogEnabled) == 'productOnly'" />
     <Import Project="..\ProgressBar\ProgressBar.vcxitems" Label="Shared" Condition="$(FeatureProgressBarEnabled) == 'true' Or $(FeatureProgressBarEnabled) == 'productOnly'" />
-	  <Import Project="..\NumberBox\NumberBox.vcxitems" Label="Shared" Condition="$(FeatureNumberBoxEnabled) == 'true' Or $(FeatureNumberBoxEnabled) == 'productOnly'" />
+    <Import Project="..\NumberBox\NumberBox.vcxitems" Label="Shared" Condition="$(FeatureNumberBoxEnabled) == 'true' Or $(FeatureNumberBoxEnabled) == 'productOnly'" />
   </ImportGroup>
   <ItemGroup>
     <SharedPage Include="@(Page)" />
@@ -166,14 +166,18 @@
     <GenerateManifest>false</GenerateManifest>
     <IgnoreImportLibrary>false</IgnoreImportLibrary>
   </PropertyGroup>
-  <!-- Disable code analysis until this compiler bug is fixed: Bug 616860: /analyze on pch.cpp using C++/WinRT takes 25 minutes and runs out of memory -->
-  <!-- <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <!-- Run code analysis: Release (locally only) -OR- Debug (pipeline only) -OR- Debug Intellisense -->
+  <PropertyGroup Condition="
+    ('$(Configuration)'=='Release' AND '$(TF_BUILD)'!='True') OR
+    ('$(Configuration)'=='Debug' AND '$(TF_BUILD)'=='True') OR
+    ('$(Configuration)'=='Debug' AND '$(IntelliSenseBuild)'=='1')
+    ">
     <RunCodeAnalysis>true</RunCodeAnalysis>
-    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\..\build\PrefastWarnings.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup> -->
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -224,7 +228,7 @@
         $(MiniWindowsSDKIncludePath);
       </AdditionalIncludeDirectories>
       <AdditionalOptions>/std:c++17 /bigobj %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions>/Wv:18 /Zm1000 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Wv:18 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)'=='Release'">%(AdditionalOptions) /d2FH4</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -239,6 +243,12 @@
       <PreprocessorDefinitions>DISABLE_WINRT_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Optimization Condition="'$(Configuration)'=='Release'">MinSpace</Optimization>
       <ConformanceMode>true</ConformanceMode>
+      <!-- Pipelines agents are low-memory configurations that struggle to compile code analysis in parallel. See 
+          https://developercommunity.visualstudio.com/content/problem/831568/cl-analyze-runs-out-of-memory.html
+          for more details. While we get that resolved (either with a fix in VS or better agents), we need
+          to disable MultiProc compile. Use NUMBER_OF_PROCESSORS==2 to check if it's one of the underpowered Azure
+          Pipelines VMs -->
+      <MultiProcessorCompilation Condition="'$(Configuration)'=='Debug' AND '$(NUMBER_OF_PROCESSORS)'=='2'">false</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -248,7 +248,7 @@
           for more details. While we get that resolved (either with a fix in VS or better agents), we need
           to disable MultiProc compile. Use NUMBER_OF_PROCESSORS==2 to check if it's one of the underpowered Azure
           Pipelines VMs -->
-      <MultiProcessorCompilation Condition="'$(Configuration)'=='Debug' AND '$(NUMBER_OF_PROCESSORS)'=='2'">false</MultiProcessorCompilation>
+      <MultiProcessorCompilation Condition="'$(RunCodeAnalysis)'=='true' AND '$(NUMBER_OF_PROCESSORS)'=='2'">false</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -366,7 +366,7 @@ void SharedHelpers::ScheduleActionAfterWait(
     // The callback that is given to CreateTimer is called off of the UI thread.
     // In order to make this useful by making it so we can interact with XAML objects,
     // we'll use the dispatcher to first post our work to the UI thread before executing it.
-    winrt::ThreadPoolTimer::CreateTimer(winrt::TimerElapsedHandler(
+    auto timer = winrt::ThreadPoolTimer::CreateTimer(winrt::TimerElapsedHandler(
         [action, dispatcherHelper](auto const&)
         {
             dispatcherHelper.RunAsync(action);
@@ -384,7 +384,7 @@ winrt::InMemoryRandomAccessStream SharedHelpers::CreateStreamFromBytes(const win
     writer.WriteBytes(winrt::array_view<const byte>(bytes));
     SyncWait(writer.StoreAsync());
     SyncWait(writer.FlushAsync());
-    writer.DetachStream();
+    auto detachedStream = writer.DetachStream();
     writer.Close();
 
     stream.Seek(0);

--- a/dev/dll/XamlMetadataProvider.cpp
+++ b/dev/dll/XamlMetadataProvider.cpp
@@ -26,7 +26,10 @@ bool XamlMetadataProvider::RegisterXamlType(
 {
     if (!s_types)
     {
+#pragma warning(push)
+#pragma warning(disable : 26409) // Disable r.11, see comment in header file
         s_types = new std::vector<Entry>();
+#pragma warning(pop)
     }
 
     Entry type{ typeName, createXamlTypeCallback };

--- a/dev/inc/CppWinRTHelpers.h
+++ b/dev/inc/CppWinRTHelpers.h
@@ -147,12 +147,12 @@ struct PropertyChanged_revoker
    PropertyChanged_revoker() noexcept = default;
    PropertyChanged_revoker(PropertyChanged_revoker const&) = delete;
    PropertyChanged_revoker& operator=(PropertyChanged_revoker const&) = delete;
-   PropertyChanged_revoker(PropertyChanged_revoker&& other)
+   PropertyChanged_revoker(PropertyChanged_revoker&& other) noexcept
    {
        move_from(other);
    }
 
-   PropertyChanged_revoker& operator=(PropertyChanged_revoker&& other)
+   PropertyChanged_revoker& operator=(PropertyChanged_revoker&& other) noexcept
    {
        move_from(other);
        return *this;
@@ -160,7 +160,7 @@ struct PropertyChanged_revoker
 
    PropertyChanged_revoker(winrt::DependencyObject const& object, const winrt::DependencyProperty&  dp, int64_t token) :
         m_object(object),
-        m_property(std::move(dp)),
+        m_property(dp),
         m_token(token)
     {}
 

--- a/dev/inc/RoutedEventHelpers.h
+++ b/dev/inc/RoutedEventHelpers.h
@@ -17,12 +17,12 @@ struct RoutedEventHandler_revoker
     RoutedEventHandler_revoker() noexcept = default;
     RoutedEventHandler_revoker(RoutedEventHandler_revoker const&) = delete;
     RoutedEventHandler_revoker& operator=(RoutedEventHandler_revoker const&) = delete;
-    RoutedEventHandler_revoker(RoutedEventHandler_revoker&& other)
+    RoutedEventHandler_revoker(RoutedEventHandler_revoker&& other) noexcept
     {
         move_from(other);
     }
 
-    RoutedEventHandler_revoker& operator=(RoutedEventHandler_revoker&& other)
+    RoutedEventHandler_revoker& operator=(RoutedEventHandler_revoker&& other) noexcept
     {
         move_from(other);
         return *this;

--- a/dev/inc/RuntimeClassHelpers.h
+++ b/dev/inc/RuntimeClassHelpers.h
@@ -165,9 +165,12 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
 #endif
         if (!this->m_inner) // We need to derive from DependencyObject. Do so if it didn't happen yet.
         {
+#pragma warning(push)
+#pragma warning(disable : 26444) // Disable es.84, there is sometimes a return value that needs to be assigned and ignored
             // Internally derive from DependencyObject to get ReferenceTracker behavior.
             winrt::impl::call_factory<winrt::DependencyObject, winrt::IDependencyObjectFactory>([&](auto&& f) { f.CreateInstance(*this, this->m_inner); });
             //winrt::get_activation_factory<winrt::DependencyObject, winrt::IDependencyObjectFactory>().CreateInstance(*this, this->m_inner);
+#pragma warning(pop)
         }
         if (this->m_inner)
         {
@@ -215,10 +218,15 @@ inline HRESULT STDMETHODCALLTYPE CppWinRTCreateActivationFactory(_In_ unsigned i
     extern "C" __declspec(allocate(section)) __declspec(selectany) const ::Microsoft::WRL::Details::CreatorMap* const __minATLObjMap_##className = &__object_##className; \
     WrlCreatorMapIncludePragma(className)
 
+#pragma warning(push)
+#pragma warning(disable : 26812) // Disable Enum.3 here, it fires at usage sites instead of declaration sites and we can't resolve it.
+
 namespace CppWinRTTemp
 {
     static TrustLevel __stdcall GetTrustLevel_BaseTrust() { return BaseTrust;  }
 }
+
+#pragma warning(pop)
 
 #define CppWinRTActivatableClassWithFactory(className, factory) \
     namespace CppWinRTTemp { static auto __stdcall RuntimeClassName__##className() { return winrt::name_of<className::class_type>().data(); } } \

--- a/dev/inc/tracker_ref.h
+++ b/dev/inc/tracker_ref.h
@@ -179,7 +179,7 @@ public:
     // carefully so that we don't end up with two tracker_ref instances
     // with the same data.
     // Move constructor.
-    tracker_ref(tracker_ref&& other)
+    tracker_ref(tracker_ref&& other) noexcept
         : m_owner(std::move(other.m_owner))
         , m_handle(std::move(other.m_handle))
         , m_valueNoRef(std::move(other.m_valueNoRef))
@@ -189,7 +189,7 @@ public:
         other.m_valueNoRef = nullptr;
     }
     // Move assignment operator.
-    tracker_ref& operator=(tracker_ref&& other)
+    tracker_ref& operator=(tracker_ref&& other) noexcept
     {
         if (this != std::addressof(other))
         {


### PR DESCRIPTION
The /analyze flag had been disabled for a while because of a bug in VS, but that's been fixed so we can re-enable it now.

This also brings in the new CppCoreGuidelines checker. We're fairly conformant on the default rule set, I only had to disable [ES.103 Don't Overflow](https://docs.microsoft.com/en-us/visualstudio/code-quality/c26451?view=vs-2019) because we trip that everywhere with our float->double promotions.

I made some fixes to get us conformant on:
1. [Enum.3: Prefer class enums over "plain" enums](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Renum-class)
2. [ES.84: Don't try to declare a local variable with no name](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-noname), which also fires when you ignore a non-trivial return value.
3. [C.66 Make move operations noexcept](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c66-make-move-operations-noexcept), and others -- make constructors noexcept.
4. [Don't std::move when you don't need to](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-move)
5. [Always initialize fields](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es20-always-initialize-an-object)

Once we establish this baseline then we can look to enable some more of the [Cpp Core Guideline checks](https://docs.microsoft.com/en-us/visualstudio/code-quality/using-the-cpp-core-guidelines-checkers?view=vs-2019#supported-rule-sets).