### PR TITLE
API Tests Refactor

### DIFF
--- a/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
+++ b/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
@@ -23,12 +23,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     [TestClass]
     public class AutoSuggestBoxTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
-
         [TestMethod]
         public void VerifyAutoSuggestBoxCornerRadius()
         {

--- a/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
+++ b/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
@@ -21,7 +21,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class AutoSuggestBoxTests
+    public class AutoSuggestBoxTests : ApiTestBase
     {
         [TestCleanup]
         public void TestCleanup()

--- a/dev/CalendarView/APITests/CalendarViewTests.cs
+++ b/dev/CalendarView/APITests/CalendarViewTests.cs
@@ -21,14 +21,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class CalendarViewTests
+    public class CalendarViewTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
-
         [TestMethod]
         public void VerifyVisualTree()
         {

--- a/dev/ColorPicker/APITests/ColorPickerTests.cs
+++ b/dev/ColorPicker/APITests/ColorPickerTests.cs
@@ -36,19 +36,8 @@ using XamlControlsXamlMetaDataProvider = Microsoft.UI.Xaml.XamlTypeInfo.XamlCont
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class ColorPickerTests
+    public class ColorPickerTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            RunOnUIThread.Execute(() =>
-            {
-                Log.Comment("TestCleanup: Restore TestContentRoot to null");
-                // Put things back the way we found them.
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
-        }
-
         [TestMethod]
         public void ColorPickerTest()
         {
@@ -310,9 +299,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     });
                 };
 
-                StackPanel root = new StackPanel();
-                root.Children.Add(element);
-                MUXControlsTestApp.App.TestContentRoot = root;
+                Content = element;
+                Content.UpdateLayout();
             });
 
             spectrumLoadedEvent.WaitOne();

--- a/dev/ComboBox/APITests/ComboBoxTests.cs
+++ b/dev/ComboBox/APITests/ComboBoxTests.cs
@@ -20,14 +20,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class ComboBoxTests
+    public class ComboBoxTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
-
         [TestMethod]
         public void VerifyComboBoxOverlayCornerRadius()
         {
@@ -100,7 +94,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifyVisualTree()
         {
-            var comboBox = SetupComboBox();
+            var comboBox = SetupComboBox(useContent: false);
             RunOnUIThread.Execute(() =>
             {
                 comboBox.IsDropDownOpen = true;
@@ -110,7 +104,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             VisualTreeTestHelper.VerifyVisualTree(root: comboBox, masterFilePrefix: "ComboBox");
         }
 
-        private ComboBox SetupComboBox()
+        private ComboBox SetupComboBox(bool useContent = true)
         {
             ComboBox comboBox = null;
             RunOnUIThread.Execute(() =>
@@ -122,8 +116,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 comboBox.Items.Add("Item 4");
                 comboBox.Items.Add("Item 5");
                 comboBox.Items.Add("Item 6");
+                if (useContent)
+                {
+                    Content = comboBox;
+                    Content.UpdateLayout();
+                }
             });
-            TestUtilities.SetAsVisualTreeRoot(comboBox);
+            if(!useContent)
+            {
+                TestUtilities.SetAsVisualTreeRoot(comboBox);
+            }
             Verify.IsNotNull(comboBox);
             return comboBox;
         }

--- a/dev/CommandBarFlyout/APITests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/APITests/CommandBarFlyoutTests.cs
@@ -28,14 +28,8 @@ using CommandBarFlyout = Microsoft.UI.Xaml.Controls.CommandBarFlyout;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class CommandBarFlyoutTests
+    public class CommandBarFlyoutTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
-
         [TestMethod]
         [TestProperty("Description", "Verifies the CommandBarFlyout's default properties.")]
         public void VerifyFlyoutDefaultPropertyValues()
@@ -299,9 +293,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 flyout.SecondaryCommands.Add(new AppBarButton() { Label = "Item 25" });
 
                 flyoutTarget = new Button() { Content = "Click for flyout" };
+                Content = flyoutTarget;
+                Content.UpdateLayout();
             });
-
-            TestUtilities.SetAsVisualTreeRoot(flyoutTarget);
 
             OpenFlyout(flyout, flyoutTarget);
 
@@ -358,9 +352,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 }
 
                 commandBarFlyoutTarget = new Button() { Content = "Click for flyout" };
+                Content = commandBarFlyoutTarget;
+                Content.UpdateLayout();
             });
 
-            TestUtilities.SetAsVisualTreeRoot(commandBarFlyoutTarget);
             flyout = commandBarFlyout;
             flyoutTarget = commandBarFlyoutTarget;
         }

--- a/dev/CommonManaged/APITestBase.cs
+++ b/dev/CommonManaged/APITestBase.cs
@@ -17,9 +17,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
-namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    public class TestsBase
+    public class ApiTestBase
     {
         private Border _host;
 

--- a/dev/CommonManaged/CommonManaged.projitems
+++ b/dev/CommonManaged/CommonManaged.projitems
@@ -10,7 +10,6 @@
     <Import_RootNamespace>CommonManaged</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)APITestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MSTestInterop.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PlatformConfiguration.cs" />
   </ItemGroup>

--- a/dev/CommonManaged/CommonManaged.projitems
+++ b/dev/CommonManaged/CommonManaged.projitems
@@ -10,6 +10,7 @@
     <Import_RootNamespace>CommonManaged</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)APITestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MSTestInterop.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PlatformConfiguration.cs" />
   </ItemGroup>

--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -32,14 +32,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class CommonStylesApiTests
+    public class CommonStylesApiTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
-
         [TestMethod]
         public void VerifyUseCompactResourcesAPI()
         {
@@ -168,17 +162,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 commandBar = (CommandBar)root.FindName("TestCommandBar");
                 Verify.IsNotNull(commandBar);
-            });
-
-            TestUtilities.SetAsVisualTreeRoot(root);
-
-            RunOnUIThread.Execute(() => {
+                Content = root;
+                Content.UpdateLayout();
                 commandBar.IsOpen = true;
-            });
-
-            MUXControlsTestApp.Utilities.IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() => {
+                Content.UpdateLayout();
                 var popup = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
                 Verify.IsNotNull(popup);
                 overflowContent = popup.Child;

--- a/dev/IconSource/APITests/IconSourceApiTests.cs
+++ b/dev/IconSource/APITests/IconSourceApiTests.cs
@@ -29,7 +29,7 @@ using XamlControlsXamlMetaDataProvider = Microsoft.UI.Xaml.XamlTypeInfo.XamlCont
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class IconSourceApiTests
+    public class IconSourceApiTests : ApiTestBase
     {
         [TestMethod]
         public void SymbolIconSourceTest()

--- a/dev/LayoutPanel/APITests/LayoutPanelTests.cs
+++ b/dev/LayoutPanel/APITests/LayoutPanelTests.cs
@@ -30,46 +30,11 @@ using NonVirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.NonVirtualizingL
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public partial class LayoutPanelTests
+    public partial class LayoutPanelTests : ApiTestBase
     {
-        private Border _host;
-
-        public const int DefaultWaitTimeInMS = 5000;
-
-        public UIElement Content
-        {
-            get { return _host.Child; }
-            set { _host.Child = value; }
-        }
-
         [ClassInitialize]
         [TestProperty("Classification", "Integration")]
         public static void ClassInitialize(TestContext context) { }
-
-        [TestInitialize]
-        public void Setup()
-        {
-            IdleSynchronizer.Wait();
-
-            var hostLoaded = new ManualResetEvent(false);
-            RunOnUIThread.Execute(() =>
-            {
-                _host = new Border();
-                _host.Loaded += delegate { hostLoaded.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = _host;
-            });
-            Verify.IsTrue(hostLoaded.WaitOne(DefaultWaitTimeInMS), "Waiting for loaded event");
-        }
-
-        [TestCleanup]
-        public void Cleanup()
-        {
-            // Put things back the way we found them.
-            RunOnUIThread.Execute(() =>
-            {
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
-        }
 
         [TestMethod]
         public void VerifyPaddingAndBorderThicknessLayoutOffset()

--- a/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
+++ b/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     }
 
     [TestClass]
-    public class LightConfigurationTests
+    public class LightConfigurationTests : ApiTestBase
     {
         MediaPlayerElement _mpe;
         AutoResetEvent _mediaFullScreened;
@@ -230,7 +230,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 }
                 else
                 {
-                    MUXControlsTestApp.App.TestContentRoot = mySPRoot;
+                    Content = mySPRoot;
                 }
             });
             IdleSynchronizer.Wait();
@@ -253,7 +253,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     }
                     else
                     {
-                        MUXControlsTestApp.App.TestContentRoot = newSPRoot;
+                        Content = newSPRoot;
                     }
                 });
                 IdleSynchronizer.Wait();
