### PR TITLE
NumberBox: Change StepFrequency to SmallChange and LargeChange

### DIFF
--- a/dev/Generated/NumberBox.properties.cpp
+++ b/dev/Generated/NumberBox.properties.cpp
@@ -99,7 +99,7 @@ void NumberBoxProperties::EnsureProperties()
                 winrt::name_of<double>(),
                 winrt::name_of<winrt::NumberBox>(),
                 false /* isAttached */,
-                ValueHelper<double>::BoxValueIfNecessary(1),
+                ValueHelper<double>::BoxValueIfNecessary(10),
                 nullptr);
     }
     if (!s_MaximumProperty)

--- a/dev/Generated/NumberBox.properties.cpp
+++ b/dev/Generated/NumberBox.properties.cpp
@@ -13,6 +13,7 @@ GlobalDependencyProperty NumberBoxProperties::s_DescriptionProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_HeaderTemplateProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_IsWrapEnabledProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_LargeChangeProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MaximumProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_MinimumProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_NumberFormatterProperty{ nullptr };
@@ -20,8 +21,8 @@ GlobalDependencyProperty NumberBoxProperties::s_PlaceholderTextProperty{ nullptr
 GlobalDependencyProperty NumberBoxProperties::s_PreventKeyboardDisplayOnProgrammaticFocusProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_SelectionFlyoutProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_SelectionHighlightColorProperty{ nullptr };
+GlobalDependencyProperty NumberBoxProperties::s_SmallChangeProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_SpinButtonPlacementModeProperty{ nullptr };
-GlobalDependencyProperty NumberBoxProperties::s_StepFrequencyProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_TextProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_TextReadingOrderProperty{ nullptr };
 GlobalDependencyProperty NumberBoxProperties::s_ValidationModeProperty{ nullptr };
@@ -89,6 +90,17 @@ void NumberBoxProperties::EnsureProperties()
                 false /* isAttached */,
                 ValueHelper<bool>::BoxValueIfNecessary(false),
                 winrt::PropertyChangedCallback(&OnIsWrapEnabledPropertyChanged));
+    }
+    if (!s_LargeChangeProperty)
+    {
+        s_LargeChangeProperty =
+            InitializeDependencyProperty(
+                L"LargeChange",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxValueIfNecessary(1),
+                nullptr);
     }
     if (!s_MaximumProperty)
     {
@@ -167,6 +179,17 @@ void NumberBoxProperties::EnsureProperties()
                 ValueHelper<winrt::SolidColorBrush>::BoxedDefaultValue(),
                 nullptr);
     }
+    if (!s_SmallChangeProperty)
+    {
+        s_SmallChangeProperty =
+            InitializeDependencyProperty(
+                L"SmallChange",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::NumberBox>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxValueIfNecessary(1),
+                winrt::PropertyChangedCallback(&OnSmallChangePropertyChanged));
+    }
     if (!s_SpinButtonPlacementModeProperty)
     {
         s_SpinButtonPlacementModeProperty =
@@ -177,17 +200,6 @@ void NumberBoxProperties::EnsureProperties()
                 false /* isAttached */,
                 ValueHelper<winrt::NumberBoxSpinButtonPlacementMode>::BoxValueIfNecessary(winrt::NumberBoxSpinButtonPlacementMode::Hidden),
                 winrt::PropertyChangedCallback(&OnSpinButtonPlacementModePropertyChanged));
-    }
-    if (!s_StepFrequencyProperty)
-    {
-        s_StepFrequencyProperty =
-            InitializeDependencyProperty(
-                L"StepFrequency",
-                winrt::name_of<double>(),
-                winrt::name_of<winrt::NumberBox>(),
-                false /* isAttached */,
-                ValueHelper<double>::BoxValueIfNecessary(1),
-                winrt::PropertyChangedCallback(&OnStepFrequencyPropertyChanged));
     }
     if (!s_TextProperty)
     {
@@ -242,6 +254,7 @@ void NumberBoxProperties::ClearProperties()
     s_HeaderProperty = nullptr;
     s_HeaderTemplateProperty = nullptr;
     s_IsWrapEnabledProperty = nullptr;
+    s_LargeChangeProperty = nullptr;
     s_MaximumProperty = nullptr;
     s_MinimumProperty = nullptr;
     s_NumberFormatterProperty = nullptr;
@@ -249,8 +262,8 @@ void NumberBoxProperties::ClearProperties()
     s_PreventKeyboardDisplayOnProgrammaticFocusProperty = nullptr;
     s_SelectionFlyoutProperty = nullptr;
     s_SelectionHighlightColorProperty = nullptr;
+    s_SmallChangeProperty = nullptr;
     s_SpinButtonPlacementModeProperty = nullptr;
-    s_StepFrequencyProperty = nullptr;
     s_TextProperty = nullptr;
     s_TextReadingOrderProperty = nullptr;
     s_ValidationModeProperty = nullptr;
@@ -299,20 +312,20 @@ void NumberBoxProperties::OnNumberFormatterPropertyChanged(
     winrt::get_self<NumberBox>(owner)->OnNumberFormatterPropertyChanged(args);
 }
 
+void NumberBoxProperties::OnSmallChangePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::NumberBox>();
+    winrt::get_self<NumberBox>(owner)->OnSmallChangePropertyChanged(args);
+}
+
 void NumberBoxProperties::OnSpinButtonPlacementModePropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
     auto owner = sender.as<winrt::NumberBox>();
     winrt::get_self<NumberBox>(owner)->OnSpinButtonPlacementModePropertyChanged(args);
