### PR TITLE
Remove whitespace from props to allow build on Mac

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.props
@@ -36,16 +36,12 @@
       <Publisher>'CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US'</Publisher>
     </AppxPackageRegistration>
   </ItemGroup>
-
   <!-- Add a dependency for the app against VCLibs since we need it but the consuming app might be .NET only. -->
   <ItemGroup Condition="('$(OutputType)' == 'AppContainerExe')">
     <SDKReference Include="Microsoft.VCLibs, Version=14.0" />
   </ItemGroup>
-
-
   <!-- This section is to work around the fact that this Nuget package contains only a .winmd and no implementation, but the
        VS targets expect that, so convince them it's ok. -->
-
   <ItemGroup>
     <XamlWinmd Include="$(MSBuildThisFileDirectory)..\lib\uap10.0\Microsoft.UI.Xaml.winmd">
       <SkipHarvestingWinmdRegistration>true</SkipHarvestingWinmdRegistration>
@@ -54,7 +50,6 @@
       <ProjectName>$(ProjectName)</ProjectName>
     </XamlWinmd>
   </ItemGroup>
-    
   <PropertyGroup>
     <XamlWinmdName>Microsoft.UI.Xaml.winmd</XamlWinmdName>
     <XamlCompactXbfName>Microsoft.UI.Xaml\DensityStyles\Compact.xbf</XamlCompactXbfName>
@@ -63,19 +58,19 @@
     <ItemGroup>
       <XamlWinMdCopyLocal Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)' == '$(XamlWinmdName)'" />
     </ItemGroup>
-    <ItemGroup Condition="'@(XamlWinMdCopyLocal)' != ''">
-      <ReferenceCopyLocalPaths Remove="@(XamlWinMdCopyLocal)" />
+    <ItemGroup Condition="'@(XamlWinMdCopyLocal)' != ''">
+      <ReferenceCopyLocalPaths Remove="@(XamlWinMdCopyLocal)" />
     </ItemGroup>
   </Target>
-  <Target Name="_FixWinmdPackaging" BeforeTargets="_ComputeAppxPackagePayload">
-    <ItemGroup>
-      <XamlWinmdPackagingOutput Include="@(PackagingOutputs)" Condition="'%(PackagingOutputs.Filename)%(PackagingOutputs.Extension)' == '$(XamlWinmdName)'" />
+  <Target Name="_FixWinmdPackaging" BeforeTargets="_ComputeAppxPackagePayload">
+    <ItemGroup>
+      <XamlWinmdPackagingOutput Include="@(PackagingOutputs)" Condition="'%(PackagingOutputs.Filename)%(PackagingOutputs.Extension)' == '$(XamlWinmdName)'" />
     </ItemGroup>
-    <ItemGroup Condition="'@(XamlWinmdPackagingOutput)' != ''">
-      <PackagingOutputs Remove="@(XamlWinmdPackagingOutput)" />
+    <ItemGroup Condition="'@(XamlWinmdPackagingOutput)' != ''">
+      <PackagingOutputs Remove="@(XamlWinmdPackagingOutput)" />
     </ItemGroup>
-    <ItemGroup>
-      <PackagingOutputs Include="@(XamlWinmd)" />
+    <ItemGroup>
+      <PackagingOutputs Include="@(XamlWinmd)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removing the whitespace from the .props file in the Nuget package allows Xamarin builds to complete when ran on a Mac.
## Description
<!--- Describe your changes in detail -->
Removed extra whitespace from Microsoft.UI.Xaml.props file in Nuget package
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes [#2343](https://github.com/microsoft/microsoft-ui-xaml/issues/2343)
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Successfully ran build on Mac. Also allows opening the project in Visual Studio for Mac if Nuget packages are included in project files.
