### PR TITLE
CppWinRT workaround for compiler issue in latest VS 16.4.3

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -17,8 +17,7 @@ parameters:
       buildPlatform: 'x86'
       buildConfiguration: 'debug'
       # %3b is the escape code for ';' which is used as the delimiter
-      # temporarily disabling windows.10.amd64.clientrs5.open.xaml. See #1892
-      helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml'
+      helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml%3bwindows.10.amd64.clientrs5.open.xaml'
     Release_x86:
       buildPlatform: 'x86'
       buildConfiguration: 'release'

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -17,11 +17,13 @@ parameters:
       buildPlatform: 'x86'
       buildConfiguration: 'debug'
       # %3b is the escape code for ';' which is used as the delimiter
-      helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml%3bwindows.10.amd64.clientrs5.open.xaml'
+      # temporarily disabling windows.10.amd64.clientrs5.open.xaml. See #1892
+      helixTargetQueues: 'windows.10.amd64.clientrs2.open.xaml'
     Release_x86:
       buildPlatform: 'x86'
       buildConfiguration: 'release'
-      helixTargetQueues: 'windows.10.amd64.clientrs3.open.xaml%3bwindows.10.amd64.client19h1.open.xaml'
+      # temporarily disabling windows.10.amd64.clientrs3.open.xaml See #1892
+      helixTargetQueues: 'windows.10.amd64.client19h1.open.xaml'
     Release_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'release'

--- a/dev/inc/CppWinRTIncludes.h
+++ b/dev/inc/CppWinRTIncludes.h
@@ -3,6 +3,15 @@
 
 #pragma once
 
+// After updating to VS 16.4.3 the updated compiler contains a bug that is hit by C++/WinRT resulting in crashes
+// at runtime.
+// See https://github.com/microsoft/cppwinrt/issues/486
+// The workaround from the cppwinrt team is to define '__INTELLISENSE__', which allows us to avoid the compiler issue.
+// Once the underlying issue has been resolved, we should remove this workaround.
+// Tracked by: #1877 - Remove "#define __INTELLISENSE__" from CppWinRTIncludes.h once underlying issue with cppwinrt/msvc has been resolved 
+// Also remove the corresponding #undef at the bottom of this file.
+#define __INTELLISENSE__
+
 #include <winrt\base.h>
 #include <winrt\Windows.Foundation.h>
 #include <winrt\Windows.Foundation.Collections.h>
@@ -375,3 +384,5 @@ namespace winrt
     using IElementFactory = winrt::IInspectable;
 #endif
 }
+
+#undef __INTELLISENSE__


### PR DESCRIPTION
We hit an issue in MUX.dll after the build machines got updated to VS 16.4.3. The updated compiler contains a bug that is hit by C++/WinRT.

The cppwinrt Issue is described here:
[Visual Studio 2019 version 16.4.3 produces bad code gen · Issue 486 · microsoft/cppwinrt](https://github.com/microsoft/cppwinrt/issues/486)

The workaround provided by the cppwinrt team is to #define '__INTELLISENSE__' before including the cppwinrt headers.

Removing this workaround is tracked by #1877 
