### PR TITLE
RadioButtons layout account for available size.

### DIFF
--- a/dev/RadioButtons/ColumnMajorUniformToLargestGridLayout.cpp
+++ b/dev/RadioButtons/ColumnMajorUniformToLargestGridLayout.cpp
@@ -136,11 +136,16 @@ int ColumnMajorUniformToLargestGridLayout::CalculateColumns(int childCount, floa
     auto const maxColumns = MaxColumns();
     auto const columnSpacing = ColumnSpacing();
 
+    // Every column after the first takes maxItemWidth + columnSpacing size.
     auto const extraSpaceAfterFirstColumn = availableWidth - maxItemWidth;
     auto const maxExtraColumns = std::max(0.0, std::floor(extraSpaceAfterFirstColumn / (columnSpacing + maxItemWidth)));
 
+    // The number of columns from data and api ignoring available space
     auto const currentMaxColumns = std::min(maxColumns, childCount);
+    // The smaller of number of columns from data and api and
+    // the number of columns the available space can support
     auto const effectiveColumnCount = std::min(static_cast<double>(currentMaxColumns), maxExtraColumns + 1);
+    // return 1 even if there isn't any data
     return std::max(1, static_cast<int>(effectiveColumnCount));
 }
 

--- a/dev/RadioButtons/ColumnMajorUniformToLargestGridLayout.h
+++ b/dev/RadioButtons/ColumnMajorUniformToLargestGridLayout.h
@@ -37,6 +37,8 @@ public:
     void LayoutChanged(winrt::event_token const& token);
 
 private:
+    int CalculateColumns(int childCount, float maxItemWidth, float availableWidth);
+    int m_actualColumnCount{ 1 };
     winrt::Size m_largestChildSize{ 0,0 };
 
     //Testhooks helpers, only function while m_testHooksEnabled == true

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTestPageElements.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTestPageElements.cs
@@ -184,6 +184,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
         private ComboBox SourceComboBox;
 
+        public Edit GetBorderWidthTextBox()
+        {
+            return GetElement(ref BorderWidthTextBox, "BorderWidthTextBox");
+        }
+        private Edit BorderWidthTextBox;
+
+        public Button GetSetBorderWidthButton()
+        {
+            return GetElement(ref SetBorderWidthButton, "SetBorderWidthButton");
+        }
+        private Button SetBorderWidthButton;
+
         public Button GetFocusSelectedItemButton()
         {
             return GetElement(ref FocusSelectedItemButton, "FocusSelectedItemButton");

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -527,6 +527,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         SetItemType(type);
                         SetNumberOfColumns(1);
                         SetNumberOfItems(10);
+                        SetBorderWidthToInf();
 
                         VerifyLayoutData(10, 1, 0);
                         SetNumberOfColumns(3);
@@ -538,10 +539,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         SetNumberOfColumns(10);
                         VerifyLayoutData(1, 10, 0);
                         SetNumberOfColumns(20);
-                        VerifyLayoutData(0, 10, 10);
+                        VerifyLayoutData(1, 10, 0);
 
                         SetNumberOfItems(77);
                         VerifyLayoutData(3, 20, 17);
+
+                        SetBorderWidth(100);
+                        VerifyLayoutData(77, 1, 0);
+                        SetBorderWidth(200);
+                        VerifyLayoutData(77, 1, 0);
+                        SetBorderWidth(300);
+                        VerifyLayoutData(38, 2, 1);
+                        SetBorderWidth(400);
+                        VerifyLayoutData(25, 3, 2);
+                        SetBorderWidth(500);
+                        VerifyLayoutData(25, 3, 2);
+                        SetBorderWidth(520);
+                        VerifyLayoutData(19, 4, 1);
                     }
                 }
             }
@@ -649,6 +663,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             elements.GetNumberOfItemsTextBlock().SetValue(items.ToString());
             elements.GetSetNumberOfItemsButton().Click();
+        }
+
+        void SetBorderWidth(float width)
+        {
+            elements.GetBorderWidthTextBox().SetValue(width.ToString());
+            elements.GetSetBorderWidthButton().Click();
+        }
+
+        void SetBorderWidthToInf()
+        {
+            elements.GetBorderWidthTextBox().SetValue("inf");
+            elements.GetSetBorderWidthButton().Click();
         }
 
         void SetSource(RadioButtonsSourceLocation location)

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -550,11 +550,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifyLayoutData(77, 1, 0);
                         SetBorderWidth(300);
                         VerifyLayoutData(38, 2, 1);
-                        SetBorderWidth(400);
-                        VerifyLayoutData(25, 3, 2);
                         SetBorderWidth(500);
                         VerifyLayoutData(25, 3, 2);
-                        SetBorderWidth(520);
+                        SetBorderWidth(550);
                         VerifyLayoutData(19, 4, 1);
                     }
                 }

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -22,7 +22,9 @@
             <Grid Grid.Column="0" Margin="5" MinWidth="500" MaxWidth="800">
                 <ScrollViewer HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Visible">
                     <StackPanel>
