### PR TITLE
Refactor loading of AdditionalStyles.xaml file

### DIFF
--- a/FeatureAreas.props
+++ b/FeatureAreas.props
@@ -79,7 +79,6 @@
     <FeatureRadialGradientBrushEnabled>true</FeatureRadialGradientBrushEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants Condition="$(FeatureScrollerEnabled) =='true'">$(DefineConstants);FEATURE_SCROLLER_ENABLED</DefineConstants>
     <DefineConstants Condition="$(FeatureNavigationViewEnabled) =='true'">$(DefineConstants);FEATURE_NAVIGATIONVIEW_ENABLED</DefineConstants>
     <DefineConstants Condition="$(SolutionName) == 'MUXControlsInnerLoop'">$(DefineConstants);INNERLOOP_BUILD</DefineConstants>
   </PropertyGroup>

--- a/dev/ScrollViewer/TestUI/ScrollViewerWithScrollControllersPage.xaml.cs
+++ b/dev/ScrollViewer/TestUI/ScrollViewerWithScrollControllersPage.xaml.cs
@@ -24,6 +24,9 @@ namespace MUXControlsTestApp
 
         public ScrollViewerWithScrollControllersPage()
         {
+            // We need the styles of the CompositionScrollController, so lets load it
+            App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
             this.InitializeComponent();
             UseScrollViewer(this.markupScrollViewer);
         }

--- a/dev/Scroller/APITests/ScrollControllerTests.cs
+++ b/dev/Scroller/APITests/ScrollControllerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using AnimationMode = Microsoft.UI.Xaml.Controls.AnimationMode;
 using SnapPointsMode = Microsoft.UI.Xaml.Controls.SnapPointsMode;
 using Scroller = Microsoft.UI.Xaml.Controls.Primitives.Scroller;
+using MUXControlsTestApp;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -40,6 +41,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 scroller = new Scroller();
                 Verify.IsNotNull(scroller);
 
@@ -91,6 +95,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 rectangleScrollerContent = new Rectangle();
                 scroller = new Scroller();
                 horizontalScrollController = new CompositionScrollController();
@@ -195,6 +202,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 rectangleScrollerContent = new Rectangle();
                 scroller = new Scroller();
                 horizontalScrollController = new CompositionScrollController();
@@ -320,6 +330,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 rectangleScrollerContent = new Rectangle();
                 scroller = new Scroller();
                 horizontalScrollController = new CompositionScrollController();
@@ -461,6 +474,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 rectangleScrollerContent = new Rectangle();
                 scroller = new Scroller();
                 biDirectionalScrollController = new BiDirectionalScrollController();
@@ -552,6 +568,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 rectangleScrollerContent = new Rectangle();
                 scroller = new Scroller();
                 biDirectionalScrollController = new BiDirectionalScrollController();
@@ -647,6 +666,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
+                // We need the styles of the CompositionScrollController, so lets load it
+                App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+
                 rectangleScrollerContent = new Rectangle();
                 scroller = new Scroller();
                 biDirectionalScrollController = new BiDirectionalScrollController();

--- a/dev/Scroller/TestUI/ScrollerPage.xaml.cs
+++ b/dev/Scroller/TestUI/ScrollerPage.xaml.cs
@@ -25,6 +25,9 @@ namespace MUXControlsTestApp
     {
         public ScrollerPage()
         {
+            // Some pages we will navigate to will need the resources, so lets load them now!
+            App.AppendResourceDictionaryToMergedDictionaries(App.AdditionStylesXaml);
+            
             LogController.InitializeLogging();
 
             this.InitializeComponent();

--- a/test/MUXControlsTestApp/App.xaml.cs
+++ b/test/MUXControlsTestApp/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -31,9 +31,15 @@ namespace MUXControlsTestApp
 {
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
+    /// This is defined globally to be able to remove it later.
     /// </summary>
     sealed partial class App : Application
     {
+        /// <summary>
+        /// AdditionalStyles.xaml file for ScrollViewer tests
+        /// </summary>
+        public static ResourceDictionary AdditionStylesXaml = new ResourceDictionary();
+        
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -194,9 +200,9 @@ namespace MUXControlsTestApp
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
             _isRootCreated = false;
-#if FEATURE_SCROLLER_ENABLED // Tracked by Issue 1043
-            AppendResourceToMergedDictionaries("AdditionalStyles.xaml");
-#endif
+            // Load the resource dictionary now
+            Application.LoadComponent(AdditionStylesXaml, new Uri(
+                            "ms-appx:///Themes/AdditionalStyles.xaml"), ComponentResourceLocation.Nested);
 
             // For test purposes, add styles that disable long animations.
             DisableLongAnimations = true;
@@ -322,6 +328,26 @@ namespace MUXControlsTestApp
                 "ms-appx:///Themes/"
                 + resource), ComponentResourceLocation.Nested);
             (targetDictionary ?? Application.Current.Resources).MergedDictionaries.Add(resourceDictionary);
+        }
+
+        public static void AppendResourceDictionaryToMergedDictionaries(ResourceDictionary dictionary)
+        {
+            // Check for null and dictionary not present
+            if (!(dictionary is null) && 
+                !Application.Current.Resources.MergedDictionaries.Contains(dictionary))
+            {
+                Application.Current.Resources.MergedDictionaries.Add(dictionary);
+            }
+        }
+
+        public static void RemoveResourceDictionaryFromMergedDictionaries(ResourceDictionary dictionary)
+        {
+            // Check for null and dictionary is in list
+            if(!(dictionary is null) &&
+                Application.Current.Resources.MergedDictionaries.Contains(dictionary))
+            { 
+                Application.Current.Resources.MergedDictionaries.Remove(dictionary);
+            }
         }
     }
 }

--- a/test/MUXControlsTestApp/MainPage.xaml.cs
+++ b/test/MUXControlsTestApp/MainPage.xaml.cs
@@ -197,6 +197,10 @@ namespace MUXControlsTestApp
         
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
+            // This method gets called when we navigate to MainPage.
+            // Now we should unload the ScrollViewer dictionary!
+            App.RemoveResourceDictionaryFromMergedDictionaries(App.AdditionStylesXaml);
+
             LanguageChooser.SelectedItem = MUXControlsTestApp.App.LanguageOverride;
 
             var testContentLoadedCheckBox = SearchVisualTree(this.Frame, "TestContentLoadedCheckBox") as CheckBox;

--- a/test/MUXControlsTestApp/MainPage.xaml.cs
+++ b/test/MUXControlsTestApp/MainPage.xaml.cs
@@ -198,7 +198,7 @@ namespace MUXControlsTestApp
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             // This method gets called when we navigate to MainPage.
-            // Now we should unload the ScrollViewer dictionary!
+            // Now we should unload the scroller dictionary!
             App.RemoveResourceDictionaryFromMergedDictionaries(App.AdditionStylesXaml);
 
             LanguageChooser.SelectedItem = MUXControlsTestApp.App.LanguageOverride;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR improves the way how the AdditionalStyles.xaml file for the scroller tests is being loaded. Instead of loading it based on a compiler setting, it now is being loaded and unloaded depending on the page we are visiting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #1043
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Ran tests to verify they still work.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->