### PR TITLE
Fix NavigationView pane not closing in minimal/compact mode when selecting an item

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1905,6 +1905,11 @@ void NavigationView::ChangeSelection(const winrt::IInspectable& prevItem, const 
         ChangeSelectStatusForItem(nextItem, true /*selected*/);
         RaiseSelectionChangedEvent(nextItem, isSettingsItem, recommendedDirection);
         AnimateSelectionChanged(nextItem);
+
+        if (auto nvi = NavigationViewItemOrSettingsContentFromData(nextItem))
+        {
+            ClosePaneIfNeccessaryAfterItemIsClicked(nvi);
+        }    
     }
 }
 

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1906,7 +1906,7 @@ void NavigationView::ChangeSelection(const winrt::IInspectable& prevItem, const 
         RaiseSelectionChangedEvent(nextItem, isSettingsItem, recommendedDirection);
         AnimateSelectionChanged(nextItem);
 
-        if (auto nvi = NavigationViewItemOrSettingsContentFromData(nextItem))
+        if (auto const nvi = NavigationViewItemOrSettingsContentFromData(nextItem))
         {
             ClosePaneIfNeccessaryAfterItemIsClicked(nvi);
         }    

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -156,6 +156,40 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "A")]
+        public void VerifyPaneIsClosedAfterSelectingItem()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+            {
+                var displayModeTextBox = new TextBlock(FindElement.ByName("DisplayModeTextBox"));
+                var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+
+                Log.Comment("Test PaneDisplayMode=LeftMinimal");
+                panelDisplayModeComboBox.SelectItemByName("LeftMinimal");
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+
+                Log.Comment("Click on ToggleButton");
+                Button navButton = new Button(FindElement.ById("TogglePaneButton"));
+                navButton.Invoke();
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Opened);
+
+                TextBlock selectionRaisedIndicator = new TextBlock(FindElement.ById("SelectionChangedRaised"));
+
+                Log.Comment("Select Apps");
+                ComboBox selectedItem = new ComboBox(FindElement.ById("SelectedItemCombobox"));
+                selectedItem.SelectItemByName("Apps");
+                Verify.AreEqual("True", selectionRaisedIndicator.GetText());
+                Wait.ForIdle();
+
+                WaitAndAssertPaneStatus(PaneOpenStatus.Closed);
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void PaneDisplayModeLeftLeftCompactLeftMinimalTest()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))


### PR DESCRIPTION
## Description
This PR fixes a regression introduced with commit 5d444b6 which prevented the NavigationView pane to be closed in minimal/compact mode after selecting the *Settings* item or selecting an item programmatically (using NavigationView.SelectedItem).

Also added an interaction test to prevent this regression from occuring in the future.

## Motivation and Context
Fixes #2244.

## How Has This Been Tested?
Tested visually and added interaction test.