### PR TITLE
Adjust the focus handler to further future proof the custom focus management.

### DIFF
--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -425,9 +425,8 @@ bool RadioButtons::MoveFocus(int indexIncrement)
                     {
                         if (auto const itemAsControl = item.try_as<winrt::IControl>())
                         {
-                            if (itemAsControl.IsEnabled() && itemAsControl.IsTabStop())
+                            if (itemAsControl.Focus(winrt::FocusState::Programmatic))
                             {
-                                itemAsControl.Focus(winrt::FocusState::Keyboard);
                                 return true;
                             }
                         }


### PR DESCRIPTION
Previously I was checking some (not all), of the conditions for which the radio button would not be focusable before trying to set focus on it. Better is to let the focus manager tell RB if moving focus was successful or not.