### PR TITLE
Unregister Window::SizeChanged event in TwoPaneView to prevent crashes with C++ apps

### DIFF
--- a/dev/TwoPaneView/TwoPaneView.cpp
+++ b/dev/TwoPaneView/TwoPaneView.cpp
@@ -26,9 +26,14 @@ TwoPaneView::TwoPaneView()
     SetDefaultStyleKey(this);
 
     SizeChanged({ this, &TwoPaneView::OnSizeChanged });
-    winrt::Window::Current().SizeChanged({ this, &TwoPaneView::OnWindowSizeChanged });
+    m_windowSizeChangedToken = winrt::Window::Current().SizeChanged({ this, &TwoPaneView::OnWindowSizeChanged });
 
     EnsureProperties();
+}
+
+TwoPaneView::~TwoPaneView()
+{
+    winrt::Window::Current().SizeChanged(m_windowSizeChangedToken);
 }
 
 void TwoPaneView::OnApplyTemplate()
@@ -124,7 +129,7 @@ void TwoPaneView::UpdateMode()
     DisplayRegionHelperInfo info = DisplayRegionHelper::GetRegionInfo();
     winrt::Rect rcControl = GetControlRect();
     bool isInMultipleRegions = IsInMultipleRegions(info, rcControl);
-    
+
     if (isInMultipleRegions)
     {
         if (info.Mode == winrt::TwoPaneViewMode::Wide)

--- a/dev/TwoPaneView/TwoPaneView.cpp
+++ b/dev/TwoPaneView/TwoPaneView.cpp
@@ -26,14 +26,9 @@ TwoPaneView::TwoPaneView()
     SetDefaultStyleKey(this);
 
     SizeChanged({ this, &TwoPaneView::OnSizeChanged });
-    m_windowSizeChangedToken = winrt::Window::Current().SizeChanged({ this, &TwoPaneView::OnWindowSizeChanged });
+    m_windowSizeChangedRevoker = winrt::Window::Current().SizeChanged(winrt::auto_revoke, { this, &TwoPaneView::OnWindowSizeChanged });
 
     EnsureProperties();
-}
-
-TwoPaneView::~TwoPaneView()
-{
-    winrt::Window::Current().SizeChanged(m_windowSizeChangedToken);
 }
 
 void TwoPaneView::OnApplyTemplate()

--- a/dev/TwoPaneView/TwoPaneView.h
+++ b/dev/TwoPaneView/TwoPaneView.h
@@ -31,7 +31,6 @@ class TwoPaneView :
 {
 public:
     TwoPaneView();
-    virtual ~TwoPaneView();
 
     // IFrameworkElement
     void OnApplyTemplate();
@@ -65,6 +64,6 @@ private:
     tracker_ref<winrt::RowDefinition> m_rowTop{ this };
     tracker_ref<winrt::RowDefinition> m_rowMiddle{ this };
     tracker_ref<winrt::RowDefinition> m_rowBottom{ this };
-    winrt::event_token m_windowSizeChangedToken{};
+    winrt::IWindow::SizeChanged_revoker m_windowSizeChangedRevoker{};
 
 };

--- a/dev/TwoPaneView/TwoPaneView.h
+++ b/dev/TwoPaneView/TwoPaneView.h
@@ -31,6 +31,7 @@ class TwoPaneView :
 {
 public:
     TwoPaneView();
+    virtual ~TwoPaneView();
 
     // IFrameworkElement
     void OnApplyTemplate();
@@ -64,4 +65,6 @@ private:
     tracker_ref<winrt::RowDefinition> m_rowTop{ this };
     tracker_ref<winrt::RowDefinition> m_rowMiddle{ this };
     tracker_ref<winrt::RowDefinition> m_rowBottom{ this };
+    winrt::event_token m_windowSizeChangedToken{};
+
 };


### PR DESCRIPTION
## Description

TwoPaneView crashes with C++ apps if the page hosting the control isn't one currently displayed and if the window is resized (manually, change screen orientation, span/unspan the window, ...)

TwoPaneView registers to "Windows::SizeChanged" events and never unregisters them. After navigation, the instance of TwoPaneView from the first page is destroyed (destructor called), but the event is still registered which will crash the application when the system will try to call the callback method.

This PR simply unregisters Window::SizeChanged event in TwoPaneView's destructor to prevent crashes.

## Motivation and Context
Fixes #2044 

## How Has This Been Tested?
Tested on Windows 10 Desktop and Windows 10X