@@ -323,7 +323,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 if (whichView == CoreApplication.MainView)
                 {
-                    MUXControlsTestApp.App.TestContentRoot = null;
+                    Content = null;
                 }
                 else
                 {

--- a/dev/Materials/Acrylic/APITests/AcrylicBrushTests.cs
+++ b/dev/Materials/Acrylic/APITests/AcrylicBrushTests.cs
@@ -32,7 +32,7 @@ using AcrylicBrush = Microsoft.UI.Xaml.Media.AcrylicBrush;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class AcrylicBrushTests
+    public class AcrylicBrushTests : ApiTestBase
     {
         private Rectangle _rectangle1 = null;
         private StackPanel _rootSP = null;
@@ -150,7 +150,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             _rootSP.Children.Add(_rectangle1);
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = _rootSP;
+            Content = _rootSP;
         }
 
         private Color GetColorByName(string name, ResourceDictionary dict)

--- a/dev/Materials/Reveal/APITests/RevealTests.cs
+++ b/dev/Materials/Reveal/APITests/RevealTests.cs
@@ -22,7 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class RevealTests
+    public class RevealTests : ApiTestBase
     {
         //[TestMethod] TODO: Re-enable once issue #644 is fixed.
         public void ValidateAppBarButtonRevealStyles()
@@ -53,12 +53,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 toggleButtonLabelsOnRight = (AppBarToggleButton)cmdBar.PrimaryCommands[1];
                 toggleButtonOverflow = (AppBarToggleButton)cmdBar.SecondaryCommands[1];
 
-                MUXControlsTestApp.App.TestContentRoot = cmdBar;
-            });
-            IdleSynchronizer.Wait();
+                Content = cmdBar;
+                Content.UpdateLayout();
 
-            RunOnUIThread.Execute(() =>
-            {
                 const double expectedLabelsOnRightWidth = 84;
                 const double expectedOverflowWidth = 264;
 

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -30,7 +30,7 @@ using NavigationViewBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationVie
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class NavigationViewTests
+    public class NavigationViewTests : ApiTestBase
     {
         private NavigationView SetupNavigationView(NavigationViewPaneDisplayMode paneDisplayMode = NavigationViewPaneDisplayMode.Auto)
         {
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.Width = 800.0;
                 navView.Height = 600.0;
                 navView.Content = "This is a simple test";
-                MUXControlsTestApp.App.TestContentRoot = navView;
+                Content = navView;
                 Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
             });
 
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.Width = 800.0;
                 navView.Height = 600.0;
                 navView.Content = "This test should have enough NavigationViewItems to scroll.";
-                MUXControlsTestApp.App.TestContentRoot = navView;
+                Content = navView;
                 Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
             });
 
@@ -142,7 +142,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.CompactModeThresholdWidth = 400.0;
                 navView.Width = 800.0;
                 navView.Height = 600.0;
-                MUXControlsTestApp.App.TestContentRoot = navView;
+                Content = navView;
                 Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
             });
 
@@ -387,51 +387,35 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifySingleSelection()
         {
-            NavigationViewItem menuItem1 = null;
-            NavigationViewItem menuItem2 = null;
-            NavigationView navView = null;
-
             RunOnUIThread.Execute(() =>
             {
-                navView = new NavigationView();
-                MUXControlsTestApp.App.TestContentRoot = navView;
+                var navView = new NavigationView();
+                Content = navView;
 
-                menuItem1 = new NavigationViewItem();
-                menuItem2 = new NavigationViewItem();
+                var menuItem1 = new NavigationViewItem();
+                var menuItem2 = new NavigationViewItem();
                 menuItem1.Content = "Item 1";
                 menuItem2.Content = "Item 2";
 
                 navView.MenuItems.Add(menuItem1);
                 navView.MenuItems.Add(menuItem2);
                 navView.Width = 1008; // forces the control into Expanded mode so that the menu renders
-            });
+                Content.UpdateLayout();
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
                 Verify.IsFalse(menuItem1.IsSelected);
                 Verify.IsFalse(menuItem2.IsSelected);
                 Verify.AreEqual(navView.SelectedItem, null);
 
                 menuItem1.IsSelected = true;
-            });
+                Content.UpdateLayout();
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
                 Verify.IsTrue(menuItem1.IsSelected);
                 Verify.IsFalse(menuItem2.IsSelected);
                 Verify.AreEqual(navView.SelectedItem, menuItem1);
 
                 menuItem2.IsSelected = true;
-            });
+                Content.UpdateLayout();
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
                 Verify.IsTrue(menuItem2.IsSelected);
                 Verify.IsFalse(menuItem1.IsSelected, "MenuItem1 should have been deselected when MenuItem2 was selected");
                 Verify.AreEqual(navView.SelectedItem, menuItem2);
