### PR TITLE
Split RadioButtons tests into smaller chunks and workloads

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
@@ -47,6 +47,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void SelectionTest()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -72,6 +73,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "B")]
         public void SelectByItem()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone4))
@@ -108,6 +110,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void FocusComingFromAnotherRepeaterTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone4))
@@ -143,7 +146,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void BasicKeyboardTest()
+        [TestProperty("TestSuite", "A")]
+        public void BasicKeyboardTestFirstBundle()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -170,7 +174,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(3);
                         KeyboardHelper.PressKey(Key.Right);
                         VerifySelectedFocusedIndex(3);
+                    }
+                }
+            }
+        }
 
+        [TestMethod]
+        [TestProperty("TestSuite", "B")]
+        public void BasicKeyboardTestSecondBundle()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
+                        bool useBackup = type == RadioButtonsSourceType.String;
+                        SetItemType(type);
                         TapOnItem(0, useBackup);
                         VerifySelectedFocusedIndex(0);
                         KeyboardHelper.PressKey(Key.Up);
@@ -186,9 +213,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void MultiColumnKeyboardTest()
+        [TestProperty("TestSuite", "B")]
+        public void MultiColumnKeyboardTestFirstBundle()
         {
-            if(!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
@@ -224,6 +252,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(2);
                         KeyboardHelper.PressKey(Key.Left);
                         VerifySelectedFocusedIndex(2);
+                    }
+                }
+            }
+        }
+        [TestMethod]
+        [TestProperty("TestSuite", "C")]
+        public void MultiColumnKeyboardTestSecondBundle()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
+                        SetItemType(type);
+                        bool useBackup = type == RadioButtonsSourceType.String;
+                        SetNumberOfColumns(3);
 
                         TapOnItem(0, useBackup);
                         VerifySelectedFocusedIndex(0);
@@ -248,7 +300,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void DisabledItemsKeyboardTest()
+        [TestProperty("TestSuite", "B")]
+        public void DisabledItemsKeyboardTestFirstBundle()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -285,7 +338,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     //VerifySelectedFocusedIndex(9);
                     //KeyboardHelper.PressKey(Key.Right);
                     //VerifySelectedFocusedIndex(9);
+                    ElementCache.Clear();
+                }
+            }
+        }
+        
+        [TestMethod]
+        [TestProperty("TestSuite", "C")]
+        public void DisabledItemsKeyboardTestSecondBundle()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                SetItemType(RadioButtonsSourceType.RadioButton);
+                SetNumberOfColumns(3);
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
 
+                    SetNumberOfItems(10);
+                    InsertDisabledRadioButton(10);
                     InsertDisabledRadioButton(6);
                     InsertDisabledRadioButton(6);
 
@@ -319,7 +396,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void DisabledItemsAtTopOfColumnKeyboardTest()
+        [TestProperty("TestSuite", "A")]
+        public void DisabledItemsAtTopOfColumnKeyboardTestFirstBundle()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -360,6 +438,34 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     VerifySelectedFocusedIndex(4);
                     KeyboardHelper.PressKey(Key.Right);
                     VerifySelectedFocusedIndex(8);
+                    ElementCache.Clear();
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "B")]
+        public void DisabledItemsAtTopOfColumnKeyboardTestSecondBundle()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                SetItemType(RadioButtonsSourceType.RadioButton);
+                SetNumberOfColumns(3);
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+
+                    SetNumberOfItems(10);
+                    InsertDisabledRadioButton(5);
+                    InsertDisabledRadioButton(5);
+                    InsertDisabledRadioButton(5);
+
                     TapOnItem(6);
                     VerifySelectedFocusedIndex(9);
                     KeyboardHelper.PressKey(Key.Left);
@@ -437,7 +543,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("Ignore", "True")] // Disabled due to: RadioButtonsTests.GamepadCanEscapeAndDoesNotSelectWithFocus is unreliable. #2202
-        public void GamepadCanEscapeAndDoesNotSelectWithFocus()
+        [TestProperty("TestSuite", "A")]
+        public void GamepadCanEscapeAndDoesNotSelectWithFocusFirstBundle()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
             {
@@ -469,6 +576,26 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(0);
                         GamepadHelper.PressButton(null, GamepadButton.DPadUp);
                         VerifyRadioButtonsHasFocus(false);
+                    }
+                }
+            }
+        }
+        [TestMethod]
+        [TestProperty("Ignore", "True")] // Disabled due to: RadioButtonsTests.GamepadCanEscapeAndDoesNotSelectWithFocus is unreliable. #2202
+        [TestProperty("TestSuite", "B")]
+        public void GamepadCanEscapeAndDoesNotSelectWithFocusSecondBundle()
+        {
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
+                        SetItemType(type);
+                        bool useBackup = type == RadioButtonsSourceType.String;
+                        SetNumberOfColumns(3);
 
                         TapOnItem(7, useBackup);
                         VerifySelectedFocusedIndex(7);
@@ -490,6 +617,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void ControlKeyKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -520,6 +648,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void ColumnsTest()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -566,6 +695,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void UIAProperties()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -608,6 +738,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void InsertedCheckedRadioButtonGetsSelection()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -625,6 +756,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void ScrollViewerSettingSelectionDoesNotMoveFocus()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -657,7 +789,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
         [TestMethod]
-        public void AccessKeys()
+        [TestProperty("TestSuite", "A")]
+        public void AccessKeysFirstBundle()
         { 
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -679,15 +812,55 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         UseAccessKey();
                         VerifyFocusedIndex(0);
                         VerifySelectedIndex(-1);
-
+                    }
+                }
+            }
+        }
+        [TestMethod]
+        [TestProperty("TestSuite", "B")]
+        public void AccessKeysSecondBundle()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
                         SelectByIndex(3);
                         VerifySelectedIndex(3);
                         VerifyFocusedIndex(-1);
