### PR TITLE
Enable chk tests

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -15,12 +15,12 @@ parameters:
   matrix: 
     Release_x86:
       buildPlatform: 'x86'
-      buildConfiguration: 'release'
+      buildConfiguration: 'debug'
       # %3b is the escape code for ';' which is used as the delimiter
       helixTargetQueues: 'windows.10.amd64.clientrs3.open.xaml%3bwindows.10.amd64.clientrs5.open.xaml'
     Release_x64:
       buildPlatform: 'x64'
-      buildConfiguration: 'release'
+      buildConfiguration: 'debug'
       helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml%3bwindows.10.amd64.clientrs4.open.xaml%3bwindows.10.amd64.client19h1.open.xaml'
 
 jobs:

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -13,15 +13,19 @@ parameters:
   # if 'useBuildOutputFromBuildId' is set, we will default to using a build from this pipeline:
   useBuildOutputFromPipeline: $(System.DefinitionId)
   matrix: 
-    Release_x86:
+    Debug_x86:
       buildPlatform: 'x86'
       buildConfiguration: 'debug'
       # %3b is the escape code for ';' which is used as the delimiter
-      helixTargetQueues: 'windows.10.amd64.clientrs3.open.xaml%3bwindows.10.amd64.clientrs5.open.xaml'
+      helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml%3bwindows.10.amd64.clientrs5.open.xaml'
+    Release_x86:
+      buildPlatform: 'x86'
+      buildConfiguration: 'release'
+      helixTargetQueues: 'windows.10.amd64.clientrs3.open.xaml%3bwindows.10.amd64.client19h1.open.xaml'
     Release_x64:
       buildPlatform: 'x64'
-      buildConfiguration: 'debug'
-      helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml%3bwindows.10.amd64.clientrs4.open.xaml%3bwindows.10.amd64.client19h1.open.xaml'
+      buildConfiguration: 'release'
+      helixTargetQueues: 'windows.10.amd64.clientrs4.open.xaml'
 
 jobs:
 - job: ${{ parameters.name }}

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -65,10 +65,10 @@ if($PublishAppxFiles)
 # Publish pdbs:
 $symbolsOutputDir = "$($FullPublishDir)\Symbols\"
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\Microsoft.UI.Xaml.pdb $symbolsOutputDir
-PublishFile -IfExists $FullBuildOutput\IXMPTestApp\IXMPTestApp.pdb $symbolsOutputDir
+PublishFile -IfExists $FullBuildOutput\IXMPTestApp.TAEF\IXMPTestApp.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXTestUtilities\MUXTestUtilities.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControls.Test\MUXControls.Test.pdb $symbolsOutputDir
-PublishFile -IfExists $FullBuildOutput\MUXControlsTestApp\MUXControlsTestApp.pdb $symbolsOutputDir
+PublishFile -IfExists $FullBuildOutput\\MUXControlsTestApp.TAEF\MUXControlsTestApp.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppForIslands\MUXControlsTestAppForIslands.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppWPF\MUXControlsTestAppWPF.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\TestAppCX\TestAppCX.pdb $symbolsOutputDir

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -68,7 +68,7 @@ PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\Microsoft.UI.Xaml.pdb $
 PublishFile -IfExists $FullBuildOutput\IXMPTestApp.TAEF\IXMPTestApp.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXTestUtilities\MUXTestUtilities.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControls.Test\MUXControls.Test.pdb $symbolsOutputDir
-PublishFile -IfExists $FullBuildOutput\\MUXControlsTestApp.TAEF\MUXControlsTestApp.pdb $symbolsOutputDir
+PublishFile -IfExists $FullBuildOutput\MUXControlsTestApp.TAEF\MUXControlsTestApp.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppForIslands\MUXControlsTestAppForIslands.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppWPF\MUXControlsTestAppWPF.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\TestAppCX\TestAppCX.pdb $symbolsOutputDir

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -31,7 +31,7 @@ jobs:
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'
-      Release_x64:
+      Debug_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Debug'
 

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -33,7 +33,7 @@ jobs:
         buildConfiguration: 'Release'
       Release_x64:
         buildPlatform: 'x64'
-        buildConfiguration: 'Release'
+        buildConfiguration: 'Debug'
 
   variables:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -31,9 +31,9 @@ jobs:
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'
-      Debug_x64:
+      Release_x64:
         buildPlatform: 'x64'