-}
-
-void NumberBoxProperties::OnStepFrequencyPropertyChanged(
-    winrt::DependencyObject const& sender,
-    winrt::DependencyPropertyChangedEventArgs const& args)
-{
-    auto owner = sender.as<winrt::NumberBox>();
-    winrt::get_self<NumberBox>(owner)->OnStepFrequencyPropertyChanged(args);
 }
 
 void NumberBoxProperties::OnTextPropertyChanged(
@@ -389,6 +402,16 @@ bool NumberBoxProperties::IsWrapEnabled()
     return ValueHelper<bool>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_IsWrapEnabledProperty));
 }
 
+void NumberBoxProperties::LargeChange(double value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_LargeChangeProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+}
+
+double NumberBoxProperties::LargeChange()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_LargeChangeProperty));
+}
+
 void NumberBoxProperties::Maximum(double value)
 {
     static_cast<NumberBox*>(this)->SetValue(s_MaximumProperty, ValueHelper<double>::BoxValueIfNecessary(value));
@@ -461,6 +484,16 @@ winrt::SolidColorBrush NumberBoxProperties::SelectionHighlightColor()
     return ValueHelper<winrt::SolidColorBrush>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_SelectionHighlightColorProperty));
 }
 
+void NumberBoxProperties::SmallChange(double value)
+{
+    static_cast<NumberBox*>(this)->SetValue(s_SmallChangeProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+}
+
+double NumberBoxProperties::SmallChange()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_SmallChangeProperty));
+}
+
 void NumberBoxProperties::SpinButtonPlacementMode(winrt::NumberBoxSpinButtonPlacementMode const& value)
 {
     static_cast<NumberBox*>(this)->SetValue(s_SpinButtonPlacementModeProperty, ValueHelper<winrt::NumberBoxSpinButtonPlacementMode>::BoxValueIfNecessary(value));
@@ -469,16 +502,6 @@ void NumberBoxProperties::SpinButtonPlacementMode(winrt::NumberBoxSpinButtonPlac
 winrt::NumberBoxSpinButtonPlacementMode NumberBoxProperties::SpinButtonPlacementMode()
 {
     return ValueHelper<winrt::NumberBoxSpinButtonPlacementMode>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_SpinButtonPlacementModeProperty));
-}
-
-void NumberBoxProperties::StepFrequency(double value)
-{
-    static_cast<NumberBox*>(this)->SetValue(s_StepFrequencyProperty, ValueHelper<double>::BoxValueIfNecessary(value));
-}
-
-double NumberBoxProperties::StepFrequency()
-{
-    return ValueHelper<double>::CastOrUnbox(static_cast<NumberBox*>(this)->GetValue(s_StepFrequencyProperty));
 }
 
 void NumberBoxProperties::Text(winrt::hstring const& value)

--- a/dev/Generated/NumberBox.properties.h
+++ b/dev/Generated/NumberBox.properties.h
@@ -24,6 +24,9 @@ public:
     void IsWrapEnabled(bool value);
     bool IsWrapEnabled();
 
+    void LargeChange(double value);
+    double LargeChange();
+
     void Maximum(double value);
     double Maximum();
 
@@ -45,11 +48,11 @@ public:
     void SelectionHighlightColor(winrt::SolidColorBrush const& value);
     winrt::SolidColorBrush SelectionHighlightColor();
 
+    void SmallChange(double value);
+    double SmallChange();
+
     void SpinButtonPlacementMode(winrt::NumberBoxSpinButtonPlacementMode const& value);
     winrt::NumberBoxSpinButtonPlacementMode SpinButtonPlacementMode();
-
-    void StepFrequency(double value);
-    double StepFrequency();
 
     void Text(winrt::hstring const& value);
     winrt::hstring Text();
