### PR TITLE
Fix incremental build break

### DIFF
--- a/test/IXMPTestApp/IXMPTestApp.Shared.projitems
+++ b/test/IXMPTestApp/IXMPTestApp.Shared.projitems
@@ -196,6 +196,7 @@
     <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(CSharpTargetsFilePath)" />
+  <Import Project="..\RetargetCopyLocalFiles.targets" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\CustomInlineTasks.targets" />
   <Target Name="CustomAfterGenerateAppPackages" AfterTargets="_GenerateAppxPackage" Condition="$(BuildingWithBuildExe) != 'true'">
     <RunPowershellScript Path="$(MSBuildThisFileDirectory)\..\..\tools\ExtractPackageDependencies.ps1" Parameters="-sourceFile $(OutDir)\$(MSBuildProjectName).build.appxrecipe -platform $(PlatformName) -outputFile $(AppxPackageTestDir)$(AppxPackageName).dependencies.txt" FilesWritten="$(AppxPackageTestDir)$(AppxPackageName).dependencies.txt" />

--- a/test/MUXControlsAdhocApp/MUXControlsAdhocApp.csproj
+++ b/test/MUXControlsAdhocApp/MUXControlsAdhocApp.csproj
@@ -181,6 +181,7 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="..\RetargetCopyLocalFiles.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -339,6 +339,7 @@
     <VisualStudioVersion>15.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(CSharpTargetsFilePath)" />
+  <Import Project="..\RetargetCopyLocalFiles.targets" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\CustomInlineTasks.targets" />
   <Target Name="RemovePagesToTest" BeforeTargets="MarkupCompilePass1">
     <ItemGroup>

