### PR TITLE
Add binary version to emitted telemetry to distinguish between versions of the same type

### DIFF
--- a/dev/Telemetry/RuntimeProfiler.cpp
+++ b/dev/Telemetry/RuntimeProfiler.cpp
@@ -11,6 +11,9 @@
 #define DEFINE_PROFILEGROUP(name, group, size) \
     CMethodProfileGroup<size>        name(group)
 
+// defined in dllmain.cpp with values from version.h
+extern const char *g_BinaryVersion;
+
 namespace RuntimeProfiler {
 
     void UninitializeRuntimeProfiler();
@@ -161,7 +164,8 @@ namespace RuntimeProfiler {
             TraceLoggingWrite(  
                 g_hTelemetryProvider,  
                 "RuntimeProfiler",
-                TraceLoggingDescription("XAML methods that have been called."),  
+                TraceLoggingDescription("XAML methods that have been called."),
+                TraceLoggingString(g_BinaryVersion, "BinaryVersion"),
                 TraceLoggingWideString(OutputBuffer, "ApiCounts"),
                 TraceLoggingUInt32(((UINT32)m_group), "ProfileGroupId"),
                 TraceLoggingUInt32(((UINT32)cMethods),"TotalCount"),

--- a/dev/dll/dllmain.cpp
+++ b/dev/dll/dllmain.cpp
@@ -4,8 +4,12 @@
 #include "pch.h"
 #include "common.h"
 #include "TraceLogging.h"
+#include "version.h"
 
 HINSTANCE g_hInstance = nullptr;
+
+// Version string to send on telemetry events, this is the version string that is used in the version resource
+const char *g_BinaryVersion = (const char *)(VER_FILE_VERSION_STR);
 
 STDAPI_(void) SendTelemetryOnSuspend();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pulling the definition of the version string (in version.h, used to construct the version resource) into a global constant and emitting that version string in RuntimeProfiler telemetry, which does our instance counting telemetry per type.

## Motivation and Context
This change allows us to accurately count instances of types **_per version_**, which is important when features have been added to later versions of types.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
Verified the new field ("BinaryVersion") was added to the payload for the RuntimeProfiler event.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->