### PR TITLE
Fix ToggleSplitButton's IsCheckedProperty not being a public DP

### DIFF
--- a/dev/SplitButton/APITests/SplitButtonTests.cs
+++ b/dev/SplitButton/APITests/SplitButtonTests.cs
@@ -69,25 +69,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             RunOnUIThread.Execute(() =>
             {
-                ToggleSplitButton toggleSplitButton = SetupToggleSplitButton();
+                ToggleSplitButton toggleSplitButton = new ToggleSplitButton();
 
                 Verify.IsFalse(toggleSplitButton.IsChecked, "ToggleSplitButton is not unchecked");
 
                 toggleSplitButton.SetValue(ToggleSplitButton.IsCheckedProperty, true);
 
-                Content.UpdateLayout();
-
                 bool isChecked = (bool)toggleSplitButton.GetValue(ToggleSplitButton.IsCheckedProperty);
                 Verify.IsTrue(isChecked, "ToggleSplitButton is not checked");
             });
-        }
-
-        private ToggleSplitButton SetupToggleSplitButton()
-        {
-            ToggleSplitButton toggleSplitButton = new ToggleSplitButton();
-            Content = toggleSplitButton;
-
-            return toggleSplitButton;
         }
     }
 

--- a/dev/SplitButton/APITests/SplitButtonTests.cs
+++ b/dev/SplitButton/APITests/SplitButtonTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 #endif
 
 using SplitButton = Microsoft.UI.Xaml.Controls.SplitButton;
+using ToggleSplitButton = Microsoft.UI.Xaml.Controls.ToggleSplitButton;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -61,10 +62,38 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual(splitButton.CommandParameter, parameter);
             });
         }
+
+        [TestMethod]
+        [Description("Verifies ToggleSplitButton IsChecked property.")]
+        public void VerifyIsCheckedProperty()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                ToggleSplitButton toggleSplitButton = SetupToggleSplitButton();
+
+                Verify.IsFalse(toggleSplitButton.IsChecked, "ToggleSplitButton is not unchecked");
+
+                toggleSplitButton.SetValue(ToggleSplitButton.IsCheckedProperty, true);
+
+                Content.UpdateLayout();
+
+                bool isChecked = (bool)toggleSplitButton.GetValue(ToggleSplitButton.IsCheckedProperty);
+                Verify.IsTrue(isChecked, "ToggleSplitButton is not checked");
+            });
+        }
+
+        private ToggleSplitButton SetupToggleSplitButton()
+        {
+            ToggleSplitButton toggleSplitButton = new ToggleSplitButton();
+            Content = toggleSplitButton;
+
+            return toggleSplitButton;
+        }
     }
 
+
     // CanExecuteChanged is never used -- that's ok, disable the compiler warning.
-    #pragma warning disable CS0067
+#pragma warning disable CS0067
     public class TestCommand : ICommand
     {
         public event EventHandler CanExecuteChanged;

--- a/dev/SplitButton/SplitButton.idl
+++ b/dev/SplitButton/SplitButton.idl
@@ -44,10 +44,11 @@ unsealed runtimeclass ToggleSplitButton : SplitButton
 {
     ToggleSplitButton();
 
-    [MUX_PROPERTY_NEEDS_DP_FIELD]
     Boolean IsChecked{ get; set; };
 
     event Windows.Foundation.TypedEventHandler<ToggleSplitButton, ToggleSplitButtonIsCheckedChangedEventArgs> IsCheckedChanged;
+
+    static Windows.UI.Xaml.DependencyProperty IsCheckedProperty{ get; };
 }
 
 }

--- a/dev/SplitButton/TestUI/SplitButtonPage.xaml
+++ b/dev/SplitButton/TestUI/SplitButtonPage.xaml
@@ -117,6 +117,11 @@
                 <TextBlock x:Name="ToggleStateOnClickTextBlock" AutomationProperties.Name="ToggleStateOnClickTextBlock" Margin="4,0,0,0" Text="Unchecked"/>
             </StackPanel>
 
+            <StackPanel Orientation="Horizontal" Margin="0,12,0,12">
+                <controls:ToggleSplitButton x:Name="BindingToggleSplitButton" Content="IsChecked" IsChecked="{Binding IsChecked, ElementName=IsCheckedCheckBox, Mode=TwoWay}"/>
+                <CheckBox x:Name="IsCheckedCheckBox" Content="IsChecked" IsChecked="False" Margin="12,0,0,0"/>
+            </StackPanel>
+
             <controls:ToggleSplitButton Content="Initially Checked" IsChecked="True"/>
 
             <StackPanel Orientation="Horizontal" Margin="0,12,0,0">


### PR DESCRIPTION
## Description
This PR adds a public DP IsCheckedProperty to the ToggleSplitButton.

## Motivation and Context
Fixes #2218.

## How Has This Been Tested?
Tested locally.

## Open Questions
1) Do I need to add an annotation for the added DP (like `[WUXC_VERSION_PREVIEW]`)?
2) Do we need to add a test here? I added an initial test to check if Binding works (no matching interaction test yet). It follows the enabled/disabled ToggleSplitButton test on the same MUXControlsTestApp page which also has no accompanying interaction test (1). Is it intentional that there is no interaction test for it?

(1)
![togglesplitbutton](https://user-images.githubusercontent.com/1398851/78823709-6eb04300-79dd-11ea-8d8b-728727943d51.png)
