### PR TITLE
Revert changes to framework package creation logic

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
@@ -3,13 +3,25 @@ parameters:
 
 steps:
   - powershell: |
-      # MakeAllAppx.cmd creates all appx files
-      # Default parameters
-      $env:BUILDOUTPUT_OVERRIDE = "${{parameters.buildOutputDir}}\$env:BUILDCONFIGURATION\$env:BUILDPLATFORM"
-      & $env:Build_SourcesDirectory\build\NuSpecs\MakeAllAppx.cmd -builddate_yymm $env:BUILDDATE_YYMM -builddate_dd $env:BUILDDATE_DD -subversion $env:BUILDREVISION -verbose
-      if ($lastexitcode -ne 0) {
-          Write-Host "##vso[task.logissue type=error;] Make AppxHelper $platform $config failed with exit code $lastexitcode"
-          Write-Host "##vso[task.complete result=Failed;]"
-          Exit 1
+      $platforms = @("x86", "x64", "arm", "arm64")
+      $configs = @("debug", "release")
+      foreach ($platform in $platforms)
+      {
+        foreach ($config in $configs)
+        {
+          $rootPath = "${{ parameters.buildOutputDir }}\$config\$platform"
+          Write-Host ""
+          Write-Host "Checking for $rootPath\Microsoft.UI.Xaml"
+          Write-Host ""
+          if (Test-Path "$rootPath\Microsoft.UI.Xaml")
+          {
+            $env:BUILDOUTPUT_OVERRIDE = $rootPath
+            & $env:Build_SourcesDirectory\tools\MakeAppxHelper.cmd $platform $config -builddate_yymm $env:BUILDDATE_YYMM -builddate_dd $env:BUILDDATE_DD -subversion $env:BUILDREVISION -verbose
+            if ($lastexitcode -ne 0) {
+                Write-Host ##vso[task.logissue type=error;] Make AppxHelper $platform $config failed with exit code $lastexitcode
+                Exit 1
+            }
+          }
+        }
       }
     displayName: 'Make FrameworkPackages'

--- a/build/NuSpecs/MakeAllAppx.cmd
+++ b/build/NuSpecs/MakeAllAppx.cmd
@@ -1,6 +1,28 @@
-call ..\..\tools\MakeAppxHelper.cmd x86 release %*
-call ..\..\tools\MakeAppxHelper.cmd x86 debug %*
-call ..\..\tools\MakeAppxHelper.cmd x64 release %*
-call ..\..\tools\MakeAppxHelper.cmd x64 debug %*
-call ..\..\tools\MakeAppxHelper.cmd arm release %*
-call ..\..\tools\MakeAppxHelper.cmd arm debug %*
+@echo off
+REM %~dp0 is position of script file
+
+
+if exist %~dp0"..\..\BuildOutput\Debug\x86\Microsoft.UI.Xaml" (
+	call %~dp0..\..\tools\MakeAppxHelper.cmd x86 debug %*
+)
+if exist %~dp0"..\..\BuildOutput\Release\x86\Microsoft.UI.Xaml" (
+	call %~dp0..\..\tools\MakeAppxHelper.cmd x86 release%*
+)
+if exist %~dp0"..\..\BuildOutput\Debug\x64\Microsoft.UI.Xaml" (
+  call %~dp0..\..\tools\MakeAppxHelper.cmd x64 debug %*
+)
+if exist %~dp0"..\..\BuildOutput\Release\x64\Microsoft.UI.Xaml" (
+  call %~dp0..\..\tools\MakeAppxHelper.cmd x64 release %*
+)
+if exist %~dp0"..\..\BuildOutput\Debug\arm\Microsoft.UI.Xaml" (
+  call %~dp0..\..\tools\MakeAppxHelper.cmd arm debug %*
+)
+if exist %~dp0"..\..\BuildOutput\Release\arm\Microsoft.UI.Xaml" (
+  call %~dp0..\..\tools\MakeAppxHelper.cmd arm release %*
+)
+if exist %~dp0"..\..\BuildOutput\Debug\arm64\Microsoft.UI.Xaml" (
+  call %~dp0..\..\tools\MakeAppxHelper.cmd arm64 debug %*
+)
+if exist %~dp0"..\..\BuildOutput\Release\arm64\Microsoft.UI.Xaml" (
+  call %~dp0..\..\tools\MakeAppxHelper.cmd arm64 release %*
+)

--- a/build/NuSpecs/MakeAllAppx.cmd
+++ b/build/NuSpecs/MakeAllAppx.cmd
@@ -1,28 +1,6 @@
-@echo off
-REM %~dp0 is position of script file
-
-
-if exist %~dp0"..\..\BuildOutput\Debug\x86\Microsoft.UI.Xaml" (
-	call %~dp0..\..\tools\MakeAppxHelper.cmd x86 debug %*
-)
-if exist %~dp0"..\..\BuildOutput\Release\x86\Microsoft.UI.Xaml" (
-	call %~dp0..\..\tools\MakeAppxHelper.cmd x86 release%*
-)
-if exist %~dp0"..\..\BuildOutput\Debug\x64\Microsoft.UI.Xaml" (
-  call %~dp0..\..\tools\MakeAppxHelper.cmd x64 debug %*
-)
-if exist %~dp0"..\..\BuildOutput\Release\x64\Microsoft.UI.Xaml" (
-  call %~dp0..\..\tools\MakeAppxHelper.cmd x64 release %*
-)
-if exist %~dp0"..\..\BuildOutput\Debug\arm\Microsoft.UI.Xaml" (
-  call %~dp0..\..\tools\MakeAppxHelper.cmd arm debug %*
-)
-if exist %~dp0"..\..\BuildOutput\Release\arm\Microsoft.UI.Xaml" (
-  call %~dp0..\..\tools\MakeAppxHelper.cmd arm release %*
-)
-if exist %~dp0"..\..\BuildOutput\Debug\arm64\Microsoft.UI.Xaml" (
-  call %~dp0..\..\tools\MakeAppxHelper.cmd arm64 debug %*
-)
-if exist %~dp0"..\..\BuildOutput\Release\arm64\Microsoft.UI.Xaml" (
-  call %~dp0..\..\tools\MakeAppxHelper.cmd arm64 release %*
-)
+call ..\..\tools\MakeAppxHelper.cmd x86 release %*
+call ..\..\tools\MakeAppxHelper.cmd x86 debug %*
+call ..\..\tools\MakeAppxHelper.cmd x64 release %*
+call ..\..\tools\MakeAppxHelper.cmd x64 debug %*
+call ..\..\tools\MakeAppxHelper.cmd arm release %*
+call ..\..\tools\MakeAppxHelper.cmd arm debug %*

--- a/dev/inc/CppWinRTHelpers.h
+++ b/dev/inc/CppWinRTHelpers.h
@@ -55,7 +55,10 @@ struct ValueHelper
 {
     static T GetDefaultValue()
     {
-        return T{};
+#pragma warning(push)
+#pragma warning(disable : 26444) 
+        return T{};    
+#pragma warning(pop)
     }
 
     static winrt::IInspectable BoxValueIfNecessary(T const& value)


### PR DESCRIPTION
#2214 included some changes to the framework package creation logic. This passed the PR build, but caused the CI build to start failing. Only the CI build runs tests against the framework package which is why the issue was not caught by the PR build.

It is not worth the time to investigate the root cause of the break, so instead I am just reverting the changes. The important part of that PR was the updates to the docs and I am not reverting that.