### PR TITLE
Update GradientOrigin property to align with WPF naming

### DIFF
--- a/dev/Generated/RadialGradientBrush.properties.cpp
+++ b/dev/Generated/RadialGradientBrush.properties.cpp
@@ -15,7 +15,7 @@ namespace winrt::Microsoft::UI::Xaml::Media
 
 GlobalDependencyProperty RadialGradientBrushProperties::s_EllipseCenterProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_EllipseRadiusProperty{ nullptr };
-GlobalDependencyProperty RadialGradientBrushProperties::s_GradientOriginOffsetProperty{ nullptr };
+GlobalDependencyProperty RadialGradientBrushProperties::s_GradientOffsetProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_InterpolationSpaceProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_MappingModeProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_SpreadMethodProperty{ nullptr };
@@ -49,16 +49,16 @@ void RadialGradientBrushProperties::EnsureProperties()
                 ValueHelper<winrt::Point>::BoxValueIfNecessary(winrt::Point(0.5,0.5)),
                 winrt::PropertyChangedCallback(&OnEllipseRadiusPropertyChanged));
     }
-    if (!s_GradientOriginOffsetProperty)
+    if (!s_GradientOffsetProperty)
     {
-        s_GradientOriginOffsetProperty =
+        s_GradientOffsetProperty =
             InitializeDependencyProperty(
-                L"GradientOriginOffset",
+                L"GradientOffset",
                 winrt::name_of<winrt::Point>(),
                 winrt::name_of<winrt::RadialGradientBrush>(),
                 false /* isAttached */,
-                ValueHelper<winrt::Point>::BoxedDefaultValue(),
-                winrt::PropertyChangedCallback(&OnGradientOriginOffsetPropertyChanged));
+                ValueHelper<winrt::Point>::BoxValueIfNecessary(winrt::Point(0.5,0.5)),
+                winrt::PropertyChangedCallback(&OnGradientOffsetPropertyChanged));
     }
     if (!s_InterpolationSpaceProperty)
     {
@@ -99,7 +99,7 @@ void RadialGradientBrushProperties::ClearProperties()
 {
     s_EllipseCenterProperty = nullptr;
     s_EllipseRadiusProperty = nullptr;
-    s_GradientOriginOffsetProperty = nullptr;
+    s_GradientOffsetProperty = nullptr;
     s_InterpolationSpaceProperty = nullptr;
     s_MappingModeProperty = nullptr;
     s_SpreadMethodProperty = nullptr;
@@ -121,12 +121,12 @@ void RadialGradientBrushProperties::OnEllipseRadiusPropertyChanged(
     winrt::get_self<RadialGradientBrush>(owner)->OnEllipseRadiusPropertyChanged(args);
 }
 
-void RadialGradientBrushProperties::OnGradientOriginOffsetPropertyChanged(
+void RadialGradientBrushProperties::OnGradientOffsetPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
     auto owner = sender.as<winrt::RadialGradientBrush>();
-    winrt::get_self<RadialGradientBrush>(owner)->OnGradientOriginOffsetPropertyChanged(args);
+    winrt::get_self<RadialGradientBrush>(owner)->OnGradientOffsetPropertyChanged(args);
 }
 
 void RadialGradientBrushProperties::OnInterpolationSpacePropertyChanged(
@@ -173,14 +173,14 @@ winrt::Point RadialGradientBrushProperties::EllipseRadius()
     return ValueHelper<winrt::Point>::CastOrUnbox(static_cast<RadialGradientBrush*>(this)->GetValue(s_EllipseRadiusProperty));
 }
 
-void RadialGradientBrushProperties::GradientOriginOffset(winrt::Point const& value)
+void RadialGradientBrushProperties::GradientOffset(winrt::Point const& value)
 {
-    static_cast<RadialGradientBrush*>(this)->SetValue(s_GradientOriginOffsetProperty, ValueHelper<winrt::Point>::BoxValueIfNecessary(value));
+    static_cast<RadialGradientBrush*>(this)->SetValue(s_GradientOffsetProperty, ValueHelper<winrt::Point>::BoxValueIfNecessary(value));
 }
 
-winrt::Point RadialGradientBrushProperties::GradientOriginOffset()
+winrt::Point RadialGradientBrushProperties::GradientOffset()
 {
-    return ValueHelper<winrt::Point>::CastOrUnbox(static_cast<RadialGradientBrush*>(this)->GetValue(s_GradientOriginOffsetProperty));
+    return ValueHelper<winrt::Point>::CastOrUnbox(static_cast<RadialGradientBrush*>(this)->GetValue(s_GradientOffsetProperty));
 }
 
 void RadialGradientBrushProperties::InterpolationSpace(winrt::CompositionColorSpace const& value)

--- a/dev/Generated/RadialGradientBrush.properties.cpp
+++ b/dev/Generated/RadialGradientBrush.properties.cpp
@@ -15,7 +15,7 @@ namespace winrt::Microsoft::UI::Xaml::Media
 
 GlobalDependencyProperty RadialGradientBrushProperties::s_EllipseCenterProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_EllipseRadiusProperty{ nullptr };
-GlobalDependencyProperty RadialGradientBrushProperties::s_GradientOffsetProperty{ nullptr };
+GlobalDependencyProperty RadialGradientBrushProperties::s_GradientOriginProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_InterpolationSpaceProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_MappingModeProperty{ nullptr };
 GlobalDependencyProperty RadialGradientBrushProperties::s_SpreadMethodProperty{ nullptr };
@@ -49,16 +49,16 @@ void RadialGradientBrushProperties::EnsureProperties()
                 ValueHelper<winrt::Point>::BoxValueIfNecessary(winrt::Point(0.5,0.5)),
                 winrt::PropertyChangedCallback(&OnEllipseRadiusPropertyChanged));
     }
