### PR TITLE
Button foreground lightstyling issue

### DIFF
--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -161,9 +161,6 @@
                                 <VisualState x:Name="Normal">
                                     <Storyboard>
                                         <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForeground}" />
-                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="PointerOver">
@@ -228,6 +225,7 @@
                         x:Name="ContentPresenter"
                         Background="{TemplateBinding Background}"
                         contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                        Foreground="{TemplateBinding Foreground}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Content="{TemplateBinding Content}"

--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -161,6 +161,9 @@
                                 <VisualState x:Name="Normal">
                                     <Storyboard>
                                         <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForeground}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="PointerOver">

--- a/dev/CommonStyles/TestUI/CommonStylesPage.xaml
+++ b/dev/CommonStyles/TestUI/CommonStylesPage.xaml
@@ -8,7 +8,10 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
+    
+    <ScrollViewer Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12"
+        HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Visible"
+        VerticalScrollMode="Disabled" HorizontalAlignment="Stretch">
         <StackPanel>
             <TextBlock Text="Control samples" Style="{ThemeResource StandardGroupHeader}" HorizontalAlignment="Center"/>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" BorderBrush="Transparent">
@@ -215,12 +218,27 @@
                         <RichEditBox Grid.Row="6" Header="RichEditBox" VerticalAlignment="Top" />
                     </Grid>
                 </StackPanel>
-                <StackPanel>
+                <StackPanel Style="{ThemeResource CompactPanelStyle}">
                     <!-- If there are styles we need to ensure that are available, they can be placed below this TextBlock -->
                     <TextBlock Text="Default style availability area" Style="{ThemeResource StandardGroupHeader}"/>
 
                     <!-- Checking that the DefaultRadioButtonStyle can be accessed as resource -->
                     <RadioButton Style="{StaticResource DefaultRadioButtonStyle}" Content="I am a RadioButton with DefaultRadioButtonStyle set" />
+
+                </StackPanel>
+                <StackPanel Style="{ThemeResource CompactPanelStyle}">
+                    <TextBlock  Text="Miscellaneous testing area" Style="{ThemeResource StandardGroupHeader}"/>
+                    <Button Width="200" Height="40" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Button.Resources>
+                            <ResourceDictionary>
+                                <SolidColorBrush x:Key="ButtonForeground" Color="Red"></SolidColorBrush>
+                                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="Teal"></SolidColorBrush>
+                                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="Aqua"></SolidColorBrush>
+                                <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Green"></SolidColorBrush>
+                            </ResourceDictionary>
+                        </Button.Resources>
+                        <FontIcon Glyph="&#xE781;" />
+                    </Button>
                 </StackPanel>
             </StackPanel>
             <StackPanel>
@@ -243,5 +261,5 @@
                 </StackPanel>
             </StackPanel>
         </StackPanel>
-    </Grid>
+    </ScrollViewer>
 </local:TestPage>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a setter to visual state to reapply the light styling themeresource for Foreground of buttons.
Only Foreground needs this "adjustment", background and borderbrush reset correctly.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Should fix #1135
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

![button-foreground-lightstyling-issue](https://user-images.githubusercontent.com/16122379/76151245-1f5fb580-60b3-11ea-8298-e8f953e5b80a.gif)
