### PR TITLE
Fix to layout cycle issue in Terminal

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -270,6 +270,16 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
         SelectedIndex(listView.SelectedIndex());
         SelectedItem(listView.SelectedItem());
 
+        // Find TabsItemsPresenter and listen for SizeChanged
+        m_itemsPresenter.set([this, listView]() {
+            auto itemsPresenter = SharedHelpers::FindInVisualTreeByName(listView, L"TabsItemsPresenter").as<winrt::ItemsPresenter>();
+            if (itemsPresenter)
+            {
+                m_itemsPresenterSizeChangedRevoker = itemsPresenter.SizeChanged(winrt::auto_revoke, { this, &TabView::OnItemsPresenterSizeChanged });
+            }
+            return itemsPresenter;
+        }());
+
         auto scrollViewer = SharedHelpers::FindInVisualTreeByName(listView, L"ScrollViewer").as<winrt::FxScrollViewer>();
         m_scrollViewer.set(scrollViewer);
         if (scrollViewer)
@@ -302,6 +312,11 @@ void TabView::OnScrollViewerLoaded(const winrt::IInspectable&, const winrt::Rout
 }
 
 void TabView::OnSizeChanged(const winrt::IInspectable&, const winrt::SizeChangedEventArgs&)
+{
+    UpdateTabWidths();
+}
+
+void TabView::OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args)
 {
     UpdateTabWidths();
 }
@@ -564,7 +579,14 @@ void TabView::UpdateTabWidths()
                     if (auto listview = m_listView.get())
                     {
                         listview.MaxWidth(availableWidth);
-                        winrt::FxScrollViewer::SetHorizontalScrollBarVisibility(listview, winrt::Windows::UI::Xaml::Controls::ScrollBarVisibility::Auto);
+
+                        // Calculate if the scroll buttons should be visible.
+                        if (auto itemsPresenter = m_itemsPresenter.get())
+                        {
+                            winrt::FxScrollViewer::SetHorizontalScrollBarVisibility(listview, itemsPresenter.ActualWidth() > availableWidth
+                                ? winrt::Windows::UI::Xaml::Controls::ScrollBarVisibility::Visible
+                                : winrt::Windows::UI::Xaml::Controls::ScrollBarVisibility::Hidden);
+                        }
                     }
                 }
                 else if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
@@ -617,7 +639,6 @@ void TabView::UpdateTabWidths()
         }
     }
 }
-
 
 void TabView::UpdateSelectedItem()
 {

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -121,6 +121,7 @@ private:
     void OnScrollDecreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnScrollIncreaseClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
+    void OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
 
     void OnListViewLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
@@ -159,6 +160,7 @@ private:
     tracker_ref<winrt::Grid> m_tabContainerGrid{ this };
     tracker_ref<winrt::FxScrollViewer> m_scrollViewer{ this };
     tracker_ref<winrt::Button> m_addButton{ this };
+    tracker_ref<winrt::ItemsPresenter> m_itemsPresenter{ this };
 
     tracker_ref<winrt::Grid> m_shadowReceiver{ this };
 
@@ -177,6 +179,8 @@ private:
 
     winrt::RepeatButton::Click_revoker m_scrollDecreaseClickRevoker{};
     winrt::RepeatButton::Click_revoker m_scrollIncreaseClickRevoker{};
+
+    winrt::ItemsPresenter::SizeChanged_revoker m_itemsPresenterSizeChangedRevoker{};
 
     DispatcherHelper m_dispatcherHelper{ *this };
 


### PR DESCRIPTION
Provides fix for Terminal bug:
https://github.com/microsoft/terminal/issues/3303
https://github.com/microsoft/terminal/issues/2277

Instead of relying on auto scrollbar visibility, which was causing the layout cycle, we are now calculating it ourselves based on the ItemsPresenter width vs. available width.