-    if (!s_GradientOffsetProperty)
+    if (!s_GradientOriginProperty)
     {
-        s_GradientOffsetProperty =
+        s_GradientOriginProperty =
             InitializeDependencyProperty(
-                L"GradientOffset",
+                L"GradientOrigin",
                 winrt::name_of<winrt::Point>(),
                 winrt::name_of<winrt::RadialGradientBrush>(),
                 false /* isAttached */,
                 ValueHelper<winrt::Point>::BoxValueIfNecessary(winrt::Point(0.5,0.5)),
-                winrt::PropertyChangedCallback(&OnGradientOffsetPropertyChanged));
+                winrt::PropertyChangedCallback(&OnGradientOriginPropertyChanged));
     }
     if (!s_InterpolationSpaceProperty)
     {
@@ -99,7 +99,7 @@ void RadialGradientBrushProperties::ClearProperties()
 {
     s_EllipseCenterProperty = nullptr;
     s_EllipseRadiusProperty = nullptr;
-    s_GradientOffsetProperty = nullptr;
+    s_GradientOriginProperty = nullptr;
     s_InterpolationSpaceProperty = nullptr;
     s_MappingModeProperty = nullptr;
     s_SpreadMethodProperty = nullptr;
@@ -121,12 +121,12 @@ void RadialGradientBrushProperties::OnEllipseRadiusPropertyChanged(
     winrt::get_self<RadialGradientBrush>(owner)->OnEllipseRadiusPropertyChanged(args);
 }
 
-void RadialGradientBrushProperties::OnGradientOffsetPropertyChanged(
+void RadialGradientBrushProperties::OnGradientOriginPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
     auto owner = sender.as<winrt::RadialGradientBrush>();
-    winrt::get_self<RadialGradientBrush>(owner)->OnGradientOffsetPropertyChanged(args);
+    winrt::get_self<RadialGradientBrush>(owner)->OnGradientOriginPropertyChanged(args);
 }
 
 void RadialGradientBrushProperties::OnInterpolationSpacePropertyChanged(
@@ -173,14 +173,14 @@ winrt::Point RadialGradientBrushProperties::EllipseRadius()
     return ValueHelper<winrt::Point>::CastOrUnbox(static_cast<RadialGradientBrush*>(this)->GetValue(s_EllipseRadiusProperty));
 }
 
-void RadialGradientBrushProperties::GradientOffset(winrt::Point const& value)
+void RadialGradientBrushProperties::GradientOrigin(winrt::Point const& value)
 {
-    static_cast<RadialGradientBrush*>(this)->SetValue(s_GradientOffsetProperty, ValueHelper<winrt::Point>::BoxValueIfNecessary(value));
+    static_cast<RadialGradientBrush*>(this)->SetValue(s_GradientOriginProperty, ValueHelper<winrt::Point>::BoxValueIfNecessary(value));
 }
 
-winrt::Point RadialGradientBrushProperties::GradientOffset()
+winrt::Point RadialGradientBrushProperties::GradientOrigin()
 {
-    return ValueHelper<winrt::Point>::CastOrUnbox(static_cast<RadialGradientBrush*>(this)->GetValue(s_GradientOffsetProperty));
+    return ValueHelper<winrt::Point>::CastOrUnbox(static_cast<RadialGradientBrush*>(this)->GetValue(s_GradientOriginProperty));
 }
 
 void RadialGradientBrushProperties::InterpolationSpace(winrt::CompositionColorSpace const& value)

--- a/dev/Generated/RadialGradientBrush.properties.h
+++ b/dev/Generated/RadialGradientBrush.properties.h
@@ -15,8 +15,8 @@ public:
     void EllipseRadius(winrt::Point const& value);
     winrt::Point EllipseRadius();
 
-    void GradientOffset(winrt::Point const& value);
-    winrt::Point GradientOffset();
+    void GradientOrigin(winrt::Point const& value);
+    winrt::Point GradientOrigin();
 
     void InterpolationSpace(winrt::CompositionColorSpace const& value);
     winrt::CompositionColorSpace InterpolationSpace();
@@ -29,14 +29,14 @@ public:
 
     static winrt::DependencyProperty EllipseCenterProperty() { return s_EllipseCenterProperty; }
     static winrt::DependencyProperty EllipseRadiusProperty() { return s_EllipseRadiusProperty; }
-    static winrt::DependencyProperty GradientOffsetProperty() { return s_GradientOffsetProperty; }
+    static winrt::DependencyProperty GradientOriginProperty() { return s_GradientOriginProperty; }
     static winrt::DependencyProperty InterpolationSpaceProperty() { return s_InterpolationSpaceProperty; }
     static winrt::DependencyProperty MappingModeProperty() { return s_MappingModeProperty; }
     static winrt::DependencyProperty SpreadMethodProperty() { return s_SpreadMethodProperty; }
 
     static GlobalDependencyProperty s_EllipseCenterProperty;
     static GlobalDependencyProperty s_EllipseRadiusProperty;
-    static GlobalDependencyProperty s_GradientOffsetProperty;
+    static GlobalDependencyProperty s_GradientOriginProperty;
     static GlobalDependencyProperty s_InterpolationSpaceProperty;
     static GlobalDependencyProperty s_MappingModeProperty;
     static GlobalDependencyProperty s_SpreadMethodProperty;
@@ -52,7 +52,7 @@ public:
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
-    static void OnGradientOffsetPropertyChanged(
+    static void OnGradientOriginPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/Generated/RadialGradientBrush.properties.h
+++ b/dev/Generated/RadialGradientBrush.properties.h
@@ -15,8 +15,8 @@ public:
     void EllipseRadius(winrt::Point const& value);
     winrt::Point EllipseRadius();
 
-    void GradientOriginOffset(winrt::Point const& value);
-    winrt::Point GradientOriginOffset();
+    void GradientOffset(winrt::Point const& value);
+    winrt::Point GradientOffset();
 
     void InterpolationSpace(winrt::CompositionColorSpace const& value);
     winrt::CompositionColorSpace InterpolationSpace();
@@ -29,14 +29,14 @@ public:
 
     static winrt::DependencyProperty EllipseCenterProperty() { return s_EllipseCenterProperty; }
     static winrt::DependencyProperty EllipseRadiusProperty() { return s_EllipseRadiusProperty; }
-    static winrt::DependencyProperty GradientOriginOffsetProperty() { return s_GradientOriginOffsetProperty; }
+    static winrt::DependencyProperty GradientOffsetProperty() { return s_GradientOffsetProperty; }
     static winrt::DependencyProperty InterpolationSpaceProperty() { return s_InterpolationSpaceProperty; }
     static winrt::DependencyProperty MappingModeProperty() { return s_MappingModeProperty; }
     static winrt::DependencyProperty SpreadMethodProperty() { return s_SpreadMethodProperty; }
 
     static GlobalDependencyProperty s_EllipseCenterProperty;
     static GlobalDependencyProperty s_EllipseRadiusProperty;
-    static GlobalDependencyProperty s_GradientOriginOffsetProperty;
+    static GlobalDependencyProperty s_GradientOffsetProperty;
     static GlobalDependencyProperty s_InterpolationSpaceProperty;
     static GlobalDependencyProperty s_MappingModeProperty;
     static GlobalDependencyProperty s_SpreadMethodProperty;
@@ -52,7 +52,7 @@ public:
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
-    static void OnGradientOriginOffsetPropertyChanged(
+    static void OnGradientOffsetPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/RadialGradientBrush/RadialGradientBrush.cpp
+++ b/dev/RadialGradientBrush/RadialGradientBrush.cpp
@@ -80,11 +80,11 @@ void RadialGradientBrush::OnEllipseRadiusPropertyChanged(const winrt::Dependency
     }
 }
 
-void RadialGradientBrush::OnGradientOffsetPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
+void RadialGradientBrush::OnGradientOriginPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
     if (SharedHelpers::IsCompositionRadialGradientBrushAvailable())
     {
-        UpdateCompositionGradientOffset();
+        UpdateCompositionGradientOrigin();
     }
 }
 
@@ -138,7 +138,7 @@ void RadialGradientBrush::EnsureCompositionBrush()
 
             UpdateCompositionGradientEllipseCenter();
             UpdateCompositionGradientEllipseRadius();
-            UpdateCompositionGradientOffset();
+            UpdateCompositionGradientOrigin();
             UpdateCompositionGradientStops();
             UpdateCompositionGradientMappingMode();
             UpdateCompositionInterpolationSpace();
@@ -197,13 +197,13 @@ void RadialGradientBrush::UpdateCompositionGradientMappingMode()
     }
 }
 
