### PR TITLE
Fix pre-rs3 keyboard navigation for NavigationView

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -294,7 +294,6 @@ void NavigationView::OnApplyTemplate()
         m_leftNavRepeaterLoadedRevoker = leftNavRepeater.Loaded(winrt::auto_revoke, { this, &NavigationView::OnRepeaterLoaded });
 
         leftNavRepeater.ItemTemplate(*m_navigationViewItemsFactory);
-        leftNavRepeater.TabFocusNavigation(winrt::KeyboardNavigationMode::Once);
     }
 
     // Change code to NOT do this if we're in left nav mode, to prevent it from being realized:
@@ -316,7 +315,6 @@ void NavigationView::OnApplyTemplate()
         m_topNavRepeaterLoadedRevoker = topNavRepeater.Loaded(winrt::auto_revoke, { this, &NavigationView::OnRepeaterLoaded });
 
         topNavRepeater.ItemTemplate(*m_navigationViewItemsFactory);
-        topNavRepeater.TabFocusNavigation(winrt::KeyboardNavigationMode::Once);
     }
 
     // Change code to NOT do this if we're in left nav mode, to prevent it from being realized:
@@ -328,7 +326,6 @@ void NavigationView::OnApplyTemplate()
         m_topNavOverflowItemsRepeaterElementClearingRevoker = topNavListOverflowRepeater.ElementClearing(winrt::auto_revoke, { this, &NavigationView::RepeaterElementClearing });
 
         topNavListOverflowRepeater.ItemTemplate(*m_navigationViewItemsFactory);
-        topNavListOverflowRepeater.TabFocusNavigation(winrt::KeyboardNavigationMode::Once);
     }
 
     if (auto topNavOverflowButton = GetTemplateChildT<winrt::Button>(c_topNavOverflowButton, controlProtected))