-        buildConfiguration: 'Debug'
+        buildConfiguration: 'Release'
 
   variables:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages

--- a/dev/CommonManaged/PlatformConfiguration.cs
+++ b/dev/CommonManaged/PlatformConfiguration.cs
@@ -101,5 +101,14 @@ namespace Common
         {
             return !IsOsVersionGreaterThanOrEqual(version);
         }
+
+        public static bool IsDebugBuildConfiguration()
+        {
+#if DEBUG
+            return true;
+#else
+            return false;
+#endif
+        }
     }
 }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -3722,6 +3722,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void EnsureDynamicSizeForPaneHeaderFooterAndCustomContent()
         {
+            if (PlatformConfiguration.IsDebugBuildConfiguration())
+            {
+                // Test is failing in chk configuration due to:
+                // Bug #1734 NavigationViewTests.EnsureDynamicSizeForPaneHeaderFooterAndCustomContent fails in CHK configuration
+                Log.Warning("Skipping test for Debug builds.");
+                return;
+            }
+
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Stretch Test" }))
             {
                 Button navButton = new Button(FindElement.ById("TogglePaneButton"));

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -168,7 +168,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #if DEBUG
             // Test is failing in chk configuration due to:
             // Bug #1726 Test Failure: RepeaterTests.VerifyCurrentAnchor 
-            Log.LogWarning("Skipping test for Debug builds.")
+            Log.LogWarning("Skipping test for Debug builds.");
             return;
 #endif
             ItemsRepeater rootRepeater = null;

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -165,12 +165,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         [TestMethod]
         public void VerifyCurrentAnchor()
         {
-#if DEBUG
-            // Test is failing in chk configuration due to:
-            // Bug #1726 Test Failure: RepeaterTests.VerifyCurrentAnchor 
-            Log.Warning("Skipping test for Debug builds.");
-            return;
-#else
+            if(PlatformConfiguration.IsDebugBuildConfiguration())
+            {
+                // Test is failing in chk configuration due to:
+                // Bug #1726 Test Failure: RepeaterTests.VerifyCurrentAnchor 
+                Log.Warning("Skipping test for Debug builds.");
+                return;
+            }
 
             ItemsRepeater rootRepeater = null;
             ScrollViewer scrollViewer = null;
@@ -230,7 +231,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Verify.AreEqual(i * 4, anchorIndex);
                 });
             }
-#endif
         }
 
         // Ensure that scrolling a nested repeater works when the 

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -168,7 +168,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 #if DEBUG
             // Test is failing in chk configuration due to:
             // Bug #1726 Test Failure: RepeaterTests.VerifyCurrentAnchor 
-            Log.LogWarning("Skipping test for Debug builds.");
+            Log.Warning("Skipping test for Debug builds.");
             return;
 #endif
             ItemsRepeater rootRepeater = null;

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -170,7 +170,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             // Bug #1726 Test Failure: RepeaterTests.VerifyCurrentAnchor 
             Log.Warning("Skipping test for Debug builds.");
             return;
-#endif
+#else
+
             ItemsRepeater rootRepeater = null;
             ScrollViewer scrollViewer = null;
             ItemsRepeaterScrollHost scrollhost = null;
@@ -229,6 +230,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Verify.AreEqual(i * 4, anchorIndex);
                 });
             }