-void RadialGradientBrush::UpdateCompositionGradientOffset()
+void RadialGradientBrush::UpdateCompositionGradientOrigin()
 {
     MUX_ASSERT(SharedHelpers::IsCompositionRadialGradientBrushAvailable());
 
     if (const auto compositionGradientBrush = m_brush.try_as<winrt::CompositionRadialGradientBrush>())
     {
-        const auto gradientOffset = GradientOffset();
+        const auto gradientOffset = GradientOrigin();
         // This sets the gradient offset center to the top left corner
         // Top Left is (-0.5,-0.5), center is (0,0)
         compositionGradientBrush.GradientOriginOffset(winrt::float2(gradientOffset.X - 0.5f, gradientOffset.Y - 0.5f));

--- a/dev/RadialGradientBrush/RadialGradientBrush.cpp
+++ b/dev/RadialGradientBrush/RadialGradientBrush.cpp
@@ -80,11 +80,11 @@ void RadialGradientBrush::OnEllipseRadiusPropertyChanged(const winrt::Dependency
     }
 }
 
-void RadialGradientBrush::OnGradientOriginOffsetPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
+void RadialGradientBrush::OnGradientOffsetPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
     if (SharedHelpers::IsCompositionRadialGradientBrushAvailable())
     {
-        UpdateCompositionGradientOriginOffset();
+        UpdateCompositionGradientOffset();
     }
 }
 
