### PR TITLE
Fix bug where scrolling a NumberBox inside ScrollViewer would scroll both

### DIFF
--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -320,6 +320,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.RotateWheel(numBox, -1);
                 Wait.ForIdle();
                 Verify.AreEqual(-1, numBox.Value);
+
+                // Testing for 1705
+                RangeValueSpinner numBoxInScrollViewer = FindElement.ByName<RangeValueSpinner>("NumberBoxInScroller");
+                FindTextBox(numBoxInScrollViewer).SetFocus();
+                InputHelper.RotateWheel(numBoxInScrollViewer, 1);
+                InputHelper.RotateWheel(numBoxInScrollViewer, 1);
+                Wait.ForIdle();
+                Verify.AreEqual(2, numBoxInScrollViewer.Value);
+
+                TextBlock vertOffset = FindElement.ByName<TextBlock>("VerticalOffsetDisplayBlock");
+                Verify.AreEqual("0", vertOffset.GetText());
+
             }
         }
 

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -421,6 +421,8 @@ void NumberBox::OnNumberBoxScroll(winrt::IInspectable const& sender, winrt::Poin
             {
                 StepValue(-SmallChange());
             }
+            // Only set as handled when we actually changed our state.
+            args.Handled(true);
         }
     }
 }

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -7,6 +7,7 @@
     xmlns:local="using:MUXControlsTestApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     mc:Ignorable="d">
@@ -63,32 +64,54 @@
 
         <Grid Grid.Column="1">
 
-            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" contract5Present:Spacing="4">
-                <controls:NumberBox
-                    x:Name="TestNumberBox"
-                    AutomationProperties.Name="TestNumberBox"
-                    Header="NumberBox"
-                    PlaceholderText="Text"
-                    ValueChanged="NumberBoxValueChanged"
-                    SmallChange="{x:Bind SmallChangeNumberBox.Value, Mode=OneWay}"
-                    LargeChange="{x:Bind LargeChangeNumberBox.Value, Mode=OneWay}"
-                    AcceptsExpression="{x:Bind ExpressionCheckBox.IsChecked.Value, Mode=OneWay}"
-                    IsWrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"
-                    IsEnabled="{x:Bind EnabledCheckBox.IsChecked.Value, Mode=OneWay}"/>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
+                        Orientation="Horizontal" contract5Present:Spacing="4">
+                <!--Standard NumberBox test UI -->
+                <StackPanel>
+                    <controls:NumberBox
+                        x:Name="TestNumberBox"
+                        AutomationProperties.Name="TestNumberBox"
+                        Header="NumberBox"
+                        PlaceholderText="Text"
+                        ValueChanged="NumberBoxValueChanged"
+                        SmallChange="{x:Bind SmallChangeNumberBox.Value, Mode=OneWay}"
+                        LargeChange="{x:Bind LargeChangeNumberBox.Value, Mode=OneWay}"
+                        AcceptsExpression="{x:Bind ExpressionCheckBox.IsChecked.Value, Mode=OneWay}"
+                        IsWrapEnabled="{x:Bind WrapCheckBox.IsChecked.Value, Mode=OneWay}"
+                        IsEnabled="{x:Bind EnabledCheckBox.IsChecked.Value, Mode=OneWay}"/>
 
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="Value:" Margin="0,0,5,0" />
-                    <TextBlock x:Name="NewValueTextBox" AutomationProperties.Name="NewValueTextBox" Text="0" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Value:" Margin="0,0,5,0" />
+                        <TextBlock x:Name="NewValueTextBox" AutomationProperties.Name="NewValueTextBox" Text="0" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Old Value:" Margin="0,0,5,0" />
+                        <TextBlock x:Name="OldValueTextBox" AutomationProperties.Name="OldValueTextBox"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Text:" Margin="0,0,5,0" />
+                        <TextBlock x:Name="TextTextBox" AutomationProperties.Name="TextTextBox" Text="0"/>
+                    </StackPanel>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="Old Value:" Margin="0,0,5,0" />
-                    <TextBlock x:Name="OldValueTextBox" AutomationProperties.Name="OldValueTextBox"/>
-                </StackPanel>
+                <!-- NumberBox for nested scrolling bug(s)-->
+                <StackPanel Margin="10,0,0,0">
+                    <TextBlock>NumberBox inside ScrollViewer test</TextBlock>
+                    <ScrollViewer x:Name="ScrollviewerWithScroll" Height="50"
+                                  Width="200"
+                            ViewChanged="ScrollviewerWithScroll_ViewChanged">
+                        <StackPanel>
+                            <controls:NumberBox x:Name="NumberBoxInScroller"
+                                    AutomationProperties.Name="NumberBoxInScroller"/>
+                            <controls:NumberBox/>
+                            <controls:NumberBox/>
+                        </StackPanel>
+                    </ScrollViewer>
 
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="Text:" Margin="0,0,5,0" />
-                    <TextBlock x:Name="TextTextBox" AutomationProperties.Name="TextTextBox" Text="0"/>
+                    <TextBlock x:Name="VerticalOffsetDisplayBlock" Text="0"
+                            AutomationProperties.Name="VerticalOffsetDisplayBlock"/>
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -7,7 +7,6 @@
     xmlns:local="using:MUXControlsTestApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     mc:Ignorable="d">

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml.cs
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml.cs
@@ -119,5 +119,10 @@ namespace MUXControlsTestApp
         {
             TextTextBox.Text = TestNumberBox.Text;
         }
+
+        private void ScrollviewerWithScroll_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+        {
+            VerticalOffsetDisplayBlock.Text = (sender as Windows.UI.Xaml.Controls.ScrollViewer).VerticalOffset.ToString();
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the scrollhandling of NumberBox to mark event as handled so it does not get passed to the ScrollViewer.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1705 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
New Interaction test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![numberbox-inside-scrollviewerbug](https://user-images.githubusercontent.com/16122379/70002781-60e73e80-1561-11ea-8c7c-f8e21cc6720a.gif)