@@ -441,66 +425,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifySettingsItemToolTip()
         {
-            NavigationView navView = null;
-            NavigationViewItem settingsItem = null;
-
             RunOnUIThread.Execute(() =>
             {
-                navView = new NavigationView();
+                var navView = new NavigationView();
 
                 navView.IsSettingsVisible = true;
                 navView.IsPaneOpen = true;
                 navView.PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
-                MUXControlsTestApp.App.TestContentRoot = navView;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                settingsItem = (NavigationViewItem)navView.SettingsItem;
+                Content = navView;
+                Content.UpdateLayout();
+                var settingsItem = (NavigationViewItem)navView.SettingsItem;
 
                 var toolTip = ToolTipService.GetToolTip(settingsItem);
                 Verify.IsNull(toolTip, "Verify tooltip is disabled when pane is open");
 
                 navView.IsPaneOpen = false;
-            });
+                Content.UpdateLayout();
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                var toolTip = ToolTipService.GetToolTip(settingsItem);
+                toolTip = ToolTipService.GetToolTip(settingsItem);
                 Verify.IsNotNull(toolTip, "Verify tooltip is enabled when pane is closed");
-
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
         [TestMethod]
         public void VerifySettingsItemTag()
         {
-            NavigationView navView = null;
-            NavigationViewItem settingsItem = null;
-
             RunOnUIThread.Execute(() =>
             {
-                navView = new NavigationView();
+                var navView = new NavigationView();
 
                 navView.IsSettingsVisible = true;
                 navView.IsPaneOpen = true;
                 navView.PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
-                MUXControlsTestApp.App.TestContentRoot = navView;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                settingsItem = (NavigationViewItem)navView.SettingsItem;
+                Content = navView;
+                Content.UpdateLayout();
+                var settingsItem = (NavigationViewItem)navView.SettingsItem;
                 Verify.AreEqual(settingsItem.Tag, "Settings");
-
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
@@ -548,19 +508,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
         private void VerifyVerifyHeaderContentMargin(NavigationViewPaneDisplayMode paneDisplayMode, string masterFilePrefix)
         {
-            NavigationView navView = null;
             UIElement headerContent = null;
 
             RunOnUIThread.Execute(() =>
             {
-                navView = new NavigationView() { Header = "HEADER", PaneDisplayMode = paneDisplayMode, Width = 400.0 };
-                MUXControlsTestApp.App.TestContentRoot = navView;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                var navView = new NavigationView() { Header = "HEADER", PaneDisplayMode = paneDisplayMode, Width = 400.0 };
+                Content = navView;
+                Content.UpdateLayout();
                 Grid rootGrid = VisualTreeHelper.GetChild(navView, 0) as Grid;
                 if (rootGrid != null)
                 {

--- a/dev/ParallaxView/APITests/ParallaxViewTests.cs
+++ b/dev/ParallaxView/APITests/ParallaxViewTests.cs
@@ -42,7 +42,7 @@ using MUXControlsTestHooksLoggingMessageEventArgs = Microsoft.UI.Private.Control
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class ParallaxViewTests
+    public class ParallaxViewTests : ApiTestBase
     {
         private const float c_shiftTolerance = 0.0001f;
         private const int c_MaxWaitDuration = 5000;
@@ -89,16 +89,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             ScrollViewer,
             Scroller,
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            RunOnUIThread.Execute(() => {
-                Log.Comment("TestCleanup: Restore TestContentRoot to null");
-                // Put things back the way we found them.
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
         }
 
         [TestMethod]
@@ -1395,7 +1385,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = stackPanel;
+            Content = stackPanel;
         }
 
         private void SetupDefaultUIWithScrollViewer(
@@ -1470,7 +1460,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = stackPanel;
+            Content = stackPanel;
         }
 
         private void SetupDefaultUIWithScroller(
@@ -1543,7 +1533,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = stackPanel;
+            Content = stackPanel;
         }
 
         private void SetupUIWithParallaxViewInsideScroller(
@@ -1609,7 +1599,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = scroller;
+            Content = scroller;
         }
 
         private void SetupUIWithParallaxViewInsideScrollViewer(
@@ -1688,7 +1678,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = scrollViewer;
+            Content = scrollViewer;
         }
 
         private void ChangePropertyAfterParallaxViewDisposal(PropertyId propertyToChange)
@@ -1736,7 +1726,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 Log.Comment("Disposing the ParallaxView");
-                (MUXControlsTestApp.App.TestContentRoot as StackPanel).Children.Remove(parallaxView);
+                (Content as StackPanel).Children.Remove(parallaxView);
                 WeakReference parallaxViewWeakReference = new WeakReference(parallaxView);
                 parallaxView = null;
                 Log.Comment("Garbage-collecting the ParallaxView");

--- a/dev/PersonPicture/APITests/PersonPictureTests.cs
+++ b/dev/PersonPicture/APITests/PersonPictureTests.cs
@@ -26,7 +26,7 @@ using PersonPicture = Microsoft.UI.Xaml.Controls.PersonPicture;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class PersonPictureTests
+    public class PersonPictureTests : ApiTestBase
     {
         [TestMethod]
         public void VerifyDefaultsAndBasicSetting()
@@ -137,74 +137,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifySmallWidthAndHeightDoNotCrash()
         {
-            PersonPicture personPicture = null;
-
-            RunOnUIThread.Execute(() =>
-            {
-                personPicture = new PersonPicture();
-                MUXControlsTestApp.App.TestContentRoot = personPicture;
-            });
-
-            IdleSynchronizer.Wait();
-
             ManualResetEvent sizeChangedEvent = new ManualResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
+                var personPicture = new PersonPicture();
+                Content = personPicture;
+                Content.UpdateLayout();
                 personPicture.SizeChanged += (sender, args) => sizeChangedEvent.Set();
                 personPicture.Width = 0.4;
                 personPicture.Height = 0.4;
+                Content.UpdateLayout();
             });
-
             sizeChangedEvent.WaitOne();
-            IdleSynchronizer.Wait();
         }
 
         [TestMethod]
         public void VerifyVSMStatesForPhotosAndInitials()
         {
-            PersonPicture personPicture = null;
-            TextBlock initialsTextBlock = null;
-
             RunOnUIThread.Execute(() =>
             {
-                personPicture = new PersonPicture();
-                MUXControlsTestApp.App.TestContentRoot = personPicture;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                initialsTextBlock = (TextBlock)VisualTreeUtils.FindVisualChildByName(personPicture, "InitialsTextBlock");
+                var personPicture = new PersonPicture();
+                Content = personPicture;
+                Content.UpdateLayout();
+                var initialsTextBlock = (TextBlock)VisualTreeUtils.FindVisualChildByName(personPicture, "InitialsTextBlock");
                 personPicture.IsGroup = true;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content.UpdateLayout();
                 Verify.AreEqual(initialsTextBlock.FontFamily.Source, "Segoe MDL2 Assets");
                 Verify.AreEqual(initialsTextBlock.Text, "\xE716");
 
                 personPicture.IsGroup = false;
                 personPicture.Initials = "JS";
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content.UpdateLayout();
                 Verify.AreEqual(initialsTextBlock.FontFamily.Source, "Segoe UI");
                 Verify.AreEqual(initialsTextBlock.Text, "JS");
 
                 personPicture.Initials = "";
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content.UpdateLayout();
                 Verify.AreEqual(initialsTextBlock.FontFamily.Source, "Segoe MDL2 Assets");
                 Verify.AreEqual(initialsTextBlock.Text, "\xE77B");
 
@@ -212,22 +180,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 // and also goes back to the MDL2 font after setting IsGroup = true.
                 personPicture.FontFamily = new FontFamily("Segoe UI Emoji");
                 personPicture.Initials = "👍";
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content.UpdateLayout();
                 Verify.AreEqual(initialsTextBlock.FontFamily.Source, "Segoe UI Emoji");
                 Verify.AreEqual(initialsTextBlock.Text, "👍");
 
                 personPicture.IsGroup = true;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content.UpdateLayout();
                 Verify.AreEqual(initialsTextBlock.FontFamily.Source, "Segoe MDL2 Assets");
                 Verify.AreEqual(initialsTextBlock.Text, "\xE716");
             });

--- a/dev/PullToRefresh/RefreshVisualizer/APITests/RefreshVisualizerTests.cs
+++ b/dev/PullToRefresh/RefreshVisualizer/APITests/RefreshVisualizerTests.cs
@@ -38,19 +38,9 @@ using PullToRefreshHelperTestApi = Microsoft.UI.Private.Controls.PullToRefreshHe
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class RefreshVisualizerTests
+    public class RefreshVisualizerTests : ApiTestBase
     {
         TimeSpan c_MaxWaitDuration = TimeSpan.FromMilliseconds(5000);
-        
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            RunOnUIThread.Execute(() => {
-                Log.Comment("TestCleanup: Restore TestContentRoot to null");
-                // Put things back the way we found them.
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
-        }
 
         [TestMethod]
         public void CanInstantiate()
@@ -64,7 +54,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Log.Comment("RefreshVisualizer.Loaded event handler");
                     refreshVisualizerLoadedEvent.Set();
                 };
-                MUXControlsTestApp.App.TestContentRoot = refreshVisualizer;
+                Content = refreshVisualizer;
             });
 
             Log.Comment("Waiting for Loaded event");
@@ -73,7 +63,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                Verify.IsNotNull(MUXControlsTestApp.App.TestContentRoot as RefreshVisualizer);
+                Verify.IsNotNull(Content as RefreshVisualizer);
             });
         }
 
@@ -97,40 +87,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void ContentIsUpdatable()
         {
-            var refreshVisualizerLoadedEvent = new AutoResetEvent(false);
             RunOnUIThread.Execute(() =>
             {
                 RefreshVisualizer refreshVisualizer = new RefreshVisualizer();
                 //The default Progress Indicator is consturcted in the OnApplyTemplate method, since that is not called in this test
                 //we expect the Content to be null.
                 Verify.IsNull(refreshVisualizer.Content);
-
-                refreshVisualizer.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    Log.Comment("RefreshVisualizer.Loaded event handler");
-                    refreshVisualizerLoadedEvent.Set();
-                };
-                MUXControlsTestApp.App.TestContentRoot = refreshVisualizer;
-            });
-
-            IdleSynchronizer.Wait();
-            refreshVisualizerLoadedEvent.WaitOne(c_MaxWaitDuration);
-
-            RunOnUIThread.Execute(() =>
-            {
-                RefreshVisualizer refreshVisualizer = MUXControlsTestApp.App.TestContentRoot as RefreshVisualizer;
-                Verify.IsNotNull(refreshVisualizer);
+                Content = refreshVisualizer;
+                Content.UpdateLayout();
                 Verify.IsNotNull(refreshVisualizer.Content);
                 Verify.AreEqual<Symbol>(Symbol.Refresh, ((SymbolIcon)(refreshVisualizer.Content)).Symbol);
-
                 refreshVisualizer.Content = new SymbolIcon(Symbol.Cancel);
                 Verify.AreEqual<Symbol>(Symbol.Cancel, ((SymbolIcon)(refreshVisualizer.Content)).Symbol);
             });
-        }
-
-        private void RefreshVisualizer_Loaded(object sender, RoutedEventArgs e)
-        {
-            throw new NotImplementedException();
         }
 
         [TestMethod]
@@ -203,7 +172,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual<int>(0, refreshInfoProviderImpl.OnRefreshStartedCalls);
                 Verify.AreEqual<int>(0, refreshInfoProviderImpl.OnRefreshCompletedCalls);
 
-                MUXControlsTestApp.App.TestContentRoot = refreshVisualizer;
+                Content = refreshVisualizer;
                 
                 refreshVisualizer.RequestRefresh();
             });
@@ -212,7 +181,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                RefreshVisualizer refreshVisualizer = (RefreshVisualizer)MUXControlsTestApp.App.TestContentRoot;
+                RefreshVisualizer refreshVisualizer = (RefreshVisualizer)Content;
                 RefreshInfoProviderImpl refreshInfoProviderImpl = ((RefreshInfoProviderImpl)((IRefreshVisualizerPrivate)refreshVisualizer).InfoProvider);
 
                 Verify.AreEqual<int>(1, refreshInfoProviderImpl.OnRefreshStartedCalls);

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/APITests/ScrollViewerAdapterTests.cs
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/APITests/ScrollViewerAdapterTests.cs
@@ -25,7 +25,7 @@ using ScrollViewerIRefreshInfoProviderAdapter = Microsoft.UI.Private.Controls.Sc
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class ScrollViewerAdapterTests
+    public class ScrollViewerAdapterTests : ApiTestBase
     {
         [TestMethod]
         public void CanInstantiate()
@@ -54,14 +54,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 ScrollViewer sv = new ScrollViewer();
                 sv.Content = 1;
-                MUXControlsTestApp.App.TestContentRoot = sv;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                ScrollViewer sv = (ScrollViewer)MUXControlsTestApp.App.TestContentRoot;
+                Content = sv;
+                Content.UpdateLayout();
                 ScrollViewerIRefreshInfoProviderAdapter adapter = new ScrollViewerIRefreshInfoProviderAdapter(RefreshPullDirection.TopToBottom, null);
                 Verify.IsNotNull(adapter);
                 Verify.Throws<ArgumentException>(() => { adapter.Adapt(sv, new Size(1.0, 1.0)); });
@@ -76,15 +70,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 ScrollViewer sv = new ScrollViewer();
                 sv.Loaded += (object sender, RoutedEventArgs e) => { resetEvent.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = sv;
-            });
-
-            IdleSynchronizer.Wait();
-            resetEvent.WaitOne();
-
-            RunOnUIThread.Execute(() =>
-            {
-                ScrollViewer sv = (ScrollViewer)MUXControlsTestApp.App.TestContentRoot;
+                Content = sv;
+                Content.UpdateLayout();
                 Verify.IsNull(sv.Content);
                 ScrollViewerIRefreshInfoProviderAdapter adapter = new ScrollViewerIRefreshInfoProviderAdapter(RefreshPullDirection.TopToBottom, null);
                 Verify.IsNotNull(adapter);
@@ -102,15 +89,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 sv.Content = new Button();
                 sv.Loaded += (object sender, RoutedEventArgs e) => { resetEvent.Set(); };
 
-                MUXControlsTestApp.App.TestContentRoot = sv;
-            });
-
-            IdleSynchronizer.Wait();
-            resetEvent.WaitOne();
-
-            RunOnUIThread.Execute(() =>
-            {
-                ScrollViewer sv = (ScrollViewer)MUXControlsTestApp.App.TestContentRoot;
+                Content = sv;
+                Content.UpdateLayout();
                 ScrollViewerIRefreshInfoProviderAdapter adapter = new ScrollViewerIRefreshInfoProviderAdapter(RefreshPullDirection.TopToBottom, null);
                 adapter.Adapt(sv, new Size(1.0, 1.0));
             });
@@ -120,27 +100,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         public void AdaptOnSVWithoutWaitingForLoaded()
         {
             var objects = new Dictionary<string, WeakReference>();
-            var resetEvent = new AutoResetEvent(false);
-            ScrollViewerIRefreshInfoProviderAdapter adapter;
             RunOnUIThread.Execute(() =>
             {
                 ScrollViewer sv = new ScrollViewer();
                 objects["sv"] = new WeakReference(sv);
                 sv.Content = new Button();
-                sv.Loaded += (object sender, RoutedEventArgs e) => { resetEvent.Set(); };
-                adapter = new ScrollViewerIRefreshInfoProviderAdapter(RefreshPullDirection.TopToBottom, null);
+                var adapter = new ScrollViewerIRefreshInfoProviderAdapter(RefreshPullDirection.TopToBottom, null);
                 objects["adapter"] = new WeakReference(adapter);
                 adapter.Adapt(sv, new Size(1.0, 1.0));
-                MUXControlsTestApp.App.TestContentRoot = sv;
-            });
-            
-            IdleSynchronizer.Wait();
-            resetEvent.WaitOne();
+                Content = sv;
+                Content.UpdateLayout();
 
-            RunOnUIThread.Execute(() =>
-            {
                 adapter = null;
-                MUXControlsTestApp.App.TestContentRoot = null;
+                Content = null;
             });
             
             IdleSynchronizer.Wait();

--- a/dev/RatingControl/APITests/RatingControlTests.cs
+++ b/dev/RatingControl/APITests/RatingControlTests.cs
@@ -30,7 +30,7 @@ using RatingItemImageInfo = Microsoft.UI.Xaml.Controls.RatingItemImageInfo;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class RatingControlTests
+    public class RatingControlTests : ApiTestBase
     {
         [TestMethod]
         public void VerifyDefaultsAndBasicSetting()

--- a/dev/Repeater/APITests/AccessibilityTests.cs
+++ b/dev/Repeater/APITests/AccessibilityTests.cs
@@ -34,7 +34,7 @@ using RepeaterAutomationPeer = Microsoft.UI.Xaml.Automation.Peers.RepeaterAutoma
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class AccessibilityTests : TestsBase
+    public class AccessibilityTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateChildrenPeers()

--- a/dev/Repeater/APITests/EffectiveViewportScrollViewerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollViewerTests.cs
@@ -42,7 +42,7 @@ using ViewportChangedEventHandler = Microsoft.UI.Private.Controls.ViewportChange
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class EffectiveViewportTests : TestsBase
+    public class EffectiveViewportTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateBasicScrollViewerScenario()

--- a/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
+++ b/dev/Repeater/APITests/EffectiveViewportScrollerTests.cs
@@ -51,7 +51,7 @@ using ViewportChangedEventHandler = Microsoft.UI.Private.Controls.ViewportChange
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class EffectiveViewportScrollerTests : TestsBase
+    public class EffectiveViewportScrollerTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateOneScrollerScenario()

--- a/dev/Repeater/APITests/ElementAnimatorTests.cs
+++ b/dev/Repeater/APITests/ElementAnimatorTests.cs
@@ -34,7 +34,7 @@ using AnimationContext = Microsoft.UI.Xaml.Controls.AnimationContext;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class ElementAnimatorTests : TestsBase
+    public class ElementAnimatorTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateElementAnimator()

--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -36,7 +36,7 @@ using System.Collections.Generic;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class FlowLayoutCollectionChangeTests : TestsBase
+    public class FlowLayoutCollectionChangeTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateInserts()

--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -41,7 +41,7 @@ using LayoutPanel = Microsoft.UI.Xaml.Controls.LayoutPanel;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class FlowLayoutTests : TestsBase
+    public class FlowLayoutTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateStackLayout()

--- a/dev/Repeater/APITests/IndexPathTests.cs
+++ b/dev/Repeater/APITests/IndexPathTests.cs
@@ -19,7 +19,7 @@ using IndexPath = Microsoft.UI.Xaml.Controls.IndexPath;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class IndexPathTests : TestsBase
+    public class IndexPathTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateIndexPath()

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -30,7 +30,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
     using IKeyIndexMapping = Microsoft.UI.Xaml.Controls.IKeyIndexMapping;
 
     [TestClass]
-    public class InspectingDataSourceTests: TestsBase
+    public class InspectingDataSourceTests: ApiTestBase
     {
         [TestMethod]
         public void CanCreateFromIBindableIterable()

--- a/dev/Repeater/APITests/ItemTemplateTests.cs
+++ b/dev/Repeater/APITests/ItemTemplateTests.cs
@@ -37,7 +37,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
     using VirtualizingLayout = Microsoft.UI.Xaml.Controls.VirtualizingLayout;
 
     [TestClass]
-    public class ItemTemplateTests : TestsBase
+    public class ItemTemplateTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateRecycling()

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -43,7 +43,7 @@ using LayoutPanel = Microsoft.UI.Xaml.Controls.LayoutPanel;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class LayoutTests : TestsBase
+    public class LayoutTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateMappingAndAutoRecycling()

--- a/dev/Repeater/APITests/PhasingTests.cs
+++ b/dev/Repeater/APITests/PhasingTests.cs
@@ -34,7 +34,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
     // Bug 17377723: crash in CControlTemplate::CreateXBindConnector in RS5.
     [TestClass]
-    public class PhasingTests : TestsBase
+    public class PhasingTests : ApiTestBase
     {
         const int expectedLastRealizedIndex = 8;
 

--- a/dev/Repeater/APITests/RecyclePoolTests.cs
+++ b/dev/Repeater/APITests/RecyclePoolTests.cs
@@ -30,7 +30,7 @@ using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHo
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class RecyclePoolTests : TestsBase
+    public class RecyclePoolTests : ApiTestBase
     {
 
         public void ValidateElementsHaveCorrectKeys()

--- a/dev/Repeater/APITests/RepeaterFocusTests.cs
+++ b/dev/Repeater/APITests/RepeaterFocusTests.cs
@@ -33,7 +33,7 @@ using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHo
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class RepeaterFocusTests : TestsBase
+    public class RepeaterFocusTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateTabNavigation()

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -34,7 +34,7 @@ using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class RepeaterTests : TestsBase
+    public class RepeaterTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateElementToIndexMapping()

--- a/dev/Repeater/APITests/Repeater_APITests.projitems
+++ b/dev/Repeater/APITests/Repeater_APITests.projitems
@@ -26,7 +26,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockViewGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockVirtualizingLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\SharedHelpers.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Common\TestsBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\WinRTCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\DataAsElementElementFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EffectiveViewportScrollerTests.cs" />

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -29,7 +29,7 @@ using SelectionModelChildrenRequestedEventArgs = Microsoft.UI.Xaml.Controls.Sele
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class SelectionModelTests : TestsBase
+    public class SelectionModelTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateOneLevelSingleSelectionNoSource()

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -39,7 +39,7 @@ using ItemsRepeaterScrollHost = Microsoft.UI.Xaml.Controls.ItemsRepeaterScrollHo
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class ViewManagerTests : TestsBase
+    public class ViewManagerTests : ApiTestBase
     {
         [TestMethod]
         public void CanQueryElementFactory()

--- a/dev/Repeater/APITests/ViewportTests.cs
+++ b/dev/Repeater/APITests/ViewportTests.cs
@@ -55,7 +55,7 @@ using ViewportChangedEventHandler = Microsoft.UI.Private.Controls.ViewportChange
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
     [TestClass]
-    public class ViewportTests : TestsBase
+    public class ViewportTests : ApiTestBase
     {
         [TestMethod]
         public void ValidateNoScrollingSurfaceScenario()

--- a/dev/ScrollViewer/APITests/ScrollViewerTests.cs
+++ b/dev/ScrollViewer/APITests/ScrollViewerTests.cs
@@ -37,7 +37,7 @@ using ScrollViewerTestHooks = Microsoft.UI.Private.Controls.ScrollViewerTestHook
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class ScrollViewerTests
+    public class ScrollViewerTests : ApiTestBase
     {
         private const int c_MaxWaitDuration = 5000;
         private const double c_epsilon = 0.0000001;
@@ -69,12 +69,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private const double c_defaultUIScrollViewerHeight = 200.0;
 
         private ScrollViewerVisualStateCounts m_scrollViewerVisualStateCounts;
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
 
         [TestMethod]
         [TestProperty("Description", "Verifies the ScrollViewer default properties.")]
@@ -189,7 +183,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Verify.IsLessThan(scrollViewer.MaxZoomFactor, 8.0 + c_epsilon);
 
                     Log.Comment("Resetting window content and ScrollViewer");
-                    MUXControlsTestApp.App.TestContentRoot = null;
+                    Content = null;
                     scrollViewer = null;
                 });
 
@@ -247,7 +241,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Verify.AreEqual(scrollViewer.ScrollableHeight, c_defaultUIScrollViewerContentHeight - c_defaultUIScrollViewerHeight);
 
                     Log.Comment("Resetting window content and ScrollViewer");
-                    MUXControlsTestApp.App.TestContentRoot = null;
+                    Content = null;
                     scrollViewer = null;
                 });
 
@@ -387,7 +381,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                             expectedScrollBarsSeparatorCollapsedWithoutAnimationStateCount: 0);
 
                         Log.Comment("Resetting window content");
-                        MUXControlsTestApp.App.TestContentRoot = null;
+                        Content = null;
                         m_scrollViewerVisualStateCounts = null;
                     });
 
@@ -608,11 +602,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Log.Comment("Setting window content");
                 if (useParentGrid)
                 {
-                    MUXControlsTestApp.App.TestContentRoot = parentGrid;
+                    Content = parentGrid;
                 }
                 else
                 {
-                    MUXControlsTestApp.App.TestContentRoot = scrollViewer;
+                    Content = scrollViewer;
                 }
             }
         }

--- a/dev/Scroller/APITests/ScrollControllerTests.cs
+++ b/dev/Scroller/APITests/ScrollControllerTests.cs
@@ -28,7 +28,7 @@ using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    partial class ScrollerTests
+    partial class ScrollerTests : ApiTestBase
     {
         [TestMethod]
         [TestProperty("Description", "Sets the Scroller.HorizontalScrollController and Scroller.VerticalScrollController properties.")]

--- a/dev/Scroller/APITests/ScrollControllerTests.cs
+++ b/dev/Scroller/APITests/ScrollControllerTests.cs
@@ -798,7 +798,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = verticalStackPanel;
+            Content = verticalStackPanel;
         }
 
         private void SetupUIWithBiDirectionalScrollController(
@@ -850,7 +850,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = horizontalStackPanel;
+            Content = horizontalStackPanel;
         }
     }
 }

