### PR TITLE
Switch border brush in HC

### DIFF
--- a/dev/NavigationView/NavigationView_rs2_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs2_themeresources.xaml
@@ -95,7 +95,7 @@
             <StaticResource x:Key="NavigationViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListMediumRevealBackgroundBrush" />
             <StaticResource x:Key="NavigationViewItemBackgroundSelectedDisabled" ResourceKey="SystemControlTransparentRevealBackgroundBrush" />
 
-            <StaticResource x:Key="NavigationViewItemBorderBrush" ResourceKey="SystemControlBackgroundTransparentRevealBorderBrush" />
+            <StaticResource x:Key="NavigationViewItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="NavigationViewItemBorderBrushPointerOver" ResourceKey="SystemControlHighlightAltTransparentRevealBorderBrush" />
             <StaticResource x:Key="NavigationViewItemBorderBrushPressed" ResourceKey="SystemControlHighlightAltTransparentRevealBorderBrush" />
             <StaticResource x:Key="NavigationViewItemBorderBrushDisabled" ResourceKey="SystemControlTransparentBrush" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In HC, the focused element of a NavigationView is not easy to distinguish. This was due to the NavigationViewItem having a border already applied when unfocused. This border is now removed as suggested by @YuliKl in #1727
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1727
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually in HC using MUXControlsTestApp
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

![Screenshot of NavigationView with the movies item selected](https://user-images.githubusercontent.com/16122379/70366211-f3574d00-1895-11ea-9cf0-bf22dd26d65f.png)
