### PR TITLE
NumberBox: Make API changes and switch from preview.

### DIFF
--- a/dev/Generated/NumberBox.properties.cpp
+++ b/dev/Generated/NumberBox.properties.cpp
@@ -8,11 +8,10 @@
 
 CppWinRTActivatableClassWithDPFactory(NumberBox)
 
-GlobalDependencyProperty NumberBoxProperties::s_AcceptsCalculationProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_AcceptsExpressionProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_DescriptionProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderTemplateProperty{ nullptr };
-GlobalDependencyProperty NumberBoxProperties::s_IsHyperScrollEnabledProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_IsWrapEnabledProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MaximumProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MinimumProperty{ nullptr };
@@ -36,11 +35,11 @@ NumberBoxProperties::NumberBoxProperties()
 
 void NumberBoxProperties::EnsureProperties()
 {
-    if (!s_AcceptsCalculationProperty)
+    if (!s_AcceptsExpressionProperty)
     {
-        s_AcceptsCalculationProperty =
+        s_AcceptsExpressionProperty =
             InitializeDependencyProperty(
-                L"AcceptsCalculation",
+                L"AcceptsExpression",
                 winrt::name_of<bool>(),
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
@@ -78,17 +77,6 @@ void NumberBoxProperties::EnsureProperties()
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
                 ValueHelper<winrt::DataTemplate>::BoxedDefaultValue(),
-                nullptr);
-    }
-    if (!s_IsHyperScrollEnabledProperty)
-    {
-        s_IsHyperScrollEnabledProperty =
-            InitializeDependencyProperty(
-                L"IsHyperScrollEnabled",
-                winrt::name_of<bool>(),
-                winrt::name_of<winrt::NumberBox>(),
-                false /* isAttached */,
-                ValueHelper<bool>::BoxValueIfNecessary(false),
                 nullptr);
     }
     if (!s_IsWrapEnabledProperty)
@@ -249,11 +237,10 @@ void NumberBoxProperties::EnsureProperties()
 
 void NumberBoxProperties::ClearProperties()
 {
-    s_AcceptsCalculationProperty = nullptr;
+    s_AcceptsExpressionProperty = nullptr;
     s_DescriptionProperty = nullptr;
     s_HeaderProperty = nullptr;
     s_HeaderTemplateProperty = nullptr;
-    s_IsHyperScrollEnabledProperty = nullptr;
     s_IsWrapEnabledProperty = nullptr;
     s_MaximumProperty = nullptr;
     s_MinimumProperty = nullptr;
@@ -352,14 +339,14 @@ void NumberBoxProperties::OnValuePropertyChanged(
     winrt::get_self<NumberBox>(owner)->OnValuePropertyChanged(args);
 }
 
-void NumberBoxProperties::AcceptsCalculation(bool value)
+void NumberBoxProperties::AcceptsExpression(bool value)
 {
-    static_cast<NumberBox*>(this)->SetValue(s_AcceptsCalculationProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+    static_cast<NumberBox*>(this)->SetValue(s_AcceptsExpressionProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
 }
 
-bool NumberBoxProperties::AcceptsCalculation()
+bool NumberBoxProperties::AcceptsExpression()
 {
-    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_AcceptsCalculationProperty));
+    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_AcceptsExpressionProperty));
 }
 
 void NumberBoxProperties::Description(winrt::IInspectable const& value)
@@ -390,16 +377,6 @@ void NumberBoxProperties::HeaderTemplate(winrt::DataTemplate const& value)
 winrt::DataTemplate NumberBoxProperties::HeaderTemplate()
 {
     return ValueHelper<winrt::DataTemplate>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_HeaderTemplateProperty));
-}
-
-void NumberBoxProperties::IsHyperScrollEnabled(bool value)
-{
-    static_cast<NumberBox*>(this)->SetValue(s_IsHyperScrollEnabledProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
-}
-
-bool NumberBoxProperties::IsHyperScrollEnabled()
-{
-    return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_IsHyperScrollEnabledProperty));
 }
 
 void NumberBoxProperties::IsWrapEnabled(bool value)

--- a/dev/Generated/NumberBox.properties.h
+++ b/dev/Generated/NumberBox.properties.h
@@ -9,8 +9,8 @@ class NumberBoxProperties
 public:
     NumberBoxProperties();
 
