### PR TITLE
Fix issue with multiple resets causing a crash due to duplicate keys.

### DIFF
--- a/dev/Repeater/UniqueIdElementPool.h
+++ b/dev/Repeater/UniqueIdElementPool.h
@@ -17,6 +17,10 @@ public:
     auto begin() const { return m_elementMap.begin(); }
     auto end() const { return m_elementMap.end(); }
 
+#ifdef _DEBUG
+    auto IsEmpty() { return m_elementMap.size() == 0; }
+#endif
+
 private:
     ItemsRepeater* m_owner{ nullptr };
     std::map<std::wstring, tracker_ref<winrt::UIElement>> m_elementMap;

--- a/dev/Repeater/ViewManager.cpp
+++ b/dev/Repeater/ViewManager.cpp
@@ -23,7 +23,7 @@ ViewManager::ViewManager(ItemsRepeater* owner) :
 winrt::UIElement ViewManager::GetElement(int index, bool forceCreate, bool suppressAutoRecycle)
 {
     winrt::UIElement element = forceCreate ? nullptr : GetElementIfAlreadyHeldByLayout(index);
-    if(!element)
+    if (!element)
     {
         // check if this is the anchor made through repeater in preparation 
         // for a bring into view.
@@ -132,7 +132,7 @@ void ViewManager::ClearElementToElementFactory(const winrt::UIElement& element)
         children.RemoveAt(childIndex);
     }
 
-    auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);    
+    auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);
     virtInfo->MoveOwnershipToElementFactory();
     m_phaser.StopPhasing(element, virtInfo);
     if (m_lastFocusedElement == element)
@@ -296,7 +296,7 @@ void ViewManager::UpdatePin(const winrt::UIElement& element, bool addPin)
                 {
                     virtInfo->AddPin();
                 }
-                else if(virtInfo->IsPinned())
+                else if (virtInfo->IsPinned())
                 {
                     if (virtInfo->RemovePin() == 0)
                     {
@@ -446,25 +446,34 @@ void ViewManager::OnItemsSourceChanged(const winrt::IInspectable&, const winrt::
     }
 
     case winrt::NotifyCollectionChangedAction::Reset:
-        if (m_owner->ItemsSourceView().HasKeyIndexMapping())
+        // If we get multiple resets back to back before
+        // running layout, we dont have to clear all the elements again.         
+        if (!m_isDataSourceStableResetPending)
         {
-            m_isDataSourceStableResetPending = true;
-        }
+            // There should be no elements in the reset pool at this time.
+            MUX_ASSERT(m_resetPool.IsEmpty());
 
-        // Walk through all the elements and make sure they are cleared, they will go into
-        // the stable id reset pool.
-        auto children = m_owner->Children();
-        for (unsigned i = 0u; i < children.Size(); ++i)
-        {
-            auto element = children.GetAt(i);
-            auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);
-            if (virtInfo->IsRealized() && virtInfo->AutoRecycleCandidate())
+            if (m_owner->ItemsSourceView().HasKeyIndexMapping())
             {
-                m_owner->ClearElementImpl(element);
+                m_isDataSourceStableResetPending = true;
+            }
+
+            // Walk through all the elements and make sure they are cleared, they will go into
+            // the stable id reset pool.
+            auto children = m_owner->Children();
+            for (unsigned i = 0u; i < children.Size(); ++i)
+            {
+                auto element = children.GetAt(i);
+                auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);
+                if (virtInfo->IsRealized() && virtInfo->AutoRecycleCandidate())
+                {
+                    m_owner->ClearElementImpl(element);
+                }
             }
         }
 
         InvalidateRealizedIndicesHeldByLayout();
+
         break;
     }
 }
@@ -502,6 +511,9 @@ void ViewManager::OnOwnerArranged()
         }
 
         m_resetPool.Clear();
+
+        // Flush the realized indices once the stable reset pool is cleared to start fresh.
+        InvalidateRealizedIndicesHeldByLayout();
     }
 }
 
@@ -569,6 +581,10 @@ winrt::UIElement ViewManager::GetElementFromUniqueIdResetPool(int index)
             auto virtInfo = ItemsRepeater::GetVirtualizationInfo(element);
             virtInfo->MoveOwnershipToLayoutFromUniqueIdResetPool();
             UpdateElementIndex(element, virtInfo, index);
+
+            // Update realized indices
+            m_firstRealizedElementIndexHeldByLayout = std::min(m_firstRealizedElementIndexHeldByLayout, index);
+            m_lastRealizedElementIndexHeldByLayout = std::max(m_lastRealizedElementIndexHeldByLayout, index);
         }
     }
 
@@ -590,6 +606,10 @@ winrt::UIElement ViewManager::GetElementFromPinnedElements(int index)
             m_pinnedPool.erase(m_pinnedPool.begin() + i);
             element = elementInfo.PinnedElement();
             elementInfo.VirtualizationInfo()->MoveOwnershipToLayoutFromPinnedPool();
+
+            // Update realized indices
+            m_firstRealizedElementIndexHeldByLayout = std::min(m_firstRealizedElementIndexHeldByLayout, index);
+            m_lastRealizedElementIndexHeldByLayout = std::max(m_lastRealizedElementIndexHeldByLayout, index);
             break;
         }
     }
@@ -692,7 +712,7 @@ winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
             // Update phase on virtInfo. Set data and templateComponent only if x:Phase was used.
             virtInfo->UpdatePhasingInfo(nextPhase, nextPhase > 0 ? data : nullptr, nextPhase > 0 ? extension : nullptr);
         }
-        else if(auto elementAsFE = element.try_as<winrt::FrameworkElement>())
+        else if (auto elementAsFE = element.try_as<winrt::FrameworkElement>())
         {
             // Set data context only if no x:Bind was used. ie. No data template component on the root.
             // If the passed in data is a UIElement and is different from the element returned by 
@@ -736,7 +756,7 @@ winrt::UIElement ViewManager::GetElementFromElementFactory(int index)
     {
         children.Append(element);
     }
-
+    
     repeater->AnimationManager().OnElementPrepared(element);
 
     repeater->OnElementPrepared(element, index);


### PR DESCRIPTION
This causes a crash when doing filtering using unique ids and happens especially often when using an animator. 

Couple of issues here - one is that calling multiple resets back to back before a layout pass would cause a crash because we try to put the same elements into the reuse pool multiple times. This manifests occasionally when you type fast in a filter text box for example that resets the data collection. The other is that after animations complete, the ownership of containers is brought back from the animator to layout. We have an optimization for index to container lookup that didn't account for containers coming back from the animator. Due to the async nature of this, this is not a consistent crash but is hit quite often.

## Motivation and Context
Fixes #1871

## How Has This Been Tested?
Added a test