+#endif
         }
 
         // Ensure that scrolling a nested repeater works when the 

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -165,6 +165,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         [TestMethod]
         public void VerifyCurrentAnchor()
         {
+#if DEBUG
+            // Test is failing in chk configuration due to:
+            // Bug #1726 Test Failure: RepeaterTests.VerifyCurrentAnchor 
+            Log.LogWarning("Skipping test for Debug builds.")
+            return;
+#endif
             ItemsRepeater rootRepeater = null;
             ScrollViewer scrollViewer = null;
             ItemsRepeaterScrollHost scrollhost = null;

--- a/test/IXMPTestApp/Tests/MetadataProviderTests.cs
+++ b/test/IXMPTestApp/Tests/MetadataProviderTests.cs
@@ -55,6 +55,9 @@ namespace IXMPTestApp.Tests
                         <Rectangle Width='100' Height='100' Fill='Red' />
                     </controls:ParallaxView>");
 
+                // This test case is disabled in Debug configuration due to:
+                // Bug #1725: RecyclingElementFactory.Templates cannot be set from Xaml on RS4 and below in debug configuration (using reflection provider) 
+#if !DEBUG
                 Log.Comment("Loading ItemsRepeater...");
                 XamlReader.Load(@"
                     <controls:ItemsRepeaterScrollHost
@@ -79,6 +82,7 @@ namespace IXMPTestApp.Tests
                             </controls:ItemsRepeater>
                         </ScrollViewer>
                     </controls:ItemsRepeaterScrollHost>");
+#endif
 
                 Log.Comment("Loading SwipeControl...");
                 XamlReader.Load(@"

--- a/test/IXMPTestApp/Tests/MetadataProviderTests.cs
+++ b/test/IXMPTestApp/Tests/MetadataProviderTests.cs
@@ -55,34 +55,36 @@ namespace IXMPTestApp.Tests
                         <Rectangle Width='100' Height='100' Fill='Red' />
                     </controls:ParallaxView>");
 
+
                 // This test case is disabled in Debug configuration due to:
                 // Bug #1725: RecyclingElementFactory.Templates cannot be set from Xaml on RS4 and below in debug configuration (using reflection provider) 
-#if !DEBUG
-                Log.Comment("Loading ItemsRepeater...");
-                XamlReader.Load(@"
-                    <controls:ItemsRepeaterScrollHost
-                        xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
-                        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
-                        xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
-                        <ScrollViewer>
-                            <controls:ItemsRepeater Name='repeater'>
-                                <controls:ItemsRepeater.Layout>
-                                    <controls:StackLayout Orientation='Vertical' Spacing='10' />
-                                </controls:ItemsRepeater.Layout>
-                                <controls:ItemsRepeater.ItemTemplate>
-                                    <controls:RecyclingElementFactory>
-                                        <controls:RecyclingElementFactory.RecyclePool>
-                                            <controls:RecyclePool />
-                                        </controls:RecyclingElementFactory.RecyclePool>
-                                        <DataTemplate x:Key='Primary'>
-                                            <TextBlock Text='{Binding}' />
-                                        </DataTemplate>
-                                    </controls:RecyclingElementFactory>
-                                </controls:ItemsRepeater.ItemTemplate>
-                            </controls:ItemsRepeater>
-                        </ScrollViewer>
-                    </controls:ItemsRepeaterScrollHost>");
-#endif
+                if (!PlatformConfiguration.IsDebugBuildConfiguration())
+                {
+                    Log.Comment("Loading ItemsRepeater...");
+                    XamlReader.Load(@"
+                        <controls:ItemsRepeaterScrollHost
+                            xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                            xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                            xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                            <ScrollViewer>
+                                <controls:ItemsRepeater Name='repeater'>
+                                    <controls:ItemsRepeater.Layout>
+                                        <controls:StackLayout Orientation='Vertical' Spacing='10' />
+                                    </controls:ItemsRepeater.Layout>
+                                    <controls:ItemsRepeater.ItemTemplate>
+                                        <controls:RecyclingElementFactory>
+                                            <controls:RecyclingElementFactory.RecyclePool>
+                                                <controls:RecyclePool />
+                                            </controls:RecyclingElementFactory.RecyclePool>
+                                            <DataTemplate x:Key='Primary'>
+                                                <TextBlock Text='{Binding}' />
+                                            </DataTemplate>
+                                        </controls:RecyclingElementFactory>
+                                    </controls:ItemsRepeater.ItemTemplate>
+                                </controls:ItemsRepeater>
+                            </ScrollViewer>
+                        </controls:ItemsRepeaterScrollHost>");
+                }
 
                 Log.Comment("Loading SwipeControl...");
                 XamlReader.Load(@"


### PR DESCRIPTION
Adds chk configuration to the test matrix.

Fixes #1563

Enabling this configuration uncovered three issues:

- RecyclingElementFactory.Templates cannot be set from Xaml on RS4 and below in debug configuration (using reflection provider) #1725
- Test Failure: RepeaterTests.VerifyCurrentAnchor #1726
- NavigationViewTests.EnsureDynamicSizeForPaneHeaderFooterAndCustomContent fails in CHK configuration on RS2 #1734

These three test cases have been disabled for chk configuration for now.