+                    }
+                }
+            }
+        }
 
+        [TestMethod]
+        [TestProperty("TestSuite", "C")]
+        public void AccessKeysThirdBundle()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            {
+                Log.Warning("This test requires RS3+ keyboarding behavior");
+                return;
+            }
+            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            {
+                elements = new RadioButtonsTestPageElements();
+                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                {
+                    SetSource(location);
+                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
+                    {
+                        SelectByIndex(3);
                         KeyboardHelper.PressKey(Key.Tab);
                         VerifyRadioButtonsHasFocus(false);
-                        UseAccessKey();
-                        VerifySelectedFocusedIndex(3);
                         UseAccessKey();
                         VerifySelectedFocusedIndex(3);
                     }

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -146,8 +146,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
-        public void BasicKeyboardTestFirstBundle()
+        public void BasicKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -174,30 +173,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(3);
                         KeyboardHelper.PressKey(Key.Right);
                         VerifySelectedFocusedIndex(3);
-                    }
-                }
-            }
-        }
 
-        [TestMethod]
-        [TestProperty("TestSuite", "B")]
-        public void BasicKeyboardTestSecondBundle()
-        {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ keyboarding behavior");
-                return;
-            }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
-                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
-                    {
-                        bool useBackup = type == RadioButtonsSourceType.String;
-                        SetItemType(type);
                         TapOnItem(0, useBackup);
                         VerifySelectedFocusedIndex(0);
                         KeyboardHelper.PressKey(Key.Up);
@@ -213,10 +189,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "B")]
-        public void MultiColumnKeyboardTestFirstBundle()
+        public void MultiColumnKeyboardTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
+            if(!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
@@ -252,30 +227,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(2);
                         KeyboardHelper.PressKey(Key.Left);
                         VerifySelectedFocusedIndex(2);
-                    }
-                }
-            }
-        }
-        [TestMethod]
-        [TestProperty("TestSuite", "C")]
-        public void MultiColumnKeyboardTestSecondBundle()
-        {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ keyboarding behavior");
-                return;
-            }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
-                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
-                    {
-                        SetItemType(type);
-                        bool useBackup = type == RadioButtonsSourceType.String;
-                        SetNumberOfColumns(3);
 
                         TapOnItem(0, useBackup);
                         VerifySelectedFocusedIndex(0);
@@ -300,8 +251,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "B")]
-        public void DisabledItemsKeyboardTestFirstBundle()
+        public void DisabledItemsKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -338,31 +288,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     //VerifySelectedFocusedIndex(9);
                     //KeyboardHelper.PressKey(Key.Right);
                     //VerifySelectedFocusedIndex(9);
-                    ElementCache.Clear();
-                }
-            }
-        }
-        
-        [TestMethod]
-        [TestProperty("TestSuite", "C")]
-        public void DisabledItemsKeyboardTestSecondBundle()
-        {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ keyboarding behavior");
-                return;
-            }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                SetItemType(RadioButtonsSourceType.RadioButton);
-                SetNumberOfColumns(3);
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
 
-                    SetNumberOfItems(10);
-                    InsertDisabledRadioButton(10);
                     InsertDisabledRadioButton(6);
                     InsertDisabledRadioButton(6);
 
@@ -396,8 +322,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
-        public void DisabledItemsAtTopOfColumnKeyboardTestFirstBundle()
+        public void DisabledItemsAtTopOfColumnKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -438,34 +363,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     VerifySelectedFocusedIndex(4);
                     KeyboardHelper.PressKey(Key.Right);
                     VerifySelectedFocusedIndex(8);
-                    ElementCache.Clear();
-                }
-            }
-        }
-
-        [TestMethod]
-        [TestProperty("TestSuite", "B")]
-        public void DisabledItemsAtTopOfColumnKeyboardTestSecondBundle()
-        {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ keyboarding behavior");
-                return;
-            }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                SetItemType(RadioButtonsSourceType.RadioButton);
-                SetNumberOfColumns(3);
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
-
-                    SetNumberOfItems(10);
-                    InsertDisabledRadioButton(5);
-                    InsertDisabledRadioButton(5);
-                    InsertDisabledRadioButton(5);
-
                     TapOnItem(6);
                     VerifySelectedFocusedIndex(9);
                     KeyboardHelper.PressKey(Key.Left);
