### PR TITLE
Switch helper functionality

### DIFF
--- a/dev/Repeater/FlowLayout.cpp
+++ b/dev/Repeater/FlowLayout.cpp
@@ -134,18 +134,18 @@ winrt::FlowLayoutAnchorInfo FlowLayout::GetAnchorForRealizationRect(
         const double averageLineSize = GetAverageLineInfo(availableSize, context, flowState, averageItemsPerLine) + LineSpacing();
         MUX_ASSERT(averageItemsPerLine != 0);
 
-        const double extentMajorSize = lastExtent.*MajorSize() == 0 ? (itemsCount / averageItemsPerLine) * averageLineSize : lastExtent.*MajorSize();
+        const double extentMajorSize = MajorSize(lastExtent) == 0 ? (itemsCount / averageItemsPerLine) * averageLineSize : MajorSize(lastExtent);
         if (itemsCount > 0 &&
-            realizationRect.*MajorSize() > 0 &&
-            DoesRealizationWindowOverlapExtent(realizationRect, MinorMajorRect(lastExtent.*MinorStart(), lastExtent.*MajorStart(), availableSize.*Minor(), static_cast<float>(extentMajorSize))))
+            MajorSize(realizationRect) > 0 &&
+            DoesRealizationWindowOverlapExtent(realizationRect, MinorMajorRect(MinorStart(lastExtent), MajorStart(lastExtent), Minor(availableSize), static_cast<float>(extentMajorSize))))
         {
-            const double realizationWindowStartWithinExtent = realizationRect.*MajorStart() - lastExtent.*MajorStart();
+            const double realizationWindowStartWithinExtent = MajorStart(realizationRect) - MajorStart(lastExtent);
             const int lineIndex = std::max(0, (int)(realizationWindowStartWithinExtent / averageLineSize));
             anchorIndex = (int)(lineIndex * averageItemsPerLine);
 
             // Clamp it to be within valid range
             anchorIndex = std::max(0, std::min(itemsCount - 1, anchorIndex));
-            offset = lineIndex * averageLineSize + lastExtent.*MajorStart();
+            offset = lineIndex * averageLineSize + MajorStart(lastExtent);
         }
     }
 
@@ -169,7 +169,7 @@ winrt::FlowLayoutAnchorInfo FlowLayout::GetAnchorForTargetElement(
         double averageItemsPerLine = 0;
         const double averageLineSize = GetAverageLineInfo(availableSize, context, flowState, averageItemsPerLine) + LineSpacing();
         const int lineIndex = (int)(targetIndex / averageItemsPerLine);
-        offset = lineIndex * averageLineSize + flowState->FlowAlgorithm().LastExtent().*MajorStart();
+        offset = lineIndex * averageLineSize + MajorStart(flowState->FlowAlgorithm().LastExtent());
     }
 
     return { index, offset };
