### PR TITLE
TabView: Make TabViewItem consume the TabViewItemHeaderForeground theme resource

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -623,6 +623,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void VerifyTabViewItemHeaderForegroundResource()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Button getSecondTabHeaderForegroundButton = FindElement.ByName<Button>("GetSecondTabHeaderForegroundButton");
+                getSecondTabHeaderForegroundButton.InvokeAndWait();
+
+                TextBlock secondTabHeaderForegroundTextBlock = FindElement.ByName<TextBlock>("SecondTabHeaderForegroundTextBlock");
+
+                Verify.AreEqual("#FF008000", secondTabHeaderForegroundTextBlock.DocumentText);
+            }
+        }
+
         public void PressButtonAndVerifyText(String buttonName, String textBlockName, String expectedText)
         {
             Button button = FindElement.ByName<Button>(buttonName);

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -647,6 +647,7 @@
                                 ContentTransitions="{TemplateBinding ContentTransitions}"
                                 FontWeight="{TemplateBinding FontWeight}"
                                 FontSize="{ThemeResource TabViewItemHeaderFontSize}"
+                                Foreground="{ThemeResource TabViewItemHeaderForeground}"
                                 OpticalMarginAlignment="TrimSideBearings"
                                 HighContrastAdjustment="None" />
 

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -99,6 +99,11 @@
                     <Button x:Name="GetFirstTabLocationButton" AutomationProperties.Name="GetFirstTabLocationButton" Content="FirstTab" Click="GetFirstTabLocationButton_Click"/>
                     <TextBlock x:Name="FirstTabLocationTextBlock" AutomationProperties.Name="FirstTabLocationTextBlock" Margin="4,0,0,0" Text=""/>
                 </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="GetSecondTabHeaderForegroundButton" AutomationProperties.Name="GetSecondTabHeaderForegroundButton" Content="SecondTabHeaderForeground" Click="GetSecondTabHeaderForegroundButton_Click" />
+                    <TextBlock x:Name="SecondTabHeaderForegroundTextBlock" AutomationProperties.Name="SecondTabHeaderForegroundTextBlock" Margin="4,0,0,0" Text=""/>
+                </StackPanel>
             </StackPanel>
 
             <Grid Grid.Column="1">
@@ -142,9 +147,10 @@
                         </StackPanel>
                     </controls:TabViewItem>
 
-                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab (in green)" IsClosable="True">
+                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab" IsClosable="True">
                         <controls:TabViewItem.Resources>
-                            <SolidColorBrush x:Key="TabViewItemHeaderForeground" Color="Green" />
+                            <!-- Do not remove or change this! We are verifying this resource in a TabView InteractionTest. -->
+                            <SolidColorBrush x:Key="TabViewItemHeaderForeground" Color="#FF008000" />
                         </controls:TabViewItem.Resources>
                         <controls:TabViewItem.IconSource>
                             <controls:SymbolIconSource Symbol="Shop"/>

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -142,7 +142,10 @@
                         </StackPanel>
                     </controls:TabViewItem>
 
-                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab" IsClosable="True">
+                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab (in green)" IsClosable="True">
+                        <controls:TabViewItem.Resources>
+                            <SolidColorBrush x:Key="TabViewItemHeaderForeground" Color="Green" />
+                        </controls:TabViewItem.Resources>
                         <controls:TabViewItem.IconSource>
                             <controls:SymbolIconSource Symbol="Shop"/>
                         </controls:TabViewItem.IconSource>

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -399,5 +399,14 @@ namespace MUXControlsTestApp
             FirstTab.Header = "s";
             LongHeaderTab.Header = "long long long long long long long long";
         }
+
+        private void GetSecondTabHeaderForegroundButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (FindVisualChildByName(SecondTab, "ContentPresenter") is ContentPresenter presenter
+                && presenter.Foreground is SolidColorBrush brush)
+            {
+                SecondTabHeaderForegroundTextBlock.Text = brush.Color.ToString();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR makes the TabViewItem consume the `TabViewItemHeaderForeground` theme resource.

## Motivation and Context
Fixes #2347.

## How Has This Been Tested?
Tested visually by setting the header foreground color of a tab of one of MUXControlsTestApp's TabViews to green.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1398851/80428559-6a938900-88ea-11ea-982b-fa74a01c4a4d.png)
