### PR TITLE
Fixed SelectionModelChildrenRequestedEventArgs returning incorrect source index

### DIFF
--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -314,21 +314,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     // Validate SourceIndices.
                     var expectedSourceIndices = new List<IndexPath>()
                     {
-                        Path(),
                         Path(1),
                         Path(1, 0),
-                        Path(1),
-                        Path(1, 0, 1),
-                        Path(1, 0, 1),
-                        Path(1, 0, 1),
                         Path(1, 0, 1),
                         Path(1, 1),
-                        Path(1, 1),
+                        Path(1, 0, 1, 3),
+                        Path(1, 0, 1, 2),
+                        Path(1, 0, 1, 1),
+                        Path(1, 0, 1, 0),
+                        Path(1, 1, 1),
                         Path(1, 1, 0),
-                        Path(1, 1, 0),
-                        Path(1, 1, 0),
-                        Path(1, 1, 0),
-                        Path(1, 1, 1)
+                        Path(1, 1, 0, 3),
+                        Path(1, 1, 0, 2),
+                        Path(1, 1, 0, 1),
+                        Path(1, 1, 0, 0),
+                        Path(1, 1, 1, 0)
                     };
 
                     Verify.AreEqual(expectedSourceIndices.Count, sourcePaths.Count);

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -497,7 +497,7 @@ void SelectionModel::OnSelectionInvalidatedDueToCollectionChange()
     OnSelectionChanged();
 }
 
-winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, const std::weak_ptr<SelectionNode>& sourceNode)
+winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, const winrt::IndexPath& dataIndexPath, const std::weak_ptr<SelectionNode>& sourceNode)
 {
     winrt::IInspectable resolved = nullptr;
     // Raise ChildrenRequested event if there is a handler
@@ -505,18 +505,18 @@ winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data,
     {
         if (!m_childrenRequestedEventArgs)
         {
-            m_childrenRequestedEventArgs = tracker_ref<winrt::SelectionModelChildrenRequestedEventArgs>(this, winrt::make<SelectionModelChildrenRequestedEventArgs>(data, sourceNode));
+            m_childrenRequestedEventArgs = tracker_ref<winrt::SelectionModelChildrenRequestedEventArgs>(this, winrt::make<SelectionModelChildrenRequestedEventArgs>(data, dataIndexPath, sourceNode));
         }
         else
         {
-            winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(data, sourceNode);
+            winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(data, dataIndexPath, sourceNode);
         }
 
         m_childrenRequestedEventSource(*this, m_childrenRequestedEventArgs.get());
         resolved = m_childrenRequestedEventArgs.get().Children();
 
         // Clear out the values in the args so that it cannot be used after the event handler call.
-        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, std::weak_ptr<SelectionNode>() /* empty weakptr */);
+        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, nullptr, std::weak_ptr<SelectionNode>() /* empty weakptr */);
     }
     else
     {

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -497,7 +497,7 @@ void SelectionModel::OnSelectionInvalidatedDueToCollectionChange()
     OnSelectionChanged();
 }
 
-winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, const winrt::IndexPath& dataIndexPath, const std::weak_ptr<SelectionNode>& sourceNode)
+winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data, const winrt::IndexPath& dataIndexPath)
 {
     winrt::IInspectable resolved = nullptr;
     // Raise ChildrenRequested event if there is a handler
@@ -505,18 +505,18 @@ winrt::IInspectable SelectionModel::ResolvePath(const winrt::IInspectable& data,
     {
         if (!m_childrenRequestedEventArgs)
         {
-            m_childrenRequestedEventArgs = tracker_ref<winrt::SelectionModelChildrenRequestedEventArgs>(this, winrt::make<SelectionModelChildrenRequestedEventArgs>(data, dataIndexPath, sourceNode));
+            m_childrenRequestedEventArgs = tracker_ref<winrt::SelectionModelChildrenRequestedEventArgs>(this, winrt::make<SelectionModelChildrenRequestedEventArgs>(data, dataIndexPath, false /*throwOnAccess*/));
         }
         else
         {
-            winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(data, dataIndexPath, sourceNode);
+            winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(data, dataIndexPath, false /*throwOnAccess*/);
         }
 
         m_childrenRequestedEventSource(*this, m_childrenRequestedEventArgs.get());
         resolved = m_childrenRequestedEventArgs.get().Children();
 
         // Clear out the values in the args so that it cannot be used after the event handler call.
-        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, nullptr, std::weak_ptr<SelectionNode>() /* empty weakptr */);
+        winrt::get_self<SelectionModelChildrenRequestedEventArgs>(m_childrenRequestedEventArgs.get())->Initialize(nullptr, nullptr, true /*throwOnAccess*/);
     }
     else
     {

--- a/dev/Repeater/SelectionModel.h
+++ b/dev/Repeater/SelectionModel.h
@@ -84,7 +84,7 @@ public:
     void OnPropertyChanged(winrt::hstring const& propertyName);
 #pragma endregion
 
-    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, const winrt::IndexPath& dataIndexPath, const std::weak_ptr<SelectionNode>& sourceNode);
+    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, const winrt::IndexPath& dataIndexPath);
     void OnSelectionInvalidatedDueToCollectionChange();
     std::shared_ptr<SelectionNode> SharedLeafNode() { return m_leafNode; }
 

