### PR TITLE
Make TabItems as content property of TabView

### DIFF
--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -46,6 +46,7 @@ runtimeclass TabViewTabDragCompletedEventArgs
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
+[contentproperty("TabItems")]
 unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.Control
 {
     TabView();

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -103,66 +103,63 @@
                         </Grid>
                     </controls:TabView.TabStripFooter>
 
-                    <controls:TabView.TabItems>
+                    <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Header="Home" CloseRequested="FirstTab_CloseRequested" ToolTipService.ToolTip="Custom Tooltip">
+                        <controls:TabViewItem.IconSource>
+                            <controls:SymbolIconSource Symbol="Home"/>
+                        </controls:TabViewItem.IconSource>
 
-                        <controls:TabViewItem x:Name="FirstTab" AutomationProperties.Name="FirstTab" Header="Home" CloseRequested="FirstTab_CloseRequested" ToolTipService.ToolTip="Custom Tooltip">
-                            <controls:TabViewItem.IconSource>
-                                <controls:SymbolIconSource Symbol="Home"/>
-                            </controls:TabViewItem.IconSource>
+                        <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
+                            <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
+                            <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
+                        </StackPanel>
+                    </controls:TabViewItem>
 
-                            <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
-                                <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
-                                <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
-                            </StackPanel>
-                        </controls:TabViewItem>
+                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab" IsClosable="True">
+                        <controls:TabViewItem.IconSource>
+                            <controls:SymbolIconSource Symbol="Shop"/>
+                        </controls:TabViewItem.IconSource>
 
-                        <controls:TabViewItem x:Name="SecondTab" Header="SecondTab" IsClosable="True">
-                            <controls:TabViewItem.IconSource>
-                                <controls:SymbolIconSource Symbol="Shop"/>
-                            </controls:TabViewItem.IconSource>
+                        <StackPanel Padding="16">
+                            <TextBlock>Shop text</TextBlock>
+                            <Button Content="SecondTabButton" AutomationProperties.Name="SecondTabButton"/>
+                        </StackPanel>
+                    </controls:TabViewItem>
 
-                            <StackPanel Padding="16">
-                                <TextBlock>Shop text</TextBlock>
-                                <Button Content="SecondTabButton" AutomationProperties.Name="SecondTabButton"/>
-                            </StackPanel>
-                        </controls:TabViewItem>
+                    <controls:TabViewItem x:Name="LongHeaderTab" AutomationProperties.Name="LongHeaderTab" Header="Long Header No Icon">
+                        <StackPanel Padding="16">
+                            <TextBlock >Emoji text</TextBlock>
+                            <Button Content="Button 3"/>
+                        </StackPanel>
+                    </controls:TabViewItem>
 
-                        <controls:TabViewItem x:Name="LongHeaderTab" AutomationProperties.Name="LongHeaderTab" Header="Long Header No Icon">
-                            <StackPanel Padding="16">
-                                <TextBlock >Emoji text</TextBlock>
-                                <Button Content="Button 3"/>
-                            </StackPanel>
-                        </controls:TabViewItem>
+                    <controls:TabViewItem x:Name="NotCloseableTab" AutomationProperties.Name="NotCloseableTab" Header="Video" IsClosable="False">
+                        <controls:TabViewItem.IconSource>
+                            <controls:SymbolIconSource Symbol="Video"/>
+                        </controls:TabViewItem.IconSource>
 
-                        <controls:TabViewItem x:Name="NotCloseableTab" AutomationProperties.Name="NotCloseableTab" Header="Video" IsClosable="False">
-                            <controls:TabViewItem.IconSource>
-                                <controls:SymbolIconSource Symbol="Video"/>
-                            </controls:TabViewItem.IconSource>
+                        <StackPanel>
+                            <TextBlock Padding="16">This tab can't be closed.</TextBlock>
+                        </StackPanel>
+                    </controls:TabViewItem>
 
-                            <StackPanel>
-                                <TextBlock Padding="16">This tab can't be closed.</TextBlock>
-                            </StackPanel>
-                        </controls:TabViewItem>
+                    <controls:TabViewItem x:Name="DisabledTab" AutomationProperties.Name="DisabledTab" Header="Disabled" IsEnabled="False">
+                        <controls:TabViewItem.IconSource>
+                            <controls:SymbolIconSource Symbol="Admin"/>
+                        </controls:TabViewItem.IconSource>
 
-                        <controls:TabViewItem x:Name="DisabledTab" AutomationProperties.Name="DisabledTab" Header="Disabled" IsEnabled="False">
-                            <controls:TabViewItem.IconSource>
-                                <controls:SymbolIconSource Symbol="Admin"/>
-                            </controls:TabViewItem.IconSource>
+                        <StackPanel>
+                            <TextBlock Padding="16">This tab can't be selected.</TextBlock>
+                        </StackPanel>
+                    </controls:TabViewItem>
 
-                            <StackPanel>
-                                <TextBlock Padding="16">This tab can't be selected.</TextBlock>
-                            </StackPanel>
-                        </controls:TabViewItem>
+                    <controls:TabViewItem x:Name="LastTab" AutomationProperties.Name="LastTab" Header="Contact">
+                        <controls:TabViewItem.IconSource>
+                            <controls:SymbolIconSource Symbol="Contact"/>
+                        </controls:TabViewItem.IconSource>
 
-                        <controls:TabViewItem x:Name="LastTab" AutomationProperties.Name="LastTab" Header="Contact">
-                            <controls:TabViewItem.IconSource>
-                                <controls:SymbolIconSource Symbol="Contact"/>
-                            </controls:TabViewItem.IconSource>
+                        <TextBlock x:Name="LastTabContent" AutomationProperties.Name="LastTabContent" Padding="16">Contact text</TextBlock>
+                    </controls:TabViewItem>
 
-                            <TextBlock x:Name="LastTabContent" AutomationProperties.Name="LastTabContent" Padding="16">Contact text</TextBlock>
-                        </controls:TabViewItem>
-
-                    </controls:TabView.TabItems>
                 </controls:TabView>
 
                 <Grid Grid.Row="1">


### PR DESCRIPTION
Make TabItems as content property of TabView. It matches the documentation we already have and how ItemsControl currently behaves.

fixes #1844 