### PR TITLE
Enable the RadioButtons Basic Keyboard Test

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -145,6 +145,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void BasicKeyboardTest()
         {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
             {
                 elements = new RadioButtonsTestPageElements();

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -142,7 +142,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        //[TestMethod] Crashing tests, issue #1655
+        [TestMethod]
         public void BasicKeyboardTest()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))


### PR DESCRIPTION
After quite a bit of debugging I determined that the bug in this tests root cause was #1447 which was fixed with #1724 so I'm re-enabling this test.

Fixes #1655