### PR TITLE
Update to use new SpanningRects API instead of DisplayRegions.

### DIFF
--- a/dev/TwoPaneView/DisplayRegionHelper.cpp
+++ b/dev/TwoPaneView/DisplayRegionHelper.cpp
@@ -14,7 +14,6 @@ DisplayRegionHelperInfo DisplayRegionHelper::GetRegionInfo()
     auto instance = LifetimeHandler::GetDisplayRegionHelperInstance();
 
     DisplayRegionHelperInfo info;
-    info.RegionCount = 1;
     info.Mode = winrt::TwoPaneViewMode::SinglePane;
 
     if (instance->m_simulateDisplayRegions)
@@ -22,25 +21,22 @@ DisplayRegionHelperInfo DisplayRegionHelper::GetRegionInfo()
         // Create fake rectangles for test app
         if (instance->m_simulateMode == winrt::TwoPaneViewMode::Wide)
         {
-            info.RegionCount = 2;
             info.Regions[0] = m_simulateWide0;
             info.Regions[1] = m_simulateWide1;
             info.Mode = winrt::TwoPaneViewMode::Wide;
         }
         else if (instance->m_simulateMode == winrt::TwoPaneViewMode::Tall)
         {
-            info.RegionCount = 2;
             info.Regions[0] = m_simulateTall0;
             info.Regions[1] = m_simulateTall1;
             info.Mode = winrt::TwoPaneViewMode::Tall;
         }
         else
         {
-            info.RegionCount = 1;
             info.Regions[0] = m_simulateWide0;
         }
     }
-    else if (SharedHelpers::IsApplicationViewGetDisplayRegionsAvailable())
+    else if (SharedHelpers::IsApplicationViewGetSpanningRectsAvailable())
     {
         // ApplicationView::GetForCurrentView throws on failure; in that case we just won't do anything.
         winrt::ApplicationView view{ nullptr };
@@ -49,30 +45,28 @@ DisplayRegionHelperInfo DisplayRegionHelper::GetRegionInfo()
             view = winrt::ApplicationView::GetForCurrentView();
         } catch(...) {}
 
-        // Verify that the window is Tiled
         if (view)
         {
-            auto regions = view.GetDisplayRegions();
-            info.RegionCount = std::min(regions.Size(), c_maxRegions);
-
-            // More than one region
-            if (info.RegionCount == 2)
+            if (const auto appView = view.as<winrt::IApplicationViewSpanningRects>())
             {
-                winrt::Rect windowRect = WindowRect();
+                winrt::IVectorView<winrt::Rect> rects = appView.GetSpanningRects();
 
-                if (windowRect.Width > windowRect.Height)
+                if (rects.Size() == 2)
                 {
-                    info.Mode = winrt::TwoPaneViewMode::Wide;
-                    float width = windowRect.Width / 2;
-                    info.Regions[0] = { 0, 0, width, windowRect.Height };
-                    info.Regions[1] = { width, 0, width, windowRect.Height };
-                }
-                else
-                {
-                    info.Mode = winrt::TwoPaneViewMode::Tall;
-                    float height = windowRect.Height / 2;
-                    info.Regions[0] = { 0, 0, windowRect.Width, height };
-                    info.Regions[1] = { 0, height, windowRect.Width, height };
+                    info.Regions[0] = rects.GetAt(0);
+                    info.Regions[1] = rects.GetAt(1);
+
+                    // Determine orientation. If neither of these are true, default to doing nothing.
+                    if (info.Regions[0].X < info.Regions[1].X && info.Regions[0].Y == info.Regions[1].Y)
+                    {
+                        // Double portrait
+                        info.Mode = winrt::TwoPaneViewMode::Wide;
+                    }
+                    else if (info.Regions[0].X == info.Regions[1].X && info.Regions[0].Y < info.Regions[1].Y)
+                    {
+                        // Double landscape
+                        info.Mode = winrt::TwoPaneViewMode::Tall;
+                    }
                 }
             }
         }

--- a/dev/TwoPaneView/DisplayRegionHelper.cpp
+++ b/dev/TwoPaneView/DisplayRegionHelper.cpp
@@ -36,7 +36,7 @@ DisplayRegionHelperInfo DisplayRegionHelper::GetRegionInfo()
             info.Regions[0] = m_simulateWide0;
         }
     }
-    else if (SharedHelpers::IsApplicationViewGetSpanningRectsAvailable())
+    else
     {
         // ApplicationView::GetForCurrentView throws on failure; in that case we just won't do anything.
         winrt::ApplicationView view{ nullptr };
@@ -47,7 +47,7 @@ DisplayRegionHelperInfo DisplayRegionHelper::GetRegionInfo()
 
         if (view)
         {
-            if (const auto appView = view.as<winrt::IApplicationViewSpanningRects>())
+            if (const auto appView = view.try_as<winrt::IApplicationViewSpanningRects>())
             {
                 winrt::IVectorView<winrt::Rect> rects = appView.GetSpanningRects();
 

--- a/dev/TwoPaneView/DisplayRegionHelper.h
+++ b/dev/TwoPaneView/DisplayRegionHelper.h
@@ -9,7 +9,6 @@ struct DisplayRegionHelperInfo
 {
     winrt::TwoPaneViewMode Mode{ winrt::TwoPaneViewMode::SinglePane };
     std::array<winrt::Rect, c_maxRegions> Regions{};
-    uint32_t RegionCount{ 0 };
 };
 
 class DisplayRegionHelper:

--- a/dev/TwoPaneView/TwoPaneView.cpp
+++ b/dev/TwoPaneView/TwoPaneView.cpp
@@ -26,6 +26,7 @@ TwoPaneView::TwoPaneView()
     SetDefaultStyleKey(this);
 
     SizeChanged({ this, &TwoPaneView::OnSizeChanged });
+    winrt::Window::Current().SizeChanged({ this, &TwoPaneView::OnWindowSizeChanged });
 
     EnsureProperties();
 }
@@ -97,6 +98,11 @@ void TwoPaneView::OnScrollViewerLoaded(const winrt::IInspectable& sender, const 
             }
         }
     }
