### PR TITLE
Fix repeater holding onto elements

### DIFF
--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -28,6 +28,7 @@ using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHo
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Collections.Generic;
+using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
@@ -143,6 +144,35 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.AreSame(dataSource, repeater.GetValue(ItemsRepeater.ItemsSourceProperty) as ItemsSourceView);
                 Verify.AreSame(dataSource, repeater.ItemsSourceView);
             });
+        }
+
+        [TestMethod]
+        public void VerifyClearingItemsSourceClearsElements()
+        {
+            var data = new ObservableCollection<string>(Enumerable.Range(0, 4).Select(i => "Item #" + i));
+            var mapping = (List<ContentControl>)null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                mapping = Enumerable.Range(0, data.Count).Select(i => new ContentControl { Width = 40, Height = 40 }).ToList();
+
+                var dataSource = MockItemsSource.CreateDataSource(data, supportsUniqueIds: false);
+                var elementFactory = MockElementFactory.CreateElementFactory(mapping);
+                ItemsRepeater repeater = new ItemsRepeater();
+                repeater.ItemsSource = dataSource;
+                repeater.ItemTemplate = elementFactory;
+                // This was an issue only for NonVirtualizing layouts
+                repeater.Layout = new MyCustomNonVirtualizingStackLayout();
+                Content = repeater;
+                Content.UpdateLayout();
+
+                repeater.ItemsSource = null;
+            });
+
+            foreach(var item in mapping)
+            {
+                Verify.IsNull(item.Parent);
+            }
         }
 
         [TestMethod]

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -544,6 +544,8 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
                     ClearElementImpl(element);
                 }
             }
+
+            Children().Clear();
         }
 
         InvalidateMeasure();


### PR DESCRIPTION
With a non virtualizing layout when repeaters item source changes repeater would put the containers that were present into the recycle pool and never let go of them. I've changed repeater to clear its children in this scenario to do a proper reset.