--- a/dev/Scroller/APITests/ScrollerAnchoringTests.cs
+++ b/dev/Scroller/APITests/ScrollerAnchoringTests.cs
@@ -38,7 +38,7 @@ using UniformGridLayout = Microsoft.UI.Xaml.Controls.UniformGridLayout;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    partial class ScrollerTests
+    partial class ScrollerTests : ApiTestBase
     {
         private const double c_defaultAnchoringUIScrollerNonConstrainedSize = 600.0;
         private const double c_defaultAnchoringUIScrollerConstrainedSize = 300.0;
@@ -654,7 +654,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             };
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = scroller;
+            Content = scroller;
         }
 
         private void InsertStackPanelChild(StackPanel stackPanel, int operationCount, int newIndex, int newCount, string namePrefix = "")
@@ -768,7 +768,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     };
 
                     Log.Comment("Setting window content");
-                    MUXControlsTestApp.App.TestContentRoot = scroller;
+                    Content = scroller;
                 });
 
                 WaitForEvent("Waiting for Scroller.Loaded event", scrollerLoadedEvent);
@@ -943,7 +943,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             };
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = scroller;
+            Content = scroller;
         }
 
         private class TestDataSource : CustomItemsSourceViewWithUniqueIdMapping

--- a/dev/Scroller/APITests/ScrollerBringIntoViewTests.cs
+++ b/dev/Scroller/APITests/ScrollerBringIntoViewTests.cs
@@ -33,7 +33,7 @@ using ScrollerViewChangeResult = Microsoft.UI.Private.Controls.ScrollerViewChang
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    partial class ScrollerTests
+    partial class ScrollerTests : ApiTestBase
     {
         private const double c_defaultBringIntoViewUIScrollerNonConstrainedSize = 600.0;
         private const double c_defaultBringIntoViewUIScrollerConstrainedSize = 300.0;

--- a/dev/Scroller/APITests/ScrollerBringIntoViewTests.cs
+++ b/dev/Scroller/APITests/ScrollerBringIntoViewTests.cs
@@ -1213,7 +1213,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             if (setAsContentRoot)
             {
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = scroller;
+                Content = scroller;
             }
         }
 
