### PR TITLE
Try reading a registry value to get the root path to the installed Wind…

### DIFF
--- a/test/MUXControls.Test/MUXControls.Test.Shared.projitems
+++ b/test/MUXControls.Test/MUXControls.Test.Shared.projitems
@@ -26,6 +26,7 @@
     <LangVersion>$(CSLangVersion)</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="$(BuildingWithBuildExe) != 'true'">
+    <UniversalCRTSdkDir Condition="'$(UniversalCRTSdkDir)' == ''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots@KitsRoot10)</UniversalCRTSdkDir>
     <UniversalCRTSdkDir Condition="'$(UniversalCRTSdkDir)' == ''">$(MSBuildProgramFiles32)\Windows Kits\10</UniversalCRTSdkDir>
     <WindowsMetadataPath>$(UniversalCRTSdkDir)\UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
     <AssemblyName>MUXControls.Test</AssemblyName>

--- a/test/MUXControls.Test/MUXControls.Test.Shared.projitems
+++ b/test/MUXControls.Test/MUXControls.Test.Shared.projitems
@@ -27,8 +27,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(BuildingWithBuildExe) != 'true'">
     <UniversalCRTSdkDir Condition="'$(UniversalCRTSdkDir)' == ''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots@KitsRoot10)</UniversalCRTSdkDir>
-    <UniversalCRTSdkDir Condition="'$(UniversalCRTSdkDir)' == ''">$(MSBuildProgramFiles32)\Windows Kits\10</UniversalCRTSdkDir>
-    <WindowsMetadataPath>$(UniversalCRTSdkDir)\UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
+    <UniversalCRTSdkDir Condition="'$(UniversalCRTSdkDir)' == ''">$(MSBuildProgramFiles32)\Windows Kits\10\</UniversalCRTSdkDir>
+    <WindowsMetadataPath>$(UniversalCRTSdkDir)UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
     <AssemblyName>MUXControls.Test</AssemblyName>
     <!-- We are using .NetCore because we are targetting CoreCLR but with Windows UAP support. It maps to netcore50 in the project.json file. 
          If you don't need UAP support, for example you are just driving UI with Microsoft.Windows.Apps.Test, you should build with .NETPlatform,Version=5.4. This maps to dotnet54 in the project.json file.


### PR DESCRIPTION
…ows SDK.

## Description
When the Windows SDK is installed in a custom location (so not `C:\Program Files (x86)\Windows Kits\...`) the MUXControls.TestApp cannot find the referenced `windows.winmd` file causing build failures when attempting to run interaction tests (via TestExplorer for example).

This PR attempts to fix this issue by reading a registry value containing the path to the installed Windows SDK. The value in question is `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Kits\Installed Roots@KitsRoot10`. If this value does not exist we fall back to the currently obtained path using `MSBuildProgramFiles32`.

## Motivation and Context
Fixes #2088.

## How Has This Been Tested?
Tested on my local machine.

## Additional info
WIth this fix, the path to the windows.winmd file obtained looks, for example, like this:
![image](https://user-images.githubusercontent.com/1398851/76518886-38c08300-6460-11ea-9164-b44fb0ef41a0.png)

Note the double backslashes `...\10\\UnionMetadata\...`. This happens because the registry value is a path containing a trailing backslash and we also manually add a backslash between `$(UniversalCRTSdkDir)` and `UnionMetadata`.

There is no issue on my local machine with the double backslashes. In case this will cause an issue in the Build pipeline though, a possible fix would be to remove the manually added backslash and add a trailing backslash when we define `UniversalCRTSdkDir` in the fallback option using 
`MSBuildProgramFiles32`, like so:
```
<UniversalCRTSdkDir Condition="'$(UniversalCRTSdkDir)' == ''">$(MSBuildProgramFiles32)\Windows Kits\10\</UniversalCRTSdkDir>
<WindowsMetadataPath>$(UniversalCRTSdkDir)UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
```
Perhaps we could also remove the trailing backslash from the registry value if that's possible and preferred to above.

## Screenshots
Pic showing the registry value:
![image](https://user-images.githubusercontent.com/1398851/76519146-b8e6e880-6460-11ea-942b-96c573011f87.png)
