### PR TITLE
Bump version in master to 2.4 and keep YYMMDDRRR version out of the release version

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -9,6 +9,7 @@ parameters:
   buildFlavor: Release
   signConfig: ''
   useReleaseTag: 'false'
+  prereleaseVersionTag: 'prerelease'
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -60,7 +61,7 @@ jobs:
         Contents: '**\Microsoft.UI.Xaml*.appx'
 
   - powershell: |
-      $prereleaseTag = "prerelease"
+      $prereleaseTag = "${{ parameters.prereleaseVersionTag }}"
       if ("${{ parameters.useReleaseTag}}" -eq [bool]::TrueString) { $prereleaseTag = "" }
 
       & "$env:Build_SourcesDirectory\build\NuSpecs\build-nupkg.ps1" `

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -47,6 +47,7 @@ jobs:
   parameters:
     jobName: CreateNugetPackage
     dependsOn: Build
+    prereleaseVersionTag: ci
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml

--- a/build/MUX-PGOInstrument.yml
+++ b/build/MUX-PGOInstrument.yml
@@ -35,6 +35,7 @@ jobs:
   parameters:
     jobName: CreateNugetPackage
     dependsOn: Build
+    prereleaseVersionTag: pgo
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -64,6 +64,7 @@ jobs:
     jobName: CreateNugetPackage
     dependsOn: Build
     primaryBuildArch: x64
+    prereleaseVersionTag: pr
 
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -137,6 +137,7 @@ jobs:
     dependsOn: SignBinariesAndPublishSymbols
     signConfig: '$(Build.SourcesDirectory)\build\NuGetSignConfig.xml'
     useReleaseTag: '$(MUXFinalRelease)'
+    prereleaseVersionTag: prerelease
  
 # Build solution that depends on nuget package
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -3,34 +3,34 @@
   <Import Project="$(MSBuildThisFileDirectory)\MicrosoftUIXamlVersion.props"/>
   <Import Project="$(MSBuildThisFileDirectory)\Common.targets"/>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.3.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.4.appx">
       <Architecture>x86</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
     <!-- Some C++/CX projects use Platform=Win32 instead of Platform=x86 -->
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.3.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x86\Release\Microsoft.UI.Xaml.2.4.appx">
       <Architecture>Win32</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
   </ItemGroup>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.3.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.4.appx">
       <Architecture>x64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
   </ItemGroup>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.2.3.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm\Release\Microsoft.UI.Xaml.2.4.appx">
       <Architecture>arm</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
   </ItemGroup>
   <ItemGroup>
-    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.3.appx">
+    <AppxPackageRegistration Include="$(MSBuildThisFileDirectory)..\tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.4.appx">
       <Architecture>arm64</Architecture>
       <Version>$(MicrosoftUIXamlAppxVersion)</Version>
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>

--- a/build/NuSpecs/build-nupkg.ps1
+++ b/build/NuSpecs/build-nupkg.ps1
@@ -40,15 +40,21 @@ else
     [xml]$customProps = (Get-Content ..\..\version.props)
     $versionMajor = $customProps.GetElementsByTagName("MUXVersionMajor").'#text'
     $versionMinor = $customProps.GetElementsByTagName("MUXVersionMinor").'#text'
+    $versionPatch = $customProps.GetElementsByTagName("MUXVersionPatch").'#text'
 
-    if ((!$versionMajor) -or (!$versionMinor))
+    if ((!$versionMajor) -or (!$versionMinor) -or (!$versionPatch))
     {
-        Write-Error "Expected MUXVersionMajor and MUXVersionMinor tags to be in version.props file"
+        Write-Error "Expected MUXVersionMajor, MUXVersionMinor, and MUXVersionPatch tags to be in version.props file"
         Exit 1
     }
 
-    $version = "$versionMajor.$versionMinor"
-    
+    $version = "$versionMajor.$versionMinor.$versionPatch"
+
+    Write-Verbose "Version = $version"
+}
+
+if ($prereleaseversion)
+{
     $versiondate = $DateOverride
     if (-not $versiondate)
     {
@@ -57,14 +63,8 @@ else
         $versiondate += ($pstTime).ToString("yyMMdd")
     }
 
-    $version += "." + $versiondate + "$subversion"
-
-    Write-Verbose "Version = $version"
-}
-
-if ($prereleaseversion)
-{
-    $version = "$version-$prereleaseversion"
+    $version = "$version-$prereleaseversion.$versiondate$subversion"
+   
 }
 
 if (!(Test-Path $OutputDir)) { mkdir $OutputDir }

--- a/dev/inc/BuildMacros.h
+++ b/dev/inc/BuildMacros.h
@@ -18,7 +18,7 @@
 #ifdef _DEBUG
 // NOTE: This could be "Microsoft.UI.Xaml.Debug" if we wanted to have Debug framework packages be distinct and
 // installed side-by-side on a machine.
-#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.2.3"
+#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.2.4"
 #else
-#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.2.3"
+#define MUXCONTROLS_PACKAGE_NAME L"Microsoft.UI.Xaml.2.4"
 #endif

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,9 +10,9 @@ The WinUI team has two major efforts underway:
 
 ## WinUI 2
 
-The next release of WinUI 2 will be **WinUI 2.3**, ETA Q4 2019.
+The next release of WinUI 2 will be **WinUI 2.4**, ETA Q1 2020.
 
-2.3 will be an incremental release that includes new WinUI Xaml features and fixes for UWP apps on Windows 10. You can find a list of currently planned work in the [WinUI 2.3 milestone](https://github.com/microsoft/microsoft-ui-xaml/milestone/8).
+2.4 will be an incremental release that includes new WinUI Xaml features and fixes for UWP apps on Windows 10. You can find a list of currently planned work in the [WinUI 2.3 milestone](https://github.com/microsoft/microsoft-ui-xaml/milestone/8).
 
 For installation instructions see [Getting started with the Windows UI Library](https://docs.microsoft.com/uwp/toolkits/winui/getting-started).
 

--- a/tools/PublishSymbols/PublishSymbols.ps1
+++ b/tools/PublishSymbols/PublishSymbols.ps1
@@ -9,14 +9,15 @@ Push-Location $PSScriptRoot
 [xml]$customProps = (Get-Content ..\..\version.props)
 $versionMajor = $customProps.GetElementsByTagName("MUXVersionMajor").'#text'
 $versionMinor = $customProps.GetElementsByTagName("MUXVersionMinor").'#text'
+$versionPatch = $customProps.GetElementsByTagName("MUXVersionPatch").'#text'
 
-if ((!$versionMajor) -or (!$versionMinor))
+if ((!$versionMajor) -or (!$versionMinor) -or (!$versionPatch))
 {
-    Write-Error "Expected MUXVersionMajor and MUXVersionMinor tags to be in version.props file"
+    Write-Error "Expected MUXVersionMajor, MUXVersionMinor, and MUXVersionPatch tags to be in version.props file"
     Exit 1
 }
 
-$buildVersion = $versionMajor + "." + $versionMinor + "." + $env:BUILD_BUILDNUMBER
+$buildVersion = "$versionMajor.$versionMinor.$versionPatch.$env:BUILD_BUILDNUMBER"
 
 Write-Host "Build = $buildVersion"
 

--- a/version.props
+++ b/version.props
@@ -3,7 +3,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MUXVersionMajor>2</MUXVersionMajor>
-    <MUXVersionMinor>3</MUXVersionMinor>
+    <MUXVersionMinor>4</MUXVersionMinor>
+    <MUXVersionPatch>0</MUXVersionPatch>
     <MUXVersionBuild Condition="$(MUXVersionBuild) == ''">0</MUXVersionBuild>
     <MUXVersionRevision Condition="$(MUXVersionRevision) == ''">0</MUXVersionRevision>
   </PropertyGroup>
@@ -13,6 +14,7 @@
         %(PreprocessorDefinitions);
         MUX_VERSION_MAJOR=$(MUXVersionMajor);
         MUX_VERSION_MINOR=$(MUXVersionMinor);
+        MUX_VERSION_PATCH=$(MUXVersionPatch);
         MUX_VERSION_BUILD=$(MUXVersionBuild);
         MUX_VERSION_REVISION=$(MUXVersionRevision);
       </PreprocessorDefinitions>
@@ -22,6 +24,7 @@
         %(PreprocessorDefinitions);
         MUX_VERSION_MAJOR=$(MUXVersionMajor);
         MUX_VERSION_MINOR=$(MUXVersionMinor);
+        MUX_VERSION_PATCH=$(MUXVersionPatch);
         MUX_VERSION_BUILD=$(MUXVersionBuild);
         MUX_VERSION_REVISION=$(MUXVersionRevision);
       </PreprocessorDefinitions>


### PR DESCRIPTION
I'd been thinking for a while that we needed to clean up our versioning scheme and the scheme we landed on for WinUI 3.0 seems good, so I'm switching us over to that for 2.4.

This change bumps us to 2.4 and adds a "patch" value to version.props as something that we manually curate as well for release builds. Release builds will no longer have the YYMMDDRRR as part of their version.

I also think it would reduce confusion to have a different prerelease tag for PR versus CI versus official prerelease builds, so I've separated that out as well. Here are some examples of what the strings would look like:
* Release: 2.4.0, 2.4.1, 2.4.2, etc
* Prerelease: 2.4.0-prerelease.191211001
* CI: 2.4.0-ci.191211001
* PR: 2.4.0-pr.191211001

I've kept the file version and framework package versioning the same. 

Since the Nuget tests only run in CI, I've done a [sanity check run on that pipeline too](https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=54157).