@@ -1271,7 +1271,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             if (setAsContentRoot)
             {
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = scrollViewer;
+                Content = scrollViewer;
             }
         }
 
@@ -1354,7 +1354,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             };
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = outerScroller;
+            Content = outerScroller;
         }
 
         private void SetupBringIntoViewUIWithScrollViewerInsideScrollViewer(
@@ -1422,7 +1422,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
 
             Log.Comment("Setting window content");
-            MUXControlsTestApp.App.TestContentRoot = outerScrollViewer;
+            Content = outerScrollViewer;
         }
 
         private void AddSnapPoints(Scroller scroller, StackPanel stackPanel)

--- a/dev/Scroller/APITests/ScrollerLayoutTests.cs
+++ b/dev/Scroller/APITests/ScrollerLayoutTests.cs
@@ -28,7 +28,7 @@ using SnapPointsMode = Microsoft.UI.Xaml.Controls.SnapPointsMode;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    partial class ScrollerTests
+    partial class ScrollerTests : ApiTestBase
     {
         private enum BiDirectionalAlignment
         {

--- a/dev/Scroller/APITests/ScrollerLayoutTests.cs
+++ b/dev/Scroller/APITests/ScrollerLayoutTests.cs
@@ -304,21 +304,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             Log.Comment($"ViewportHeight test case - isScrollerParentSizeSet: {isScrollerParentSizeSet}, isScrollerParentMaxSizeSet: {isScrollerParentMaxSizeSet}, scrollerVerticalAlignment: {scrollerVerticalAlignment}, scrollerContentHeight: {scrollerContentHeight}");
 
-            Border border = null;
-            Scroller scroller = null;
-            StackPanel stackPanel = null;
-            Rectangle rectangle = null;
-            AutoResetEvent borderLoadedEvent = new AutoResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
-                rectangle = new Rectangle()
+                var rectangle = new Rectangle()
                 {
                     Width = 30,
                     Height = scrollerContentHeight
                 };
 
-                stackPanel = new StackPanel()
+                var stackPanel = new StackPanel()
                 {
                     BorderThickness = new Thickness(5),
                     Margin = new Thickness(7),
@@ -326,14 +320,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 };
                 stackPanel.Children.Add(rectangle);
 
-                scroller = new Scroller()
+                var scroller = new Scroller()
                 {
                     Content = stackPanel,
                     ContentOrientation = ContentOrientation.Vertical,
                     VerticalAlignment = scrollerVerticalAlignment
                 };
 
-                border = new Border()
+                var border = new Border()
                 {
                     BorderThickness = new Thickness(2),
                     Margin = new Thickness(3),
@@ -351,21 +345,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     border.MaxHeight = 200.0;
                 }
 
-                border.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    Log.Comment("Border.Loaded event handler");
-                    borderLoadedEvent.Set();
-                };
-
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = border;
-            });
+                Content = border;
+                Content.UpdateLayout();
 
-            WaitForEvent("Waiting for Border.Loaded event", borderLoadedEvent);
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
                 double expectedViewportHeight =
                     rectangle.Height + stackPanel.BorderThickness.Top + stackPanel.BorderThickness.Bottom +
                     stackPanel.Margin.Top + stackPanel.Margin.Bottom;
@@ -391,36 +374,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestProperty("Description", "Uses a StackPanel with Stretch alignment as Scroller.Content to verify it stretched to the size of the Scroller.")]
         public void StretchAlignment()
         {
-            Scroller scroller = null;
-            StackPanel stackPanel = null;
-            Rectangle rectangle = null;
-            AutoResetEvent scrollerLoadedEvent = new AutoResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
-                rectangle = new Rectangle();
+                var rectangle = new Rectangle();
                 rectangle.Height = c_defaultUIScrollerContentHeight;
-                stackPanel = new StackPanel();
+                var stackPanel = new StackPanel();
                 stackPanel.Children.Add(rectangle);
-                scroller = new Scroller();
+                var scroller = new Scroller();
                 scroller.Width = c_defaultUIScrollerWidth;
                 scroller.Height = c_defaultUIScrollerHeight;
                 scroller.Content = stackPanel;
 
-                scroller.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    Log.Comment("Scroller.Loaded event handler");
-                    scrollerLoadedEvent.Set();
-                };
-
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = scroller;
-            });
+                Content = scroller;
+                Content.UpdateLayout();
 
