### PR TITLE
Fix issue with selection being raised when selection did not change

### DIFF
--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -978,6 +978,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     12);
 
             });
+        }
+
+        [TestMethod]
+        public void AlreadySelectedDoesNotRaiseEvent()
+        {
+            var testName = "Select(int32 index)";
+
+            RunOnUIThread.Execute(() =>
+            {
+                var list = Enumerable.Range(0, 10).ToList();
+
+                var selectionModel = new SelectionModel() { 
+                    Source = list,
+                    SingleSelect = true
+                };
+
+                // Single select index
+                selectionModel.Select(0);
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.Select(0);
+
+                selectionModel = new SelectionModel() {
+                    Source = list,
+                    SingleSelect = true
+                };
+                // Single select indexpath
+                testName = "SelectAt(IndexPath index)";
+                selectionModel.SelectAt(IndexPath.CreateFrom(1));
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectAt(IndexPath.CreateFrom(1));
+            });
+
+            void SelectionModel_SelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
+            {
+                throw new Exception("SelectionChangedEvent was raised, but shouldn't have been raised as selection did not change. Tested method: " + testName);
+            }
         }
 
         private void Select(SelectionModel manager, int index, bool select)

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -996,7 +996,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 // Single select index
                 selectionModel.Select(0);
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.Select(0);
 
                 selectionModel = new SelectionModel() {
@@ -1006,7 +1006,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 // Single select indexpath
                 testName = "SelectAt(IndexPath index), single select";
                 selectionModel.SelectAt(IndexPath.CreateFrom(1));
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.SelectAt(IndexPath.CreateFrom(1));
 
                 // multi select index
@@ -1016,7 +1016,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 selectionModel.Select(1);
                 selectionModel.Select(2);
                 testName = "Select(int32 index), multiselect";
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.Select(1);
                 selectionModel.Select(2);
 
@@ -1028,12 +1028,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 selectionModel.SelectAt(IndexPath.CreateFrom(1));
                 selectionModel.SelectAt(IndexPath.CreateFrom(2));
                 testName = "SelectAt(IndexPath index), multiselect";
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.SelectAt(IndexPath.CreateFrom(1));
                 selectionModel.SelectAt(IndexPath.CreateFrom(2));
             });
 
-            void SelectionModel_SelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
+            void ThrowIfRaisedSelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
             {
                 throw new Exception("SelectionChangedEvent was raised, but shouldn't have been raised as selection did not change. Tested method: " + testName);
             }
@@ -1054,7 +1054,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 };
 
                 // Single select index
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.Deselect(0);
 
                 selectionModel = new SelectionModel() {
@@ -1063,7 +1063,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 };
                 // Single select indexpath
                 testName = "DeselectAt(IndexPath index), single select";
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.DeselectAt(IndexPath.CreateFrom(1));
 
                 // multi select index
@@ -1071,7 +1071,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Source = list
                 };
                 testName = "Deselect(int32 index), multiselect";
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.Deselect(1);
                 selectionModel.Deselect(2);
 
@@ -1081,12 +1081,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 // multi select indexpath
                 testName = "DeselectAt(IndexPath index), multiselect";
-                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectionChanged += ThrowIfRaisedSelectionChanged;
                 selectionModel.DeselectAt(IndexPath.CreateFrom(1));
                 selectionModel.DeselectAt(IndexPath.CreateFrom(2));
             });
 
-            void SelectionModel_SelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
+            void ThrowIfRaisedSelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
             {
                 throw new Exception("SelectionChangedEvent was raised, but shouldn't have been raised as selection did not change. Tested method: " + testName);
             }

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -983,13 +983,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         [TestMethod]
         public void AlreadySelectedDoesNotRaiseEvent()
         {
-            var testName = "Select(int32 index)";
+            var testName = "Select(int32 index), single select";
 
             RunOnUIThread.Execute(() =>
             {
                 var list = Enumerable.Range(0, 10).ToList();
 
-                var selectionModel = new SelectionModel() { 
+                var selectionModel = new SelectionModel() {
                     Source = list,
                     SingleSelect = true
                 };
@@ -1004,10 +1004,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     SingleSelect = true
                 };
                 // Single select indexpath
-                testName = "SelectAt(IndexPath index)";
+                testName = "SelectAt(IndexPath index), single select";
                 selectionModel.SelectAt(IndexPath.CreateFrom(1));
                 selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
                 selectionModel.SelectAt(IndexPath.CreateFrom(1));
+
+                // multi select index
+                selectionModel = new SelectionModel() {
+                    Source = list
+                };
+                selectionModel.Select(1);
+                selectionModel.Select(2);
+                testName = "Select(int32 index), multiselect";
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.Select(1);
+                selectionModel.Select(2);
+
+                selectionModel = new SelectionModel() {
+                    Source = list
+                };
+
+                // multi select indexpath
+                selectionModel.SelectAt(IndexPath.CreateFrom(1));
+                selectionModel.SelectAt(IndexPath.CreateFrom(2));
+                testName = "SelectAt(IndexPath index), multiselect";
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.SelectAt(IndexPath.CreateFrom(1));
+                selectionModel.SelectAt(IndexPath.CreateFrom(2));
             });
 
             void SelectionModel_SelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1039,6 +1039,59 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             }
         }
 
