### PR TITLE
Enable C++/WinRT heap enforcement

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -12,7 +12,7 @@
 
 // Derive from DeriveFromPanelHelper_base so that we get access to Children collection
 // in Panel. The Children collection holds the fallback content.
-struct AnimatedVisualPlayer final :
+struct AnimatedVisualPlayer:
     public ReferenceTracker<AnimatedVisualPlayer, DeriveFromPanelHelper_base, winrt::AnimatedVisualPlayer>,
     public AnimatedVisualPlayerProperties
 {

--- a/dev/Common/LifetimeHandler.h
+++ b/dev/Common/LifetimeHandler.h
@@ -32,9 +32,9 @@ private:
 #ifdef TWOPANEVIEW_INCLUDED
     com_ptr<DisplayRegionHelper> m_displayRegionHelper;
 #endif
-    ~LifetimeHandler();
 public:
-    LifetimeHandler() = default; // Trying to make this private gives: cannot access private member declared in class 'LifeTimeHandler'
+    LifetimeHandler() = default;
+    ~LifetimeHandler();
 
 #ifdef REPEATER_INCLUDED
     static com_ptr<CachedVisualTreeHelpers> GetCachedVisualTreeHelpersInstance();

--- a/dev/ScrollViewer/ScrollBarController.h
+++ b/dev/ScrollViewer/ScrollBarController.h
@@ -9,7 +9,7 @@ class ScrollViewer;
 
 using namespace std;
 
-class ScrollBarController final:
+class ScrollBarController:
     public winrt::implements<ScrollBarController, winrt::IScrollController>
 {
 public:

--- a/dev/dll/CommandingHelpers.cpp
+++ b/dev/dll/CommandingHelpers.cpp
@@ -118,7 +118,7 @@ void CommandingHelpers::BindToIconSourcePropertyIfUnset(
 
     if (!localIconSource)
     {
-        SharedHelpers::SetBinding(uiCommand, L"IconSource", target, iconSourceProperty, WUXIconSourceToMUXIconSourceConverter());
+        SharedHelpers::SetBinding(uiCommand, L"IconSource", target, iconSourceProperty, winrt::make<WUXIconSourceToMUXIconSourceConverter>());
     }
 }
 
@@ -129,7 +129,7 @@ void CommandingHelpers::BindToIconPropertyIfUnset(
 {
     if (!target.ReadLocalValue(iconProperty).try_as<winrt::IconElement>())
     {
-        SharedHelpers::SetBinding(uiCommand, L"Icon", target, iconProperty, IconSourceToIconSourceElementConverter());
+        SharedHelpers::SetBinding(uiCommand, L"Icon", target, iconProperty, winrt::make<IconSourceToIconSourceElementConverter>());
     }
 }
 

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -42,6 +42,7 @@
          -->
     <CppWinRTParameters>-ignore_velocity</CppWinRTParameters>
     <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTHeapEnforcement>true</CppWinRTHeapEnforcement>
   </PropertyGroup>
   <!-- <PropertyGroup Condition="'$(Use64BitLinker)' == 'true' AND '$(BuildingWithBuildExe)' != 'true'">
       <LinkToolPath>$(OSBuildToolsRoot)\vc\HostX64\$(BuildArchName)</LinkToolPath>


### PR DESCRIPTION
Turn on the C++/WinRT heap enforcement to catch cases where we incorrectly stack-allocate a WinRT object. I believe this is normally on but was disabled for XAML projects because of https://github.com/microsoft/xlang/pull/343. We don't use XAML compiler so we aren't affected by this and can turn this feature on.

If this was on this would have saved @karenbtlai some headache... and also seems to be catching a latent bug in CommandingHelpers.