### PR TITLE
Fix FlowLayout LineSpacing and MinItemSpacing

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutTests.cs
@@ -1601,22 +1601,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         break;
 
                     case LayoutChoice.Grid:
-                        var minRowSpacing = om.ScrollOrientation == ScrollOrientation.Vertical ? lineSpacing : 0;
-                        var minColumnSpacing = om.ScrollOrientation == ScrollOrientation.Horizontal ? lineSpacing : 0;
-                        layout = new UniformGridLayout() { MinItemWidth = itemSize, MinItemHeight = itemSize, MinRowSpacing = minRowSpacing, MinColumnSpacing = minColumnSpacing };
+                        {
+                            var minRowSpacing = om.ScrollOrientation == ScrollOrientation.Vertical ? lineSpacing : 0;
+                            var minColumnSpacing = om.ScrollOrientation == ScrollOrientation.Horizontal ? lineSpacing : 0;
+                            layout = new UniformGridLayout() { MinItemWidth = itemSize, MinItemHeight = itemSize, MinRowSpacing = minRowSpacing, MinColumnSpacing = minColumnSpacing };
+                        }
                         break;
 
                     case LayoutChoice.Flow:
-                        layout = new FlowLayoutDerived()
                         {
-                            MinColumnSpacing = lineSpacing,
-                            OnLineArrangedFunc = (int startIndex, int countInLine, double lineSize, VirtualizingLayoutContext context) =>
+                            var minRowSpacing = om.ScrollOrientation == ScrollOrientation.Vertical ? lineSpacing : 0;
+                            var minColumnSpacing = om.ScrollOrientation == ScrollOrientation.Horizontal ? lineSpacing : 0;
+                            layout = new FlowLayoutDerived()
                             {
-                                Verify.AreEqual(0, startIndex % 4);
-                                Verify.AreEqual(4, countInLine);
-                                Verify.AreEqual(lineSize, itemSize);
-                            }
-                        };
+                                MinRowSpacing = minRowSpacing,
+                                MinColumnSpacing = minColumnSpacing,
+                                OnLineArrangedFunc = (int startIndex, int countInLine, double lineSize, VirtualizingLayoutContext context) =>
+                                {
+                                    Verify.AreEqual(0, startIndex % 4);
+                                    Verify.AreEqual(4, countInLine);
+                                    Verify.AreEqual(lineSize, itemSize);
+                                }
+                            };
+                        }
                         break;
 
                     default:

--- a/dev/Repeater/FlowLayout.h
+++ b/dev/Repeater/FlowLayout.h
@@ -145,12 +145,12 @@ private:
 
     double LineSpacing()
     {
-        return ScrollOrientation() == ScrollOrientation::Vertical ? m_minColumnSpacing : m_minRowSpacing;
+        return GetScrollOrientation() == ScrollOrientation::Vertical ? m_minRowSpacing : m_minColumnSpacing;
     }
 
     double MinItemSpacing()
     {
-        return ScrollOrientation() == ScrollOrientation::Vertical ? m_minRowSpacing : m_minColumnSpacing;
+        return GetScrollOrientation() == ScrollOrientation::Vertical ? m_minColumnSpacing : m_minRowSpacing;
     }
 
     // Fields


### PR DESCRIPTION
## Description
Fix `FlowLayout`'s `LineSpacing` and `MinItemSpacing` and make them consistent with `UniformGridLayout`.

## Motivation and Context
The `ScrollOrientation()` originally used in `LineSpacing()` and `MinItemSpacing()` always evaluated to `ScrollOrientation::Vertical`, and the expressions after the `?` operator were reversed.

## How Has This Been Tested?
Modified existing test.