### PR TITLE
Add an access key handler to radio buttons

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -657,7 +657,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
         [TestMethod]
         public void AccessKeys()
-        {
+        { 
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
             {
                 elements = new RadioButtonsTestPageElements();

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -682,6 +682,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifyRadioButtonsHasFocus(false);
                         UseAccessKey();
                         VerifySelectedFocusedIndex(3);
+                        UseAccessKey();
+                        VerifySelectedFocusedIndex(3);
                     }
                 }
             }

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -655,6 +655,37 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 }
             }
         }
+        [TestMethod]
+        public void AccessKeys()
+        {
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
+                        SetItemType(type);
+                        SetNumberOfItems(10);
+
+                        VerifyRadioButtonsHasFocus(false);
+                        UseAccessKey();
+                        VerifyFocusedIndex(0);
+                        VerifySelectedIndex(-1);
+
+                        SelectByIndex(3);
+                        VerifySelectedIndex(3);
+                        VerifyFocusedIndex(-1);
+
+                        KeyboardHelper.PressKey(Key.Tab);
+                        VerifyRadioButtonsHasFocus(false);
+                        UseAccessKey();
+                        VerifySelectedFocusedIndex(3);
+                    }
+                }
+            }
+        }
 
         void SetNumberOfColumns(int columns)
         {
@@ -783,6 +814,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             Log.Comment("Clicking on item 'Radio Button " + index + "'");
             RadioButton item = FindElement.ByName<RadioButton>("Radio Button " + index);
             item.Click();
+        }
+
+        void UseAccessKey()
+        {
+            KeyboardHelper.PressDownModifierKey(ModifierKey.Alt);
+            KeyboardHelper.PressKey(Key.R);
+            KeyboardHelper.ReleaseModifierKey(ModifierKey.Alt);
         }
 
         void TapOnItem(int index, bool useBackup = false)

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -26,10 +26,8 @@ RadioButtons::RadioButtons()
     {
         thisAsIUIElement7.PreviewKeyDown({ this, &RadioButtons::OnChildPreviewKeyDown });
     }
-    if (auto const thisAsIUIElement4 = this->try_as<winrt::IUIElement4>())
-    {
-        thisAsIUIElement4.AccessKeyInvoked({ this, &RadioButtons::OnAccessKeyInvoked });
-    }
+
+    AccessKeyInvoked({ this, &RadioButtons::OnAccessKeyInvoked });
     GettingFocus({ this, &RadioButtons::OnGettingFocus });
 
     // RadioButtons adds handlers to its child radio button elements' checked and unchecked events.
