### PR TITLE
NavigationView: Fix SelectedItem not being unset when no NavigationViewItem is selected

### DIFF
--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -653,5 +653,37 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 MUXControlsTestApp.App.TestContentRoot = null;
             });
         }
+
+        [TestMethod]
+        public void VerifySelectedItemIsNullWhenNoItemIsSelected()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var navView = new NavigationView();
+                Content = navView;
+
+                var menuItem1 = new NavigationViewItem();
+                menuItem1.Content = "Item 1";
+
+                navView.MenuItems.Add(menuItem1);
+                navView.Width = 1008; // forces the control into Expanded mode so that the menu renders
+                Content.UpdateLayout();
+
+                Verify.IsFalse(menuItem1.IsSelected);
+                Verify.AreEqual(null, navView.SelectedItem);
+
+                menuItem1.IsSelected = true;
+                Content.UpdateLayout();
+
+                Verify.IsTrue(menuItem1.IsSelected);
+                Verify.AreEqual(menuItem1, navView.SelectedItem);
+
+                menuItem1.IsSelected = false;
+                Content.UpdateLayout();
+
+                Verify.IsFalse(menuItem1.IsSelected);
+                Verify.AreEqual(null, navView.SelectedItem, "SelectedItem should have been [null] as no item is selected");
+            });
+        }
     }
 }

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -53,9 +53,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 SelectionModel selectionModel = new SelectionModel() { SingleSelect = true };
                 Log.Comment("Set the source to 10 items");
                 selectionModel.Source = Enumerable.Range(0, 10).ToList();
+
+                // Check index selection
                 Select(selectionModel, 3, true);
                 ValidateSelection(selectionModel, new List<IndexPath>() { Path(3) }, new List<IndexPath>() { Path() });
                 Select(selectionModel, 3, false);
+                ValidateSelection(selectionModel, new List<IndexPath>() { });
+
+                // Check index path selection
+                Select(selectionModel, Path(4), true);
+                ValidateSelection(selectionModel, new List<IndexPath>() { Path(4) }, new List<IndexPath>() { Path() });
+                Select(selectionModel, Path(4), false);
                 ValidateSelection(selectionModel, new List<IndexPath>() { });
             });
         }
@@ -68,17 +76,27 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 SelectionModel selectionModel = new SelectionModel() { SingleSelect = true };
                 selectionModel.Source = Enumerable.Range(0, 10).ToList();
 
+                bool select = true;
                 int selectionChangedFiredCount = 0;
                 selectionModel.SelectionChanged += delegate (SelectionModel sender, SelectionModelSelectionChangedEventArgs args) {
                     selectionChangedFiredCount++;
+
+                    // Verify SelectionChanged was raised after selection state was changed in the SelectionModel
+                    if (select)
+                    {
+                        ValidateSelection(selectionModel, new List<IndexPath>() { Path(4) }, new List<IndexPath>() { Path() });
+                    }
+                    else
+                    {
+                        ValidateSelection(selectionModel, new List<IndexPath>() { });
+                    }
                 };
 
-                Select(selectionModel, Path(4), true);
-                ValidateSelection(selectionModel, new List<IndexPath>() { Path(4) }, new List<IndexPath>() { Path() });
+                Select(selectionModel, Path(4), select);
                 Verify.AreEqual(1, selectionChangedFiredCount);
 
-                Select(selectionModel, Path(4), false);
-                ValidateSelection(selectionModel, new List<IndexPath>());
+                select = false;
+                Select(selectionModel, Path(4), select);
                 Verify.AreEqual(2, selectionChangedFiredCount);
             });
         }
@@ -95,11 +113,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 selectionModel.SelectionChanged += delegate (SelectionModel sender, SelectionModelSelectionChangedEventArgs args) 
                 {
                     selectionChangedFiredCount++;
+
+                    // Verify SelectionChanged was raised after selection state was changed in the SelectionModel
                     ValidateSelection(selectionModel, new List<IndexPath>() { Path(4) }, new List<IndexPath>() { Path() });
                 };
 
                 Select(selectionModel, 4, true);
-                ValidateSelection(selectionModel, new List<IndexPath>() { Path(4) }, new List<IndexPath>() { Path() });
                 Verify.AreEqual(1, selectionChangedFiredCount);
             });
         }

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -61,7 +61,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        public void ValidateSelectionChangedEvent()
+        public void ValidateSelectionChangedEventSingleSelection()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                SelectionModel selectionModel = new SelectionModel() { SingleSelect = true };
+                selectionModel.Source = Enumerable.Range(0, 10).ToList();
+
+                int selectionChangedFiredCount = 0;
+                selectionModel.SelectionChanged += delegate (SelectionModel sender, SelectionModelSelectionChangedEventArgs args) {
+                    selectionChangedFiredCount++;
+                };
+
+                Select(selectionModel, Path(4), true);
+                ValidateSelection(selectionModel, new List<IndexPath>() { Path(4) }, new List<IndexPath>() { Path() });
+                Verify.AreEqual(1, selectionChangedFiredCount);
+
+                Select(selectionModel, Path(4), false);
+                ValidateSelection(selectionModel, new List<IndexPath>());
+                Verify.AreEqual(2, selectionChangedFiredCount);
+            });
+        }
+
+        [TestMethod]
+        public void ValidateSelectionChangedEventMultipleSelection()
         {
             RunOnUIThread.Execute(() =>
             {

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -647,8 +647,9 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
         // If we unselect something, raise event any way, otherwise changedSelection is false
         bool changedSelection = false;
 
-        // We only need to clear selection by walking the data structure from the beginning when we are in single selection mode
-        // and want to select something.
+        // We only need to clear selection by walking the data structure from the beginning when:
+        // - we are in single selection mode and 
+        // - want to select something.
         // If we want to unselect something we unselect it directly in TraverseIndexPath below and raise the SelectionChanged event
         // if required.
         if (m_singleSelect && select)

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -649,8 +649,8 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
 
         // We only need to clear selection by walking the data structure from the beginning when we are in single selection mode
         // and want to select something.
-        // If we want to deselect something we can deselect it directly in TraverseIndexPath below instead of walking the complete
-        // data structure.
+        // If we want to unselect something we unselect it directly in TraverseIndexPath below and raise the SelectionChanged event
+        // if required.
         if (m_singleSelect && select)
         {
             ClearSelection(true /*resetAnchor*/, false /* raiseSelectionChanged */);

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -650,6 +650,7 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
         // We only need to clear selection by walking the data structure from the beginning when:
         // - we are in single selection mode and 
         // - want to select something.
+        // 
         // If we want to unselect something we unselect it directly in TraverseIndexPath below and raise the SelectionChanged event
         // if required.
         if (m_singleSelect && select)

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -647,7 +647,11 @@ void SelectionModel::SelectWithPathImpl(const winrt::IndexPath& index, bool sele
         // If we unselect something, raise event any way, otherwise changedSelection is false
         bool changedSelection = false;
 
-        if (m_singleSelect)
+        // We only need to clear selection by walking the data structure from the beginning when we are in single selection mode
+        // and want to select something.
+        // If we want to deselect something we can deselect it directly in TraverseIndexPath below instead of walking the complete
+        // data structure.
+        if (m_singleSelect && select)
         {
             ClearSelection(true /*resetAnchor*/, false /* raiseSelectionChanged */);
         }


### PR DESCRIPTION
## Description
Fix issue where NavView's SelectedItem property was not set to null when all navigation view items are no longer selected.

## Motivation and Context
Fixes #957 

## How Has This Been Tested?
Added API test.