### PR TITLE
StackLayout incorrect sizing bug

### DIFF
--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -193,6 +193,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
+        public void ValidateStackLayoutDoesNotRetainIncorrectMinorWidth()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var repeater = new ItemsRepeater();
+                var stackLayout = new StackLayout();
+                repeater.Layout = stackLayout;
+                repeater.ItemsSource = Enumerable.Range(0, 1);
+                repeater.ItemTemplate = (DataTemplate)XamlReader.Load(
+                    @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+                         <Button Content='{Binding}' Height='100' />
+                    </DataTemplate>");
+                var scrollViewer = new ScrollViewer() {
+                    Content = repeater
+                };
+                scrollViewer.Width = 300;
+                Content = scrollViewer;
+                Content.UpdateLayout();
+
+                repeater.Measure(new Size(600, 100));
+                Content.UpdateLayout();
+
+                Verify.AreEqual(repeater.ActualSize.X, 300);
+            });
+        }
+
+        [TestMethod]
         public void ValidateStackLayoutDisabledVirtualizationWithItemsRepeater()
         {
             RunOnUIThread.Execute(() =>

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -197,25 +197,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         {
             RunOnUIThread.Execute(() =>
             {
-                var repeater = new ItemsRepeater();
-                var stackLayout = new StackLayout();
-                repeater.Layout = stackLayout;
-                repeater.ItemsSource = Enumerable.Range(0, 1);
-                repeater.ItemTemplate = (DataTemplate)XamlReader.Load(
+                var repeater = new ItemsRepeater() {
+                    ItemsSource = Enumerable.Range(0, 1),
+                    Layout = new StackLayout(),
+                    ItemTemplate = (DataTemplate)XamlReader.Load(
                     @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
                          <Button Content='{Binding}' Height='100' />
-                    </DataTemplate>");
+                    </DataTemplate>")
+                };
                 var scrollViewer = new ScrollViewer() {
+                    Width = 300,
                     Content = repeater
                 };
-                scrollViewer.Width = 300;
                 Content = scrollViewer;
                 Content.UpdateLayout();
-
                 repeater.Measure(new Size(600, 100));
                 Content.UpdateLayout();
-
-                Verify.AreEqual(repeater.ActualSize.X, 300);
+                Verify.AreEqual(repeater.ActualWidth, 300);
             });
         }
 

--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -197,23 +197,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         {
             RunOnUIThread.Execute(() =>
             {
-                var repeater = new ItemsRepeater() {
-                    ItemsSource = Enumerable.Range(0, 1),
-                    Layout = new StackLayout(),
-                    ItemTemplate = (DataTemplate)XamlReader.Load(
-                    @"<DataTemplate  xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
-                         <Button Content='{Binding}' Height='100' />
-                    </DataTemplate>")
+                var repeater = new ItemsRepeater() 
+                {
+                    ItemsSource = Enumerable.Range(0, 1)
                 };
-                var scrollViewer = new ScrollViewer() {
-                    Width = 300,
-                    Content = repeater
+
+                Content = new ScrollViewer() 
+                {
+                    Content = repeater,
+                    Width = 400,
                 };
-                Content = scrollViewer;
+
                 Content.UpdateLayout();
+
+                // Measure with large width.
                 repeater.Measure(new Size(600, 100));
+                Verify.AreEqual(600, repeater.DesiredSize.Width);
+                // Measure with smaller width again before arrange. 
+                // StackLayout has to pick up the smaller width for its extent.
+                repeater.Measure(new Size(300, 100));
+                Verify.AreEqual(300, repeater.DesiredSize.Width);
+
                 Content.UpdateLayout();
-                Verify.AreEqual(repeater.ActualWidth, 300);
+                Verify.AreEqual(400, repeater.ActualWidth);
             });
         }
 

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -57,7 +57,7 @@ winrt::Size StackLayout::MeasureOverride(
     winrt::VirtualizingLayoutContext const& context,
     winrt::Size const& availableSize)
 {
-    GetAsStackState(context.LayoutState())->OnArrangeLayoutEnd();
+    GetAsStackState(context.LayoutState())->OnMeasureStart();
 
     auto desiredSize = GetFlowAlgorithm(context).Measure(
         availableSize,

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -57,6 +57,8 @@ winrt::Size StackLayout::MeasureOverride(
     winrt::VirtualizingLayoutContext const& context,
     winrt::Size const& availableSize)
 {
+    GetAsStackState(context.LayoutState())->OnArrangeLayoutEnd();
+
     auto desiredSize = GetFlowAlgorithm(context).Measure(
         availableSize,
         context,
@@ -80,8 +82,6 @@ winrt::Size StackLayout::ArrangeOverride(
         false, /* isWraping */
         FlowLayoutAlgorithm::LineAlignment::Start,
         LayoutId());
-
-    GetAsStackState(context.LayoutState())->OnArrangeLayoutEnd();
 
     return { value.Width, value.Height };
 }

--- a/dev/Repeater/StackLayoutState.cpp
+++ b/dev/Repeater/StackLayoutState.cpp
@@ -43,7 +43,7 @@ void StackLayoutState::OnElementMeasured(int elementIndex, double majorSize, dou
     m_maxArrangeBounds = std::max(m_maxArrangeBounds, minorSize);
 }
 
-void StackLayoutState::OnArrangeLayoutEnd()
+void StackLayoutState::OnMeasureStart()
 {
     m_maxArrangeBounds = 0.0;
 }

--- a/dev/Repeater/StackLayoutState.h
+++ b/dev/Repeater/StackLayoutState.h
@@ -15,7 +15,7 @@ public:
         IFlowLayoutAlgorithmDelegates* callbacks);
     void UninitializeForContext(const winrt::VirtualizingLayoutContext& context);
     void OnElementMeasured(int elementIndex, double majorSize, double minorSize);
-    void OnArrangeLayoutEnd();
+    void OnMeasureStart();
 
     ::FlowLayoutAlgorithm& FlowAlgorithm() { return m_flowAlgorithm; }
     double TotalElementSize() const { return m_totalElementSize; }


### PR DESCRIPTION
Fixes #2071 

## Description
Calling Measure on StackLayout multiple times before Arrange causes it to size itself based on the largest element size it sees across the multiple Measure calls. Made a change so that this max size is calculated for every individual measure call.

## Motivation and Context
This bug can results in items getting sized incorrectly when the available size differs across the measure calls.

## How Has This Been Tested?
Added an API test