@@ -193,7 +193,7 @@ winrt::Rect FlowLayout::GetExtent(
 
     if (itemsCount > 0)
     {
-        const float availableSizeMinor = availableSize.*Minor();
+        const float availableSizeMinor = Minor(availableSize);
         const auto state = context.LayoutState();
         const auto flowState = GetAsFlowState(state);
         double averageItemsPerLine = 0;
@@ -204,17 +204,17 @@ winrt::Rect FlowLayout::GetExtent(
         {
             MUX_ASSERT(lastRealized);
             const int linesBeforeFirst = static_cast<int>(firstRealizedItemIndex / averageItemsPerLine);
-            const double extentMajorStart = firstRealizedLayoutBounds.*MajorStart() - linesBeforeFirst * averageLineSize;
-            extent.*MajorStart() = static_cast<float>(extentMajorStart);
+            const double extentMajorStart = MajorStart(firstRealizedLayoutBounds) - linesBeforeFirst * averageLineSize;
+            MajorStart(extent) = static_cast<float>(extentMajorStart);
             const int remainingItems = itemsCount - lastRealizedItemIndex - 1;
             const int remainingLinesAfterLast = static_cast<int>((remainingItems / averageItemsPerLine));
-            const double extentMajorSize = MajorEnd(lastRealizedLayoutBounds) - extent.*MajorStart() + remainingLinesAfterLast * averageLineSize;
-            extent.*MajorSize() = static_cast<float>(extentMajorSize);
+            const double extentMajorSize = MajorEnd(lastRealizedLayoutBounds) - MajorStart(extent) + remainingLinesAfterLast * averageLineSize;
+            MajorSize(extent) = static_cast<float>(extentMajorSize);
 
             // If the available size is infinite, we will have realized all the items in one line.
             // In that case, the extent in the non virtualizing direction should be based on the
             // right/bottom of the last realized element.
-            extent.*MinorSize() =
+            MinorSize(extent) =
                 std::isfinite(availableSizeMinor) ?
                 availableSizeMinor :
                 std::max(0.0f, MinorEnd(lastRealizedLayoutBounds));
@@ -231,7 +231,7 @@ winrt::Rect FlowLayout::GetExtent(
                 MinorMajorRect(
                     0,
                     0,
-                    std::max(0.0f, static_cast<float>((flowState->SpecialElementDesiredSize().*Minor() + minItemSpacing) * itemsCount - minItemSpacing)),
+                    std::max(0.0f, static_cast<float>((Minor(flowState->SpecialElementDesiredSize()) + minItemSpacing) * itemsCount - minItemSpacing)),
                     std::max(0.0f, static_cast<float>(averageLineSize - lineSpacing)));
             REPEATER_TRACE_INFO(L"%*s: \tEstimating extent with no realized elements. \n", winrt::get_self<VirtualizingLayoutContext>(context)->Indent(), LayoutId().data());
         }
@@ -412,8 +412,8 @@ double FlowLayout::GetAverageLineInfo(
         const auto desiredSize = flowState->FlowAlgorithm().MeasureElement(tmpElement, 0, availableSize, context);
         context.RecycleElement(tmpElement);
 
-        int estimatedCountInLine = std::max(1, static_cast<int>(availableSize.*Minor() / desiredSize.*Minor()));
-        flowState->OnLineArranged(0, estimatedCountInLine, desiredSize.*Major(), context);
+        int estimatedCountInLine = std::max(1, static_cast<int>(Minor(availableSize) / Minor(desiredSize)));
+        flowState->OnLineArranged(0, estimatedCountInLine, Major(desiredSize), context);
         flowState->SpecialElementDesiredSize(desiredSize);
     }
 

--- a/dev/Repeater/FlowLayout.h
+++ b/dev/Repeater/FlowLayout.h
@@ -140,7 +140,7 @@ private:
 
     bool DoesRealizationWindowOverlapExtent(const winrt::Rect& realizationWindow, const winrt::Rect& extent)
     {
-        return MajorEnd(realizationWindow) >= extent.*MajorStart() && realizationWindow.*MajorStart() <= MajorEnd(extent);
+        return MajorEnd(realizationWindow) >= MajorStart(extent) && MajorStart(realizationWindow) <= MajorEnd(extent);
     }
 
     double LineSpacing()

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -41,7 +41,7 @@ winrt::Size FlowLayoutAlgorithm::Measure(
     SetScrollOrientation(orientation);
 
     // If minor size is infinity, there is only one line and no need to align that line.
-    m_scrollOrientationSameAsFlow = availableSize.*Minor() == std::numeric_limits<float>::infinity();
+    m_scrollOrientationSameAsFlow = Minor(availableSize) == std::numeric_limits<float>::infinity();
     const auto realizationRect = RealizationRect();
     REPEATER_TRACE_INFO(L"%*s: \tMeasureLayout Realization(%.0f,%.0f,%.0f,%.0f)\n",
         winrt::get_self<VirtualizingLayoutContext>(context)->Indent(),
@@ -67,7 +67,7 @@ winrt::Size FlowLayoutAlgorithm::Measure(
     {
         REPEATER_TRACE_INFO(L"%*s: \tReflow Pass \n", winrt::get_self<VirtualizingLayoutContext>(context)->Indent(), layoutId.data());
         auto firstElementBounds = m_elementManager.GetLayoutBoundsForRealizedIndex(0);
-        firstElementBounds.*MinorStart() = 0;
+        MinorStart(firstElementBounds) = 0;
         m_elementManager.SetLayoutBoundsForRealizedIndex(0, firstElementBounds);
         Generate(GenerateDirection::Forward, 0 /*anchorIndex*/, availableSize, minItemSpacing, lineSpacing, maxItemsPerLine, disableVirtualization, layoutId);
     }
@@ -165,7 +165,7 @@ int FlowLayoutAlgorithm::GetAnchorIndex(
         // and get a new column position. In that case we need the anchor to be positioned in the
         // correct column.
         bool needAnchorColumnRevaluation = isWrapping && (
-            m_lastAvailableSize.*Minor() != availableSize.*Minor() ||
+            Minor(m_lastAvailableSize) != Minor(availableSize) ||
             m_lastItemSpacing != minItemSpacing ||
             m_collectionChangePending);
 
@@ -190,7 +190,7 @@ int FlowLayoutAlgorithm::GetAnchorIndex(
                     // We were provided a valid anchor, but its position might be incorrect because for example it is in
                     // the wrong column. We do know that the anchor is the first element in the row, so we can force the minor position
                     // to start at 0.
-                    anchorPosition = MinorMajorPoint(0, anchorBounds.*MajorStart());
+                    anchorPosition = MinorMajorPoint(0, MajorStart(anchorBounds));
                 }
                 else
                 {
@@ -211,7 +211,7 @@ int FlowLayoutAlgorithm::GetAnchorIndex(
                 }
 
                 auto anchorBounds = m_elementManager.GetLayoutBoundsForDataIndex(suggestedAnchorIndex);
-                anchorPosition = MinorMajorPoint(0, anchorBounds.*MajorStart());
+                anchorPosition = MinorMajorPoint(0, MajorStart(anchorBounds));
             }
         }
         else if (needAnchorColumnRevaluation || !isRealizationWindowConnected)
@@ -301,8 +301,8 @@ void FlowLayoutAlgorithm::Generate(
         int previousIndex = anchorIndex;
         int currentIndex = anchorIndex + step;
         auto anchorBounds = m_elementManager.GetLayoutBoundsForDataIndex(anchorIndex);
-        float lineOffset = anchorBounds.*MajorStart();
-        float lineMajorSize = anchorBounds.*MajorSize();
+        float lineOffset = MajorStart(anchorBounds);
+        float lineMajorSize = MajorSize(anchorBounds);
         unsigned int countInLine = 1;
         bool lineNeedsReposition = false;
 
@@ -321,12 +321,12 @@ void FlowLayoutAlgorithm::Generate(
 
             if (direction == GenerateDirection::Forward)
             {
-                double remainingSpace = availableSize.*Minor() - (previousElementBounds.*MinorStart() + previousElementBounds.*MinorSize() + minItemSpacing + desiredSize.*Minor());
+                double remainingSpace = Minor(availableSize) - (MinorStart(previousElementBounds) + MinorSize(previousElementBounds) + minItemSpacing + Minor(desiredSize));
                 if (countInLine >= maxItemsPerLine || m_algorithmCallbacks->Algorithm_ShouldBreakLine(currentIndex, remainingSpace))
                 {
                     // No more space in this row. wrap to next row.
-                    currentBounds.*MinorStart() = 0;
-                    currentBounds.*MajorStart() = previousElementBounds.*MajorStart() + lineMajorSize + static_cast<float>(lineSpacing);
+                    MinorStart(currentBounds) = 0;
+                    MajorStart(currentBounds) = MajorStart(previousElementBounds) + lineMajorSize + static_cast<float>(lineSpacing);
 
                     if (lineNeedsReposition)
                     {
@@ -335,41 +335,41 @@ void FlowLayoutAlgorithm::Generate(
                         {
                             auto dataIndex = currentIndex - 1 - i;
                             auto bounds = m_elementManager.GetLayoutBoundsForDataIndex(dataIndex);
-                            bounds.*MajorSize() = lineMajorSize;
+                            MajorSize(bounds) = lineMajorSize;
                             m_elementManager.SetLayoutBoundsForDataIndex(dataIndex, bounds);
                         }
                     }
 
                     // Setup for next line.
-                    lineMajorSize = currentBounds.*MajorSize();
-                    lineOffset = currentBounds.*MajorStart();
+                    lineMajorSize = MajorSize(currentBounds);
+                    lineOffset = MajorStart(currentBounds);
                     lineNeedsReposition = false;
                     countInLine = 1;
                 }
                 else
                 {
                     // More space is available in this row.
-                    currentBounds.*MinorStart() = previousElementBounds.*MinorStart() + previousElementBounds.*MinorSize() + static_cast<float>(minItemSpacing);
-                    currentBounds.*MajorStart() = lineOffset;
-                    lineMajorSize = std::max(lineMajorSize, currentBounds.*MajorSize());
-                    lineNeedsReposition = previousElementBounds.*MajorSize() != currentBounds.*MajorSize();
+                    MinorStart(currentBounds) = MinorStart(previousElementBounds) + MinorSize(previousElementBounds) + static_cast<float>(minItemSpacing);
+                    MajorStart(currentBounds) = lineOffset;
+                    lineMajorSize = std::max(lineMajorSize, MajorSize(currentBounds));
+                    lineNeedsReposition = MajorSize(previousElementBounds) != MajorSize(currentBounds);
                     countInLine++;
                 }
             }
             else
             {
                 // Backward
-                double remainingSpace = previousElementBounds.*MinorStart() - (desiredSize.*Minor() + static_cast<float>(minItemSpacing));
+                double remainingSpace = MinorStart(previousElementBounds) - (Minor(desiredSize) + static_cast<float>(minItemSpacing));
                 if (countInLine >= maxItemsPerLine || m_algorithmCallbacks->Algorithm_ShouldBreakLine(currentIndex, remainingSpace))
                 {
                     // Does not fit, wrap to the previous row
-                    const auto availableSizeMinor = availableSize.*Minor();
-                    currentBounds.*MinorStart() = std::isfinite(availableSizeMinor) ? availableSizeMinor - desiredSize.*Minor() : 0.0f;
-                    currentBounds.*MajorStart() = lineOffset - desiredSize.*Major() - static_cast<float>(lineSpacing);
+                    const auto availableSizeMinor = Minor(availableSize);
+                    MinorStart(currentBounds) = std::isfinite(availableSizeMinor) ? availableSizeMinor - Minor(desiredSize) : 0.0f;
+                    MajorStart(currentBounds) = lineOffset - Major(desiredSize) - static_cast<float>(lineSpacing);
 
                     if (lineNeedsReposition)
                     {
-                        auto previousLineOffset = m_elementManager.GetLayoutBoundsForDataIndex(currentIndex + countInLine + 1).*MajorStart();
+                        auto previousLineOffset = MajorStart(m_elementManager.GetLayoutBoundsForDataIndex(currentIndex + countInLine + 1));
                         // reposition the previous line (countInLine items)
                         for (unsigned int i = 0; i < countInLine; i++)
                         {
@@ -377,8 +377,8 @@ void FlowLayoutAlgorithm::Generate(
                             if (dataIndex != anchorIndex)
                             {
                                 auto bounds = m_elementManager.GetLayoutBoundsForDataIndex(dataIndex);
-                                bounds.*MajorStart() = previousLineOffset - lineMajorSize - static_cast<float>(lineSpacing);
-                                bounds.*MajorSize() = lineMajorSize;
+                                MajorStart(bounds) = previousLineOffset - lineMajorSize - static_cast<float>(lineSpacing);
+                                MajorSize(bounds) = lineMajorSize;
                                 m_elementManager.SetLayoutBoundsForDataIndex(dataIndex, bounds);
                                 REPEATER_TRACE_INFO(L"%*s: \t Corrected Layout bounds of element %d are (%.0f,%.0f,%.0f,%.0f). \n",
                                     winrt::get_self<VirtualizingLayoutContext>(m_context.get())->Indent(),
@@ -390,18 +390,18 @@ void FlowLayoutAlgorithm::Generate(
                     }
 
                     // Setup for next line.
-                    lineMajorSize = currentBounds.*MajorSize();
-                    lineOffset = currentBounds.*MajorStart();
+                    lineMajorSize = MajorSize(currentBounds);
+                    lineOffset = MajorStart(currentBounds);
                     lineNeedsReposition = false;
                     countInLine = 1;
                 }
                 else
                 {
                     // Fits in this row. put it in the previous position
-                    currentBounds.*MinorStart() = previousElementBounds.*MinorStart() - desiredSize.*Minor() - static_cast<float>(minItemSpacing);
-                    currentBounds.*MajorStart() = lineOffset;
-                    lineMajorSize = std::max(lineMajorSize, currentBounds.*MajorSize());
-                    lineNeedsReposition = previousElementBounds.*MajorSize() != currentBounds.*MajorSize();
+                    MinorStart(currentBounds) = MinorStart(previousElementBounds) - Minor(desiredSize) - static_cast<float>(minItemSpacing);
+                    MajorStart(currentBounds) = lineOffset;
+                    lineMajorSize = std::max(lineMajorSize, MajorSize(currentBounds));
+                    lineNeedsReposition = MajorSize(previousElementBounds) != MajorSize(currentBounds);
                     countInLine++;
                 }
             }
@@ -443,7 +443,9 @@ bool FlowLayoutAlgorithm::IsReflowRequired() const
     return
         m_elementManager.GetRealizedElementCount() > 0 &&
         m_elementManager.GetDataIndexFromRealizedRangeIndex(0) == 0 &&
-        m_elementManager.GetLayoutBoundsForRealizedIndex(0).*MinorStart() != 0;
+        (GetScrollOrientation() == ScrollOrientation::Vertical ?
+        m_elementManager.GetLayoutBoundsForRealizedIndex(0).X != 0 :
+        m_elementManager.GetLayoutBoundsForRealizedIndex(0).Y != 0);
 }
 
 bool FlowLayoutAlgorithm::ShouldContinueFillingUpSpace(
@@ -460,14 +462,14 @@ bool FlowLayoutAlgorithm::ShouldContinueFillingUpSpace(
         auto realizationRect = m_context.get().RealizationRect();
         auto elementBounds = m_elementManager.GetLayoutBoundsForDataIndex(index);
 
-        auto elementMajorStart = elementBounds.*MajorStart();
+        auto elementMajorStart = MajorStart(elementBounds);
         auto elementMajorEnd = MajorEnd(elementBounds);
-        auto rectMajorStart = realizationRect.*MajorStart();
+        auto rectMajorStart = MajorStart(realizationRect);
         auto rectMajorEnd = MajorEnd(realizationRect);
 
-        auto elementMinorStart = elementBounds.*MinorStart();
+        auto elementMinorStart = MinorStart(elementBounds);
         auto elementMinorEnd = MinorEnd(elementBounds);
-        auto rectMinorStart = realizationRect.*MinorStart();
+        auto rectMinorStart = MinorStart(realizationRect);
         auto rectMinorEnd = MinorEnd(realizationRect);
 
         // Ensure that both minor and major directions are taken into consideration so that if the scrolling direction
@@ -526,21 +528,21 @@ void FlowLayoutAlgorithm::RaiseLineArranged()
             MUX_ASSERT(m_firstRealizedDataIndexInsideRealizationWindow != -1 && m_lastRealizedDataIndexInsideRealizationWindow != -1);
             int countInLine = 0;
             auto previousElementBounds = m_elementManager.GetLayoutBoundsForDataIndex(m_firstRealizedDataIndexInsideRealizationWindow);
-            auto currentLineOffset = previousElementBounds.*MajorStart();
-            auto currentLineSize = previousElementBounds.*MajorSize();
+            auto currentLineOffset = MajorStart(previousElementBounds);
+            auto currentLineSize = MajorSize(previousElementBounds);
             for (int currentDataIndex = m_firstRealizedDataIndexInsideRealizationWindow; currentDataIndex <= m_lastRealizedDataIndexInsideRealizationWindow; currentDataIndex++)
             {
                 auto currentBounds = m_elementManager.GetLayoutBoundsForDataIndex(currentDataIndex);
-                if (currentBounds.*MajorStart() != currentLineOffset)
+                if (MajorStart(currentBounds) != currentLineOffset)
                 {
                     // Staring a new line
                     m_algorithmCallbacks->Algorithm_OnLineArranged(currentDataIndex - countInLine, countInLine, currentLineSize, m_context.get());
                     countInLine = 0;
-                    currentLineOffset = currentBounds.*MajorStart();
+                    currentLineOffset = MajorStart(currentBounds);
                     currentLineSize = 0;
                 }
 
-                currentLineSize = std::max(static_cast<float>(currentLineSize), currentBounds.*MajorSize());
+                currentLineSize = std::max(static_cast<float>(currentLineSize), MajorSize(currentBounds));
                 countInLine++;
                 previousElementBounds = currentBounds;
             }
@@ -568,25 +570,25 @@ void FlowLayoutAlgorithm::ArrangeVirtualizingLayout(
     {
         int countInLine = 1;
         auto previousElementBounds = m_elementManager.GetLayoutBoundsForRealizedIndex(0);
-        auto currentLineOffset = previousElementBounds.*MajorStart();
-        auto spaceAtLineStart = previousElementBounds.*MinorStart();
+        auto currentLineOffset = MajorStart(previousElementBounds);
+        auto spaceAtLineStart = MinorStart(previousElementBounds);
         float spaceAtLineEnd = 0;
-        float currentLineSize = previousElementBounds.*MajorSize();
+        float currentLineSize = MajorSize(previousElementBounds);
         for (int i = 1; i < realizedElementCount; i++)
         {
             auto currentBounds = m_elementManager.GetLayoutBoundsForRealizedIndex(i);
-            if (currentBounds.*MajorStart() != currentLineOffset)
+            if (MajorStart(currentBounds) != currentLineOffset)
             {
-                spaceAtLineEnd = finalSize.*Minor() - previousElementBounds.*MinorStart() - previousElementBounds.*MinorSize();
+                spaceAtLineEnd = Minor(finalSize) - MinorStart(previousElementBounds) - MinorSize(previousElementBounds);
                 PerformLineAlignment(i - countInLine, countInLine, spaceAtLineStart, spaceAtLineEnd, currentLineSize, lineAlignment, isWrapping, finalSize, layoutId);
-                spaceAtLineStart = currentBounds.*MinorStart();
+                spaceAtLineStart = MinorStart(currentBounds);
                 countInLine = 0;
-                currentLineOffset = currentBounds.*MajorStart();
+                currentLineOffset = MajorStart(currentBounds);
                 currentLineSize = 0;
             }
 
             countInLine++; // for current element
-            currentLineSize = std::max(currentLineSize, currentBounds.*MajorSize());
+            currentLineSize = std::max(currentLineSize, MajorSize(currentBounds));
             previousElementBounds = currentBounds;
         }
 
@@ -594,7 +596,7 @@ void FlowLayoutAlgorithm::ArrangeVirtualizingLayout(
         // aligning the last line or not.
         if (countInLine > 0)
         {
-            float spaceAtEnd = finalSize.*Minor() - previousElementBounds.*MinorStart() - previousElementBounds.*MinorSize();
+            float spaceAtEnd = Minor(finalSize) - MinorStart(previousElementBounds) - MinorSize(previousElementBounds);
             PerformLineAlignment(realizedElementCount - countInLine, countInLine, spaceAtLineStart, spaceAtEnd, currentLineSize, lineAlignment, isWrapping, finalSize, layoutId);
         }
     }
@@ -616,7 +618,7 @@ void FlowLayoutAlgorithm::PerformLineAlignment(
     for (int rangeIndex = lineStartIndex; rangeIndex < lineStartIndex + countInLine; ++rangeIndex)
     {
         auto bounds = m_elementManager.GetLayoutBoundsForRealizedIndex(rangeIndex);
-        bounds.*MajorSize() = lineSize;
+        MajorSize(bounds) = lineSize;
 
         if (!m_scrollOrientationSameAsFlow)
         {
@@ -628,44 +630,44 @@ void FlowLayoutAlgorithm::PerformLineAlignment(
                 {
                 case FlowLayoutAlgorithm::LineAlignment::Start:
                 {
-                    bounds.*MinorStart() -= spaceAtLineStart;
+                    MinorStart(bounds) -= spaceAtLineStart;
                     break;
                 }
 
                 case FlowLayoutAlgorithm::LineAlignment::End:
                 {
-                    bounds.*MinorStart() += spaceAtLineEnd;
+                    MinorStart(bounds) += spaceAtLineEnd;
                     break;
                 }
 
                 case FlowLayoutAlgorithm::LineAlignment::Center:
                 {
-                    bounds.*MinorStart() -= spaceAtLineStart;
-                    bounds.*MinorStart() += totalSpace / 2;
+                    MinorStart(bounds) -= spaceAtLineStart;
+                    MinorStart(bounds) += totalSpace / 2;
                     break;
                 }
 
                 case FlowLayoutAlgorithm::LineAlignment::SpaceAround:
                 {
                     float interItemSpace = countInLine >= 1 ? totalSpace / (countInLine * 2) : 0;
-                    bounds.*MinorStart() -= spaceAtLineStart;
-                    bounds.*MinorStart() += interItemSpace * ((rangeIndex - lineStartIndex + 1) * 2 - 1);
+                    MinorStart(bounds) -= spaceAtLineStart;
+                    MinorStart(bounds) += interItemSpace * ((rangeIndex - lineStartIndex + 1) * 2 - 1);
                     break;
                 }
 
                 case FlowLayoutAlgorithm::LineAlignment::SpaceBetween:
                 {
                     float interItemSpace = countInLine > 1 ? totalSpace / (countInLine - 1) : 0;
-                    bounds.*MinorStart() -= spaceAtLineStart;
-                    bounds.*MinorStart() += interItemSpace * (rangeIndex - lineStartIndex);
+                    MinorStart(bounds) -= spaceAtLineStart;
+                    MinorStart(bounds) += interItemSpace * (rangeIndex - lineStartIndex);
                     break;
                 }
 
                 case FlowLayoutAlgorithm::LineAlignment::SpaceEvenly:
                 {
                     float interItemSpace = countInLine >= 1 ? totalSpace / (countInLine + 1) : 0;
-                    bounds.*MinorStart() -= spaceAtLineStart;
-                    bounds.*MinorStart() += interItemSpace * (rangeIndex - lineStartIndex + 1);
+                    MinorStart(bounds) -= spaceAtLineStart;
+                    MinorStart(bounds) += interItemSpace * (rangeIndex - lineStartIndex + 1);
                     break;
                 }
                 }
@@ -677,7 +679,7 @@ void FlowLayoutAlgorithm::PerformLineAlignment(
 
         if (!isWrapping)
         {
-            bounds.*MinorSize() = std::max(bounds.*MinorSize(), finalSize.*Minor());
+            MinorSize(bounds) = std::max(MinorSize(bounds), Minor(finalSize));
         }
 
         auto element = m_elementManager.GetAt(rangeIndex);

--- a/dev/Repeater/OrientationBasedMeasures.cpp
+++ b/dev/Repeater/OrientationBasedMeasures.cpp
@@ -6,7 +6,7 @@
 
 float& OrientationBasedMeasures::Major(const winrt::Size &size)
 {
-    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Size&)size).Height : ((winrt::Size&)size).Height;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Size&)size).Height : ((winrt::Size&)size).Width;
 }
 
 float& OrientationBasedMeasures::Minor(const winrt::Size& size)

--- a/dev/Repeater/OrientationBasedMeasures.cpp
+++ b/dev/Repeater/OrientationBasedMeasures.cpp
@@ -1,32 +1,32 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include <pch.h>
 #include "OrientationBasedMeasures.h"
 
-float winrt::Size::* OrientationBasedMeasures::Major() const
+float& OrientationBasedMeasures::Major(const winrt::Size &size)
 {
-    return m_orientation == ScrollOrientation::Vertical ? &winrt::Size::Height : &winrt::Size::Width;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Size&)size).Height : ((winrt::Size&)size).Height;
 }
 
-float winrt::Size::* OrientationBasedMeasures::Minor() const
+float& OrientationBasedMeasures::Minor(const winrt::Size& size)
 {
-    return m_orientation == ScrollOrientation::Vertical ? &winrt::Size::Width : &winrt::Size::Height;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Size&)size).Width : ((winrt::Size&)size).Height;
 }
 
-float winrt::Rect::* OrientationBasedMeasures::MajorSize() const
+float& OrientationBasedMeasures::MajorSize(const winrt::Rect& rect)
 {
-    return m_orientation == ScrollOrientation::Vertical ? &winrt::Rect::Height : &winrt::Rect::Width;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Rect&)rect).Height : ((winrt::Rect&)rect).Width;
 }
 
-float winrt::Rect::* OrientationBasedMeasures::MinorSize() const
+float& OrientationBasedMeasures::MinorSize(const winrt::Rect& rect)
 {
-    return m_orientation == ScrollOrientation::Vertical ? &winrt::Rect::Width : &winrt::Rect::Height;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Rect&)rect).Width : ((winrt::Rect&)rect).Height;
 }
 
-float winrt::Rect::* OrientationBasedMeasures::MajorStart() const
+float& OrientationBasedMeasures::MajorStart(const winrt::Rect& rect)
 {
-    return m_orientation == ScrollOrientation::Vertical ? &winrt::Rect::Y : &winrt::Rect::X;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Rect&)rect).Y : ((winrt::Rect&)rect).X;
 }
 
 float OrientationBasedMeasures::MajorEnd(const winrt::Rect& rect) const
@@ -35,9 +35,9 @@ float OrientationBasedMeasures::MajorEnd(const winrt::Rect& rect) const
         rect.Y + rect.Height : rect.X + rect.Width;
 }
 
-float winrt::Rect::* OrientationBasedMeasures::MinorStart() const
+float& OrientationBasedMeasures::MinorStart(const winrt::Rect& rect)
 {
-    return m_orientation == ScrollOrientation::Vertical ? &winrt::Rect::X : &winrt::Rect::Y;
+    return m_orientation == ScrollOrientation::Vertical ? ((winrt::Rect&)rect).X : ((winrt::Rect&)rect).Y;
 }
 
 float OrientationBasedMeasures::MinorEnd(const winrt::Rect& rect) const

--- a/dev/Repeater/OrientationBasedMeasures.h
+++ b/dev/Repeater/OrientationBasedMeasures.h
@@ -17,14 +17,14 @@ public:
 
     // Major - Scrolling/virtualizing direction
     // Minor - Opposite direction
-    float winrt::Size::* Major() const;
-    float winrt::Size::* Minor() const;
+    float& Major(const winrt::Size& size);
+    float& Minor(const winrt::Size& size);
 
-    float winrt::Rect::* MajorSize() const;
-    float winrt::Rect::* MinorSize() const;
-    float winrt::Rect::* MajorStart() const;
+    float& MajorSize(const winrt::Rect& rect);
+    float& MinorSize(const winrt::Rect& rect);
+    float& MajorStart(const winrt::Rect& rect);
     float MajorEnd(const winrt::Rect& rect) const;
-    float winrt::Rect::* MinorStart() const;
+    float& MinorStart(const winrt::Rect& rect);
     float MinorEnd(const winrt::Rect& rect) const;
 
     winrt::Rect MinorMajorRect(float minor, float major, float minorSize, float majorSize);

--- a/dev/Repeater/StackLayout.cpp
+++ b/dev/Repeater/StackLayout.cpp
@@ -117,18 +117,18 @@ winrt::FlowLayoutAnchorInfo StackLayout::GetAnchorForRealizationRect(
         const auto lastExtent = state->FlowAlgorithm().LastExtent();
 
         const double averageElementSize = GetAverageElementSize(availableSize, context, state) + m_itemSpacing;
-        const double realizationWindowOffsetInExtent = realizationRect.*MajorStart() - lastExtent.*MajorStart();
-        const double majorSize = lastExtent.*MajorSize() == 0 ? std::max(0.0, averageElementSize * itemsCount - m_itemSpacing) : lastExtent.*MajorSize();
+        const double realizationWindowOffsetInExtent = MajorStart(realizationRect) - MajorStart(lastExtent);
+        const double majorSize = MajorSize(lastExtent) == 0 ? std::max(0.0, averageElementSize * itemsCount - m_itemSpacing) : MajorSize(lastExtent);
         if (itemsCount > 0 &&
-            realizationRect.*MajorSize() >= 0 &&
+            MajorSize(realizationRect) >= 0 &&
             // MajorSize = 0 will account for when a nested repeater is outside the realization rect but still being measured. Also,
             // note that if we are measuring this repeater, then we are already realizing an element to figure out the size, so we could
             // just keep that element alive. It also helps in XYFocus scenarios to have an element realized for XYFocus to find a candidate
             // in the navigating direction.
-            realizationWindowOffsetInExtent + realizationRect.*MajorSize() >= 0 && realizationWindowOffsetInExtent <= majorSize)
+            realizationWindowOffsetInExtent + MajorSize(realizationRect) >= 0 && realizationWindowOffsetInExtent <= majorSize)
         {
             anchorIndex = (int)(realizationWindowOffsetInExtent / averageElementSize);
-            offset = anchorIndex * averageElementSize + lastExtent.*MajorStart();
+            offset = anchorIndex * averageElementSize + MajorStart(lastExtent);
             anchorIndex = std::max(0, std::min(itemsCount - 1, anchorIndex));
         }
     }
@@ -155,16 +155,16 @@ winrt::Rect StackLayout::GetExtent(
     const auto stackState = GetAsStackState(context.LayoutState());
     const double averageElementSize = GetAverageElementSize(availableSize, context, stackState) + m_itemSpacing;
 
-    extent.*MinorSize() = static_cast<float>(stackState->MaxArrangeBounds());
-    extent.*MajorSize() = std::max(0.0f, static_cast<float>(itemsCount * averageElementSize - m_itemSpacing));
+    MinorSize(extent) = static_cast<float>(stackState->MaxArrangeBounds());
+    MajorSize(extent) = std::max(0.0f, static_cast<float>(itemsCount * averageElementSize - m_itemSpacing));
     if (itemsCount > 0)
     {
         if (firstRealized)
         {
             MUX_ASSERT(lastRealized);
-            extent.*MajorStart() = static_cast<float>(firstRealizedLayoutBounds.*MajorStart() - firstRealizedItemIndex * averageElementSize);
+            MajorStart(extent) = static_cast<float>(MajorStart(firstRealizedLayoutBounds) - firstRealizedItemIndex * averageElementSize);
             auto remainingItems = itemsCount - lastRealizedItemIndex - 1;
-            extent.*MajorSize() = MajorEnd(lastRealizedLayoutBounds) - extent.*MajorStart() + static_cast<float>(remainingItems* averageElementSize);
+            MajorSize(extent) = MajorEnd(lastRealizedLayoutBounds) - MajorStart(extent) + static_cast<float>(remainingItems* averageElementSize);
         }
         else
         {
@@ -202,8 +202,8 @@ void StackLayout::OnElementMeasured(
         const auto provisionalArrangeSizeWinRt = provisionalArrangeSize;
         stackState->OnElementMeasured(
             index,
-            provisionalArrangeSizeWinRt.*Major(),
-            provisionalArrangeSizeWinRt.*Minor());
+            Major(provisionalArrangeSizeWinRt),
+            Minor(provisionalArrangeSizeWinRt));
     }
 }
 
@@ -218,12 +218,12 @@ winrt::Size StackLayout::Algorithm_GetMeasureSize(int /*index*/, const winrt::Si
 
 winrt::Size StackLayout::Algorithm_GetProvisionalArrangeSize(int /*index*/, const winrt::Size & measureSize, winrt::Size const& desiredSize, const winrt::VirtualizingLayoutContext& /*context*/)
 {
-    const auto measureSizeMinor = measureSize.*Minor();
+    const auto measureSizeMinor = Minor(measureSize);
     return MinorMajorSize(
         std::isfinite(measureSizeMinor) ?
-            std::max(measureSizeMinor, desiredSize.*Minor()) :
-            desiredSize.*Minor(),
-        desiredSize.*Major());
+            std::max(measureSizeMinor, Minor(desiredSize)) :
+            Minor(desiredSize),
+        Major(desiredSize));
 }
 
 bool StackLayout::Algorithm_ShouldBreakLine(int /*index*/, double /*remainingSpace*/)
@@ -252,7 +252,7 @@ winrt::FlowLayoutAnchorInfo StackLayout::Algorithm_GetAnchorForTargetElement(
         index = targetIndex;
         const auto state = GetAsStackState(context.LayoutState());
         const double averageElementSize = GetAverageElementSize(availableSize, context, state) + m_itemSpacing;
-        offset = index * averageElementSize + state->FlowAlgorithm().LastExtent().*MajorStart();
+        offset = index * averageElementSize + MajorStart(state->FlowAlgorithm().LastExtent());
     }
 
     return winrt::FlowLayoutAnchorInfo{ index, offset };

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -134,18 +134,18 @@ winrt::FlowLayoutAnchorInfo UniformGridLayout::Algorithm_GetAnchorForRealization
 
     int itemsCount = context.ItemCount();
     auto realizationRect = context.RealizationRect();
-    if (itemsCount > 0 && realizationRect.*MajorSize() > 0)
+    if (itemsCount > 0 && MajorSize(realizationRect) > 0)
     {
         const auto gridState = GetAsGridState(context.LayoutState());
         const auto lastExtent = gridState->FlowAlgorithm().LastExtent();
         const int itemsPerLine = std::min( // note use of unsigned ints
-            std::max(1u, static_cast<unsigned int>(availableSize.*Minor() / GetMinorSizeWithSpacing(context))),
+            std::max(1u, static_cast<unsigned int>(Minor(availableSize) / GetMinorSizeWithSpacing(context))),
             std::max(1u, m_maximumRowsOrColumns));
         const double majorSize = (itemsCount / itemsPerLine) * (double)(GetMajorSizeWithSpacing(context));
-        const double realizationWindowStartWithinExtent = (double)(realizationRect.*MajorStart() - lastExtent.*MajorStart());
-        if ((realizationWindowStartWithinExtent + realizationRect.*MajorSize()) >= 0 && realizationWindowStartWithinExtent <= majorSize)
+        const double realizationWindowStartWithinExtent = (double)(MajorStart(realizationRect) - MajorStart(lastExtent));
+        if ((realizationWindowStartWithinExtent + MajorSize(realizationRect)) >= 0 && realizationWindowStartWithinExtent <= majorSize)
         {
-            const double offset = std::max(0.0f, realizationRect.*MajorStart() - lastExtent.*MajorStart());
+            const double offset = std::max(0.0f, MajorStart(realizationRect) - MajorStart(lastExtent));
             const int anchorRowIndex = static_cast<int>(offset / GetMajorSizeWithSpacing(context));
 
             anchorIndex = std::max(0, std::min(itemsCount - 1, anchorRowIndex * itemsPerLine));
@@ -156,7 +156,7 @@ winrt::FlowLayoutAnchorInfo UniformGridLayout::Algorithm_GetAnchorForRealization
     return winrt::FlowLayoutAnchorInfo
     {
         anchorIndex,
-        bounds.*MajorStart()
+        MajorStart(bounds)
     };
 }
 
@@ -171,12 +171,12 @@ winrt::FlowLayoutAnchorInfo UniformGridLayout::Algorithm_GetAnchorForTargetEleme
     if (targetIndex >= 0 && targetIndex < count)
     {
         int itemsPerLine = std::min( // note use of unsigned ints
-            std::max(1u, static_cast<unsigned int>(availableSize.*Minor() / GetMinorSizeWithSpacing(context))),
+            std::max(1u, static_cast<unsigned int>(Minor(availableSize) / GetMinorSizeWithSpacing(context))),
             std::max(1u, m_maximumRowsOrColumns));
         int indexOfFirstInLine = (targetIndex / itemsPerLine) * itemsPerLine;
         index = indexOfFirstInLine;
         auto state = GetAsGridState(context.LayoutState());
-        offset = GetLayoutRectForDataIndex(availableSize, indexOfFirstInLine, state->FlowAlgorithm().LastExtent(), context).*MajorStart();
+        offset = MajorStart(GetLayoutRectForDataIndex(availableSize, indexOfFirstInLine, state->FlowAlgorithm().LastExtent(), context));
     }
 
     return winrt::FlowLayoutAnchorInfo
@@ -203,7 +203,7 @@ winrt::Rect UniformGridLayout::Algorithm_GetExtent(
 
     // Constants
     const int itemsCount = context.ItemCount();
-    const float availableSizeMinor = availableSize.*Minor();
+    const float availableSizeMinor = Minor(availableSize);
     const int itemsPerLine =
         std::min( // note use of unsigned ints
             std::max(1u, std::isfinite(availableSizeMinor)
@@ -215,19 +215,19 @@ winrt::Rect UniformGridLayout::Algorithm_GetExtent(
     if (itemsCount > 0)
     {
         // Only use all of the space if item stretch is fill, otherwise size layout according to items placed
-        extent.*MinorSize() =
+        MinorSize(extent) =
             std::isfinite(availableSizeMinor) && m_itemsStretch == winrt::UniformGridLayoutItemsStretch::Fill ?
             availableSizeMinor :
             std::max(0.0f, itemsPerLine * GetMinorSizeWithSpacing(context) - static_cast<float>(MinItemSpacing()));
-        extent.*MajorSize() = std::max(0.0f, (itemsCount / itemsPerLine) * lineSize - static_cast<float>(LineSpacing()));
+        MajorSize(extent) = std::max(0.0f, (itemsCount / itemsPerLine) * lineSize - static_cast<float>(LineSpacing()));
 
         if (firstRealized)
         {
             MUX_ASSERT(lastRealized);
 
-            extent.*MajorStart() = firstRealizedLayoutBounds.*MajorStart() - (firstRealizedItemIndex / itemsPerLine) * lineSize;
+            MajorStart(extent) = MajorStart(firstRealizedLayoutBounds) - (firstRealizedItemIndex / itemsPerLine) * lineSize;
             int remainingItems = itemsCount - lastRealizedItemIndex - 1;
-            extent.*MajorSize() = MajorEnd(lastRealizedLayoutBounds) - extent.*MajorStart() + (remainingItems / itemsPerLine) * lineSize;
+            MajorSize(extent) = MajorEnd(lastRealizedLayoutBounds) - MajorStart(extent) + (remainingItems / itemsPerLine) * lineSize;
         }
         else
         {
@@ -318,15 +318,15 @@ winrt::Rect UniformGridLayout::GetLayoutRectForDataIndex(
     const winrt::VirtualizingLayoutContext& context)
 {
     int itemsPerLine = std::min( //note use of unsigned ints
-        std::max(1u, static_cast<unsigned int>(availableSize.*Minor() / GetMinorSizeWithSpacing(context))),
+        std::max(1u, static_cast<unsigned int>(Minor(availableSize) / GetMinorSizeWithSpacing(context))),
         std::max(1u, m_maximumRowsOrColumns));
     int rowIndex = static_cast<int>(index / itemsPerLine);
     int indexInRow = index - (rowIndex * itemsPerLine);
 
     auto gridState = GetAsGridState(context.LayoutState());
     winrt::Rect bounds = MinorMajorRect(
-        indexInRow * GetMinorSizeWithSpacing(context) + lastExtent.*MinorStart(),
-        rowIndex * GetMajorSizeWithSpacing(context) + lastExtent.*MajorStart(),
+        indexInRow * GetMinorSizeWithSpacing(context) + MinorStart(lastExtent),
+        rowIndex * GetMajorSizeWithSpacing(context) + MajorStart(lastExtent),
         GetScrollOrientation() == ScrollOrientation::Vertical ? static_cast<float>(gridState->EffectiveItemWidth()) : static_cast<float>(gridState->EffectiveItemHeight()),
         GetScrollOrientation() == ScrollOrientation::Vertical ? static_cast<float>(gridState->EffectiveItemHeight()) : static_cast<float>(gridState->EffectiveItemWidth()));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Switches the way the OrientedBasedMeasure sizing helpers.

Two things to watch out:
- We do need cast inside the helpers as in almost all cases where the functions are used we have a const pointer and if we get const pointers, we need to cast it to get a reference to the property
- In FlowLayoutAlgorithm.cpp in line 446 I polyfilled the function logic instead of calling the function as we do not have a const reference there and casting it would be too much work. Just putting the logic there seems easier.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #678
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->