+        [TestMethod]
+        public void AlreadyDeselectedDoesNotRaiseEvent()
+        {
+            var testName = "Deselect(int32 index), single select";
+
+            RunOnUIThread.Execute(() =>
+            {
+                var list = Enumerable.Range(0, 10).ToList();
+
+                var selectionModel = new SelectionModel() {
+                    Source = list,
+                    SingleSelect = true
+                };
+
+                // Single select index
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.Deselect(0);
+
+                selectionModel = new SelectionModel() {
+                    Source = list,
+                    SingleSelect = true
+                };
+                // Single select indexpath
+                testName = "DeselectAt(IndexPath index), single select";
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.DeselectAt(IndexPath.CreateFrom(1));
+
+                // multi select index
+                selectionModel = new SelectionModel() {
+                    Source = list
+                };
+                testName = "Deselect(int32 index), multiselect";
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.Deselect(1);
+                selectionModel.Deselect(2);
+
+                selectionModel = new SelectionModel() {
+                    Source = list
+                };
+
+                // multi select indexpath
+                testName = "DeselectAt(IndexPath index), multiselect";
+                selectionModel.SelectionChanged += SelectionModel_SelectionChanged;
+                selectionModel.DeselectAt(IndexPath.CreateFrom(1));
+                selectionModel.DeselectAt(IndexPath.CreateFrom(2));
+            });
+
+            void SelectionModel_SelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
+            {
+                throw new Exception("SelectionChangedEvent was raised, but shouldn't have been raised as selection did not change. Tested method: " + testName);
+            }
+        }
+
         private void Select(SelectionModel manager, int index, bool select)
         {
             Log.Comment((select ? "Selecting " : "DeSelecting ") + index);

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -585,9 +585,9 @@ void SelectionModel::OnSelectionChanged()
 
 void SelectionModel::SelectImpl(int index, bool select)
 {
-    // New index is same as already selected
     if (m_singleSelect)
     {
+        // Check if new index is different to current one
         if (m_rootNode->SelectedIndex() != index)
         {
             ClearSelection(true /*resetAnchor*/, false /* raiseSelectionChanged */);
@@ -642,7 +642,7 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
             }
         }
     }
-    // Selection is actually different from previous one, so run code.
+    // Selection is actually different from previous one, so update.
     if (selectionChanged)
     {
         if (m_singleSelect)

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -619,7 +619,6 @@ void SelectionModel::SelectWithGroupImpl(int groupIndex, int itemIndex, bool sel
 
 void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool select, bool raiseSelectionChanged)
 {
-    bool selected = false;
     bool newSelection = true;
 
     // Handle single select differently as comparing indexpaths is faster
@@ -628,7 +627,7 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
         if (auto const selectedIndex = SelectedIndex())
         {
             // If paths are equal and we want to select, skip everything and do nothing
-            if (selectedIndex.CompareTo(index) == 0 && select)
+            if (select && selectedIndex.CompareTo(index) == 0)
             {
                 newSelection = false;
             }
@@ -644,6 +643,7 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
     // Selection is actually different from previous one, so update.
     if (newSelection)
     {
+        bool selected = false;
         // If we unselect something, raise event any way, otherwise changedSelection is false
         bool changedSelection = false;
 

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include <pch.h>
@@ -585,7 +585,7 @@ void SelectionModel::OnSelectionChanged()
 
 void SelectionModel::SelectImpl(int index, bool select)
 {
-    if (!m_rootNode->IsSelected(index))
+    if (m_rootNode->IsSelected(index) != select)
     {
         if (m_singleSelect)
         {
@@ -627,8 +627,8 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
     {
         if (auto const selectedIndex = SelectedIndex())
         {
-            // If paths are equal, skip everything and do nothing
-            if (selectedIndex.CompareTo(index) == 0)
+            // If paths are equal and we want to select, skip everything and do nothing
+            if (selectedIndex.CompareTo(index) == 0 && select)
             {
                 newSelection = false;
             }
@@ -638,7 +638,8 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
     // Selection is actually different from previous one, so update.
     if (newSelection)
     {
-        bool changedSelection = false;
+        // If we unselect something, raise event any way, otherwise changedSelection is false
+        bool changedSelection = !select;
 
         if (m_singleSelect)
         {
@@ -655,7 +656,7 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
                 {
                     if (!currentNode->IsSelected(childIndex))
                     {
-                        // Node is not already selected, so we need to raise event
+                        // Node has different value then we want to set, so lets update!
                         changedSelection = true;
                     }
                     selected = currentNode->Select(childIndex, select);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add checks for single selection to prevent raising event in case new selection is previous one.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #1642
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add API test
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->