-            WaitForEvent("Waiting for Loaded event", scrollerLoadedEvent);
-
-            RunOnUIThread.Execute(() =>
-            {
                 Log.Comment("Checking Stretch/Strech alignments");
                 Verify.AreEqual(HorizontalAlignment.Stretch, stackPanel.HorizontalAlignment);
                 Verify.AreEqual(VerticalAlignment.Stretch, stackPanel.VerticalAlignment);

--- a/dev/Scroller/APITests/ScrollerSnapPointTests.cs
+++ b/dev/Scroller/APITests/ScrollerSnapPointTests.cs
@@ -26,7 +26,7 @@ using ScrollerTestHooks = Microsoft.UI.Private.Controls.ScrollerTestHooks;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    partial class ScrollerTests
+    partial class ScrollerTests : ApiTestBase
     {
         [TestMethod]
         [TestProperty("Description", "Create a bunch of snap points with invalid arguments.")]

--- a/dev/Scroller/APITests/ScrollerTests.cs
+++ b/dev/Scroller/APITests/ScrollerTests.cs
@@ -790,9 +790,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Log.Warning("Skipped ValidateXYFocusNavigation because XYFocus support for third party scrollers is only available in RS4+.");
                 return;
             }
-
-            Button innerCenterButton = null;
-
             RunOnUIThread.Execute(() =>
             {
                 var rootPanel = (Grid)XamlReader.Load(TestUtilities.ProcessTestXamlForRepo(
@@ -819,13 +816,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                         </controlsPrimitives:Scroller>
                     </Grid>"));
 
-                innerCenterButton = (Button)rootPanel.FindName("innerCenterButton");
-                MUXControlsTestApp.App.TestContentRoot = rootPanel;
-            });
-            IdleSynchronizer.Wait();
+                var innerCenterButton = (Button)rootPanel.FindName("innerCenterButton");
+                Content = rootPanel;
+                Content.UpdateLayout();
 
-            RunOnUIThread.Execute(() =>
-            {
                 Log.Comment("Ensure inner center button has keyboard focus.");
                 innerCenterButton.Focus(FocusState.Keyboard);
                 Verify.AreEqual(innerCenterButton, FocusManager.GetFocusedElement());
@@ -928,7 +922,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             if (setAsContentRoot)
             {
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = scroller;
+                Content = scroller;
             }
         }
 

--- a/dev/Scroller/APITests/ScrollerTests.cs
+++ b/dev/Scroller/APITests/ScrollerTests.cs
@@ -43,7 +43,7 @@ using SnapPointsMode = Microsoft.UI.Xaml.Controls.SnapPointsMode;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public partial class ScrollerTests
+    public partial class ScrollerTests : ApiTestBase
     {
         private const InteractionState c_defaultState = InteractionState.Idle;
         private const ChainingMode c_defaultHorizontalScrollChainingMode = ChainingMode.Auto;

--- a/dev/Scroller/APITests/ScrollerViewChangeTests.cs
+++ b/dev/Scroller/APITests/ScrollerViewChangeTests.cs
@@ -37,7 +37,7 @@ using Windows.UI.ViewManagement;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
-    partial class ScrollerTests
+    partial class ScrollerTests : ApiTestBase
     {
         // Enum used in tests that use InterruptViewChange
         private enum ViewChangeInterruptionKind
@@ -53,15 +53,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private const int c_MaxStockZoomFactorChangeDuration = 1000;
 
         private uint viewChangedCount = 0u;
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            RunOnUIThread.Execute(() =>
-            {
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
-        }
 
         [TestMethod]
         [TestProperty("Description", "Changes Scroller offsets using ScrollTo, ScrollBy, ScrollFrom and AnimationMode/SnapPointsMode enum values.")]
@@ -561,7 +552,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     scrollerViewChangeOperationEvent);
 
                 Log.Comment("Resetting window content to unparent Scroller");
-                MUXControlsTestApp.App.TestContentRoot = null;
+                Content = null;
             });
 
             WaitForEvent("Waiting for view change completion", scrollerViewChangeOperationEvent);
@@ -1292,7 +1283,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     scrollerViewChangeOperationEvent);
 
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = scroller;
+                Content = scroller;
             });
 
             WaitForEvent("Waiting for Loaded event", scrollerLoadedEvent);
@@ -1341,7 +1332,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     scrollerViewChangeOperationEvent);
 
                 Log.Comment("Setting window content");
-                MUXControlsTestApp.App.TestContentRoot = scroller;
+                Content = scroller;
             });
 
             WaitForEvent("Waiting for Loaded event", scrollerLoadedEvent);