@@ -68,6 +71,7 @@ public:
     static winrt::DependencyProperty HeaderProperty() { return s_HeaderProperty; }
     static winrt::DependencyProperty HeaderTemplateProperty() { return s_HeaderTemplateProperty; }
     static winrt::DependencyProperty IsWrapEnabledProperty() { return s_IsWrapEnabledProperty; }
+    static winrt::DependencyProperty LargeChangeProperty() { return s_LargeChangeProperty; }
     static winrt::DependencyProperty MaximumProperty() { return s_MaximumProperty; }
     static winrt::DependencyProperty MinimumProperty() { return s_MinimumProperty; }
     static winrt::DependencyProperty NumberFormatterProperty() { return s_NumberFormatterProperty; }
@@ -75,8 +79,8 @@ public:
     static winrt::DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty() { return s_PreventKeyboardDisplayOnProgrammaticFocusProperty; }
     static winrt::DependencyProperty SelectionFlyoutProperty() { return s_SelectionFlyoutProperty; }
     static winrt::DependencyProperty SelectionHighlightColorProperty() { return s_SelectionHighlightColorProperty; }
+    static winrt::DependencyProperty SmallChangeProperty() { return s_SmallChangeProperty; }
     static winrt::DependencyProperty SpinButtonPlacementModeProperty() { return s_SpinButtonPlacementModeProperty; }
-    static winrt::DependencyProperty StepFrequencyProperty() { return s_StepFrequencyProperty; }
     static winrt::DependencyProperty TextProperty() { return s_TextProperty; }
     static winrt::DependencyProperty TextReadingOrderProperty() { return s_TextReadingOrderProperty; }
     static winrt::DependencyProperty ValidationModeProperty() { return s_ValidationModeProperty; }
@@ -87,6 +91,7 @@ public:
     static GlobalDependencyProperty s_HeaderProperty;
     static GlobalDependencyProperty s_HeaderTemplateProperty;
     static GlobalDependencyProperty s_IsWrapEnabledProperty;
+    static GlobalDependencyProperty s_LargeChangeProperty;
     static GlobalDependencyProperty s_MaximumProperty;
     static GlobalDependencyProperty s_MinimumProperty;
     static GlobalDependencyProperty s_NumberFormatterProperty;
@@ -94,8 +99,8 @@ public:
     static GlobalDependencyProperty s_PreventKeyboardDisplayOnProgrammaticFocusProperty;
     static GlobalDependencyProperty s_SelectionFlyoutProperty;
     static GlobalDependencyProperty s_SelectionHighlightColorProperty;
+    static GlobalDependencyProperty s_SmallChangeProperty;
     static GlobalDependencyProperty s_SpinButtonPlacementModeProperty;
-    static GlobalDependencyProperty s_StepFrequencyProperty;
     static GlobalDependencyProperty s_TextProperty;
     static GlobalDependencyProperty s_TextReadingOrderProperty;
     static GlobalDependencyProperty s_ValidationModeProperty;