-                        <controls:RadioButtons x:Name="TestRadioButtons" AutomationProperties.Name="TestRadioButtons" Header="I'm the header" SelectionChanged="TestRadioButtons_SelectionChanged" GotFocus="TestRadioButtons_GotFocus" LostFocus="TestRadioButtons_LostFocus"/>
+                        <Border x:Name="TestRadioButtonsBorder" BorderBrush="Black" BorderThickness="1">
+                            <controls:RadioButtons x:Name="TestRadioButtons" AutomationProperties.Name="TestRadioButtons" Header="I'm the header" SelectionChanged="TestRadioButtons_SelectionChanged" GotFocus="TestRadioButtons_GotFocus" LostFocus="TestRadioButtons_LostFocus"/>
+                        </Border>
                         <controls:RadioButtons x:Name="SecondTestRadioButton" Header="A Second Radio Buttons, 0 selected">
                             <RadioButton x:Name="TheRadioButton">"I'm really a Radio Button"</RadioButton>
                             <x:String>I'm just a string</x:String>
@@ -68,6 +70,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <!--20-->
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
@@ -111,9 +114,11 @@
                             <TextBlock Text="Checked:" HorizontalAlignment="Right" VerticalAlignment="Center" Grid.Row="16" Grid.Column="0"/>
                             <CheckBox x:Name="CustomCheckedCheckBox" AutomationProperties.Name="CustomCheckedCheckBox" HorizontalAlignment="Left" Grid.Row="16" Grid.Column="1"/>
                             <TextBlock Text="TestPage Utilities" HorizontalAlignment="Center" Foreground="Red" Grid.Row="17" Grid.Column="0" Grid.ColumnSpan="2"/>
-                            <Button Content="Focus Selected Item" AutomationProperties.Name="FocusSelectedItemButton" Grid.Row="18" Grid.Column="0" Grid.ColumnSpan="2" Click="FocusSelectedItemButton_Clicked"/>
-                            <Button Content="Select 5 then change source" AutomationProperties.Name="Select5ThenChangeSourceButton" Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" Click="Select5ThenChangeSourceButton_Clicked"/>
-                            <CheckBox x:Name="AllowInvalidValuesCheckBox" AutomationProperties.Name="AllowInvalidValuesCheckBox" Content="Allow Invalid Values" HorizontalAlignment="Center" IsChecked="False" IsEnabled="False" Grid.Row="20" Grid.Column="0" Grid.ColumnSpan="2" />
+                            <TextBox x:Name="BorderWidthTextBox" AutomationProperties.Name="BorderWidthTextBox" Text="inf" Grid.Row="18" Grid.Column="0" HorizontalAlignment="Right"/>
+                            <Button x:Name="SetBorderWidthButton" AutomationProperties.Name="SetBorderWidthButton" Content="Set" Grid.Row="18" Grid.Column="1" HorizontalAlignment="Left" Click="SetBorderWidthButton_Click"/>
+                            <Button Content="Focus Selected Item" AutomationProperties.Name="FocusSelectedItemButton" Grid.Row="19" Grid.Column="0" Grid.ColumnSpan="2" Click="FocusSelectedItemButton_Clicked"/>
+                            <Button Content="Select 5 then change source" AutomationProperties.Name="Select5ThenChangeSourceButton" Grid.Row="20" Grid.Column="0" Grid.ColumnSpan="2" Click="Select5ThenChangeSourceButton_Clicked"/>
+                            <CheckBox x:Name="AllowInvalidValuesCheckBox" AutomationProperties.Name="AllowInvalidValuesCheckBox" Content="Allow Invalid Values" HorizontalAlignment="Center" IsChecked="False" IsEnabled="False" Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="2" />
                         </Grid>
                     </ScrollViewer>
                     <ScrollViewer Margin="5">

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml.cs
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml.cs
@@ -242,6 +242,27 @@ namespace MUXControlsTestApp
             ((Control)repeater.TryGetElement(TestRadioButtons.SelectedIndex)).Focus(FocusState.Keyboard);
         }
 
+        private void SetBorderWidthButton_Click(object sender, RoutedEventArgs e)
+        {
+            if(this.BorderWidthTextBox.Text == "inf")
+            {
+                this.TestRadioButtonsBorder.Width = float.NaN;
+                this.BorderWidthTextBox.BorderBrush = new SolidColorBrush(Colors.Black);
+            }
+            else
+            {
+                if(float.TryParse(this.BorderWidthTextBox.Text, out float value))
+                {
+                    this.TestRadioButtonsBorder.Width = value;
+                    this.BorderWidthTextBox.BorderBrush = new SolidColorBrush(Colors.Black);
+                }
+                else
+                {
+                    this.BorderWidthTextBox.BorderBrush = new SolidColorBrush(Colors.DarkRed);
+                }
+            }
+        }
+
         private void Select5ThenChangeSourceButton_Clicked(object sender, RoutedEventArgs e)
         {
             TestRadioButtons.SelectedIndex = 5;


### PR DESCRIPTION
When there isn't enough space to display the requested number of columns we have layout reduce the number of columns to the maximum that fits in the space.

Fixes #1695 