### PR TITLE
Remove TwoPaneView from tab navigation

### DIFF
--- a/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
+++ b/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
@@ -4,6 +4,7 @@
 using System;
 
 using Common;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 using Windows.Foundation.Metadata;
@@ -146,7 +147,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 Log.Comment("Verify horizontal split regions");
                 SetComboBox("SimulateComboBox", "LeftRight");
-                
+
                 VerifyViewMode(ViewMode.LeftRight);
                 VerifyPaneSize(1, c_simulatedPaneWidth, c_simulatedPaneHeight);
                 VerifyPaneSize(2, c_simulatedPaneWidth, c_simulatedPaneHeight);
@@ -245,24 +246,43 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 VerifyPaneSize(1, controlWidth / 2.0, 0);
                 VerifyPaneSize(2, controlWidth / 2.0, 0);
-                
+
                 Log.Comment("Verify changing pane 2 length to pixel sizing");
                 SetLength(2, 199, "Pixel");
 
                 VerifyPaneSize(1, controlWidth - 199, 0);
                 VerifyPaneSize(2, 199, 0);
-                
+
                 Log.Comment("Verify column sizes stay the same when switching pane order");
                 SetWideModeConfiguration(WideModeConfiguration.RightLeft);
 
                 VerifyPaneSize(1, controlWidth - 199, 0);
                 VerifyPaneSize(2, 199, 0);
-                
+
                 Log.Comment("Verify lengths apply to top/bottom configuration");
                 SetControlWidth(ControlWidth.Narrow);
-                
+
                 VerifyPaneSize(1, 0, controlHeight - 199);
                 VerifyPaneSize(2, 0, 199);
+            }
+        }
+
+
+        // Verify that tabbing around puts us where we expect
+        [TestMethod]
+        public void VerifyTabKeyWorks()
+        {
+            using (var setup = new TestSetupHelper("TwoPaneView Tests")) // This clicks the button corresponding to the test page.
+            {
+                UIObject twoPaneView = TryFindElement.ByName("TwoPaneView");
+                Verify.IsNotNull(twoPaneView, "TwoPaneView is present");
+                twoPaneView.SetFocus();
+                Wait.ForIdle();
+                Verify.IsFalse(twoPaneView.HasKeyboardFocus, "TwoPaneView isn't focused");
+                KeyboardHelper.PressKey(Key.Tab);
+                Verify.IsFalse(twoPaneView.HasKeyboardFocus, "TwoPaneView isn't focused");
+                KeyboardHelper.PressKey(Key.Tab, ModifierKey.Shift);
+                Verify.IsFalse(twoPaneView.HasKeyboardFocus, "TwoPaneView isn't focused");
             }
         }
 

--- a/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
+++ b/dev/TwoPaneView/InteractionTests/TwoPaneViewTests.cs
@@ -4,7 +4,6 @@
 using System;
 
 using Common;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 using Windows.Foundation.Metadata;
@@ -274,15 +273,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             using (var setup = new TestSetupHelper("TwoPaneView Tests")) // This clicks the button corresponding to the test page.
             {
-                UIObject twoPaneView = TryFindElement.ByName("TwoPaneView");
+                UIObject twoPaneView = TryFindElement.ByName("TwoPaneViewLarge");
                 Verify.IsNotNull(twoPaneView, "TwoPaneView is present");
                 twoPaneView.SetFocus();
                 Wait.ForIdle();
-                Verify.IsFalse(twoPaneView.HasKeyboardFocus, "TwoPaneView isn't focused");
+                Verify.AreNotEqual(UIObject.Focused, twoPaneView, "TwoPaneView should not be focused");
                 KeyboardHelper.PressKey(Key.Tab);
-                Verify.IsFalse(twoPaneView.HasKeyboardFocus, "TwoPaneView isn't focused");
+                Verify.AreNotEqual(UIObject.Focused, twoPaneView, "TwoPaneView should not be focused");
                 KeyboardHelper.PressKey(Key.Tab, ModifierKey.Shift);
-                Verify.IsFalse(twoPaneView.HasKeyboardFocus, "TwoPaneView isn't focused");
+                Verify.AreNotEqual(UIObject.Focused, twoPaneView, "TwoPaneView should not be focused");
             }
         }
 

--- a/dev/TwoPaneView/TestUI/TwoPaneViewPage.xaml
+++ b/dev/TwoPaneView/TestUI/TwoPaneViewPage.xaml
@@ -136,7 +136,8 @@
         <Grid Grid.Column="1" Margin="12">
             <Grid x:Name="SimulatedWindow" AutomationProperties.Name="SimulatedWindow" Grid.Column="1" Background="Gray">
 
-                <muxcontrols:TwoPaneView x:Name="TwoPaneView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SizeChanged="TwoPaneView_SizeChanged">
+                <muxcontrols:TwoPaneView x:Name="TwoPaneView" AutomationProperties.Name="TwoPaneViewLarge"
+                                         HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SizeChanged="TwoPaneView_SizeChanged">
                     <muxcontrols:TwoPaneView.Pane1>
                         <Grid x:Name="Pane1Content" AutomationProperties.Name="Pane1Content" Background="{ThemeResource SystemChromeDisabledHighColor}" SizeChanged="PaneSizeChanged">
 

--- a/dev/TwoPaneView/TwoPaneView.xaml
+++ b/dev/TwoPaneView/TwoPaneView.xaml
@@ -11,6 +11,7 @@
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="MinWideModeWidth" Value="641"/>
         <Setter Property="MinTallModeHeight" Value="641"/>
+        <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TwoPaneView">

--- a/dev/TwoPaneView/TwoPaneView_rs1.xaml
+++ b/dev/TwoPaneView/TwoPaneView_rs1.xaml
@@ -9,6 +9,7 @@
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="MinWideModeWidth" Value="641"/>
         <Setter Property="MinTallModeHeight" Value="641"/>
+        <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TwoPaneView">


### PR DESCRIPTION
## Description
Added `IsTabStop` to the 2 templates of `TwoPaneView` to prevent the control to capture the focus when users use tab navigation.

## Motivation and Context
Fixes #2150 

## How Has This Been Tested?
Tested on Win10 and 10X