-    void AcceptsCalculation(bool value);
-    bool AcceptsCalculation();
+    void AcceptsExpression(bool value);
+    bool AcceptsExpression();
 
     void Description(winrt::IInspectable const& value);
     winrt::IInspectable Description();
@@ -20,9 +20,6 @@ public:
 
     void HeaderTemplate(winrt::DataTemplate const& value);
     winrt::DataTemplate HeaderTemplate();
-
-    void IsHyperScrollEnabled(bool value);
-    bool IsHyperScrollEnabled();
 
     void IsWrapEnabled(bool value);
     bool IsWrapEnabled();
@@ -66,11 +63,10 @@ public:
     void Value(double value);
     double Value();
 
-    static winrt::DependencyProperty AcceptsCalculationProperty() { return s_AcceptsCalculationProperty; }
+    static winrt::DependencyProperty AcceptsExpressionProperty() { return s_AcceptsExpressionProperty; }
     static winrt::DependencyProperty DescriptionProperty() { return s_DescriptionProperty; }
     static winrt::DependencyProperty HeaderProperty() { return s_HeaderProperty; }
     static winrt::DependencyProperty HeaderTemplateProperty() { return s_HeaderTemplateProperty; }
-    static winrt::DependencyProperty IsHyperScrollEnabledProperty() { return s_IsHyperScrollEnabledProperty; }
     static winrt::DependencyProperty IsWrapEnabledProperty() { return s_IsWrapEnabledProperty; }
     static winrt::DependencyProperty MaximumProperty() { return s_MaximumProperty; }
     static winrt::DependencyProperty MinimumProperty() { return s_MinimumProperty; }
@@ -86,11 +82,10 @@ public:
     static winrt::DependencyProperty ValidationModeProperty() { return s_ValidationModeProperty; }
     static winrt::DependencyProperty ValueProperty() { return s_ValueProperty; }
 
-    static GlobalDependencyProperty s_AcceptsCalculationProperty;
+    static GlobalDependencyProperty s_AcceptsExpressionProperty;
     static GlobalDependencyProperty s_DescriptionProperty;
     static GlobalDependencyProperty s_HeaderProperty;
     static GlobalDependencyProperty s_HeaderTemplateProperty;
