### PR TITLE
Navview fix issue with compact pane length not being behaving correctly

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -1344,7 +1344,7 @@ void NavigationView::UpdateIsClosedCompact()
 
 void NavigationView::UpdatePaneButtonsWidths()
 {
-    auto newButtonWidths = [this]()
+    const auto newButtonWidths = [this]()
     {
         if (DisplayMode() == winrt::NavigationViewDisplayMode::Minimal)
         {
@@ -3496,6 +3496,7 @@ void NavigationView::OnLoaded(winrt::IInspectable const& sender, winrt::RoutedEv
         m_titleBarMetricsChangedRevoker = coreTitleBar.LayoutMetricsChanged(winrt::auto_revoke, { this, &NavigationView::OnTitleBarMetricsChanged });
         m_titleBarIsVisibleChangedRevoker = coreTitleBar.IsVisibleChanged(winrt::auto_revoke, { this, &NavigationView::OnTitleBarIsVisibleChanged });
     }
+    UpdatePaneButtonsWidths();
 }
 
 void NavigationView::OnIsPaneOpenChanged()

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -3496,6 +3496,7 @@ void NavigationView::OnLoaded(winrt::IInspectable const& sender, winrt::RoutedEv
         m_titleBarMetricsChangedRevoker = coreTitleBar.LayoutMetricsChanged(winrt::auto_revoke, { this, &NavigationView::OnTitleBarMetricsChanged });
         m_titleBarIsVisibleChangedRevoker = coreTitleBar.IsVisibleChanged(winrt::auto_revoke, { this, &NavigationView::OnTitleBarIsVisibleChanged });
     }
+    // Update pane buttons now since we the CompactPaneLength is actually known now.
     UpdatePaneButtonsWidths();
 }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -4366,17 +4366,22 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 var currentStatus = new CheckBox(FindElement.ByName("MenuItemsCorrectOffset"));
 
                 checkMenuItemsButton.Click();
+                Log.Comment("Verifying compact pane length set before loading working");
                 Wait.ForIdle();
+                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox")); 
                 Verify.IsTrue(currentStatus.ToggleState == ToggleState.On);
 
+                Log.Comment("Verifying changing compact pane length in left mode working");
                 compactpaneCheckbox.SelectItemByName("96");
                 Wait.ForIdle();
 
                 checkMenuItemsButton.Click();
                 Wait.ForIdle();
+                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox")); 
                 Verify.IsTrue(currentStatus.ToggleState == ToggleState.On);
 
                 // Check if changing displaymode to top and then changing length gets used correctly
+                Log.Comment("Verifying changing compact pane length during top mode working");
                 displayModeToggle.SelectItemByName("Top");
                 compactpaneCheckbox.SelectItemByName("48");
                 Wait.ForIdle();
@@ -4386,6 +4391,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 checkMenuItemsButton.Click();
                 Wait.ForIdle();
+                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox")); 
                 Verify.IsTrue(currentStatus.ToggleState == ToggleState.On);
             }
         }

--- a/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/NavigationViewTests.cs
@@ -4361,14 +4361,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView compact pane length test" }))
             {
                 var checkMenuItemsButton = FindElement.ByName("CheckMenuItemsOffset");
-                var compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox"));
+                var compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLengthComboBox"));
                 var displayModeToggle = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
                 var currentStatus = new CheckBox(FindElement.ByName("MenuItemsCorrectOffset"));
 
                 checkMenuItemsButton.Click();
                 Log.Comment("Verifying compact pane length set before loading working");
                 Wait.ForIdle();
-                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox")); 
+                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLengthComboBox")); 
                 Verify.IsTrue(currentStatus.ToggleState == ToggleState.On);
 
                 Log.Comment("Verifying changing compact pane length in left mode working");
@@ -4377,7 +4377,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 checkMenuItemsButton.Click();
                 Wait.ForIdle();
-                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox")); 
+                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLengthComboBox")); 
                 Verify.IsTrue(currentStatus.ToggleState == ToggleState.On);
 
                 // Check if changing displaymode to top and then changing length gets used correctly
@@ -4391,7 +4391,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 checkMenuItemsButton.Click();
                 Wait.ForIdle();
-                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLenghtComboBox")); 
+                compactpaneCheckbox = new ComboBox(FindElement.ByName("CompactPaneLengthComboBox")); 
                 Verify.IsTrue(currentStatus.ToggleState == ToggleState.On);
             }
         }

--- a/dev/NavigationView/TestUI/NavigationViewCompactPaneLengthTestPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewCompactPaneLengthTestPage.xaml
@@ -55,8 +55,8 @@
                             Content="IsPaneVisible"
                             IsChecked="{Binding IsPaneVisible, ElementName=NavView, Mode=TwoWay}"
                             Margin="5"/>
-                        
-                        <ComboBox x:Name="CompactPaneLength" Header="Compact Pane Length" AutomationProperties.Name="CompactPaneLenghtComboBox"
+
+                        <ComboBox x:Name="CompactPaneLength" Header="Compact Pane Length" AutomationProperties.Name="CompactPaneLengthComboBox"
                             SelectionChanged="CompactPaneLength_SelectionChanged"  Margin="5">
                             <ComboBoxItem Content="0" Tag="0"/>
                             <ComboBoxItem Content="40" Tag="40" IsSelected="True"/>

--- a/dev/NavigationView/TestUI/NavigationViewCompactPaneLengthTestPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewCompactPaneLengthTestPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.UI.Xaml.Controls;
@@ -20,6 +20,8 @@ namespace MUXControlsTestApp
         public NavigationViewCompactPaneLengthTestPage()
         {
             this.InitializeComponent();
+
+            NavView.CompactPaneLength = 96;
         }
         
         private void CompactPaneLength_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -74,7 +76,8 @@ namespace MUXControlsTestApp
         private void CheckMenuItemsOffset_Click(object sender, RoutedEventArgs e)
         {
             bool allCorrect = true;
-            foreach(var item in NavView.MenuItems)
+
+            foreach (var item in NavView.MenuItems)
             {
                 if(item as NavigationViewItem == null)
                 {
@@ -86,6 +89,23 @@ namespace MUXControlsTestApp
                     allCorrect = false;
                 }
             }
+
+            var rootgrid = VisualTreeHelper.GetChild(NavView, 0);
+            var paneToggleButtonGrid = VisualTreeHelper.GetChild(rootgrid, 0);
+            var buttonHolderGrid = VisualTreeHelper.GetChild(paneToggleButtonGrid, 1);
+            var backButton = VisualTreeHelper.GetChild(buttonHolderGrid, 0) as Button;
+            var togglePaneButton = VisualTreeHelper.GetChild(buttonHolderGrid, 2) as Button;
+
+            if (Math.Abs(backButton.ActualWidth - NavView.CompactPaneLength) > double.Epsilon)
+            {
+                allCorrect = false;
+            }
+
+            if (Math.Abs(togglePaneButton.ActualWidth - NavView.CompactPaneLength) > double.Epsilon)
+            {
+                allCorrect = false;
+            }
+
             MenuItemsCorrectOffset.IsChecked = allCorrect;
 
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix issue when we set the CompactPaneLength before the page has finished loading.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2277 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Update existing interaction test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->