### PR TITLE
Fix TreeView expand

### DIFF
--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -95,22 +95,43 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 SetContentMode(isContentMode);
 
-                UIObject ItemRoot = LabelFirstItem();
+                UIObject itemRoot = LabelFirstItem();
 
                 ClickButton("GetItemCount");
                 Verify.AreEqual("1", ReadResult());
 
-                InputHelper.Tap(ItemRoot);
+                InputHelper.Tap(itemRoot);
 
                 // Should be expanded now
                 ClickButton("GetItemCount");
                 Verify.AreEqual("4", ReadResult());
 
-                InputHelper.Tap(ItemRoot);
+                ClickButton("AddSecondLevelOfNodes");
+                ClickButton("LabelItems");
 
-                // Should be collapsed now
+                var root0 = FindElement.ById("Root.0");
+                InputHelper.Tap(root0);
+                ClickButton("GetItemCount");
+                Verify.AreEqual("5", ReadResult());
+
+                InputHelper.Tap(itemRoot);
                 ClickButton("GetItemCount");
                 Verify.AreEqual("1", ReadResult());
+
+                InputHelper.Tap(itemRoot);
+                ClickButton("GetItemCount");
+                Verify.AreEqual("5", ReadResult());
+
+                var root1 = FindElement.ById("Root.1");
+                InputHelper.Tap(root1);
+                ClickButton("GetItemCount");
+                Verify.AreEqual("8", ReadResult());
+
+                // Collapse and expand
+                InputHelper.Tap(itemRoot);
+                InputHelper.Tap(itemRoot);
+                ClickButton("GetItemCount");
+                Verify.AreEqual("8", ReadResult());
             }
         }
 
@@ -2779,16 +2800,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 SetContentMode(true);
 
-                var root = new TreeItem(LabelFirstItem());
-                root.Expand();
-                Wait.ForIdle();
+                ClickButton("GetItemCount");
+                Verify.AreEqual("1", ReadResult());
 
+                ClickButton("ResetItemsSource");
+                Wait.ForIdle();
                 ClickButton("GetItemCount");
                 Verify.AreEqual("4", ReadResult());
 
-                ClickButton("SyncItemsSource");
+                ClickButton("ResetItemsSourceAsync");
                 Wait.ForIdle();
-                Verify.AreEqual("4", ReadResult());
+                ClickButton("GetItemCount");
+                Verify.AreEqual("6", ReadResult());
             }
         }
 

--- a/dev/TreeView/TestUI/TreeViewPage.xaml
+++ b/dev/TreeView/TestUI/TreeViewPage.xaml
@@ -71,7 +71,9 @@
                     <Button x:Name="SelectLastRootNode" AutomationProperties.Name="SelectLastRootNode" Content="SelectLastRootNode" HorizontalAlignment="Stretch" Margin="1" Click="SelectLastRootNode_Click"/>
                     <Button x:Name="TreeViewLateDataInitTestPage" AutomationProperties.Name="TreeViewLateDataInitTestPage" Content="TreeViewLateDataInitTestPage" HorizontalAlignment="Stretch" Margin="1" Click="TreeViewLateDataInitTestPage_Click"/>
                     <Button x:Name="TreeViewNodeInMarkupTestPage" AutomationProperties.Name="TreeViewNodeInMarkupTestPage" Content="TreeViewNodeInMarkupTestPage" HorizontalAlignment="Stretch" Margin="1" Click="TreeViewNodeInMarkupTestPage_Click"/>
-                    <Button x:Name="SyncItemsSource" AutomationProperties.Name="SyncItemsSource" Content="SyncItemsSource" HorizontalAlignment="Stretch" Margin="1" Click="SyncItemsSource_Click"/>
+                    <Button x:Name="ResetItemsSource" AutomationProperties.Name="ResetItemsSource" Content="ResetItemsSource" HorizontalAlignment="Stretch" Margin="1" Click="ResetItemsSource_Click"/>
+                    <Button x:Name="ResetItemsSourceAsync" AutomationProperties.Name="ResetItemsSourceAsync" Content="ResetItemsSourceAsync" HorizontalAlignment="Stretch" Margin="1" Click="ResetItemsSourceAsync_Click"/>
+                    <Button x:Name="ExpandRootNode" AutomationProperties.Name="ExpandRootNode" Content="ExpandRootNode" HorizontalAlignment="Stretch" Margin="1" Click="ExpandRootNode_Click"/>
                 </StackPanel>
             </ScrollViewer>
             <ScrollViewer Grid.Column="1">

--- a/dev/TreeView/TestUI/TreeViewPage.xaml.cs
+++ b/dev/TreeView/TestUI/TreeViewPage.xaml.cs
@@ -24,6 +24,7 @@ using TreeViewDragItemsCompletedEventArgs = Microsoft.UI.Xaml.Controls.TreeViewD
 using TreeViewList = Microsoft.UI.Xaml.Controls.TreeViewList;
 using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
 using MaterialHelperTestApi = Microsoft.UI.Private.Media.MaterialHelperTestApi;
