### PR TITLE
Fix RadioButtons putting focus on wrong element when moving between RadioButton groups

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -71,6 +71,41 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void FocusComingFromAnotherRepeaterTest()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone4))
+            {
+                Log.Warning("This test requires TrySetNewFocusedElement from RS4");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                SetItemType(RadioButtonsSourceType.RadioButton);
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+
+                    TapOnItem(3);
+                    VerifySelectedFocusedIndex(3);
+                    RadioButton item3 = FindElement.ByName<RadioButton>("Radio Button 3");
+                    Verify.IsTrue(item3.IsSelected);
+
+                    KeyboardHelper.PressKey(Key.Tab);
+                    VerifyRadioButtonsHasFocus(false);
+                    Verify.IsTrue(item3.IsSelected);
+
+                    KeyboardHelper.PressDownModifierKey(ModifierKey.Shift);
+                    KeyboardHelper.PressKey(Key.Tab);
+                    KeyboardHelper.ReleaseModifierKey(ModifierKey.Shift);
+                    VerifySelectedFocusedIndex(3);
+                    Verify.IsTrue(item3.IsSelected);
+
+                }
+            }
+        }
+
         //[TestMethod] Crashing tests, issue #1655
         public void BasicKeyboardTest()
         {

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -73,19 +73,17 @@ void RadioButtons::OnGettingFocus(const winrt::IInspectable&, const winrt::Getti
             {
                 if (auto const oldFocusedElement = args.OldFocusedElement())
                 {
-                    if (auto const oldFocusedElementAsUIElement = oldFocusedElement.try_as<winrt::UIElement>())
+                    auto oldElementParent = winrt::VisualTreeHelper::GetParent(oldFocusedElement);
+                    // If focus is coming from outside the repeater, put focus on the selected item.
+                    if (repeater != oldElementParent)
                     {
-                        // If focus is coming from outside the repeater, put focus on the selected item.
-                        if (repeater.GetElementIndex(oldFocusedElementAsUIElement) < 0)
+                        if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
                         {
-                            if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
+                            if (auto const argsAsIGettingFocusEventArgs2 = args.try_as<winrt::IGettingFocusEventArgs2>())
                             {
-                                if (auto const argsAsIGettingFocusEventArgs2 = args.try_as<winrt::IGettingFocusEventArgs2>())
+                                if (args.TrySetNewFocusedElement(selectedItem))
                                 {
-                                    if (args.TrySetNewFocusedElement(selectedItem))
-                                    {
-                                        args.Handled(true);
-                                    }
+                                    args.Handled(true);
                                 }
                             }
                         }

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -48,6 +48,9 @@
     <PackageReference Include="DiffPlex">
       <Version>1.2.1</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.Platforms">
+      <Version>3.1.0-preview3.19551.4</Version>
+    </PackageReference>
     <PackageReference Include="Win2D.uwp">
       <Version>1.22.0</Version>
     </PackageReference>

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -48,9 +48,6 @@
     <PackageReference Include="DiffPlex">
       <Version>1.2.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Platforms">
-      <Version>3.1.0-preview3.19551.4</Version>
-    </PackageReference>
     <PackageReference Include="Win2D.uwp">
       <Version>1.22.0</Version>
     </PackageReference>


### PR DESCRIPTION
## Description
RadioButtons was putting focus on the first or last element if the previously focused element was a RadioButton in another RadioButtons group.

## Motivation and Context
The problem is that ItemsRepeater.GetElementIndex is returning non-zero for elements in other repeaters. I'm following up on whether that's expected but RadioButtons doesn't need to use that logic here so I'm changing to a simpler parent check.

## How Has This Been Tested?
New test added which fails before this change and passes afterwards.

Fixes #1666