@@ -202,6 +200,22 @@ void RadioButtons::OnChildPreviewKeyDown(const winrt::IInspectable&, const winrt
 
 void RadioButtons::OnAccessKeyInvoked(const winrt::UIElement&, const winrt::AccessKeyInvokedEventArgs& args)
 {
+    if (m_selectedIndex)
+    {
+        if (auto const repeater = m_repeater.get())
+        {
+            if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
+            {
+                if (auto const selectedItemAsControl = selectedItem.try_as<winrt::Control>())
+                {
+                    selectedItemAsControl.Focus(winrt::FocusState::Keyboard);
+                    return;
+                }
+            }
+        }
+    }
+    // If we don't have a selected index, focus the RadioButton's which under normal
+    // circumstances will put focus on the first radio button.
     this->Focus(winrt::FocusState::Keyboard);
 }
 

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -200,23 +200,28 @@ void RadioButtons::OnChildPreviewKeyDown(const winrt::IInspectable&, const winrt
 
 void RadioButtons::OnAccessKeyInvoked(const winrt::UIElement&, const winrt::AccessKeyInvokedEventArgs& args)
 {
-    if (m_selectedIndex)
+    // If RadioButtons is an AccessKeyScope then we do not want to handle the access
+    // key invoked event because the user has (probably) set up access keys for the
+    // RadioButton elements.
+    if (!IsAccessKeyScope)
     {
-        if (auto const repeater = m_repeater.get())
+        if (m_selectedIndex)
         {
-            if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
+            if (auto const repeater = m_repeater.get())
             {
-                if (auto const selectedItemAsControl = selectedItem.try_as<winrt::Control>())
+                if (auto const selectedItem = repeater.TryGetElement(m_selectedIndex))
                 {
-                    selectedItemAsControl.Focus(winrt::FocusState::Keyboard);
-                    return;
+                    if (auto const selectedItemAsControl = selectedItem.try_as<winrt::Control>())
+                    {
+                        return args.Handled(selectedItemAsControl.Focus(winrt::FocusState::Programmatic));
+                    }
                 }
             }
         }
+        // If we don't have a selected index, focus the RadioButton's which under normal
+        // circumstances will put focus on the first radio button.
+        args.Handled(this->Focus(winrt::FocusState::Programmatic));
     }
-    // If we don't have a selected index, focus the RadioButton's which under normal
-    // circumstances will put focus on the first radio button.
-    this->Focus(winrt::FocusState::Keyboard);
 }
 
 // If we haven't handled the key yet and the original source was the first(for up and left)

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -203,7 +203,7 @@ void RadioButtons::OnAccessKeyInvoked(const winrt::UIElement&, const winrt::Acce
     // If RadioButtons is an AccessKeyScope then we do not want to handle the access
     // key invoked event because the user has (probably) set up access keys for the
     // RadioButton elements.
-    if (!IsAccessKeyScope)
+    if (!IsAccessKeyScope())
     {
         if (m_selectedIndex)
         {

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -24,7 +24,11 @@ RadioButtons::RadioButtons()
     // because RadioButton has a key down handler for up and down that gets called before we can intercept. Issue #1634.
     if (auto const thisAsIUIElement7 = this->try_as<winrt::IUIElement7>())
     {
-        PreviewKeyDown({ this, &RadioButtons::OnChildPreviewKeyDown });
+        thisAsIUIElement7.PreviewKeyDown({ this, &RadioButtons::OnChildPreviewKeyDown });
+    }
+    if (auto const thisAsIUIElement4 = this->try_as<winrt::IUIElement4>())
+    {
+        thisAsIUIElement4.AccessKeyInvoked({ this, &RadioButtons::OnAccessKeyInvoked });
     }
     GettingFocus({ this, &RadioButtons::OnGettingFocus });
 
@@ -194,6 +198,11 @@ void RadioButtons::OnChildPreviewKeyDown(const winrt::IInspectable&, const winrt
         args.Handled(HandleEdgeCaseFocus(true, args.OriginalSource()));
         break;
     }
+}
+
+void RadioButtons::OnAccessKeyInvoked(const winrt::UIElement&, const winrt::AccessKeyInvokedEventArgs& args)
+{
+    this->Focus(winrt::FocusState::Keyboard);
 }
 
 // If we haven't handled the key yet and the original source was the first(for up and left)

--- a/dev/RadioButtons/RadioButtons.h
+++ b/dev/RadioButtons/RadioButtons.h
@@ -56,6 +56,7 @@ private:
     void OnChildChecked(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnChildUnchecked(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
+    void OnAccessKeyInvoked(const winrt::UIElement&, const winrt::AccessKeyInvokedEventArgs& args);
 
     void UpdateItemsSource();
     winrt::IInspectable GetItemsSource();

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml
@@ -23,7 +23,7 @@
                 <ScrollViewer HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Visible">
                     <StackPanel>
                         <Border x:Name="TestRadioButtonsBorder" BorderBrush="Black" BorderThickness="1">
-                            <controls:RadioButtons x:Name="TestRadioButtons" AutomationProperties.Name="TestRadioButtons" Header="I'm the header" SelectionChanged="TestRadioButtons_SelectionChanged" GotFocus="TestRadioButtons_GotFocus" LostFocus="TestRadioButtons_LostFocus"/>
+                            <controls:RadioButtons x:Name="TestRadioButtons" AutomationProperties.Name="TestRadioButtons" AccessKey="r" Header="I'm the header" SelectionChanged="TestRadioButtons_SelectionChanged" GotFocus="TestRadioButtons_GotFocus" LostFocus="TestRadioButtons_LostFocus"/>
                         </Border>
                         <controls:RadioButtons x:Name="SecondTestRadioButton" Header="A Second Radio Buttons, 0 selected">
                             <RadioButton x:Name="TheRadioButton">"I'm really a Radio Button"</RadioButton>

--- a/test/MUXControls.Test/Common/KeyboardHelper.cs
+++ b/test/MUXControls.Test/Common/KeyboardHelper.cs
@@ -39,7 +39,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common
         Backspace,
         F10,
         F4,
-        F6
+        F6,
+        R
     }
 
     [Flags]
@@ -72,6 +73,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common
             { Key.F10, "{F10}" },
             { Key.F4, "{F4}" },
             { Key.F6, "{F6}" },
+            { Key.R, "{R}" }
         };
 
         private static string ApplyModifierKey(string keyStrokes, ModifierKey key)


### PR DESCRIPTION
Invoking the RadioButtons' access key puts focus on the selected radio button. Or the first radio button if there is no selected radio button.
Fixes #467