+using System.Threading.Tasks;
 
 namespace MUXControlsTestApp
 {
@@ -70,6 +71,26 @@ namespace MUXControlsTestApp
             var root = new TreeViewItemSource() { Content = "Root", Children = { root0, root1, root2 }, IsExpanded = expandRootNode };
 
             return new ObservableCollection<TreeViewItemSource>{root};
+        }
+
+        private async Task<ObservableCollection<TreeViewItemSource>> PrepareItemsSourceAsync()
+        {
+            return await Task.Run(() => {
+                var items = PrepareItemsSource(expandRootNode: true);
+
+                var root0 = items[0].Children[0];
+                var x0 = new TreeViewItemSource { Content = "Root.0.0" };
+                root0.Children.Add(x0);
+
+                var root1 = items[0].Children[1];
+                var y0 = new TreeViewItemSource { Content = "Root.1.0" };
+                var y1 = new TreeViewItemSource { Content = "Root.1.1" };
+                root1.Children.Add(y0);
+                root1.Children.Add(y1);
+                root1.IsExpanded = true;
+
+                return items;
+            });
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
@@ -962,9 +983,20 @@ namespace MUXControlsTestApp
             ExceptionMessage.Text = string.Empty;
         }
 
-        private void SyncItemsSource_Click(object sender, RoutedEventArgs e)
+        private async void ResetItemsSourceAsync_Click(object sender, RoutedEventArgs e)
         {
-            ContentModeTestTreeView.ItemsSource = PrepareItemsSource(expandRootNode:true);
+            TestTreeViewItemsSource = await PrepareItemsSourceAsync();
+            this.Bindings.Update();
+        }
+
+        private void ResetItemsSource_Click(object sender, RoutedEventArgs e)
+        {
+            ContentModeTestTreeView.ItemsSource = PrepareItemsSource(expandRootNode: true);
+        }
+
+        private void ExpandRootNode_Click(object sender, RoutedEventArgs e)
+        {
+            TestTreeViewItemsSource[0].IsExpanded = !TestTreeViewItemsSource[0].IsExpanded;
         }
     }
 }

--- a/dev/TreeView/TreeViewItem.cpp
+++ b/dev/TreeView/TreeViewItem.cpp
@@ -331,7 +331,6 @@ void TreeViewItem::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
                 // The children have changed, validate and update GlyphOpacity
                 bool hasChildren = HasUnrealizedChildren() || treeViewNode->HasChildren();
                 GlyphOpacity(hasChildren ? 1.0 : 0.0);
-                UpdateNodeIsExpandedAsync(*treeViewNode, IsExpanded());
             }
         }
         else if (property == s_HasUnrealizedChildrenProperty)

--- a/dev/TreeView/TreeViewList.cpp
+++ b/dev/TreeView/TreeViewList.cpp
@@ -320,6 +320,15 @@ void TreeViewList::PrepareContainerForItemOverride(winrt::DependencyObject const
     {
         bool hasChildren = itemContainer.HasUnrealizedChildren() || itemNode->HasChildren();
         itemContainer.GlyphOpacity(hasChildren ? 1.0 : 0.0);
+        if (itemContainer.IsExpanded() != itemNode->IsExpanded()) {
+            auto dispatcher = winrt::Window::Current().Dispatcher();
+            auto ignore = dispatcher.RunAsync(
+                winrt::CoreDispatcherPriority::Normal,
+                winrt::DispatchedHandler([itemNode, itemContainer]()
+                    {
+                        itemNode->IsExpanded(itemContainer.IsExpanded());
+                    }));
+        }
     }
     else
     {

--- a/dev/TreeView/TreeViewList.cpp
+++ b/dev/TreeView/TreeViewList.cpp
@@ -8,8 +8,8 @@
 #include "TreeViewList.h"
 #include "TreeViewListAutomationPeer.h"
 #include "TreeViewItem.h"
-
 #include "TreeViewList.properties.cpp"
+#include "DispatcherHelper.h"
 
 TreeViewList::TreeViewList()
 {
@@ -321,13 +321,12 @@ void TreeViewList::PrepareContainerForItemOverride(winrt::DependencyObject const
         bool hasChildren = itemContainer.HasUnrealizedChildren() || itemNode->HasChildren();
         itemContainer.GlyphOpacity(hasChildren ? 1.0 : 0.0);
         if (itemContainer.IsExpanded() != itemNode->IsExpanded()) {
-            auto dispatcher = winrt::Window::Current().Dispatcher();
-            auto ignore = dispatcher.RunAsync(
-                winrt::CoreDispatcherPriority::Normal,
-                winrt::DispatchedHandler([itemNode, itemContainer]()
-                    {
-                        itemNode->IsExpanded(itemContainer.IsExpanded());
-                    }));
+            const DispatcherHelper dispatcher{ *this };
+            dispatcher.RunAsync(
+                [itemNode, itemContainer]()
+                {
+                    itemNode->IsExpanded(itemContainer.IsExpanded());
+                });
         }
     }
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We made changes in previous PR #1917 to update expand state when ItemsSource changes, it doesn't work as expected when ItemsSource is set in an async way. PrepareContainerForItemOverride is a better place to do this, this should keep the property value and actual expand state always in sync.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fix #1790.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added more interaction tests.