--- a/dev/SplitButton/APITests/SplitButtonTests.cs
+++ b/dev/SplitButton/APITests/SplitButtonTests.cs
@@ -23,17 +23,8 @@ using SplitButton = Microsoft.UI.Xaml.Controls.SplitButton;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class SplitButtonTests
+    public class SplitButtonTests : ApiTestBase
     {
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            RunOnUIThread.Execute(() => {
-                Log.Comment("TestCleanup: Restore TestContentRoot to null");
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
-        }
-
         [TestMethod]
         [Description("Verifies SplitButton default properties.")]
         public void VerifyDefaultsAndBasicSetting()

--- a/dev/SwipeControl/SwipeControl_APITests/SwipeControlTests.cs
+++ b/dev/SwipeControl/SwipeControl_APITests/SwipeControlTests.cs
@@ -28,7 +28,7 @@ using FontIconSource = Microsoft.UI.Xaml.Controls.FontIconSource;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class SwipeControlTests
+    public class SwipeControlTests : ApiTestBase
     {
         [TestMethod]
         public void SwipeItemTest()
@@ -95,7 +95,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void SwipeControlTest()
         {
-            var resetEvent = new AutoResetEvent(false);
             RunOnUIThread.Execute(() =>
             {
                 SwipeControl swipeControl = new SwipeControl();
@@ -107,16 +106,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.IsNull(swipeControl.BottomItems);
                 swipeControl.LeftItems = new SwipeItems();
                 swipeControl.RightItems = new SwipeItems();
-                swipeControl.Loaded += (object sender, RoutedEventArgs args) => { resetEvent.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = swipeControl;
-            });
-
-            IdleSynchronizer.Wait();
-            resetEvent.WaitOne();
-
-            RunOnUIThread.Execute(() =>
-            {
-                SwipeControl swipeControl = (SwipeControl)MUXControlsTestApp.App.TestContentRoot;
+                Content = swipeControl;
+                Content.UpdateLayout();
                 Verify.IsFalse(swipeControl.IsTabStop);
                 Verify.IsNotNull(swipeControl.LeftItems);
                 Verify.IsNotNull(swipeControl.RightItems);
@@ -145,15 +136,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 SwipeControl swipeControl = new SwipeControl();
                 swipeControl.Loaded += (object sender, RoutedEventArgs args) => { resetEvent.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = swipeControl;
-            });
-
-            IdleSynchronizer.Wait();
-            resetEvent.WaitOne();
-
-            RunOnUIThread.Execute(() =>
-            {
-                SwipeControl swipeControl = (SwipeControl)MUXControlsTestApp.App.TestContentRoot;
+                Content = swipeControl;
+                Content.UpdateLayout();
                 swipeControl.TopItems = new SwipeItems();
                 swipeControl.LeftItems = new SwipeItems();
                 swipeControl.LeftItems.Add(new SwipeItem());
@@ -169,11 +153,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Log.Warning("Test is disabled pre RS3.");
                 return;
             }
-            Windows.UI.Xaml.Controls.Grid rootGrid;
 
             RunOnUIThread.Execute(() =>
             {
-                rootGrid = (Windows.UI.Xaml.Controls.Grid)XamlReader.LoadWithInitialTemplateValidation(
+                var rootGrid = (Windows.UI.Xaml.Controls.Grid)XamlReader.LoadWithInitialTemplateValidation(
                 "<Grid xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'> " +
                     "<GridView> " +
                         "<GridViewItem> " +
@@ -192,10 +175,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     "</GridView> " +
                 "</Grid>");
 
-                MUXControlsTestApp.App.TestContentRoot = rootGrid;
+                Content = rootGrid;
+                Content.UpdateLayout();
             });
-            
-            IdleSynchronizer.Wait();
         }
     }
 }

--- a/dev/TeachingTip/APITests/TeachingTipTests.cs
+++ b/dev/TeachingTip/APITests/TeachingTipTests.cs
@@ -29,7 +29,7 @@ using Microsoft.UI.Private.Controls;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class TeachingTipTests
+    public class TeachingTipTests : ApiTestBase
     {
         [TestMethod]
         [TestProperty("TestPass:IncludeOnlyOn", "Desktop")] // TeachingTip doesn't appear to show up correctly in OneCore.
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 teachingTip.Content = contentGrid;
                 teachingTip.IconSource = (IconSource)iconSource;
                 teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = teachingTip;
+                Content = teachingTip;
             });
 
             IdleSynchronizer.Wait();
@@ -160,7 +160,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 teachingTip.Content = contentGrid;
                 teachingTip.HeroContent = heroGrid;
                 teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
-                MUXControlsTestApp.App.TestContentRoot = teachingTip;
+                Content = teachingTip;
             });
 
             IdleSynchronizer.Wait();

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -45,15 +45,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     class SpecialTreeViewNode : TreeViewNode { }
 
     [TestClass]
-    public class TreeViewTests
+    public class TreeViewTests : ApiTestBase
     {
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            TestUtilities.ClearVisualTreeRoot();
-        }
-
         [TestMethod]
         public void TreeViewNodeTest()
         {
@@ -115,26 +108,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void TreeViewClearAndSetAtTest()
         {
-            TreeView treeView = null;
-            TreeViewList listControl = null;
-
-            var loadedWaiter = new ManualResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
-                treeView = new TreeView();
-                treeView.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
-                    loadedWaiter.Set();
-                };
+                var treeView = new TreeView();
 
-                MUXControlsTestApp.App.TestContentRoot = treeView;
-            });
-
-            Verify.IsTrue(loadedWaiter.WaitOne(TimeSpan.FromMinutes(1)), "Check if Loaded was successfully raised");
-            RunOnUIThread.Execute(() =>
-            {
+                Content = treeView;
+                Content.UpdateLayout();
+                var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                 // Verify TreeViewNode::SetAt
                 TreeViewNode setAtChildCheckNode = new TreeViewNode() { Content = "Set At Child" };
                 TreeViewNode setAtRootCheckNode = new TreeViewNode() { Content = "Set At Root" };
@@ -167,9 +147,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 // test clear without any child node
                 treeView.RootNodes.Clear();
                 Verify.AreEqual(listControl.Items.Count, 0);
-
-                // Put things back
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
@@ -213,43 +190,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void TreeViewUpdateTest()
         {
-            TreeView treeView = null;
-            TreeViewList listControl = null;
-            TreeViewNode treeViewNode1 = null;
-            TreeViewNode treeViewNode2 = null;
-            TreeViewNode treeViewNode3 = null;
-            TreeViewNode treeViewNode4 = null;
-            TreeViewNode treeViewNode5 = null;
-
-            var loadedWaiter = new ManualResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
-                treeViewNode1 = new TreeViewNode();
-                treeViewNode2 = new TreeViewNode();
-                treeViewNode3 = new TreeViewNode();
-                treeViewNode4 = new TreeViewNode();
-                treeViewNode5 = new TreeViewNode();
+                var treeViewNode1 = new TreeViewNode();
+                var treeViewNode2 = new TreeViewNode();
+                var treeViewNode3 = new TreeViewNode();
+                var treeViewNode4 = new TreeViewNode();
+                var treeViewNode5 = new TreeViewNode();
 
                 treeViewNode1.Children.Add(treeViewNode2);
                 treeViewNode1.Children.Add(treeViewNode3);
                 treeViewNode1.Children.Add(treeViewNode4);
                 treeViewNode1.Children.Add(treeViewNode5);
 
-                treeView = new TreeView();
-
-                treeView.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
-                    loadedWaiter.Set();
-                };
-
-                MUXControlsTestApp.App.TestContentRoot = treeView;
-            });
-
-            Verify.IsTrue(loadedWaiter.WaitOne(TimeSpan.FromMinutes(1)), "Check if Loaded was successfully raised");
-            RunOnUIThread.Execute(() =>
-            {
+                var treeView = new TreeView();
+                Content = treeView;
+                Content.UpdateLayout();
+                var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                 treeView.RootNodes.Add(treeViewNode1);
                 Verify.AreEqual(listControl.Items.Count, 1);
 
@@ -274,9 +231,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 treeViewNode1.Children.Clear();
                 Verify.AreEqual(listControl.Items.Count, 1);
                 Verify.AreEqual(listControl.Items[0], treeViewNode1);
-
-                // Put things back
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
@@ -297,9 +251,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 stackPanel.Children.Add(inheritedTreeViewList);
                 inheritedTreeViewList.ItemsSource = data;
                 MUXControlsTestApp.App.TestContentRoot = stackPanel;
-
-                // Put things back
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
@@ -309,8 +260,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 var treeView = new TreeView();
-                MUXControlsTestApp.App.TestContentRoot = treeView;
-                treeView.UpdateLayout();
+                Content = treeView;
+                Content.UpdateLayout();
                 Verify.IsFalse(treeView.IsTabStop);
             });
         }