@@ -125,11 +130,11 @@ public:
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
-    static void OnSpinButtonPlacementModePropertyChanged(
+    static void OnSmallChangePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
-    static void OnStepFrequencyPropertyChanged(
+    static void OnSpinButtonPlacementModePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -64,14 +64,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 downButton.InvokeAndWait();
                 Verify.AreEqual(0, numBox.Value);
 
-                Log.Comment("Change Step value to 5");
-                RangeValueSpinner stepNumBox = FindElement.ByName<RangeValueSpinner>("StepNumberBox");
-                stepNumBox.SetValue(5);
+                Log.Comment("Change SmallChange value to 5");
+                RangeValueSpinner smallChangeNumBox = FindElement.ByName<RangeValueSpinner>("SmallChangeNumberBox");
+                smallChangeNumBox.SetValue(5);
                 Wait.ForIdle();
 
                 Log.Comment("Verify that up button increases value by 5");
                 upButton.InvokeAndWait();
                 Verify.AreEqual(5, numBox.Value);
+
+                Log.Comment("Change LargeChange value to 50");
+                RangeValueSpinner largeChangeNumBox = FindElement.ByName<RangeValueSpinner>("LargeChangeNumberBox");
+                largeChangeNumBox.SetValue(50);
+                Wait.ForIdle();
+
+                Log.Comment("Verify that up button increases value by 50");
+                upButton.InvokeAndWait();
+                Verify.AreEqual(55, numBox.Value);
 
                 Check("MinCheckBox");
                 Check("MaxCheckBox");

--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -73,15 +73,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 upButton.InvokeAndWait();
                 Verify.AreEqual(5, numBox.Value);
 
-                Log.Comment("Change LargeChange value to 50");
-                RangeValueSpinner largeChangeNumBox = FindElement.ByName<RangeValueSpinner>("LargeChangeNumberBox");
-                largeChangeNumBox.SetValue(50);
-                Wait.ForIdle();
-
-                Log.Comment("Verify that up button increases value by 50");
-                upButton.InvokeAndWait();
-                Verify.AreEqual(55, numBox.Value);
-
                 Check("MinCheckBox");
                 Check("MaxCheckBox");
 
@@ -276,6 +267,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(Key.Down);
                 Wait.ForIdle();
                 Verify.AreEqual(75, numBox.Value);
+
+                Log.Comment("Verify that pressing PageUp key increases value by 10");
+                KeyboardHelper.PressKey(Key.PageUp);
+                Wait.ForIdle();
+                Verify.AreEqual(85, numBox.Value);
             }
         }
 

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -367,22 +367,22 @@ void NumberBox::OnNumberBoxKeyDown(winrt::IInspectable const& sender, winrt::Key
     switch (args.OriginalKey())
     {
         case winrt::VirtualKey::Up:
+            StepValue(SmallChange());
+            args.Handled(true); 
+            break;
+
+        case winrt::VirtualKey::Down:
             StepValue(-SmallChange());
             args.Handled(true);
             break;
 
-        case winrt::VirtualKey::Down:
-            StepValue(SmallChange());
-            args.Handled(true);
-            break;
-
         case winrt::VirtualKey::PageUp:
-            StepValue(-LargeChange());
+            StepValue(LargeChange());
             args.Handled(true);
             break;
 
         case winrt::VirtualKey::PageDown:
-            StepValue(LargeChange());
+            StepValue(-LargeChange());
             args.Handled(true);
             break;
     }

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -189,7 +189,7 @@ void NumberBox::OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedE
     UpdateSpinButtonEnabled();
 }
 
-void NumberBox::OnStepFrequencyPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
+void NumberBox::OnSmallChangePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
     UpdateSpinButtonEnabled();
 }
@@ -353,12 +353,12 @@ void NumberBox::ValidateInput()
 
 void NumberBox::OnSpinDownClick(winrt::IInspectable const&  sender, winrt::RoutedEventArgs const& args)
 {
-    StepValueDown();
+    StepValue(-SmallChange());
 }
 
 void NumberBox::OnSpinUpClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args)
 {
-    StepValueUp();
+    StepValue(SmallChange());
 }
 
 void NumberBox::OnNumberBoxKeyDown(winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)
@@ -367,12 +367,22 @@ void NumberBox::OnNumberBoxKeyDown(winrt::IInspectable const& sender, winrt::Key
     switch (args.OriginalKey())
     {
         case winrt::VirtualKey::Up:
-            StepValueUp();
+            StepValue(-SmallChange());
             args.Handled(true);
             break;
 
         case winrt::VirtualKey::Down:
-            StepValueDown();
+            StepValue(SmallChange());
+            args.Handled(true);
+            break;
+
+        case winrt::VirtualKey::PageUp:
+            StepValue(-LargeChange());
+            args.Handled(true);
+            break;
+
+        case winrt::VirtualKey::PageDown:
+            StepValue(LargeChange());
             args.Handled(true);
             break;
     }
@@ -405,17 +415,17 @@ void NumberBox::OnNumberBoxScroll(winrt::IInspectable const& sender, winrt::Poin
             const auto delta = args.GetCurrentPoint(*this).Properties().MouseWheelDelta();
             if (delta > 0)
             {
-                StepValueUp();
+                StepValue(SmallChange());
             }
             else if (delta < 0)
             {
-                StepValueDown();
+                StepValue(-SmallChange());
             }
         }
     }
 }
 
