### PR TITLE
Fix bug with UniformGridLayout MaximumRowsOrColumns and requested size

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common;
@@ -580,6 +580,65 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        [TestMethod]
+        public void ValidateGridLayoutDesiredSizingWithMaxRowsOrColumnsSet()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                foreach (ScrollOrientation scrollOrientation in Enum.GetValues(typeof(ScrollOrientation)))
+                {
+                    Log.Comment(string.Format("ScrollOrientation: {0}", scrollOrientation));
+                    var om = new OrientationBasedMeasures(scrollOrientation, useLayoutRounding: true);
+                    const int numItems = 4;
+
+                    int itemSize = 100;
+
+                    LayoutPanel panel = new LayoutPanel();
+                    var layout = new UniformGridLayout() {
+                        Orientation = scrollOrientation.ToOrthogonalLayoutOrientation(),
+                        ItemsJustification = UniformGridLayoutItemsJustification.Start,
+                        MinItemWidth = itemSize,
+                        MinItemHeight = itemSize,
+                        MinRowSpacing = 0,
+                        MinColumnSpacing = 0
+                    };
+                    
+                    for (int i = 0; i < numItems; i++)
+                    {
+                        panel.Children.Add(new Button() { Content = i,Width = itemSize,Height = itemSize });
+                    }
+                    
+                    panel.Layout = layout;
+                    Content = panel;
+                    panel.UpdateLayout();
+
+                    // Place in top left corner to prevent stretch of panel
+                    panel.VerticalAlignment = VerticalAlignment.Top;
+                    panel.HorizontalAlignment = HorizontalAlignment.Left;
+                    layout.ItemsJustification = UniformGridLayoutItemsJustification.Start;
+                    layout.ItemsStretch = UniformGridLayoutItemsStretch.Fill;
+
+
+                    for(int i = 1; i < numItems; i++)
+                    {
+                        layout.MaximumRowsOrColumns = i;
+                        panel.UpdateLayout();
+
+                        if (om.IsVerical)
+                        {
+                            // Vertical so fill columns first
+                            Verify.AreEqual(itemSize * i, panel.DesiredSize.Height);
+                        }
+                        else
+                        {
+                            // Horizontal, fill rows first
+                            Verify.AreEqual(itemSize * i, panel.DesiredSize.Width);
+                        }
+                    }
+
+                }
+            });
+        }
 
         [TestMethod]
         public void ValidateFlowLayout()

--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common;
@@ -610,14 +610,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     
                     panel.Layout = layout;
                     Content = panel;
-                    panel.UpdateLayout();
 
                     // Place in top left corner to prevent stretch of panel
                     panel.VerticalAlignment = VerticalAlignment.Top;
                     panel.HorizontalAlignment = HorizontalAlignment.Left;
                     layout.ItemsJustification = UniformGridLayoutItemsJustification.Start;
-                    layout.ItemsStretch = UniformGridLayoutItemsStretch.Fill;
-
 
                     for(int i = 1; i < numItems; i++)
                     {
@@ -627,12 +624,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         if (om.IsVerical)
                         {
                             // Vertical so fill columns first
-                            Verify.AreEqual(itemSize * i, panel.DesiredSize.Height);
+                            Verify.AreEqual(itemSize * i, panel.DesiredSize.Width);
+                            Verify.AreEqual(Math.Ceiling((double)numItems / (double)i) * itemSize, panel.DesiredSize.Height);
                         }
                         else
                         {
                             // Horizontal, fill rows first
-                            Verify.AreEqual(itemSize * i, panel.DesiredSize.Width);
+                            Verify.AreEqual(itemSize * i, panel.DesiredSize.Height);
+                            Verify.AreEqual(Math.Ceiling((double)numItems / (double)i) * itemSize, panel.DesiredSize.Width);
                         }
                     }
 

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -213,11 +213,12 @@ winrt::Rect UniformGridLayout::Algorithm_GetExtent(
 
     if (itemsCount > 0)
     {
+        // Only use all of the space if item stretch is fill, otherwise size layout according to items placed
         extent.*MinorSize() =
-            std::isfinite(availableSizeMinor) ?
+            std::isfinite(availableSizeMinor) && m_itemsStretch == winrt::UniformGridLayoutItemsStretch::Fill ?
             availableSizeMinor :
-            std::max(0.0f, itemsCount * GetMinorSizeWithSpacing(context) - static_cast<float>(MinItemSpacing()));
-        extent.*MajorSize() = std::max(0.0f, (itemsCount / itemsPerLine) * lineSize - static_cast<float>(LineSpacing()));
+            std::max(0.0f, itemsPerLine * GetMinorSizeWithSpacing(context) - static_cast<float>(MinItemSpacing()));
+         extent.*MajorSize() = std::max(0.0f, (itemsCount / itemsPerLine) * lineSize - static_cast<float>(LineSpacing()));
 
         if (firstRealized)
         {

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -218,7 +218,7 @@ winrt::Rect UniformGridLayout::Algorithm_GetExtent(
             std::isfinite(availableSizeMinor) && m_itemsStretch == winrt::UniformGridLayoutItemsStretch::Fill ?
             availableSizeMinor :
             std::max(0.0f, itemsPerLine * GetMinorSizeWithSpacing(context) - static_cast<float>(MinItemSpacing()));
-         extent.*MajorSize() = std::max(0.0f, (itemsCount / itemsPerLine) * lineSize - static_cast<float>(LineSpacing()));
+        extent.*MajorSize() = std::max(0.0f, (itemsCount / itemsPerLine) * lineSize - static_cast<float>(LineSpacing()));
 
         if (firstRealized)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix bug where the UniformGridLayout would ignore thefact that it only renders a certain amount of columns/rows and then request the whole width/height instead of requesting what is needed.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1549 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new API test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->