@@ -543,8 +440,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("Ignore", "True")] // Disabled due to: RadioButtonsTests.GamepadCanEscapeAndDoesNotSelectWithFocus is unreliable. #2202
-        [TestProperty("TestSuite", "A")]
-        public void GamepadCanEscapeAndDoesNotSelectWithFocusFirstBundle()
+        public void GamepadCanEscapeAndDoesNotSelectWithFocus()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
             {
@@ -576,26 +472,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         VerifySelectedFocusedIndex(0);
                         GamepadHelper.PressButton(null, GamepadButton.DPadUp);
                         VerifyRadioButtonsHasFocus(false);
-                    }
-                }
-            }
-        }
-        [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled due to: RadioButtonsTests.GamepadCanEscapeAndDoesNotSelectWithFocus is unreliable. #2202
-        [TestProperty("TestSuite", "B")]
-        public void GamepadCanEscapeAndDoesNotSelectWithFocusSecondBundle()
-        {
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
-                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
-                    {
-                        SetItemType(type);
-                        bool useBackup = type == RadioButtonsSourceType.String;
-                        SetNumberOfColumns(3);
 
                         TapOnItem(7, useBackup);
                         VerifySelectedFocusedIndex(7);
@@ -617,7 +493,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
         public void ControlKeyKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -648,7 +523,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "C")]
         public void ColumnsTest()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -695,7 +569,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
         public void UIAProperties()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -738,7 +611,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
         public void InsertedCheckedRadioButtonGetsSelection()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -756,7 +628,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
         public void ScrollViewerSettingSelectionDoesNotMoveFocus()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -789,8 +660,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
-        public void AccessKeysFirstBundle()
+        public void AccessKeys()
         { 
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
             {
@@ -812,55 +682,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                         UseAccessKey();
                         VerifyFocusedIndex(0);
                         VerifySelectedIndex(-1);
-                    }
-                }
-            }
-        }
-        [TestMethod]
-        [TestProperty("TestSuite", "B")]
-        public void AccessKeysSecondBundle()
-        {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ keyboarding behavior");
-                return;
-            }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
-                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
-                    {
+
                         SelectByIndex(3);
                         VerifySelectedIndex(3);
                         VerifyFocusedIndex(-1);
-                    }
-                }
-            }
-        }
 
-        [TestMethod]
-        [TestProperty("TestSuite", "C")]
-        public void AccessKeysThirdBundle()
-        {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
-            {
-                Log.Warning("This test requires RS3+ keyboarding behavior");
-                return;
-            }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
-            {
-                elements = new RadioButtonsTestPageElements();
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
-                {
-                    SetSource(location);
-                    foreach (RadioButtonsSourceType type in Enum.GetValues(typeof(RadioButtonsSourceType)))
-                    {
-                        SelectByIndex(3);
                         KeyboardHelper.PressKey(Key.Tab);
                         VerifyRadioButtonsHasFocus(false);
+                        UseAccessKey();
+                        VerifySelectedFocusedIndex(3);
                         UseAccessKey();
                         VerifySelectedFocusedIndex(3);
                     }

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "C")]
+        [TestProperty("TestSuite", "A")]
         public void SelectionTest()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -146,6 +146,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void BasicKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -189,6 +190,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "B")]
         public void MultiColumnKeyboardTest()
         {
             if(!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -251,6 +253,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void DisabledItemsKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -322,6 +325,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void DisabledItemsAtTopOfColumnKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -440,6 +444,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("Ignore", "True")] // Disabled due to: RadioButtonsTests.GamepadCanEscapeAndDoesNotSelectWithFocus is unreliable. #2202
+        [TestProperty("TestSuite", "B")]
         public void GamepadCanEscapeAndDoesNotSelectWithFocus()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -493,6 +498,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void ControlKeyKeyboardTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -523,6 +529,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void ColumnsTest()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -569,6 +576,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "B")]
         public void UIAProperties()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -611,6 +619,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "C")]
         public void InsertedCheckedRadioButtonGetsSelection()
         {
             using (var setup = new TestSetupHelper("RadioButtons Tests"))
@@ -628,6 +637,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void ScrollViewerSettingSelectionDoesNotMoveFocus()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
@@ -660,6 +670,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
         [TestMethod]
+        [TestProperty("TestSuite", "B")]
         public void AccessKeys()
         { 
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've split up the larger tests into smaller chunks and added them into TestSuite's in order to reduce the time we need to rerun tests and potentially improve test reliability

![image](https://user-images.githubusercontent.com/16122379/78278629-9b181b00-7516-11ea-908e-a34cd0c54b1a.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Potentially Fixes #2160 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Ran tests
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
