### PR TITLE
Refactor tracker_ref a little to avoid ICE in VS 16.4

### DIFF
--- a/dev/inc/tracker_ref.h
+++ b/dev/inc/tracker_ref.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "SharedHelpers.h"
+
 struct __declspec(novtable) ITrackerHandleManager
 {
     virtual ~ITrackerHandleManager() = default;
@@ -78,13 +80,6 @@ struct __declspec(novtable) ITrackerHandleManager
     bool m_wasEnsureCalled{};
 #endif
 
-    // Specifies if this instance is composed by an outer object.
-    // Only returns true if this is an AggregableComObject<T> instance.
-    virtual bool IsComposed()
-    {
-        return false;
-    }
-
 protected:
     ::ITrackerOwner* m_trackerOwnerInnerNoRef{ nullptr };
 };
@@ -128,9 +123,10 @@ enum class TrackerRefFallback
     FallbackToComPtrBeforeRS4
 };
 
-template<typename T, TrackerRefFallback fallback = TrackerRefFallback::None, typename RawStorageT = ::IUnknown*, typename IUnknownAccessorT = typename IUnknownAccessor<T>>
+template<typename T, TrackerRefFallback fallback = TrackerRefFallback::None, typename RawStorageT = ::IUnknown*>
 class tracker_ref sealed
 {
+    using IUnknownAccessorT = typename IUnknownAccessor<T>;
 public:
     explicit tracker_ref(const ITrackerHandleManager* owner)
     {


### PR DESCRIPTION
I upgraded locally to VS 16.4 public thinking "oh cool, new version". But then the C++ compiler started crashing. :(

After randomly making changes I believe I narrowed down the problem to some default template argument stuff in tracker_ref which I was able to refactor to avoid the crash.