@@ -318,29 +269,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifyClearingNodeWithNoChildren()
         {
-            TreeView treeView = null;
-            TreeViewList listControl = null;
-            TreeViewNode treeViewNode1 = null;
-
-            var loadedWaiter = new ManualResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
-                treeViewNode1 = new TreeViewNode();
-                treeView = new TreeView();
+                var treeViewNode1 = new TreeViewNode();
+                var treeView = new TreeView();
 
-                treeView.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
-                    loadedWaiter.Set();
-                };
-
-                MUXControlsTestApp.App.TestContentRoot = treeView;
-            });
-
-            Verify.IsTrue(loadedWaiter.WaitOne(TimeSpan.FromMinutes(1)), "Check if Loaded was successfully raised");
-            RunOnUIThread.Execute(() =>
-            {
+                Content = treeView;
+                Content.UpdateLayout();
+                var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                 treeView.RootNodes.Add(treeViewNode1);
                 var children = (treeViewNode1.Children as IObservableVector<TreeViewNode>);
                 children.VectorChanged += (vector, args) =>
@@ -355,9 +291,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 // this should no-op and not crash
                 treeViewNode1.Children.Clear();
-
-                // Put things back
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
@@ -410,33 +343,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void ValidateTreeViewItemSourceChangeUpdatesChevronOpacity()
         {
-            var collection = new ObservableCollection<int>();
-            collection.Add(5);
-            TreeViewItem tvi = null;
-            TreeView treeView = null;
-
             RunOnUIThread.Execute(() =>
             {
-                treeView = new TreeView();
+                var treeView = new TreeView();
+                var collection = new ObservableCollection<int>();
+                collection.Add(5);
                 treeView.ItemsSource = collection;
-                MUXControlsTestApp.App.TestContentRoot = treeView;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                tvi = (TreeViewItem)treeView.ContainerFromItem(5);
+                Content = treeView;
+                Content.UpdateLayout();
+                var tvi = (TreeViewItem)treeView.ContainerFromItem(5);
                 Verify.AreEqual(tvi.GlyphOpacity, 0.0);
                 tvi.ItemsSource = collection;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content.UpdateLayout();
                 Verify.AreEqual(tvi.GlyphOpacity, 1.0);
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 
@@ -548,38 +467,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void TreeViewPendingSelectedNodesTest()
         {
-            TreeView treeView = null;
-            TreeViewNode node1 = null;
-            TreeViewNode node2 = null;
-
-            var loadedWaiter = new ManualResetEvent(false);
-
             RunOnUIThread.Execute(() =>
             {
-                treeView = new TreeView();
+                var treeView = new TreeView();
                 treeView.SelectionMode = TreeViewSelectionMode.Multiple;
 
-                node1 = new TreeViewNode() { Content = "Node1" };
-                node2 = new TreeViewNode() { Content = "Node2" };
+                var node1 = new TreeViewNode() { Content = "Node1" };
+                var node2 = new TreeViewNode() { Content = "Node2" };
                 treeView.RootNodes.Add(node1);
                 treeView.RootNodes.Add(node2);
                 treeView.SelectedNodes.Add(node1);
 
-                treeView.Loaded += (object sender, RoutedEventArgs e) =>
-                {
-                    loadedWaiter.Set();
-                };
-
-                MUXControlsTestApp.App.TestContentRoot = treeView;
-            });
-
-            Verify.IsTrue(loadedWaiter.WaitOne(TimeSpan.FromMinutes(1)), "Check if Loaded was successfully raised");
-            RunOnUIThread.Execute(() =>
-            {
+                Content = treeView;
+                Content.UpdateLayout();
                 Verify.AreEqual(true, IsMultiSelectCheckBoxChecked(treeView, node1));
                 Verify.AreEqual(false, IsMultiSelectCheckBoxChecked(treeView, node2));
-
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
 

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -250,7 +250,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 stackPanel.Children.Add(inheritedTreeView);
                 stackPanel.Children.Add(inheritedTreeViewList);
                 inheritedTreeViewList.ItemsSource = data;
-                MUXControlsTestApp.App.TestContentRoot = stackPanel;
+                Content = stackPanel;
+                Content.UpdateLayout();
             });
         }
 

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -234,7 +234,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
-        [TestMethod]
+        //[TestMethod] Disabled with issue number #1775
         public void TreeViewInheritanceTest()
         {
             RunOnUIThread.Execute(() =>

--- a/dev/TwoPaneView/APITests/TwoPaneViewTests.cs
+++ b/dev/TwoPaneView/APITests/TwoPaneViewTests.cs
@@ -35,20 +35,10 @@ using TwoPaneViewTallModeConfiguration = Microsoft.UI.Xaml.Controls.TwoPaneViewT
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class TwoPaneViewTests
+    public class TwoPaneViewTests : ApiTestBase
     {
         private const double c_defaultMinWideModeWidth = 641.0;
         private const double c_defaultMinTallModeHeight = 641.0;
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            RunOnUIThread.Execute(() => {
-                Log.Comment("TestCleanup: Restore TestContentRoot to null");
-                // Put things back the way we found them.
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
-        }
 
         [TestMethod]
         [Description("Verifies the TwoPaneView default properties.")]

--- a/test/MUXControlsTestApp/LeakTests.cs
+++ b/test/MUXControlsTestApp/LeakTests.cs
@@ -32,7 +32,7 @@ using TreeViewNode = Microsoft.UI.Xaml.Controls.TreeViewNode;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class LeakTests
+    public class LeakTests : ApiTestBase
     {
         void CheckLeaks(Dictionary<string, WeakReference> objects)
         {
@@ -121,16 +121,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 var eventCycle = new MUXControlsTestApp.EventCycleTest();
-                MUXControlsTestApp.App.TestContentRoot = eventCycle;
+                Content = eventCycle;
                 objects["EventCycle"] = new WeakReference(eventCycle);
-            });
-            IdleSynchronizer.Wait();
-
-            // After templates have been expanded, now remove it. After the dust has settled we expect that things have been GC'd.
-            Log.Comment("After templates have been expanded, now remove it. After the dust has settled we expect that things have been GC'd.");
-            RunOnUIThread.Execute(() =>
-            {
-                MUXControlsTestApp.App.TestContentRoot = null;
+                Content.UpdateLayout();
+                // After templates have been expanded, now remove it. After the dust has settled we expect that things have been GC'd.
+                Log.Comment("After templates have been expanded, now remove it. After the dust has settled we expect that things have been GC'd.");
+                Content = null;
             });
             IdleSynchronizer.Wait();
 
@@ -145,11 +141,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         public void VerifyTreeViewHasNoLeak()
         {
             var objects = new Dictionary<string, WeakReference>();
-            TreeView tree = null;
 
             RunOnUIThread.Execute(() =>
             {
-                tree = new TreeView();
+                var tree = new TreeView();
                 objects["Tree"] = new WeakReference(tree);
 
                 for (int i = 1; i <= 3; i++)
@@ -166,16 +161,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     tree.RootNodes.Add(parentNode);
                 }
 
-                MUXControlsTestApp.App.TestContentRoot = tree;
-            });
-
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
+                Content = tree;
+                Content.UpdateLayout();
                 objects["TreeViewList"] = new WeakReference(FindVisualChildByName(tree, "ListControl"));
                 tree = null;
-                MUXControlsTestApp.App.TestContentRoot = null;
+                Content = null;
             });
 
             IdleSynchronizer.Wait();

--- a/test/MUXControlsTestApp/LocalizationTests.cs
+++ b/test/MUXControlsTestApp/LocalizationTests.cs
@@ -29,7 +29,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public class LocalizationTests
+    public class LocalizationTests : ApiTestBase
     {
         [TestMethod]
         public void VerifyLanguages()

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -5,7 +5,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\..\environment.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\SdkVersion.props" Condition="$(BuildingWithBuildExe) == 'true'" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') And $(BuildingWithBuildExe) != 'true'" />
-  <Import Project="$(MSBuildProjectDirectory)\..\..\..\mux.PGO.props" /> 
+  <Import Project="$(MSBuildProjectDirectory)\..\..\..\mux.PGO.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\FeatureAreas.props" />
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -155,6 +155,7 @@
     <None Include="$(MSBuildThisFileDirectory)\..\..\build\MSTest.pfx" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\APITestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ExtendedObservableCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TopLevelTestPageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)VisualTreeTestHelper.cs" />

--- a/test/MUXControlsTestApp/ThemeResourcesTests.cs
+++ b/test/MUXControlsTestApp/ThemeResourcesTests.cs
@@ -36,7 +36,7 @@ using PersonPicture = Microsoft.UI.Xaml.Controls.PersonPicture;
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
-    public partial class ThemeResourcesTests
+    public partial class ThemeResourcesTests : ApiTestBase
     {
         [ClassInitialize]
         [TestProperty("Classification", "Integration")]
@@ -48,11 +48,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestProperty("IsolationLevel", "Method")]
         public void VerifyOverrides()
         {
-            RatingControl ratingControl = null;
-            PersonPicture personPicture = null;
-            Slider slider = null;
-            Grid root = null;
-
             RunOnUIThread.Execute(() =>
             {
                 var appResources = Application.Current.Resources;
@@ -68,16 +63,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 // 3) Override brush name used by a system control
                 appResources["SliderTrackValueFill"] = new SolidColorBrush(Colors.Purple);
 
-                root = new Grid
+                var root = new Grid
                 {
                     Background = new SolidColorBrush(Colors.AntiqueWhite),
                 };
+                var slider = new Slider();
+                var ratingControl = new RatingControl() { Value = 2 };
+                var personPicture = new PersonPicture();
 
                 StackPanel panel = new StackPanel { Orientation = Orientation.Vertical };
-                panel.Children.Add(slider = new Slider());
+                panel.Children.Add(slider);
             
-                panel.Children.Add(ratingControl = new RatingControl() { Value = 2 });
-                panel.Children.Add(personPicture = new PersonPicture());
+                panel.Children.Add(ratingControl);
+                panel.Children.Add(personPicture);
 
                 root.Children.Add(panel);
                 // Add an element over top to prevent stray mouse input from interfering.
@@ -88,14 +86,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     VerticalAlignment = VerticalAlignment.Stretch
                 });
 
-                MUXControlsTestApp.App.TestContentRoot = root;
-            });
-            IdleSynchronizer.TryWait();
+                Content = root;
+                Content.UpdateLayout();
 
-            //System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(20)).Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
                 // 1) Verify that overriding WinUI defined brushes in App.Resources works.
                 Verify.AreEqual(Colors.Orange, ((SolidColorBrush)ratingControl.Foreground).Color,
                     "Verify RatingControlCaptionForeground override in Application.Resources gets picked up by WinUI control");
@@ -116,11 +109,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 {
                     // Before RS1, we used to reference system brushes directly.
                 }
-
-                Log.Comment("Setting Window.Current.Content = null");
-                MUXControlsTestApp.App.TestContentRoot = null;
             });
-            IdleSynchronizer.TryWait();
         }
 
         [TestMethod]

--- a/test/MUXControlsTestApp/Utilities/APITestBase.cs
+++ b/test/MUXControlsTestApp/Utilities/APITestBase.cs
@@ -52,11 +52,7 @@ namespace MUXControlsTestApp.Utilities
         [TestCleanup]
         public void Cleanup()
         {
-            // Put things back the way we found them.
-            RunOnUIThread.Execute(() =>
-            {
-                MUXControlsTestApp.App.TestContentRoot = null;
-            });
+            TestUtilities.ClearVisualTreeRoot();
         }
     }
 }

--- a/test/MUXControlsTestApp/Utilities/TestHelpers.cs
+++ b/test/MUXControlsTestApp/Utilities/TestHelpers.cs
@@ -139,7 +139,7 @@ namespace MUXControlsTestApp.Utilities
                     // to make sure that we don't wait on an event that won't actually come.
                     unloadedEvent.Set();
                 }
-                
+
                 Log.Comment("Clearing visual tree root and waiting for Unloaded to be raised...");
                 MUXControlsTestApp.App.TestContentRoot = null;
             });

--- a/test/TestAppUtils/APITestBase.cs
+++ b/test/TestAppUtils/APITestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using MUXControlsTestApp.Utilities;
 using System;
 using System.Threading;
 using Windows.UI.Xaml;
@@ -17,7 +16,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
-namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
+namespace MUXControlsTestApp.Utilities
 {
     public class ApiTestBase
     {

--- a/test/TestAppUtils/TestAppUtils.projitems
+++ b/test/TestAppUtils/TestAppUtils.projitems
@@ -10,7 +10,6 @@
     <Import_RootNamespace>TestAppUtils</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)APITestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesignModeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IdleSynchronizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NavigateToTestCommand.cs" />

--- a/test/TestAppUtils/TestAppUtils.projitems
+++ b/test/TestAppUtils/TestAppUtils.projitems
@@ -10,6 +10,7 @@
     <Import_RootNamespace>TestAppUtils</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)APITestBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesignModeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IdleSynchronizer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NavigateToTestCommand.cs" />


### PR DESCRIPTION
Repeater uses an API testing pattern that moves a bunch of boiler plate code to a base class, I've pulled that out to a shared base and refactored most of our tests to use that instead. Some of the visual verification tests failed with the change, if we want we can update their masters to get them to this patern as well.