### PR TITLE
Fix crash in selection model during SelectRange

### DIFF
--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -927,6 +927,37 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        [TestMethod]
+        public void SelectRangeRegressionTest()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var selectionModel = new SelectionModel() {
+                    Source = CreateNestedData(1, 2, 3)
+                };
+
+                // length of start smaller than end used to cause an out of range error.
+                selectionModel.SelectRange(IndexPath.CreateFrom(0), IndexPath.CreateFrom(1, 1));
+
+                ValidateSelection(selectionModel,
+                   new List<IndexPath>()
+                   {
+                       Path(0, 0),
+                       Path(0, 1),
+                       Path(0, 2),
+                       Path(0),
+                       Path(1, 0),
+                       Path(1, 1)
+                   },
+                   new List<IndexPath>()
+                   {
+                       Path(),
+                       Path(1)
+                   },
+                   1 /* selectedInnerNodes */);
+            });
+        }
+
         private void Select(SelectionModel manager, int index, bool select)
         {
             Log.Comment((select ? "Selecting " : "DeSelecting ") + index);

--- a/dev/Repeater/SelectionTreeHelper.cpp
+++ b/dev/Repeater/SelectionTreeHelper.cpp
@@ -132,25 +132,21 @@ void SelectionTreeHelper::TraverseRangeRealizeChildren(
 // static 
 bool SelectionTreeHelper::IsSubSet(const winrt::IndexPath& path, const winrt::IndexPath& subset)
 {
-    bool isSubset = true;
-
-    const auto pathSize = path.GetSize();
     const auto subsetSize = subset.GetSize();
-    if (pathSize < subsetSize)
+    if (path.GetSize() < subsetSize)
     {
-        isSubset = false;
+        return false;
     }
-    else
+
+    for (int i = 0; i < subsetSize; i++)
     {
-        for (int i = 0; i < subsetSize; i++)
+        if (path.GetAt(i) != subset.GetAt(i))
         {
-            isSubset = path.GetAt(i) == subset.GetAt(i);
-            if (!isSubset)
-                break;
+            return false;
         }
     }
 
-    return isSubset;
+    return true;
 }
 
 // static 

--- a/dev/Repeater/SelectionTreeHelper.cpp
+++ b/dev/Repeater/SelectionTreeHelper.cpp
@@ -133,11 +133,21 @@ void SelectionTreeHelper::TraverseRangeRealizeChildren(
 bool SelectionTreeHelper::IsSubSet(const winrt::IndexPath& path, const winrt::IndexPath& subset)
 {
     bool isSubset = true;
-    for (int i = 0; i < subset.GetSize(); i++)
+
+    const auto pathSize = path.GetSize();
+    const auto subsetSize = subset.GetSize();
+    if (pathSize < subsetSize)
     {
-        isSubset = path.GetAt(i) == subset.GetAt(i);
-        if (!isSubset)
-            break;
+        isSubset = false;
+    }
+    else
+    {
+        for (int i = 0; i < subsetSize; i++)
+        {
+            isSubset = path.GetAt(i) == subset.GetAt(i);
+            if (!isSubset)
+                break;
+        }
     }
 
     return isSubset;


### PR DESCRIPTION
Fix a crash in SelectRange call of selection model. Adding a vector size check before indexing into it.

## Motivation and Context
Fixes #1915
## How Has This Been Tested?
API test
