### PR TITLE
Fix issue with icons on TabView clipping with textscaling > 175%

### DIFF
--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -60,6 +60,8 @@
                                 Grid.Column="2"
                                 x:Name="AddButton"
                                 Content="&#xE710;"
+                                VerticalAlignment="Stretch"
+                                IsTextScaleFactorEnabled="False"
                                 Command="{TemplateBinding AddTabButtonCommand}"
                                 CommandParameter="{TemplateBinding AddTabButtonCommandParameter}"
                                 Visibility="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}"
@@ -539,6 +541,7 @@
                                 Padding="0"
                                 Margin="{ThemeResource TabViewItemHeaderCloseMargin}"
                                 Content="&#xE711;"
+                                IsTextScaleFactorEnabled="False"
                                 IsTabStop="False">
                                 <Button.Resources>
                                     <ResourceDictionary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set IsTextScaleFactorEnabled to false on the close and add button for TabView.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1650
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
Normal:
![image](https://user-images.githubusercontent.com/16122379/69468584-fe39ba00-0d8c-11ea-94da-a94ffa6b9261.png)

Textscaling 225%:
![image](https://user-images.githubusercontent.com/16122379/69468553-dfd3be80-0d8c-11ea-8ae8-c4b7f4d4921c.png)
