### PR TITLE
Fix NavigationView light dismiss issue

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1297,7 +1297,7 @@ void NavigationView::OnSplitViewPaneClosing(const winrt::DependencyObject& /*sen
         {
             if (auto paneList = m_leftNavRepeater.get())
             {
-                if (!splitView.IsPaneOpen() && (splitView.DisplayMode() == winrt::SplitViewDisplayMode::CompactOverlay || splitView.DisplayMode() == winrt::SplitViewDisplayMode::CompactInline))
+                if (splitView.DisplayMode() == winrt::SplitViewDisplayMode::CompactOverlay || splitView.DisplayMode() == winrt::SplitViewDisplayMode::CompactInline)
                 {
                     // See UpdateIsClosedCompact 'RS3+ animation timing enhancement' for explanation:
                     winrt::VisualStateManager::GoToState(*this, L"ListSizeCompact", true /*useTransitions*/);

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -4358,6 +4358,77 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        public void VerifyCorrectVisualStateWhenClosingPaneInLeftDisplayMode()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+            {
+                // Test for explicit pane close
+
+                // make sure the NavigationView is in left mode with pane expanded
+                Log.Comment("Change display mode to left expanded");
+                var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+                panelDisplayModeComboBox.SelectItemByName("Left");
+                Wait.ForIdle();
+
+                TextBlock displayModeTextBox = new TextBlock(FindElement.ByName("DisplayModeTextBox"));
+                Verify.AreEqual(expanded, displayModeTextBox.DocumentText);
+
+                Button togglePaneButton = new Button(FindElement.ById("TogglePaneButton"));
+
+                // manually close pane
+                Log.Comment("Close NavView pane explicitly");
+                togglePaneButton.Invoke();
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+
+                Log.Comment("Get NavView Active VisualStates");
+                var getNavViewActiveVisualStatesButton = new Button(FindElement.ByName("GetNavViewActiveVisualStates"));
+                getNavViewActiveVisualStatesButton.Invoke();
+                Wait.ForIdle();
+
+                // check visual state
+                var visualStateName = "ListSizeCompact";
+                var result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
+
+                Verify.IsTrue(result.GetText().Contains(visualStateName), "active VisualStates doesn't include " + visualStateName);
+
+                // Test for light dismiss pane close
+
+                Log.Comment("Change display mode to left compact");
+                panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+                panelDisplayModeComboBox.SelectItemByName("LeftCompact");
+                Wait.ForIdle();
+
+                displayModeTextBox = new TextBlock(FindElement.ByName("DisplayModeTextBox"));
+                Verify.AreEqual(compact, displayModeTextBox.DocumentText);
+
+                // expand pane
+                Log.Comment("Expand NavView pane");
+                togglePaneButton.Invoke();
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
+
+                // light dismiss pane
+                Log.Comment("Light dismiss NavView pane");
+                getNavViewActiveVisualStatesButton.Click(); // NOTE: Must be Click because this is verifying that the mouse light dismiss behavior closes the nav view
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+
+                Log.Comment("Get NavView Active VisualStates");
+                getNavViewActiveVisualStatesButton.Invoke();
+                Wait.ForIdle();
+
+                // check visual state
+                result = new TextBlock(FindElement.ByName("NavViewActiveVisualStatesResult"));
+                Verify.IsTrue(result.GetText().Contains(visualStateName), "active VisualStates doesn't include " + visualStateName);
+            }
+        }
+
         private void EnsurePaneHeaderCanBeModifiedHelper(RegressionTestType navviewMode)
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone2))


### PR DESCRIPTION
## Description
Fixes the NavigationView light dismiss issue where the NavigationViewItems would not work with the correct closed pane width.

#### Implementation details 
I removed the check if the navigation pane (a SplitView pane) is closed. When we close the pane using the pane toggle button (or set SplitView.IsPaneOpen to false), we were already entering the *ListSizeCompact* visual state. In other words, splitView.IsPaneOpen() returned *false*. However, if the pane was light dismissed, splitView.IsPaneOpen() returned *true* at this point, thus not entering the *ListSizeCompact* visual state, causing the issue to manifest. 
Now that the check is removed, we enter this visual state no matter how the navigation pane is closed . And since we are only calling this code in a handler for the event when the pane is closing (OnSplitViewPaneClosing) having removed this check should not introduce any other side-effects.

## Motivation and Context
Fixes #2208 

## How Has This Been Tested?
Tested visually.

## Screenshots
See the following GIF:

![navviewpane_issue_fix](https://user-images.githubusercontent.com/1398851/78242655-ab160780-74e2-11ea-84fd-6d92413dba9f.gif)