--- a/dev/Repeater/SelectionModel.h
+++ b/dev/Repeater/SelectionModel.h
@@ -84,7 +84,7 @@ public:
     void OnPropertyChanged(winrt::hstring const& propertyName);
 #pragma endregion
 
-    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, const std::weak_ptr<SelectionNode>& sourceNode);
+    winrt::IInspectable ResolvePath(const winrt::IInspectable& data, const winrt::IndexPath& dataIndexPath, const std::weak_ptr<SelectionNode>& sourceNode);
     void OnSelectionInvalidatedDueToCollectionChange();
     std::shared_ptr<SelectionNode> SharedLeafNode() { return m_leafNode; }
 

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
@@ -27,6 +27,12 @@ winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 
 winrt::IndexPath SelectionModelChildrenRequestedEventArgs::SourceIndex()
 {
+    auto node = m_sourceNode.lock();
+    if (!node)
+    {
+        throw winrt::hresult_error(E_FAIL, L"SourceIndex can only be accesed in the ChildrenRequested event handler.");
+    }
+
     return m_sourceIndexPath.get();
 }
 

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
@@ -7,17 +7,16 @@
 #include "SelectionNode.h"
 #include "SelectionModelChildrenRequestedEventArgs.h"
 
-SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode)
+SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, bool throwOnAccess)
 {
-    Initialize(source, sourceIndexPath, sourceNode);
+    Initialize(source, sourceIndexPath, throwOnAccess);
 }
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
 
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 {
-    auto node = m_sourceNode.lock();
-    if (!node)
+    if (m_throwOnAccess)
     {
         throw winrt::hresult_error(E_FAIL, L"Source can only be accesed in the ChildrenRequested event handler.");
     }
@@ -27,8 +26,7 @@ winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 
 winrt::IndexPath SelectionModelChildrenRequestedEventArgs::SourceIndex()
 {
-    auto node = m_sourceNode.lock();
-    if (!node)
+    if (m_throwOnAccess)
     {
         throw winrt::hresult_error(E_FAIL, L"SourceIndex can only be accesed in the ChildrenRequested event handler.");
     }
@@ -48,10 +46,10 @@ void SelectionModelChildrenRequestedEventArgs::Children(winrt::IInspectable cons
 
 #pragma endregion
 
-void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode)
+void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, bool throwOnAccess)
 {
     m_source.set(source);
     m_sourceIndexPath.set(sourceIndexPath);
-    m_sourceNode = sourceNode;
+    m_throwOnAccess = throwOnAccess;
     m_children.set(nullptr);
 }

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.cpp
@@ -7,9 +7,9 @@
 #include "SelectionNode.h"
 #include "SelectionModelChildrenRequestedEventArgs.h"
 
-SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, const std::weak_ptr<SelectionNode>& sourceNode)
+SelectionModelChildrenRequestedEventArgs::SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode)
 {
-    Initialize(source, sourceNode);
+    Initialize(source, sourceIndexPath, sourceNode);
 }
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
@@ -27,13 +27,7 @@ winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Source()
 
 winrt::IndexPath SelectionModelChildrenRequestedEventArgs::SourceIndex()
 {
-    auto node = m_sourceNode.lock();
-    if (!node)
-    {
-        throw winrt::hresult_error(E_FAIL, L"SourceIndex can only be accesed in the ChildrenRequested event handler.");
-    }
-
-    return node->IndexPath();
+    return m_sourceIndexPath.get();
 }
 
 winrt::IInspectable SelectionModelChildrenRequestedEventArgs::Children()
@@ -48,9 +42,10 @@ void SelectionModelChildrenRequestedEventArgs::Children(winrt::IInspectable cons
 
 #pragma endregion
 
-void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, const std::weak_ptr<SelectionNode>& sourceNode)
+void SelectionModelChildrenRequestedEventArgs::Initialize(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode)
 {
     m_source.set(source);
+    m_sourceIndexPath.set(sourceIndexPath);
     m_sourceNode = sourceNode;
     m_children.set(nullptr);
 }

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
@@ -9,7 +9,7 @@ class SelectionModelChildrenRequestedEventArgs :
     public ReferenceTracker<SelectionModelChildrenRequestedEventArgs, winrt::implementation::SelectionModelChildrenRequestedEventArgsT, winrt::composable, winrt::composing>
 {
 public:
-    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, const std::weak_ptr<SelectionNode>& sourceNode);
+    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode);
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
     winrt::IInspectable Source();