@@ -138,7 +138,7 @@ void RadialGradientBrush::EnsureCompositionBrush()
 
             UpdateCompositionGradientEllipseCenter();
             UpdateCompositionGradientEllipseRadius();
-            UpdateCompositionGradientOriginOffset();
+            UpdateCompositionGradientOffset();
             UpdateCompositionGradientStops();
             UpdateCompositionGradientMappingMode();
             UpdateCompositionInterpolationSpace();
@@ -197,14 +197,16 @@ void RadialGradientBrush::UpdateCompositionGradientMappingMode()
     }
 }
 
-void RadialGradientBrush::UpdateCompositionGradientOriginOffset()
+void RadialGradientBrush::UpdateCompositionGradientOffset()
 {
     MUX_ASSERT(SharedHelpers::IsCompositionRadialGradientBrushAvailable());
 
     if (const auto compositionGradientBrush = m_brush.try_as<winrt::CompositionRadialGradientBrush>())
     {
-        const auto gradientOriginOffset = GradientOriginOffset();
-        compositionGradientBrush.GradientOriginOffset(winrt::float2(gradientOriginOffset.X, gradientOriginOffset.Y));
+        const auto gradientOffset = GradientOffset();
+        // This sets the gradient offset center to the top left corner
+        // Top Left is (-0.5,-0.5), center is (0,0)
+        compositionGradientBrush.GradientOriginOffset(winrt::float2(gradientOffset.X - 0.5f, gradientOffset.Y - 0.5f));
     }
 }
 

