### PR TITLE
ProgressRing State Transitions Inconsistency Fix

### DIFF
--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -12,20 +12,20 @@
 float GetCircleRadius(double thickness, double actualWidth);
 winrt::float4 Color4(winrt::Color color);
 
-static constexpr wstring_view s_LayoutRootName{ L"LayoutRoot" };
-static constexpr wstring_view s_OutlinePathName{ L"OutlinePathPart" };
-static constexpr wstring_view s_OutlineFigureName{ L"OutlineFigurePart" };
-static constexpr wstring_view s_OutlineArcName{ L"OutlineArcPart" };
-static constexpr wstring_view s_RingPathName{ L"RingPathPart" };
-static constexpr wstring_view s_RingFigureName{ L"RingFigurePart" };
-static constexpr wstring_view s_RingArcName{ L"RingArcPart" };
-static constexpr wstring_view s_LottiePlayerName{ L"LottiePlayer" };
-static constexpr wstring_view s_DeterminateStateName{ L"Determinate" };
-static constexpr wstring_view s_IndeterminateStateName{ L"Indeterminate" };
-static constexpr wstring_view s_DefaultForegroundThemeResourceName{ L"SystemControlHighlightAccentBrush" };
-static constexpr wstring_view s_DefaultBackgroundThemeResourceName{ L"SystemControlBackgroundBaseLowBrush" };
-static constexpr wstring_view s_ForegroundName{ L"Foreground" };
-static constexpr wstring_view s_BackgroundName{ L"Background" };
+static constexpr wstring_view s_LayoutRootName{ L"LayoutRoot"sv };
+static constexpr wstring_view s_OutlinePathName{ L"OutlinePathPart"sv };
+static constexpr wstring_view s_OutlineFigureName{ L"OutlineFigurePart"sv };
+static constexpr wstring_view s_OutlineArcName{ L"OutlineArcPart"sv };
+static constexpr wstring_view s_RingPathName{ L"RingPathPart"sv };
+static constexpr wstring_view s_RingFigureName{ L"RingFigurePart"sv };
+static constexpr wstring_view s_RingArcName{ L"RingArcPart"sv };
+static constexpr wstring_view s_LottiePlayerName{ L"LottiePlayer"sv };
+static constexpr wstring_view s_DeterminateStateName{ L"Determinate"sv };
+static constexpr wstring_view s_IndeterminateStateName{ L"Indeterminate"sv };
+static constexpr wstring_view s_DefaultForegroundThemeResourceName{ L"SystemControlHighlightAccentBrush"sv };
+static constexpr wstring_view s_DefaultBackgroundThemeResourceName{ L"SystemControlBackgroundBaseLowBrush"sv };
+static constexpr wstring_view s_ForegroundName{ L"Foreground"sv };
+static constexpr wstring_view s_BackgroundName{ L"Background"sv };
 
 ProgressRing::ProgressRing()
 {
@@ -55,7 +55,17 @@ void ProgressRing::OnApplyTemplate()
     m_ringPath.set(GetTemplateChildT<winrt::Path>(s_RingPathName, controlProtected));
     m_ringFigure.set(GetTemplateChildT<winrt::PathFigure>(s_RingFigureName, controlProtected));
     m_ringArc.set(GetTemplateChildT<winrt::ArcSegment>(s_RingArcName, controlProtected));
-    m_player.set(GetTemplateChildT<winrt::AnimatedVisualPlayer>(s_LottiePlayerName, controlProtected));
+    //m_player.set(GetTemplateChildT<winrt::AnimatedVisualPlayer>(s_LottiePlayerName, controlProtected));
+
+    m_player.set([this, controlProtected]()
+    {
+        auto const player = GetTemplateChildT<winrt::AnimatedVisualPlayer>(s_LottiePlayerName, controlProtected);
+        if (player)
+        {
+            player.RegisterPropertyChangedCallback(winrt::UIElement::OpacityProperty(), { this, &ProgressRing::OnOpacityPropertyChanged });
+        }
+        return player;
+    }());
 
     GetStrokeThickness();
     ApplyLottieAnimation();
@@ -112,6 +122,17 @@ void ProgressRing::OnBackgroundColorPropertyChanged(const winrt::DependencyObjec
         if (auto const progressRingIndeterminate = player.Source().try_as<AnimatedVisuals::ProgressRingIndeterminate>())
         {
             SetLottieBackgroundColor(progressRingIndeterminate);
+        }
+    }
+}
+
+void ProgressRing::OnOpacityPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&)
+{
+    if (auto&& player = m_player.get())
+    {
+        if (player.Opacity() == 0)
+        {
+            player.Stop();
         }
     }
 }