@@ -18,10 +18,11 @@ public:
     void Children(winrt::IInspectable const& value);
 #pragma endregion
 
-    void Initialize(const winrt::IInspectable& source, const std::weak_ptr<SelectionNode>& sourceNode);
+    void Initialize(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode);
 
 private:
     tracker_ref<winrt::IInspectable> m_source{ this };
+    tracker_ref<winrt::IndexPath> m_sourceIndexPath{ this };
     tracker_ref<winrt::IInspectable> m_children{ this };
     std::weak_ptr<SelectionNode> m_sourceNode;
 };

--- a/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
+++ b/dev/Repeater/SelectionModelChildrenRequestedEventArgs.h
@@ -9,7 +9,7 @@ class SelectionModelChildrenRequestedEventArgs :
     public ReferenceTracker<SelectionModelChildrenRequestedEventArgs, winrt::implementation::SelectionModelChildrenRequestedEventArgsT, winrt::composable, winrt::composing>
 {
 public:
-    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode);
+    SelectionModelChildrenRequestedEventArgs(const winrt::IInspectable& data, const winrt::IndexPath& sourceIndexPath, bool throwOnAccess);
 
 #pragma region ISelectionModelChildrenRequestedEventArgs
     winrt::IInspectable Source();
@@ -18,11 +18,13 @@ public:
     void Children(winrt::IInspectable const& value);
 #pragma endregion
 
-    void Initialize(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, const std::weak_ptr<SelectionNode>& sourceNode);
+    void Initialize(const winrt::IInspectable& source, const winrt::IndexPath& sourceIndexPath, bool throwOnAccess);
 
 private:
     tracker_ref<winrt::IInspectable> m_source{ this };
     tracker_ref<winrt::IndexPath> m_sourceIndexPath{ this };
     tracker_ref<winrt::IInspectable> m_children{ this };
-    std::weak_ptr<SelectionNode> m_sourceNode;
+    // This flag allows for the re-use of a SelectionModelChildrenRequestedEventArgs object.
+    // We do not want someone to cache the args object and access its properties later on, so we use this flag to only allow property access in the ChildrenRequested event handler.
+    bool m_throwOnAccess{ true };
 };

--- a/dev/Repeater/SelectionNode.cpp
+++ b/dev/Repeater/SelectionNode.cpp
@@ -127,7 +127,7 @@ std::shared_ptr<SelectionNode> SelectionNode::GetAt(int index, bool realizeChild
             if (childData != nullptr)
             {
                 auto const childDataIndexPath = winrt::get_self<class IndexPath>(IndexPath())->CloneWithChildIndex(index);
-                auto resolvedChild = m_manager->ResolvePath(childData, childDataIndexPath, weak_from_this());
+                auto resolvedChild = m_manager->ResolvePath(childData, childDataIndexPath);
                 if (resolvedChild != nullptr)
                 {
                     child = std::make_shared<SelectionNode>(m_manager, this /* parent */);

--- a/dev/Repeater/SelectionNode.cpp
+++ b/dev/Repeater/SelectionNode.cpp
@@ -126,7 +126,8 @@ std::shared_ptr<SelectionNode> SelectionNode::GetAt(int index, bool realizeChild
             auto childData = m_dataSource.get().GetAt(index);
             if (childData != nullptr)
             {
-                auto resolvedChild = m_manager->ResolvePath(childData, weak_from_this());
+                auto const childDataIndexPath = winrt::get_self<class IndexPath>(IndexPath())->CloneWithChildIndex(index);
+                auto resolvedChild = m_manager->ResolvePath(childData, childDataIndexPath, weak_from_this());
                 if (resolvedChild != nullptr)
                 {
                     child = std::make_shared<SelectionNode>(m_manager, this /* parent */);


### PR DESCRIPTION
Fixes #1962 

## Description
The incorrect `IndexPath` is being returned when retrieving the `SourceIndex` parameter from `SelectionModelChildrenRequestedEventArgs`. It returns the `Source`'s parent's `IndexPath`.
Updated the args to store and return the source's actual `IndexPath`.

## Motivation and Context
We want the `SourceIndex` to match the actual index of the `Source` object that is being passed through the args object.

## How Has This Been Tested?
Updated API test to expect this behavior 