### PR TITLE
Fix Discord invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
           <h2>Resources that empower your development experience.</h2><br/>
           <h4>With expansive documentation, videos, blog posts, and recorded monthly Community Calls where you get your questions answered, WinUI is rich with educational materials designed to empower you and your development decisions.</h4>
           <br/><br/>
-          <h4>Get connected with us on <a href="https://twitter.com/WindowsUI">Twitter</a> and <a href="https://discord.gg/mzvxKf">Discord</a>, and file issues or feature requests on our <a href="https://github.com/microsoft/microsoft-ui-xaml">Github repository</a>.</h4>
+          <h4>Get connected with us on <a href="https://twitter.com/WindowsUI">Twitter</a> and <a href="https://discord.gg/PF8FCHZ">Discord</a>, and file issues or feature requests on our <a href="https://github.com/microsoft/microsoft-ui-xaml">Github repository</a>.</h4>
           <br/><br/>
           <h4>Our next community call is on:</h4>
           <h4><span style="font-weight: 600; margin-top: 5px;"> March 18, 2020<span style="vertical-align: text-top;"> |</span> </span> <i class="icon-calendar m-auto text-icon"></i><span id="add-to-cal"><a href="./WinUICommunityCall.ics"> Add to calendar</a></span></h4>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where the user generated Discord server link for the "UWP Community" server was expired, which meant that it prevented folks from joining the server.

The solution to this was to generate a permanent invite link.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
This change was required because it prevented folks from joining the "UWP Community" Discord server, where the "win-ui" channel currently resides.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
N/A