+}
+
+void TwoPaneView::OnWindowSizeChanged(const winrt::IInspectable& sender, const winrt::WindowSizeChangedEventArgs& args)
+{
+    UpdateMode();
 }
 
 void TwoPaneView::OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args)

--- a/dev/TwoPaneView/TwoPaneView.h
+++ b/dev/TwoPaneView/TwoPaneView.h
@@ -43,6 +43,7 @@ private:
     void OnScrollViewerLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
 
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
+    void OnWindowSizeChanged(const winrt::IInspectable& sender, const winrt::WindowSizeChangedEventArgs& args);
 
     void UpdateRowsColumns(ViewMode newMode, DisplayRegionHelperInfo info, winrt::Rect rcControl);
     void UpdateMode();

--- a/dev/TwoPaneView/TwoPaneView.idl
+++ b/dev/TwoPaneView/TwoPaneView.idl
@@ -77,4 +77,13 @@ unsealed runtimeclass TwoPaneView : Windows.UI.Xaml.Controls.Control
     static Windows.UI.Xaml.DependencyProperty MinTallModeHeightProperty { get; };
 }
 
+// TODO: Once IApplicationViewSpanningRects is available in the official SDK, remove this.
+[WUXC_VERSION_INTERNAL]
+[webhosthidden]
+[uuid(645737E4-A882-4E16-B289-FD860560106A)]
+interface IApplicationViewSpanningRects : IInspectable
+{
+    Windows.Foundation.Collections.IVectorView<Windows.Foundation.Rect> GetSpanningRects();
+}
+
 }

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -143,12 +143,11 @@ bool SharedHelpers::IsFrameworkElementInvalidateViewportAvailable()
     return s_isFrameworkElementInvalidateViewportAvailable;
 }
 
-bool SharedHelpers::IsApplicationViewGetDisplayRegionsAvailable()
+bool SharedHelpers::IsApplicationViewGetSpanningRectsAvailable()
 {
-    static bool s_isApplicationViewGetDisplayRegionsAvailable =
-        Is19H1OrHigher() ||
-        winrt::ApiInformation::IsMethodPresent(L"Windows.UI.ViewManagement.ApplicationView", L"GetDisplayRegions");
-    return s_isApplicationViewGetDisplayRegionsAvailable;
+    static bool s_isApplicationViewGetSpanningRectsAvailable =
+        winrt::ApiInformation::IsMethodPresent(L"Windows.UI.ViewManagement.ApplicationView", L"GetSpanningRects");
+    return s_isApplicationViewGetSpanningRectsAvailable;
 }
 
 bool SharedHelpers::IsControlCornerRadiusAvailable()

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -143,13 +143,6 @@ bool SharedHelpers::IsFrameworkElementInvalidateViewportAvailable()
     return s_isFrameworkElementInvalidateViewportAvailable;
 }
 
-bool SharedHelpers::IsApplicationViewGetSpanningRectsAvailable()
-{
-    static bool s_isApplicationViewGetSpanningRectsAvailable =
-        winrt::ApiInformation::IsMethodPresent(L"Windows.UI.ViewManagement.ApplicationView", L"GetSpanningRects");
-    return s_isApplicationViewGetSpanningRectsAvailable;
-}
-
 bool SharedHelpers::IsControlCornerRadiusAvailable()
 {
     static bool s_isControlCornerRadiusAvailable =

--- a/dev/dll/pch.h
+++ b/dev/dll/pch.h
@@ -194,7 +194,6 @@ void specialize_guids()
 #endif
 
 #ifdef TWOPANEVIEW_INCLUDED
-    winrt::guid_of<struct winrt::Windows::Foundation::IReference<enum winrt::Microsoft::UI::Xaml::Controls::TreeViewSelectionMode>>();
     winrt::guid_of<struct winrt::Windows::Foundation::IReference<enum winrt::Microsoft::UI::Xaml::Controls::TwoPaneViewMode>>();
     winrt::guid_of<struct winrt::Windows::Foundation::IReference<enum winrt::Microsoft::UI::Xaml::Controls::TwoPaneViewPriority>>();
     winrt::guid_of<struct winrt::Windows::Foundation::IReference<enum winrt::Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration>>();

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -41,8 +41,6 @@ public:
 
     static bool IsFrameworkElementInvalidateViewportAvailable();
 
-    static bool IsApplicationViewGetSpanningRectsAvailable();
-
     static bool IsControlCornerRadiusAvailable();
 
     static bool IsTranslationFacadeAvailable(const winrt::UIElement& element);

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -41,7 +41,7 @@ public:
 
     static bool IsFrameworkElementInvalidateViewportAvailable();
 
-    static bool IsApplicationViewGetDisplayRegionsAvailable();
+    static bool IsApplicationViewGetSpanningRectsAvailable();
 
     static bool IsControlCornerRadiusAvailable();
 


### PR DESCRIPTION
Shell added a new API called SpanningRects, which is to replace DisplayRegions, so I'm updating TwoPaneView. Since it's not in the released SDK yet, I added the API to my own idl temporarily. Verified that it works on the latest VM in both double landscape and double portrait, when spanning and unspanning. It's necessary to listen to Window.SizeChanged because it fires at the right time when unspanning; shell may have further work to do on a timing here.