--- a/dev/RadialGradientBrush/RadialGradientBrush.cpp
+++ b/dev/RadialGradientBrush/RadialGradientBrush.cpp
@@ -203,10 +203,10 @@ void RadialGradientBrush::UpdateCompositionGradientOrigin()
 
     if (const auto compositionGradientBrush = m_brush.try_as<winrt::CompositionRadialGradientBrush>())
     {
-        const auto gradientOffset = GradientOrigin();
+        const auto gradientOrigin = GradientOrigin();
         // This sets the gradient offset center to the top left corner
         // Top Left is (-0.5,-0.5), center is (0,0)
-        compositionGradientBrush.GradientOriginOffset(winrt::float2(gradientOffset.X - 0.5f, gradientOffset.Y - 0.5f));
+        compositionGradientBrush.GradientOriginOffset(winrt::float2(gradientOrigin.X - 0.5f, gradientOrigin.Y - 0.5f));
     }
 }
 

--- a/dev/RadialGradientBrush/RadialGradientBrush.h
+++ b/dev/RadialGradientBrush/RadialGradientBrush.h
@@ -25,7 +25,7 @@ public:
 
     void OnEllipseCenterPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnEllipseRadiusPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnGradientOriginOffsetPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnGradientOffsetPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMappingModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnInterpolationSpacePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnSpreadMethodPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
@@ -46,7 +46,7 @@ private:
     void UpdateCompositionGradientEllipseCenter();
     void UpdateCompositionGradientEllipseRadius();
     void UpdateCompositionGradientMappingMode();
-    void UpdateCompositionGradientOriginOffset();
+    void UpdateCompositionGradientOffset();
     void UpdateCompositionGradientStops();
     void UpdateCompositionInterpolationSpace();
     void UpdateCompositionExtendMode();

--- a/dev/RadialGradientBrush/RadialGradientBrush.h
+++ b/dev/RadialGradientBrush/RadialGradientBrush.h
@@ -25,7 +25,7 @@ public:
 
     void OnEllipseCenterPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnEllipseRadiusPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnGradientOffsetPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnGradientOriginPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMappingModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnInterpolationSpacePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnSpreadMethodPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
@@ -46,7 +46,7 @@ private:
     void UpdateCompositionGradientEllipseCenter();
     void UpdateCompositionGradientEllipseRadius();
     void UpdateCompositionGradientMappingMode();
-    void UpdateCompositionGradientOffset();
+    void UpdateCompositionGradientOrigin();
     void UpdateCompositionGradientStops();
     void UpdateCompositionInterpolationSpace();
     void UpdateCompositionExtendMode();

--- a/dev/RadialGradientBrush/RadialGradientBrush.idl
+++ b/dev/RadialGradientBrush/RadialGradientBrush.idl
@@ -18,7 +18,7 @@ unsealed runtimeclass RadialGradientBrush : Windows.UI.Xaml.Media.XamlCompositio
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("winrt::Point(0.5,0.5)")]
-    Windows.Foundation.Point GradientOffset { get; set; };
+    Windows.Foundation.Point GradientOrigin { get; set; };
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("winrt::BrushMappingMode::RelativeToBoundingBox")]
@@ -36,7 +36,7 @@ unsealed runtimeclass RadialGradientBrush : Windows.UI.Xaml.Media.XamlCompositio
 
     static Windows.UI.Xaml.DependencyProperty EllipseCenterProperty { get; };
     static Windows.UI.Xaml.DependencyProperty EllipseRadiusProperty { get; };
