### PR TITLE
Narrow selection follows focus

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTestPageElements.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTestPageElements.cs
@@ -106,6 +106,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
         private TextBlock SelectedIndexTextBlock;
 
+        public TextBlock GetReproTextBlock()
+        {
+            return GetElement(ref ReproTextBlock, "ReproTextBlock");
+        }
+        private TextBlock ReproTextBlock;
+
         public TextBlock GetSelectedItemTextBlock()
         {
             return GetElement(ref SelectedItemTextBlock, "SelectedItemTextBlock");

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -431,7 +431,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void GamepadCanEscape()
+        public void GamepadCanEscapeAndDoesNotSelectWithFocus()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
             {
@@ -468,6 +468,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(7);
                         GamepadHelper.PressButton(null, GamepadButton.DPadRight);
                         VerifyRadioButtonsHasFocus(false);
+
+                        TapOnItem(7, useBackup);
+                        VerifySelectedFocusedIndex(7);
+                        GamepadHelper.PressButton(null, GamepadButton.DPadDown);
+                        VerifySelectedIndex(7);
+                        VerifyFocusedIndex(8);
+
+                        GamepadHelper.PressButton(null, GamepadButton.DPadLeft);
+                        VerifySelectedIndex(7);
+                        VerifyFocusedIndex(5);
                     }
                 }
             }
@@ -596,6 +606,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void ScrollViewerSettingSelectionDoesNotMoveFocus()
+        {
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
+                        SetItemType(type);
+                        SelectByIndex(3);
+                        VerifySelectedIndex(3);
+                        VerifyRadioButtonsHasFocus(false);
+
+                        elements.GetReproTextBlock().Click();
+                        VerifySelectedIndex(3);
+                        // This behavior is probably wrong, it is probably more correct for focus to be on the selected item...
+                        VerifyFocusedIndex(0);
+
+                        KeyboardHelper.PressKey(Key.Down);
+                        VerifySelectedFocusedIndex(1);
+                    }
+                }
+            }
+        }
 
         void SetNumberOfColumns(int columns)
         {

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -609,6 +609,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void ScrollViewerSettingSelectionDoesNotMoveFocus()
         {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test is disabled on RS2 because it requires RS3+ keyboarding behavior.");
+                return;
+            }
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
             {
                 elements = new RadioButtonsTestPageElements();
@@ -628,12 +633,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifyFocusedIndex(0);
 
                         KeyboardHelper.PressKey(Key.Down);
-                        VerifyFocusedIndex(1);
-                        if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-                        {
-                            Log.Warning("This check requires selection follows focus which isn't available on RS2");
-                            VerifySelectedIndex(1);
-                        }
+                        VerifySelectedFocusedIndex(1);
                     }
                 }
             }

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -629,7 +629,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                         KeyboardHelper.PressKey(Key.Down);
                         VerifyFocusedIndex(1);
