### PR TITLE
Extend the fix for Recycling the focused element to non virtualized layouts

### DIFF
--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
 using ItemsRepeater = Microsoft.UI.Xaml.Controls.ItemsRepeater;
+using Layout = Microsoft.UI.Xaml.Controls.Layout;
 using ItemsSourceView = Microsoft.UI.Xaml.Controls.ItemsSourceView;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using RecyclePool = Microsoft.UI.Xaml.Controls.RecyclePool;
@@ -238,51 +239,63 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         public void VerifyFocusedItemIsRecycledOnCollectionReset()
         {
             List<string> items = new List<string> { "item0", "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
-            ItemsRepeater repeater = null;
+
             const int targetIndex = 4;
-            string targetItem = items[targetIndex]; 
-            
+            string targetItem = items[targetIndex];
+            List<Layout> layouts = new List<Layout>();
             RunOnUIThread.Execute(() =>
             {
-                repeater = new ItemsRepeater() {
-                    ItemsSource = items,
-                    ItemTemplate = CreateDataTemplateWithContent(@"<Button Content='{Binding}'/>")
-                };
-                Content = repeater;
-            });
-            
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                Log.Comment("Setting Focus on item " + targetIndex);
-                Button toFocus = (Button)repeater.TryGetElement(targetIndex);
-                Verify.AreEqual(targetItem, toFocus.Content as string);
-                toFocus.Focus(FocusState.Keyboard);
+                layouts.Add(new MyCustomNonVirtualizingStackLayout());
+                layouts.Add(new StackLayout());
             });
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
+            foreach (var layout in layouts)
             { 
-                Log.Comment("Removing focused element from collection");
-                items.Remove(targetItem);
+                ItemsRepeater repeater = null;
 
-                Log.Comment("Reset the collection with an empty list");
-                repeater.ItemsSource = new List<string>() ;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() => 
-            { 
-                Log.Comment("Verify new elements");
-                for (int i = 0; i < items.Count; i++)
+                RunOnUIThread.Execute(() =>
                 {
-                    Button currentButton = (Button)repeater.TryGetElement(i);
-                    Verify.IsNull(currentButton);
-                }
-            });
+                    repeater = new ItemsRepeater() {
+                        ItemsSource = items,
+                        ItemTemplate = CreateDataTemplateWithContent(@"<Button Content='{Binding}'/>"),
+                        Layout = layout
+                    };
+                    Content = repeater;
+                });
+
+                IdleSynchronizer.Wait();
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Log.Comment("Setting Focus on item " + targetIndex);
+                    Button toFocus = (Button)repeater.TryGetElement(targetIndex);
+                    Verify.AreEqual(targetItem, toFocus.Content as string);
+                    toFocus.Focus(FocusState.Keyboard);
+                });
+
+                IdleSynchronizer.Wait();
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Log.Comment("Removing focused element from collection");
+                    items.Remove(targetItem);
+
+                    Log.Comment("Reset the collection with an empty list");
+                    repeater.ItemsSource = new List<string>();
+                });
+
+                IdleSynchronizer.Wait();
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Log.Comment("Verify new elements");
+                    for (int i = 0; i < items.Count; i++)
+                    {
+                        Button currentButton = (Button)repeater.TryGetElement(i);
+                        Verify.IsNull(currentButton);
+                    }
+                });
+            }
         }
 
         private DataTemplate CreateDataTemplateWithContent(string content)

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -238,10 +238,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         [TestMethod]
         public void VerifyFocusedItemIsRecycledOnCollectionReset()
         {
-            List<string> items = new List<string> { "item0", "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
-
-            const int targetIndex = 4;
-            string targetItem = items[targetIndex];
             List<Layout> layouts = new List<Layout>();
             RunOnUIThread.Execute(() =>
             {
@@ -250,7 +246,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
 
             foreach (var layout in layouts)
-            { 
+            {
+                List<string> items = new List<string> { "item0", "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
+                const int targetIndex = 4;
+                string targetItem = items[targetIndex];
                 ItemsRepeater repeater = null;
 
                 RunOnUIThread.Execute(() =>

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -514,26 +514,26 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
         m_itemsSourceViewChanged = newValue.CollectionChanged(winrt::auto_revoke, { this, &ItemsRepeater::OnItemsSourceViewChanged });
     }
 
-    if (auto layout = Layout())
+    if (auto const layout = Layout())
     {
-        if (auto virtualLayout = layout.try_as<winrt::VirtualizingLayout>())
-        {
-            auto args = winrt::NotifyCollectionChangedEventArgs(
-                winrt::NotifyCollectionChangedAction::Reset,
-                nullptr /* newItems */,
-                nullptr /* oldItems */,
-                -1 /* newIndex */,
-                -1 /* oldIndex */);
-            args.Action();
-            m_processingItemsSourceChange.set(args);
-            auto processingChange = gsl::finally([this]()
-                {
-                    m_processingItemsSourceChange.set(nullptr);
-                });
+        auto const args = winrt::NotifyCollectionChangedEventArgs(
+            winrt::NotifyCollectionChangedAction::Reset,
+            nullptr /* newItems */,
+            nullptr /* oldItems */,
+            -1 /* newIndex */,
+            -1 /* oldIndex */);
+        args.Action();
+        auto const processingChange = gsl::finally([this]()
+            {
+                m_processingItemsSourceChange.set(nullptr);
+            });
+        m_processingItemsSourceChange.set(args);
 
+        if (auto const virtualLayout = layout.try_as<winrt::VirtualizingLayout>())
+        {
             virtualLayout.OnItemsChangedCore(GetLayoutContext(), newValue, args);
         }
-        else if (auto nonVirtualLayout = layout.try_as<winrt::NonVirtualizingLayout>())
+        else if (auto const nonVirtualLayout = layout.try_as<winrt::NonVirtualizingLayout>())
         {
             // Walk through all the elements and make sure they are cleared for
             // non-virtualizing layouts.
@@ -561,36 +561,34 @@ void ItemsRepeater::OnItemTemplateChanged(const winrt::IElementFactory& oldValue
     // have already been created and are now in the tree. The easiest way to do that
     // would be to do a reset.. Note that this has to be done before we change the template
     // so that the cleared elements go back into the old template.
-    if (auto layout = Layout())
+    if (auto const layout = Layout())
     {
-        if (auto virtualLayout = layout.try_as<winrt::VirtualizingLayout>())
-        {
-            auto args = winrt::NotifyCollectionChangedEventArgs(
-                winrt::NotifyCollectionChangedAction::Reset,
-                nullptr /* newItems */,
-                nullptr /* oldItems */,
-                -1 /* newIndex */,
-                -1 /* oldIndex */);
-            args.Action();
-            m_processingItemsSourceChange.set(args);
-            auto processingChange = gsl::finally([this]()
-                {
-                    m_processingItemsSourceChange.set(nullptr);
-                });
+        auto const args = winrt::NotifyCollectionChangedEventArgs(
+            winrt::NotifyCollectionChangedAction::Reset,
+            nullptr /* newItems */,
+            nullptr /* oldItems */,
+            -1 /* newIndex */,
+            -1 /* oldIndex */);
+        args.Action();
+        auto const processingChange = gsl::finally([this]()
+            {
+                m_processingItemsSourceChange.set(nullptr);
+            });
+        m_processingItemsSourceChange.set(args);
 
+        if (auto const virtualLayout = layout.try_as<winrt::VirtualizingLayout>())
+        {
             virtualLayout.OnItemsChangedCore(GetLayoutContext(), newValue, args);
         }
-        else if (auto nonVirtualLayout = layout.try_as<winrt::NonVirtualizingLayout>())
+        else if (auto const nonVirtualLayout = layout.try_as<winrt::NonVirtualizingLayout>())
         {
             // Walk through all the elements and make sure they are cleared for
             // non-virtualizing layouts.
-            auto children = Children();
-            for (unsigned i = 0u; i < children.Size(); ++i)
+            for (auto const& child : Children())
             {
-                auto element = children.GetAt(i);
-                if (GetVirtualizationInfo(element)->IsRealized())
+                if (GetVirtualizationInfo(child)->IsRealized())
                 {
-                    ClearElementImpl(element);
+                    ClearElementImpl(child);
                 }
             }
         }


### PR DESCRIPTION
This PR #1548 Fixed #1447 for virtual layouts but not nonvirtual layouts. I've extended the fix to nonvirtual layouts as well.

Fixes #1447