### PR TITLE
Disable unreliable test

### DIFF
--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -637,7 +637,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        [TestMethod]
+        //[TestMethod] Disabled with issue #1769
         public void SettingTitleOrSubtitleToEmptyStringCollapsesTextBox()
         {
             using (var setup = new TestSetupHelper("TeachingTip Tests"))


### PR DESCRIPTION
This test is too unreliable and has resulted in a couple of failed PR gates for unrelated changes as well as a few failed CI runs. I've opened issue #1769 to investigate and re-enable.