-                        if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+                        if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
                         {
                             Log.Warning("This check requires selection follows focus which isn't available on RS2");
                             VerifySelectedIndex(1);

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -628,7 +628,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifyFocusedIndex(0);
 
                         KeyboardHelper.PressKey(Key.Down);
-                        VerifySelectedFocusedIndex(1);
+                        VerifyFocusedIndex(1);
+                        if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+                        {
+                            Log.Warning("This check requires selection follows focus which isn't available on RS2");
+                            VerifySelectedIndex(1);
+                        }
                     }
                 }
             }

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -69,36 +69,33 @@ void RadioButtons::OnGettingFocus(const winrt::IInspectable&, const winrt::Getti
         auto const inputDevice = args.InputDevice();
         if (inputDevice == winrt::FocusInputDeviceKind::Keyboard)
         {
-            if (m_selectedIndex >= 0)
+            if (auto const oldFocusedElement = args.OldFocusedElement())
             {
-                if (auto const oldFocusedElement = args.OldFocusedElement())
+                auto const oldElementParent = winrt::VisualTreeHelper::GetParent(oldFocusedElement);
+                // If focus is coming from outside the repeater, put focus on the selected item.
+                if (repeater != oldElementParent)
                 {
-                    auto const oldElementParent = winrt::VisualTreeHelper::GetParent(oldFocusedElement);
-                    // If focus is coming from outside the repeater, put focus on the selected item.
-                    if (repeater != oldElementParent)
+                    if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
                     {
-                        if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
+                        if (auto const argsAsIGettingFocusEventArgs2 = args.try_as<winrt::IGettingFocusEventArgs2>())
                         {
-                            if (auto const argsAsIGettingFocusEventArgs2 = args.try_as<winrt::IGettingFocusEventArgs2>())
+                            if (args.TrySetNewFocusedElement(selectedItem))
                             {
-                                if (args.TrySetNewFocusedElement(selectedItem))
-                                {
-                                    args.Handled(true);
-                                }
+                                args.Handled(true);
                             }
                         }
                     }
+                }
 
-                    // On RS3+ Selection follows focus unless control is held down.
-                    if (SharedHelpers::IsRS3OrHigher() &&
-                        (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) &
-                            winrt::CoreVirtualKeyStates::Down) != winrt::CoreVirtualKeyStates::Down)
+                // On RS3+ Selection follows focus unless control is held down.
+                else if (SharedHelpers::IsRS3OrHigher() &&
+                    (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) &
+                        winrt::CoreVirtualKeyStates::Down) != winrt::CoreVirtualKeyStates::Down)
+                {
+                    if (auto const newFocusedElementAsUIE = args.NewFocusedElement().as<winrt::UIElement>())
                     {
-                        if (auto const newFocusedElementAsUIE = args.NewFocusedElement().as<winrt::UIElement>())
-                        {
-                            Select(repeater.GetElementIndex(newFocusedElementAsUIE));
-                            args.Handled(true);
-                        }
+                        Select(repeater.GetElementIndex(newFocusedElementAsUIE));
+                        args.Handled(true);
                     }
                 }
             }

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -67,13 +67,13 @@ void RadioButtons::OnGettingFocus(const winrt::IInspectable&, const winrt::Getti
     if (auto const repeater = m_repeater.get())
     {
         auto const inputDevice = args.InputDevice();
-        if (inputDevice == winrt::FocusInputDeviceKind::Keyboard || inputDevice == winrt::FocusInputDeviceKind::GameController)
+        if (inputDevice == winrt::FocusInputDeviceKind::Keyboard)
         {
             if (m_selectedIndex >= 0)
             {
                 if (auto const oldFocusedElement = args.OldFocusedElement())
                 {
-                    auto oldElementParent = winrt::VisualTreeHelper::GetParent(oldFocusedElement);
+                    auto const oldElementParent = winrt::VisualTreeHelper::GetParent(oldFocusedElement);
                     // If focus is coming from outside the repeater, put focus on the selected item.
                     if (repeater != oldElementParent)
                     {
@@ -88,19 +88,19 @@ void RadioButtons::OnGettingFocus(const winrt::IInspectable&, const winrt::Getti
                             }
                         }
                     }
-                }
-            }
-        }
 
-        // On RS3+ Selection follows focus unless control is held down.
-        if (SharedHelpers::IsRS3OrHigher() && 
-            (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) &
-            winrt::CoreVirtualKeyStates::Down) != winrt::CoreVirtualKeyStates::Down)
-        {
-            if (auto const newFocusedElementAsUIE = args.NewFocusedElement().as<winrt::UIElement>())
-            {
-                Select(repeater.GetElementIndex(newFocusedElementAsUIE));
-                args.Handled(true);
+                    // On RS3+ Selection follows focus unless control is held down.
+                    if (SharedHelpers::IsRS3OrHigher() &&
+                        (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) &
+                            winrt::CoreVirtualKeyStates::Down) != winrt::CoreVirtualKeyStates::Down)
+                    {
+                        if (auto const newFocusedElementAsUIE = args.NewFocusedElement().as<winrt::UIElement>())
+                        {
+                            Select(repeater.GetElementIndex(newFocusedElementAsUIE));
+                            args.Handled(true);
+                        }
+                    }
+                }
             }
         }
     }

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -28,7 +28,7 @@
                             <x:String>I'm just a string</x:String>
                             <Button>And I'm a Button!</Button>
                         </controls:RadioButtons>
-                        <TextBlock x:Name="ReproTextBlock" AutomationProperties.Name="ReproTextBlock" TextWrapping="WrapWholeWords">Click me to have Scroll Viewer place focus on the first radio button. Selection shouldn't change but down will move selection and focus to the second radio button.</TextBlock>
+                        <TextBlock MaxWidth="400" x:Name="ReproTextBlock" AutomationProperties.Name="ReproTextBlock" TextWrapping="WrapWholeWords">Click me to have Scroll Viewer place focus on the first radio button. Selection shouldn't change but down will move selection and focus to the second radio button.</TextBlock>
                     </StackPanel>
                 </ScrollViewer>
             </Grid>
@@ -60,6 +60,8 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <!--20-->
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -28,7 +28,7 @@
                             <x:String>I'm just a string</x:String>
                             <Button>And I'm a Button!</Button>
                         </controls:RadioButtons>
-                        <TextBlock MaxWidth="400" x:Name="ReproTextBlock" AutomationProperties.Name="ReproTextBlock" TextWrapping="WrapWholeWords">Click me to have Scroll Viewer place focus on the first radio button. Selection shouldn't change but down will move selection and focus to the second radio button.</TextBlock>
+                        <TextBlock MaxWidth="300" x:Name="ReproTextBlock" AutomationProperties.Name="ReproTextBlock" TextWrapping="WrapWholeWords">Click me to have Scroll Viewer place focus on the first radio button. Selection shouldn't change but down will move selection and focus to the second radio button.</TextBlock>
                     </StackPanel>
                 </ScrollViewer>
             </Grid>

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -28,6 +28,7 @@
                             <x:String>I'm just a string</x:String>
                             <Button>And I'm a Button!</Button>
                         </controls:RadioButtons>
+                        <TextBlock x:Name="ReproTextBlock" AutomationProperties.Name="ReproTextBlock" TextWrapping="WrapWholeWords">Click me to have Scroll Viewer place focus on the first radio button. Selection shouldn't change but down will move selection and focus to the second radio button.</TextBlock>
                     </StackPanel>
                 </ScrollViewer>
             </Grid>


### PR DESCRIPTION
Move the selection follows focus logic into a condition block which only executes when focus is moving within radio buttons by keyboard. Add a test to ensure game pad doesn't have selection follows focus anymore and another to ensure scrollview putting focus on the first radio button doesn't move selection.

Fixes #886