--- a/test/RetargetCopyLocalFiles.targets
+++ b/test/RetargetCopyLocalFiles.targets
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="RetargetCopyLocalFiles" AfterTargets="GetCopyToOutputDirectoryItems" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory">
+    <!-- Microsoft.UI.Xaml lists its CopyToOutputDirectory files as the ones from the IntDir, since that's where
+         *it* copies to *its* output directory. However, the IncrementalClean target will clean up those files
+         if they weren't rebuilt, so anything including Microsoft.UI.Xaml will need to retarget the files' sources
+         to the project's OutDir instead. -->
+    <PropertyGroup>
+      <_ThemesSuffix>Themes\</_ThemesSuffix>
+      <_DensityStylesSuffix>DensityStyles\</_DensityStylesSuffix>
+      <_MuxIntDir>$([System.IO.Path]::GetFullPath('$(IntDir)..\..\Microsoft.UI.Xaml\obj\Generated Files\'))</_MuxIntDir>
+      <_MuxIntDirThemes>$(_MuxIntDir)$(_ThemesSuffix)</_MuxIntDirThemes>
+      <_MuxIntDirDensityStyles>$(_MuxIntDir)$(_DensityStylesSuffix)</_MuxIntDirDensityStyles>
+      <_MuxOutDir>$([System.IO.Path]::GetFullPath('$(OutDir)..\Microsoft.UI.Xaml\Microsoft.UI.Xaml\'))</_MuxOutDir>
+      <_MuxOutDirThemes>$(_MuxOutDir)$(_ThemesSuffix)</_MuxOutDirThemes>
+      <_MuxOutDirDensityStyles>$(_MuxOutDir)$(_DensityStylesSuffix)</_MuxOutDirDensityStyles>
+    </PropertyGroup>
+    <ItemGroup>
+      <_MuxCopyLocalXamlThemesFiles Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="'%(RootDir)%(Directory)' == '$(_MuxIntDirThemes)'" />
+      <_MuxCopyLocalXamlDensityStylesFiles Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="'%(RootDir)%(Directory)' == '$(_MuxIntDirDensityStyles)'" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_MuxCopyLocalXamlThemesFiles)" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_MuxCopyLocalXamlDensityStylesFiles)" />
+      <_SourceItemsToCopyToOutputDirectory Include="@(_MuxCopyLocalXamlThemesFiles -> '$(_MuxOutDirThemes)%(Filename)%(Extension)')" />
+      <_SourceItemsToCopyToOutputDirectory Include="@(_MuxCopyLocalXamlDensityStylesFiles -> '$(_MuxOutDirDensityStyles)%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <Message Text="_SourceItemsToCopyToOutputDirectory = @(_SourceItemsToCopyToOutputDirectory -> '%(RootDir)%(Directory)')" />
+  </Target>
+</Project>

--- a/test/RetargetCopyLocalFiles.targets
+++ b/test/RetargetCopyLocalFiles.targets
@@ -1,11 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="RetargetCopyLocalFiles" AfterTargets="GetCopyToOutputDirectoryItems" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory">
-    <!-- Microsoft.UI.Xaml lists its CopyToOutputDirectory files as the ones from the IntDir, since that's where
-         *it* copies to *its* output directory. However, the IncrementalClean target will clean up those files
-         if they weren't rebuilt, so anything including Microsoft.UI.Xaml will need to retarget the files' sources
-         to the project's OutDir instead. -->
+  <!-- We'll put these properties in a target to ensure that IntDir and OutDir have been populated when we set the other properties. -->
+  <Target Name="_SetMuxDirs">
     <PropertyGroup>
       <_ThemesSuffix>Themes\</_ThemesSuffix>
       <_DensityStylesSuffix>DensityStyles\</_DensityStylesSuffix>
@@ -16,6 +13,15 @@
       <_MuxOutDirThemes>$(_MuxOutDir)$(_ThemesSuffix)</_MuxOutDirThemes>
       <_MuxOutDirDensityStyles>$(_MuxOutDir)$(_DensityStylesSuffix)</_MuxOutDirDensityStyles>
     </PropertyGroup>
+  </Target>
+  <!-- Microsoft.UI.Xaml lists its CopyToOutputDirectory files as the ones from the IntDir, since that's where
+       *it* copies to *its* output directory. However, the IncrementalClean target will clean up those files
+       if they weren't rebuilt, so anything including Microsoft.UI.Xaml will need to retarget the files' sources
+       to the project's OutDir instead. -->
+  <Target Name="RetargetCopyLocalFiles" AfterTargets="GetCopyToOutputDirectoryItems" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory" DependsOnTargets="_SetMuxDirs">
+    <Message Text="_MuxIntDir = $(_MuxIntDir)" />
+    <Message Text="_MuxOutDir = $(_MuxOutDir)" />
+    <Message Text="_SourceItemsToCopyToOutputDirectory = @(_SourceItemsToCopyToOutputDirectory)" />
     <ItemGroup>
       <_MuxCopyLocalXamlThemesFiles Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="'%(RootDir)%(Directory)' == '$(_MuxIntDirThemes)'" />
       <_MuxCopyLocalXamlDensityStylesFiles Include="@(_SourceItemsToCopyToOutputDirectory)" Condition="'%(RootDir)%(Directory)' == '$(_MuxIntDirDensityStyles)'" />
@@ -24,6 +30,24 @@
       <_SourceItemsToCopyToOutputDirectory Include="@(_MuxCopyLocalXamlThemesFiles -> '$(_MuxOutDirThemes)%(Filename)%(Extension)')" />
       <_SourceItemsToCopyToOutputDirectory Include="@(_MuxCopyLocalXamlDensityStylesFiles -> '$(_MuxOutDirDensityStyles)%(Filename)%(Extension)')" />
     </ItemGroup>
-    <Message Text="_SourceItemsToCopyToOutputDirectory = @(_SourceItemsToCopyToOutputDirectory -> '%(RootDir)%(Directory)')" />
+    <Message Text="_MuxCopyLocalXamlThemesFiles = @(_MuxCopyLocalXamlThemesFiles)" />
+    <Message Text="_MuxCopyLocalXamlDensityStylesFiles = @(_MuxCopyLocalXamlDensityStylesFiles)" />
+    <Message Text="_SourceItemsToCopyToOutputDirectory = @(_SourceItemsToCopyToOutputDirectory)" />
+  </Target>
+  <Target Name="RetargetAppxPackagePayloadFiles" AfterTargets="_WireUpCoreRuntime" BeforeTargets="_GenerateAppxPackageRecipeFile" DependsOnTargets="_SetMuxDirs">
+    <Message Text="_MuxIntDir = $(_MuxIntDir)" />
+    <Message Text="_MuxOutDir = $(_MuxOutDir)" />
+    <Message Text="AppxPackagePayload = @(AppxPackagePayload)" />
+    <ItemGroup>
+      <_MuxPayloadXamlThemesFiles Include="@(AppxPackagePayload)" Condition="'%(RootDir)%(Directory)' == '$(_MuxIntDirThemes)'" />
+      <_MuxPayloadXamlDensityStylesFiles Include="@(AppxPackagePayload)" Condition="'%(RootDir)%(Directory)' == '$(_MuxIntDirDensityStyles)'" />
+      <AppxPackagePayload Remove="@(_MuxPayloadXamlThemesFiles)" />
+      <AppxPackagePayload Remove="@(_MuxPayloadXamlDensityStylesFiles)" />
+      <AppxPackagePayload Include="@(_MuxPayloadXamlThemesFiles -> '$(_MuxOutDirThemes)%(Filename)%(Extension)')" />
+      <AppxPackagePayload Include="@(_MuxPayloadXamlDensityStylesFiles -> '$(_MuxOutDirDensityStyles)%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <Message Text="_MuxPayloadXamlThemesFiles = @(_MuxPayloadXamlThemesFiles)" />
+    <Message Text="_MuxPayloadXamlDensityStylesFiles = @(_MuxPayloadXamlDensityStylesFiles)" />
+    <Message Text="AppxPackagePayload = @(AppxPackagePayload)" />
   </Target>
 </Project>

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -272,6 +272,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="..\RetargetCopyLocalFiles.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>


### PR DESCRIPTION
## Description
This adds a targets file that our test projects import that fixes up our copy-local items from Microsoft.UI.Xaml.vcxproj.  That project reports the files from its $(IntDir), but those are deleted during IncrementalClean if they weren't built, leading to build breaks.  The targets file includes a target that repoints those files to Microsoft.UI.Xaml.vcxproj's $(OutDir) instead, which is where those files ultimately end up.

I'm not sure what changed here in VS 16.5 - either IncrementalClean changed to delete these files when it wasn't deleting them before, or the importing of copy-local items was changed.  I suspect this may be working around a bug in VS of some sort.  Either way, repointing the files that include the project to its $(OutDir) fixes the issue.

## Motivation and Context
Fixes #2221 

## How Has This Been Tested?
Compiled the solution fully, then made a dummy change in Microsoft.UI.Xaml.vcxproj and built incrementally.  Verified both that the build only built the file that was changed and that there were no build errors in other projects.