### PR TITLE
Enable setting selected index/item from markup

### DIFF
--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -113,8 +113,7 @@ void RadioButtons::OnRepeaterLoaded(const winrt::IInspectable&, const winrt::Rou
         }
 
         m_blockSelecting = false;
-        if (ReadLocalValue(s_SelectedIndexProperty) == winrt::DependencyProperty::UnsetValue()
-            && ReadLocalValue(s_SelectedItemProperty) != winrt::DependencyProperty::UnsetValue())
+        if (SelectedIndex() == -1 && SelectedItem())
         {
             UpdateSelectedItem();
         }

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -112,6 +112,7 @@ void RadioButtons::OnRepeaterLoaded(const winrt::IInspectable&, const winrt::Rou
             AttachToLayoutChanged();
         }
 
+        m_blockSelecting = false;
         if (ReadLocalValue(s_SelectedIndexProperty) == winrt::DependencyProperty::UnsetValue()
             && ReadLocalValue(s_SelectedItemProperty) != winrt::DependencyProperty::UnsetValue())
         {
@@ -317,7 +318,7 @@ void RadioButtons::OnRepeaterCollectionChanged(const winrt::IInspectable&, const
 
 void RadioButtons::Select(int index)
 {
-    if(!m_currentlySelecting && m_selectedIndex != index)
+    if(!m_blockSelecting && !m_currentlySelecting && m_selectedIndex != index)
     {
         // Calling Select updates the checked state on the radio button being selected
         // and the radio button being unselected, as well as updates the SelectedIndex

--- a/dev/RadioButtons/RadioButtons.h
+++ b/dev/RadioButtons/RadioButtons.h
@@ -73,7 +73,11 @@ private:
     bool HandleEdgeCaseFocus(bool first, const winrt::IInspectable& source);
 
     int m_selectedIndex{ -1 };
+    // This is used to guard against reentrency when calling select, since select changes
+    // the Selected Index/Item which in turn calls select.
     bool m_currentlySelecting{ false };
+    // We block selection before the control has loaded.
+    // This is to ensure that we do not overwrite a provided Selected Index/Item value.
     bool m_blockSelecting{ true };
 
     tracker_ref<winrt::ItemsRepeater> m_repeater{ this };

--- a/dev/RadioButtons/RadioButtons.h
+++ b/dev/RadioButtons/RadioButtons.h
@@ -74,6 +74,7 @@ private:
 
     int m_selectedIndex{ -1 };
     bool m_currentlySelecting{ false };
+    bool m_blockSelecting{ true };
 
     tracker_ref<winrt::ItemsRepeater> m_repeater{ this };
 

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -23,12 +23,12 @@
                 <ScrollViewer HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Visible">
                     <StackPanel>
                         <controls:RadioButtons x:Name="TestRadioButtons" AutomationProperties.Name="TestRadioButtons" Header="I'm the header" SelectionChanged="TestRadioButtons_SelectionChanged" GotFocus="TestRadioButtons_GotFocus" LostFocus="TestRadioButtons_LostFocus"/>
-                        <controls:RadioButtons x:Name="SecondTestRadioButton" Header="A Second Radio Buttons">
+                        <controls:RadioButtons x:Name="SecondTestRadioButton" Header="A Second Radio Buttons, 0 selected">
                             <RadioButton x:Name="TheRadioButton">"I'm really a Radio Button"</RadioButton>
                             <x:String>I'm just a string</x:String>
                             <Button>And I'm a Button!</Button>
                         </controls:RadioButtons>
-                        <controls:RadioButtons Header="A Third Radio Buttons" SelectedIndex="1">
+                        <controls:RadioButtons Header="A Third Radio Buttons, 1 selected" SelectedIndex="1">
                             <x:Double>0.0</x:Double>
                             <x:Double>1.0</x:Double>
                             <x:Double>2.0</x:Double>

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -23,10 +23,15 @@
                 <ScrollViewer HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Visible">
                     <StackPanel>
                         <controls:RadioButtons x:Name="TestRadioButtons" AutomationProperties.Name="TestRadioButtons" Header="I'm the header" SelectionChanged="TestRadioButtons_SelectionChanged" GotFocus="TestRadioButtons_GotFocus" LostFocus="TestRadioButtons_LostFocus"/>
-                        <controls:RadioButtons Header="A Second Radio Buttons">
-                            <RadioButton>"I'm really a Radio Button"</RadioButton>
+                        <controls:RadioButtons x:Name="SecondTestRadioButton" Header="A Second Radio Buttons">
+                            <RadioButton x:Name="TheRadioButton">"I'm really a Radio Button"</RadioButton>
                             <x:String>I'm just a string</x:String>
                             <Button>And I'm a Button!</Button>
+                        </controls:RadioButtons>
+                        <controls:RadioButtons Header="A Third Radio Buttons" SelectedIndex="1">
+                            <x:Double>0.0</x:Double>
+                            <x:Double>1.0</x:Double>
+                            <x:Double>2.0</x:Double>
                         </controls:RadioButtons>
                     </StackPanel>
                 </ScrollViewer>

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml.cs
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml.cs
@@ -34,6 +34,7 @@ namespace MUXControlsTestApp
             m_stringItemCollection = new ObservableCollection<string>();
             m_radioButtonItemCollection = new ObservableCollection<RadioButton>();
             this.Loaded += RadioButtonsPage_Loaded;
+            this.SecondTestRadioButton.SelectedItem = this.TheRadioButton;
         }
 
         private void RadioButtonsPage_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Before this change RadioButtons would trample any consumer provided values for SelectedIndex or SelectedItem during its set up. Now those values are respected. Fixes #1678