@@ -1823,7 +1820,7 @@ void NavigationView::ArrowKeyNavigationPolyfill(const winrt::NavigationViewItem&
 
 bool NavigationView::FocusNextFocusableElement(const winrt::ItemsRepeater& ir, const int elementIndex)
 {
-    if (auto itemsSourceView = ir.ItemsSourceView())
+    if (auto const itemsSourceView = ir.ItemsSourceView())
     {
         for (int i = elementIndex + 1; i < itemsSourceView.Count(); i++)
         {
@@ -1839,7 +1836,7 @@ bool NavigationView::FocusNextFocusableElement(const winrt::ItemsRepeater& ir, c
 
 bool NavigationView::FocusPreviousFocusableElement(const winrt::ItemsRepeater& ir, const int elementIndex)
 {
-    if (auto itemsSourceView = ir.ItemsSourceView())
+    if (auto const itemsSourceView = ir.ItemsSourceView())
     {
         for (int i = elementIndex - 1; i >= 0; i--)
         {

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -82,6 +82,12 @@ public:
     winrt::NavigationViewItem GetSelectedContainer();
 
 private:
+    enum class Direction
+    {
+        Down,
+        Up
+    };
+
     void ClosePaneIfNeccessaryAfterItemIsClicked();
     bool NeedTopPaddingForRS5OrHigher(winrt::CoreApplicationViewTitleBar const& coreTitleBar);
     void OnAccessKeyInvoked(winrt::IInspectable const& sender, winrt::AccessKeyInvokedEventArgs const& args);
@@ -115,8 +121,9 @@ private:
     bool IsSettingsItem(winrt::IInspectable const& item);
     void HandleKeyEventForNavigationViewItem(const winrt::NavigationViewItem& nvi, const winrt::KeyRoutedEventArgs& args);
     void ArrowKeyNavigationPolyfill(const winrt::NavigationViewItem& nvi, const winrt::KeyRoutedEventArgs& args);
-    bool FocusNextFocusableElement(const winrt::ItemsRepeater& ir, const int elementIndex);
-    bool FocusPreviousFocusableElement(const winrt::ItemsRepeater& ir, const int elementIndex);
+    winrt::NavigationViewItem FindNextFocusableElement(const winrt::NavigationViewItem& nvi, const Direction direction);
+    winrt::NavigationViewItem FindNextFocusableElementDown(const winrt::ItemsRepeater& ir, int elementIndex);
+    winrt::NavigationViewItem FindNextFocusableElementUp(const winrt::ItemsRepeater& ir, int elementIndex);
 
     // This property is attached to the NavigationViewItems that are being
     // displayed by the repeaters in this control. It is used to keep track of the

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -114,6 +114,9 @@ private:
     void RaiseItemInvokedForNavigationViewItem(const winrt::NavigationViewItem& nvi);
     bool IsSettingsItem(winrt::IInspectable const& item);
     void HandleKeyEventForNavigationViewItem(const winrt::NavigationViewItem& nvi, const winrt::KeyRoutedEventArgs& args);
+    void ArrowKeyNavigationPolyfill(const winrt::NavigationViewItem& nvi, const winrt::KeyRoutedEventArgs& args);
+    bool FocusNextFocusableElement(const winrt::ItemsRepeater& ir, const int elementIndex);
+    bool FocusPreviousFocusableElement(const winrt::ItemsRepeater& ir, const int elementIndex);
 
     // This property is attached to the NavigationViewItems that are being
     // displayed by the repeaters in this control. It is used to keep track of the
@@ -382,5 +385,7 @@ private:
     bool m_isOpenPaneForInteraction{ false };
 
     int32_t m_indexOfLastFocusedItem{ -1 };
+
+    DispatcherHelper m_dispatcherHelper{ *this };
 };
 

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -266,6 +266,7 @@
                                                 AutomationProperties.LandmarkType="Navigation"
                                                 AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                                 AutomationProperties.AccessibilityView = "Content"
+                                                TabFocusNavigation="Once"
                                                 x:Name="TopNavMenuItemsHost">
                                                 <local:ItemsRepeater.Layout>
                                                     <local:StackLayout Orientation="Horizontal"/>
@@ -294,6 +295,7 @@
                                                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                                                         <local:ItemsRepeater
                                                                     AutomationProperties.AccessibilityView = "Content"
+                                                                    TabFocusNavigation="Once"
                                                                     x:Name="TopNavMenuItemsOverflowHost">
                                                             <local:ItemsRepeater.Layout>
                                                                 <local:StackLayout Orientation="Vertical"/>
@@ -436,6 +438,7 @@
                                                 VerticalScrollBarVisibility="Auto">
                                                 <local:ItemsRepeater 
                                                         x:Name="MenuItemsHost"
+                                                        TabFocusNavigation="Once"
                                                         AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                                         AutomationProperties.AccessibilityView = "Content">
                                                     <local:ItemsRepeater.Layout>

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -1173,13 +1173,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", testScenario.TestPageName }))
                 {
-                    //TODO: Update RS3 and below tab behavior to match RS4+
-                    if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone4))
-                    {
-                        Log.Warning("Test is disabled because the repeater tab behavior is current different rs3 and below.");
-                        return;
-                    }
-
                     SetNavViewWidth(ControlWidth.Wide);
 
                     Button togglePaneButton = new Button(FindElement.ById("TogglePaneButton"));
@@ -1280,13 +1273,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", testScenario.TestPageName }))
                 {
-                    //TODO: Update RS3 and below tab behavior to match RS4+
-                    if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone4))
-                    {
-                        Log.Warning("Test is disabled because the repeater tab behavior is current different rs3 and below.");
-                        return;
-                    }
-
                     SetNavViewWidth(ControlWidth.Wide);
 
                     Button togglePaneButton = new Button(FindElement.ById("TogglePaneButton"));
@@ -2679,13 +2665,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", testScenario.TestPageName }))
                 {
-                    //TODO: Re-enable for RS2 once repeater behavior is fixed
-                    if (PlatformConfiguration.IsOsVersion(OSVersion.Redstone2))
-                    {
-                        Log.Warning("Test is disabled on RS2 because repeater has a bug where arrow navigation scrolls instead of going to next item.");
-                        return;
-                    }
-
                     SetNavViewHeight(ControlHeight.Small);
 
                     UIObject lastItem = FindElement.ByName("TV");


### PR DESCRIPTION
Fixes #1818 

## Description
Handle arrow key navigation behavior for the NavigationView items pre-rs3. Also explicitly set `TabFocusNavigation` behavior for the Repeaters to `once` in order to ensure it behaves as expected down level.

## Motivation and Context
Down level keyboard navigation using the arrow and tab keys were not functioning as expected after the move to repeater.

## How Has This Been Tested?
Ran test corpus