-    static Windows.UI.Xaml.DependencyProperty GradientOffsetProperty { get; };
+    static Windows.UI.Xaml.DependencyProperty GradientOriginProperty { get; };
     static Windows.UI.Xaml.DependencyProperty InterpolationSpaceProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MappingModeProperty { get; };
     static Windows.UI.Xaml.DependencyProperty SpreadMethodProperty { get; };

--- a/dev/RadialGradientBrush/RadialGradientBrush.idl
+++ b/dev/RadialGradientBrush/RadialGradientBrush.idl
@@ -17,7 +17,8 @@ unsealed runtimeclass RadialGradientBrush : Windows.UI.Xaml.Media.XamlCompositio
     Windows.Foundation.Point EllipseRadius { get; set; };
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
-    Windows.Foundation.Point GradientOriginOffset { get; set; };
+    [MUX_DEFAULT_VALUE("winrt::Point(0.5,0.5)")]
+    Windows.Foundation.Point GradientOffset { get; set; };
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("winrt::BrushMappingMode::RelativeToBoundingBox")]
@@ -35,7 +36,7 @@ unsealed runtimeclass RadialGradientBrush : Windows.UI.Xaml.Media.XamlCompositio
 
     static Windows.UI.Xaml.DependencyProperty EllipseCenterProperty { get; };
     static Windows.UI.Xaml.DependencyProperty EllipseRadiusProperty { get; };
-    static Windows.UI.Xaml.DependencyProperty GradientOriginOffsetProperty { get; };
+    static Windows.UI.Xaml.DependencyProperty GradientOffsetProperty { get; };
     static Windows.UI.Xaml.DependencyProperty InterpolationSpaceProperty { get; };
     static Windows.UI.Xaml.DependencyProperty MappingModeProperty { get; };
     static Windows.UI.Xaml.DependencyProperty SpreadMethodProperty { get; };

--- a/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml
+++ b/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml
@@ -120,8 +120,8 @@
                             <TextBlock Text="{x:Bind DynamicGradientBrush.MappingMode}" Grid.Row="0" Grid.Column="1" />
                             <TextBlock Text="GradientStops.Count: " Grid.Row="1" />
                             <TextBlock Text="{x:Bind DynamicGradientBrush.GradientStops.Count}" Grid.Row="1" Grid.Column="1" x:Name="GradientStopCountText" AutomationProperties.Name="GradientStopCountText" />
-                            <TextBlock Text="GradientOriginOffset: " Grid.Row="2" />
-                            <TextBlock Text="{x:Bind DynamicGradientBrush.GradientOriginOffset}" Grid.Row="2" Grid.Column="1" />
+                            <TextBlock Text="GradientOffset: " Grid.Row="2" />
+                            <TextBlock Text="{x:Bind DynamicGradientBrush.GradientOffset}" Grid.Row="2" Grid.Column="1" />
                             <TextBlock Text="EllipseCenter: " Grid.Row="3" />
                             <TextBlock Text="{x:Bind DynamicGradientBrush.EllipseCenter}" Grid.Row="3" Grid.Column="1" />
                             <TextBlock Text="EllipseRadius: " Grid.Row="4" />

--- a/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml
+++ b/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml
@@ -120,8 +120,8 @@
                             <TextBlock Text="{x:Bind DynamicGradientBrush.MappingMode}" Grid.Row="0" Grid.Column="1" />
                             <TextBlock Text="GradientStops.Count: " Grid.Row="1" />
                             <TextBlock Text="{x:Bind DynamicGradientBrush.GradientStops.Count}" Grid.Row="1" Grid.Column="1" x:Name="GradientStopCountText" AutomationProperties.Name="GradientStopCountText" />
-                            <TextBlock Text="GradientOffset: " Grid.Row="2" />
-                            <TextBlock Text="{x:Bind DynamicGradientBrush.GradientOffset}" Grid.Row="2" Grid.Column="1" />
+                            <TextBlock Text="GradientOrigin: " Grid.Row="2" />
+                            <TextBlock Text="{x:Bind DynamicGradientBrush.GradientOrigin}" Grid.Row="2" Grid.Column="1" />
                             <TextBlock Text="EllipseCenter: " Grid.Row="3" />
                             <TextBlock Text="{x:Bind DynamicGradientBrush.EllipseCenter}" Grid.Row="3" Grid.Column="1" />
                             <TextBlock Text="EllipseRadius: " Grid.Row="4" />