-    static GlobalDependencyProperty s_IsHyperScrollEnabledProperty;
     static GlobalDependencyProperty s_IsWrapEnabledProperty;
     static GlobalDependencyProperty s_MaximumProperty;
     static GlobalDependencyProperty s_MinimumProperty;

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -270,7 +270,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // [TestMethod] Disabled because GamePad A gets eaten by the TextBox.
+        [TestMethod]
         public void GamepadTest()
         {
             using (var setup = new TestSetupHelper("NumberBox Tests"))
@@ -297,8 +297,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper("NumberBox Tests"))
             {
                 RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");
-
-                Check("HyperScrollCheckBox");
 
                 Log.Comment("Verify that scroll doesn't work when the control doesn't have focus.");
                 InputHelper.RotateWheel(numBox, 1);
@@ -421,17 +419,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void BasicCalculationTest()
+        public void BasicExpressionTest()
         {
             using (var setup = new TestSetupHelper("NumberBox Tests"))
             {
                 RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");
 
-                Log.Comment("Verify that calculations don't work if AcceptsCalculations is false");
+                Log.Comment("Verify that expressions don't work if AcceptsExpression is false");
                 EnterText(numBox, "5 + 3");
                 Verify.AreEqual(0, numBox.Value);
 
-                Check("CalculationCheckBox");
+                Check("ExpressionCheckBox");
 
                 int numErrors = 0;
                 const double resetValue = 1234;

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -58,6 +58,7 @@ private:
     void OnSpinDownClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnSpinUpClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnNumberBoxKeyDown(winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args);
+    void OnNumberBoxKeyUp(winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args);
     void OnNumberBoxGotFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnNumberBoxLostFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnNumberBoxScroll(winrt::IInspectable const& sender, winrt::PointerRoutedEventArgs const& args);
@@ -88,6 +89,7 @@ private:
     winrt::RepeatButton::Click_revoker m_upButtonClickRevoker{};
     winrt::RepeatButton::Click_revoker m_downButtonClickRevoker{};
     winrt::TextBox::KeyDown_revoker m_textBoxKeyDownRevoker{};
+    winrt::TextBox::KeyUp_revoker m_textBoxKeyUpRevoker{};
     winrt::RepeatButton::Click_revoker m_popupUpButtonClickRevoker{};
     winrt::RepeatButton::Click_revoker m_popupDownButtonClickRevoker{};
 };

--- a/dev/NumberBox/NumberBox.idl
+++ b/dev/NumberBox/NumberBox.idl
@@ -1,7 +1,7 @@
 ﻿namespace MU_XC_NAMESPACE
 {
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 enum NumberBoxSpinButtonPlacementMode
 {
@@ -10,7 +10,7 @@ enum NumberBoxSpinButtonPlacementMode
     Inline
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 enum NumberBoxValidationMode
 {
@@ -18,7 +18,7 @@ enum NumberBoxValidationMode
     Disabled
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 runtimeclass NumberBoxValueChangedEventArgs
 {
@@ -26,7 +26,7 @@ runtimeclass NumberBoxValueChangedEventArgs
     Double NewValue{ get; };
 };
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
 {
@@ -69,14 +69,11 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     NumberBoxSpinButtonPlacementMode SpinButtonPlacementMode{ get; set; };
 
     [MUX_DEFAULT_VALUE("false")]
-    Boolean IsHyperScrollEnabled;
-
-    [MUX_DEFAULT_VALUE("false")]
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Boolean IsWrapEnabled;
 
     [MUX_DEFAULT_VALUE("false")]
-    Boolean AcceptsCalculation;
+    Boolean AcceptsExpression;
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_PROPERTY_VALIDATION_CALLBACK("ValidateNumberFormatter")]
@@ -101,9 +98,8 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
 
     static Windows.UI.Xaml.DependencyProperty ValidationModeProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty SpinButtonPlacementModeProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty IsHyperScrollEnabledProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty IsWrapEnabledProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty AcceptsCalculationProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty AcceptsExpressionProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty NumberFormatterProperty{ get; };
 }
@@ -113,7 +109,7 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
 namespace MU_XAP_NAMESPACE
 {
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
 unsealed runtimeclass NumberBoxAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 {

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -32,10 +32,8 @@
             </ComboBox>
 
             <CheckBox x:Name="EnabledCheckBox" AutomationProperties.Name="EnabledCheckBox" IsChecked="True" Content="Enabled"/>
-            
-            <CheckBox x:Name="CalculationCheckBox" AutomationProperties.Name="CalculationCheckBox" IsChecked="False" Content="Accepts Calculations"/>
 
-            <CheckBox x:Name="HyperScrollCheckBox" AutomationProperties.Name="HyperScrollCheckBox" IsChecked="False" Content="HyperScroll Enabled"/>
+            <CheckBox x:Name="ExpressionCheckBox" AutomationProperties.Name="ExpressionCheckBox" IsChecked="False" Content="Accepts Expression"/>
 
             <CheckBox x:Name="WrapCheckBox" AutomationProperties.Name="WrapCheckBox" IsChecked="False" Content="Wrap Enabled"/>
 
@@ -72,8 +70,7 @@
                     PlaceholderText="Text"
                     ValueChanged="NumberBoxValueChanged"
                     StepFrequency="{x:Bind StepNumberBox.Value, Mode=OneWay}"
-                    AcceptsCalculation="{x:Bind CalculationCheckBox.IsChecked.Value, Mode=OneWay}"
-                    IsHyperScrollEnabled="{x:Bind HyperScrollCheckBox.IsChecked.Value, Mode=OneWay}"
+                    AcceptsExpression="{x:Bind ExpressionCheckBox.IsChecked.Value, Mode=OneWay}"
                     IsWrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"
                     IsEnabled="{x:Bind EnabledCheckBox.IsChecked.Value, Mode=OneWay}"/>
 


### PR DESCRIPTION
Two changes from API review:
- AcceptsCalculation -> AcceptsExpression
- Removed HyperScroll property (but kept the behavior as always on)

Also fixed gamepad behavior by listening to KeyUp instead of KeyDown for A/B/Enter/Escape, as we should. And switched out of preview!