-void NumberBox::StepValue(bool isPositive)
+void NumberBox::StepValue(double change)
 {
     // Before adjusting the value, validate the contents of the textbox so we don't override it.
     ValidateInput();
@@ -423,14 +433,7 @@ void NumberBox::StepValue(bool isPositive)
     auto newVal = Value();
     if (!std::isnan(newVal))
     {
-        if (isPositive)
-        {
-            newVal += StepFrequency();
-        }
-        else
-        {
-            newVal -= StepFrequency();
-        }
+        newVal += change;
 
         if (IsWrapEnabled())
         {

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -47,7 +47,8 @@ public:
     void OnValuePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMinimumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnStepFrequencyPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnSmallChangePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnLargeChangePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnIsWrapEnabledPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
     void OnNumberFormatterPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
@@ -72,9 +73,7 @@ private:
 
     void UpdateSpinButtonPlacement();
     void UpdateSpinButtonEnabled();
-    void StepValue(bool isPositive);
-    void StepValueUp() { StepValue(true); }
-    void StepValueDown() { StepValue(false); }
+    void StepValue(double change);
 
     bool IsInBounds(double value);
 

--- a/dev/NumberBox/NumberBox.idl
+++ b/dev/NumberBox/NumberBox.idl
@@ -46,7 +46,10 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
 
     [MUX_DEFAULT_VALUE("1")]
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
-    Double StepFrequency;
+    Double SmallChange;
+
+    [MUX_DEFAULT_VALUE("1")]
+    Double LargeChange;
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     String Text;
@@ -84,7 +87,8 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty MinimumProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty MaximumProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty ValueProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty StepFrequencyProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty SmallChangeProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty LargeChangeProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty TextProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty HeaderProperty{ get; };

--- a/dev/NumberBox/NumberBox.idl
+++ b/dev/NumberBox/NumberBox.idl
@@ -48,7 +48,7 @@ unsealed runtimeclass NumberBox : Windows.UI.Xaml.Controls.Control
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Double SmallChange;
 
-    [MUX_DEFAULT_VALUE("1")]
+    [MUX_DEFAULT_VALUE("10")]
     Double LargeChange;
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]

--- a/dev/NumberBox/NumberBoxAutomationPeer.cpp
+++ b/dev/NumberBox/NumberBoxAutomationPeer.cpp
@@ -64,12 +64,12 @@ double NumberBoxAutomationPeer::Value()
 
 double NumberBoxAutomationPeer::SmallChange()
 {
-    return GetImpl()->StepFrequency();
+    return GetImpl()->SmallChange();
 }
 
 double NumberBoxAutomationPeer::LargeChange()
 {
-    return GetImpl()->StepFrequency();
+    return GetImpl()->LargeChange();
 }
 
 void NumberBoxAutomationPeer::SetValue(double value)

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -38,7 +38,8 @@
             <CheckBox x:Name="WrapCheckBox" AutomationProperties.Name="WrapCheckBox" IsChecked="False" Content="Wrap Enabled"/>
 
             <!-- Set Text instead of Value to verify that it works -->
-            <controls:NumberBox x:Name="StepNumberBox" AutomationProperties.Name="StepNumberBox" Text="1" Header="Step"/>
+            <controls:NumberBox x:Name="SmallChangeNumberBox" AutomationProperties.Name="SmallChangeNumberBox" Text="1" Header="SmallChange"/>
+            <controls:NumberBox x:Name="LargeChangeNumberBox" AutomationProperties.Name="LargeChangeNumberBox" Text="10" Header="LargeChange"/>
 
             <StackPanel Orientation="Horizontal">
                 <CheckBox x:Name="MinCheckBox" AutomationProperties.Name="MinCheckBox" IsChecked="False" Checked="MinCheckBox_CheckChanged" Unchecked="MinCheckBox_CheckChanged" MinWidth="32" VerticalAlignment="Bottom"/>
@@ -69,7 +70,8 @@
                     Header="NumberBox"
                     PlaceholderText="Text"
                     ValueChanged="NumberBoxValueChanged"
-                    StepFrequency="{x:Bind StepNumberBox.Value, Mode=OneWay}"
+                    SmallChange="{x:Bind SmallChangeNumberBox.Value, Mode=OneWay}"
+                    LargeChange="{x:Bind LargeChangeNumberBox.Value, Mode=OneWay}"
                     AcceptsExpression="{x:Bind ExpressionCheckBox.IsChecked.Value, Mode=OneWay}"
                     IsWrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"
                     IsEnabled="{x:Bind EnabledCheckBox.IsChecked.Value, Mode=OneWay}"/>

--- a/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/CollectionChangeDemo.xaml
@@ -62,7 +62,7 @@
             </ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
         
-        <controls:ItemsRepeater ItemsSource="{x:Bind ResettingListItems, Mode=OneWay}" Grid.Row="2" x:Name="ResettingCollectionRepeater">
+        <controls:ItemsRepeater ItemsSource="{x:Bind ResettingListItems}" Grid.Row="2" x:Name="ResettingCollectionRepeater">
             <controls:ItemsRepeater.ItemTemplate>
                 <DataTemplate>
                     <Grid Width="300" HorizontalAlignment="Left">


### PR DESCRIPTION
We got feedback that the "StepFrequency" name was confusing and also that folks wanted support for PageUp/PageDown to make large changes. This change adds SmallChange and LargeChange properties and gets rid of StepFrequency.