--- a/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml.cs
+++ b/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml.cs
@@ -121,7 +121,7 @@ namespace MUXControlsTestApp
 
         private void RandomizeGradientOriginButton_Click(object sender, RoutedEventArgs e)
         {
-            RandomizeGradientOffset(DynamicGradientBrush);
+            RandomizeGradientOrigin(DynamicGradientBrush);
         }
 
         private void RandomizeEllipseCenterButton_Click(object sender, RoutedEventArgs e)
@@ -198,17 +198,17 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void RandomizeGradientOffset(RadialGradientBrush gradientBrush)
+        private void RandomizeGradientOrigin(RadialGradientBrush gradientBrush)
         {
             if (gradientBrush != null)
             {
                 if (gradientBrush.MappingMode == BrushMappingMode.Absolute)
                 {
-                    gradientBrush.GradientOffset = new Point(_random.Next(0, 100), _random.Next(0, 100));
+                    gradientBrush.GradientOrigin = new Point(_random.Next(0, 100), _random.Next(0, 100));
                 }
                 else
                 {
-                    gradientBrush.GradientOffset = new Point(_random.Next(-100, 100) / 100f, _random.Next(-100, 100) / 100f);
+                    gradientBrush.GradientOrigin = new Point(_random.Next(-100, 100) / 100f, _random.Next(-100, 100) / 100f);
                 }
             }
         }
@@ -251,7 +251,7 @@ namespace MUXControlsTestApp
 
                 RandomizeEllipseCenter(gradientBrush);
                 RandomizeEllipseRadius(gradientBrush);
-                RandomizeGradientOffset(gradientBrush);
+                RandomizeGradientOrigin(gradientBrush);
             }
         }
 

--- a/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml.cs
+++ b/dev/RadialGradientBrush/TestUI/RadialGradientBrushPage.xaml.cs
@@ -121,7 +121,7 @@ namespace MUXControlsTestApp
 
         private void RandomizeGradientOriginButton_Click(object sender, RoutedEventArgs e)
         {
-            RandomizeGradientOriginOffset(DynamicGradientBrush);
+            RandomizeGradientOffset(DynamicGradientBrush);
         }
 
         private void RandomizeEllipseCenterButton_Click(object sender, RoutedEventArgs e)
@@ -198,17 +198,17 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void RandomizeGradientOriginOffset(RadialGradientBrush gradientBrush)
+        private void RandomizeGradientOffset(RadialGradientBrush gradientBrush)
         {
             if (gradientBrush != null)
             {
                 if (gradientBrush.MappingMode == BrushMappingMode.Absolute)
                 {
-                    gradientBrush.GradientOriginOffset = new Point(_random.Next(0, 100), _random.Next(0, 100));
+                    gradientBrush.GradientOffset = new Point(_random.Next(0, 100), _random.Next(0, 100));
                 }
                 else
                 {
-                    gradientBrush.GradientOriginOffset = new Point(_random.Next(-100, 100) / 100f, _random.Next(-100, 100) / 100f);
+                    gradientBrush.GradientOffset = new Point(_random.Next(-100, 100) / 100f, _random.Next(-100, 100) / 100f);
                 }
             }
         }
@@ -251,7 +251,7 @@ namespace MUXControlsTestApp
 
                 RandomizeEllipseCenter(gradientBrush);
                 RandomizeEllipseRadius(gradientBrush);
-                RandomizeGradientOriginOffset(gradientBrush);
+                RandomizeGradientOffset(gradientBrush);
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update naming from "GradientOriginOffset" to "GradientOffset" and change the offsetting behavior from Center to TopLeft.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2180 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Ran interaction tests
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

## Open question:
Should I open a PR over at https://github.com/microsoft/microsoft-ui-xaml-specs/ to incorporate those changes? There is already running a PR currently open for the RadialGradientBrush that does not reflect this new behavior, so what would be the best way now?