### PR TITLE
Fix for Issue:2066 - around-the-end segments were played incorrectly

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -66,7 +66,7 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
             auto timeToEnd = (1 - m_fromProgress) / ((1 - m_fromProgress) + m_toProgress);
             animation.InsertKeyFrame(timeToEnd, 1, linearEasing);
             // Jump to the beginning.
-            animation.InsertKeyFrame(::nextafterf(timeToEnd, 0), 0, linearEasing);
+            animation.InsertKeyFrame(::nextafterf(timeToEnd, 1), 0, linearEasing);
         }
 
         // Play to toProgress
@@ -477,7 +477,7 @@ winrt::Size AnimatedVisualPlayer::MeasureOverride(winrt::Size const& availableSi
     auto heightScale = ((availableSize.Height == std::numeric_limits<double>::infinity()) ? FLT_MAX : availableSize.Height) / m_animatedVisualSize.y;
     return (heightScale > widthScale)
         ? winrt::Size{ availableSize.Width, m_animatedVisualSize.y * widthScale }
-    : winrt::Size{ m_animatedVisualSize.x * heightScale, availableSize.Height };
+        : winrt::Size{ m_animatedVisualSize.x * heightScale, availableSize.Height };
 }
 
 // Public API.

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
@@ -46,6 +46,7 @@
                 <TextBlock Text="Actions" Style="{ThemeResource StandardGroupHeader}"/>
                 <Button x:Name="PlayButton" Click="PlayButton_Click">Play forwards from 0 to 1</Button>
                 <Button x:Name="ToZeroKeyframeAnimationPlayButton" Click="ToZeroKeyframeAnimationPlayButton_Click">Play forwards from 0.35 to 0</Button>
+                <Button x:Name="AroundTheEndAnimationPlayButton" Click="AroundTheEndAnimationPlayButton_Click">Play forwards from 0.35 to 0.3</Button>
                 <Button x:Name="FromOneKeyframeAnimationPlayButton" Click="FromOneKeyframeAnimationPlayButton_Click">Play forwards from 1 to 0.35</Button>
                 <Button x:Name="ReverseNegativePlaybackRateAnimationPlayButton" Click="ReverseNegativePlaybackRateAnimationPlayButton_Click">Play backwards from 1 to 0.5 then forwards from 0.5 to 1</Button>
                 <Button x:Name="ReversePositivePlaybackRateAnimationPlayButton" Click="ReversePositivePlaybackRateAnimationPlayButton_Click">Play forwards from 0 to 0.5 then backwards from 0.5 to 0</Button>
@@ -57,18 +58,21 @@
 
                 <StackPanel Margin="0,0,8,0">
                     <TextBlock Text="General"  FontSize="18"/>
-                    <TextBox x:Name="ProgressTextBox" Header="Current status"/>
-                    <TextBox x:Name="IsPlayingTextBoxBeforePlaying" Header="Started playing"/>
-                    <TextBox x:Name="IsPlayingTextBoxBeingPlaying" Header="Is playing"/>
-                    <TextBox x:Name="FallenBackTextBox" Header="Fallback working"/>
+                    <TextBox Text="{x:Bind Player.IsPlaying,Mode=OneWay}" Header="Is playing"/>
+                    <TextBox Text="{x:Bind Player.PlaybackRate,Mode=OneWay}" Header="Playback rate"/>
+                    <TextBox x:Name="IsPlayingTextBoxBeforePlaying" Header="IsPlaying state before playing"/>
+                    <TextBox x:Name="IsPlayingTextBoxBeingPlaying" Header="IsPlaying state during playing"/>
                 </StackPanel>
                 <StackPanel Margin="0,0,0,0">
                     <TextBlock Text="Specific scenarios" FontSize="18"/>
                     <TextBox x:Name="HittestingTextBox" Header="Pointer status"/>
+                    <TextBox x:Name="ProgressTextBox" Header="Animate 0 to 1 status"/>
                     <TextBox x:Name="ToZeroKeyframeAnimationProgressTextBox" Header="Animate to 0 status"/>
+                    <TextBox x:Name="AroundTheEndAnimationProgressTextBox" Header="Animate 0.35 to 0.3 status"/>
                     <TextBox x:Name="FromOneKeyframeAnimationProgressTextBox" Header="Animate from 1 status"/>
                     <TextBox x:Name="ReverseNegativePlaybackRateAnimationTextBox" Header="Animate backwards (negative rate) status"/>
                     <TextBox x:Name="ReversePositivePlaybackRateAnimationTextBox" Header="Animate backwards (positive rate) status"/>
+                    <TextBox x:Name="FallenBackTextBox" Header="Fallback working"/>
                 </StackPanel>
 
             </StackPanel>


### PR DESCRIPTION
Fix for Issue:2066 - around-the-end segments were played incorrectly

## Description
The bug was introduced by an earlier change that got the direction wrong in a call to ::nextafterf which meant that we jumped backwards in time instead of continuing forwards.
I've added a test for around-the-end segments, and did a big cleanup of our tests because I was struggling to understand them.

## Motivation and Context
"Fixes #2066"

## How Has This Been Tested?
I ran the automated tests. And fixed up the automated tests to make them more reliable after having issues with them.