@@ -194,10 +215,11 @@ void ProgressRing::UpdateStates()
     {
         winrt::VisualStateManager::GoToState(*this, s_DeterminateStateName, true);
 
-        if (auto&& player = m_player.get())
-        {
-            player.Stop();
-        }
+        //if (auto&& player = m_player.get())
+        //{
+        //    const auto _ = player.PlayAsync(0, 1, false);
+        //    //player.Stop();
+        //}
     }
 }
 

--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -55,7 +55,6 @@ void ProgressRing::OnApplyTemplate()
     m_ringPath.set(GetTemplateChildT<winrt::Path>(s_RingPathName, controlProtected));
     m_ringFigure.set(GetTemplateChildT<winrt::PathFigure>(s_RingFigureName, controlProtected));
     m_ringArc.set(GetTemplateChildT<winrt::ArcSegment>(s_RingArcName, controlProtected));
-    //m_player.set(GetTemplateChildT<winrt::AnimatedVisualPlayer>(s_LottiePlayerName, controlProtected));
 
     m_player.set([this, controlProtected]()
     {
@@ -214,12 +213,6 @@ void ProgressRing::UpdateStates()
     else
     {
         winrt::VisualStateManager::GoToState(*this, s_DeterminateStateName, true);
-
-        //if (auto&& player = m_player.get())
-        //{
-        //    const auto _ = player.PlayAsync(0, 1, false);
-        //    //player.Stop();
-        //}
     }
 }
 

--- a/dev/ProgressRing/ProgressRing.h
+++ b/dev/ProgressRing/ProgressRing.h
@@ -31,6 +31,7 @@ public:
 
 private:
     void OnRangeBasePropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
+    void OnOpacityPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
     void OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&);
     void ApplyLottieAnimation();
     void SetLottieForegroundColor(winrt::impl::com_ref<AnimatedVisuals::ProgressRingIndeterminate> progressRingIndeterminate);

--- a/dev/ProgressRing/ProgressRing.vcxitems.filters
+++ b/dev/ProgressRing/ProgressRing.vcxitems.filters
@@ -20,6 +20,6 @@
     <Page Include="$(MSBuildThisFileDirectory)ProgressRing_themeresources.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <PRIResource Include="$(MSBuildThisFileDirectory)Resources.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-us\Resources.resw" />
   </ItemGroup>
 </Project>

--- a/dev/ProgressRing/ProgressRing.xaml
+++ b/dev/ProgressRing/ProgressRing.xaml
@@ -16,6 +16,22 @@
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="Indeterminate" To="Determinate">
+                                        <Storyboard>
+                                            <DoubleAnimation
+                                                Storyboard.TargetName="DeterminateProgressRingRoot"
+                                                Storyboard.TargetProperty="Opacity"
+                                                To="1"
+                                                Duration="0:0:0.15" />
+                                            <DoubleAnimation
+                                                Storyboard.TargetName="LottiePlayer"
+                                                Storyboard.TargetProperty="Opacity"
+                                                To="0"
+                                                Duration="0:0:0.15" />
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Determinate" />
                                 <VisualState x:Name="Indeterminate">
                                     <Storyboard>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a fade transition for ProgressRing from `Indeterminate` to `Determinate`.

Turns out `player.stop()` is causing the abrupt jump in animation. Thus,  the OpacityDependency property for LottiePlayer is registered so `player.Stop(`) only runs after the transition animation is complete (ie. is equal to 0)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2089 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually checking the animation fade transition

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->