### PR TITLE
SelectionModel: Fix for missing SelectionChanged event raise

### DIFF
--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1134,6 +1134,83 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             }
         }
 
+        [TestMethod] 
+        public void ValidateSelectionModeChangeFromMultipleToSingle()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                SelectionModel selectionModel = new SelectionModel();
+                selectionModel.Source = Enumerable.Range(0, 10).ToList();
+
+                // First test: switching from multiple to single selection mode with just one selected item
+                selectionModel.Select(4);
+
+                selectionModel.SingleSelect = true;
+
+                // Verify that the item at IndexPath 4 is still selected 
+                Verify.IsTrue(selectionModel.SelectedIndex.CompareTo(Path(4)) == 0, "Item at index 4 should have still been selected");
+
+                // Second test: this time switching from multiple to single selection mode with more than one selected item
+                selectionModel.SingleSelect = false;
+                selectionModel.Select(5);
+                selectionModel.Select(6);
+
+                // Now switch to single selection mode
+                selectionModel.SingleSelect = true;
+
+                // Verify that 
+                // - only one item is currently selected
+                // - the currently selected item was among the previously selected items
+                Verify.AreEqual(1, selectionModel.SelectedIndices.Count,
+                    "Exactly one item should have been selected now after we switched from Multiple to Single selection mode");
+                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0);
+                Verify.IsTrue(
+                    selectionModel.SelectedIndex.CompareTo(Path(4)) == 0
+                    || selectionModel.SelectedIndex.CompareTo(Path(5)) == 0
+                    || selectionModel.SelectedIndex.CompareTo(Path(6)) == 0,
+                    "The currently selected item should have been one of the previously selected items");
+            });
+        }
+
+        [TestMethod]
+        public void ValidateSelectionChangedEventOnSwitchFromMultipleSelectionToSingleSelection()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                SelectionModel selectionModel = new SelectionModel();
+                selectionModel.Source = Enumerable.Range(0, 10).ToList();
+
+                // First test: switching from multiple to single selection mode with just one selected item
+                selectionModel.Select(4);
+
+                int selectionChangedFiredCount = 0;
+                selectionModel.SelectionChanged += IncreaseCountIfRaisedSelectionChanged;
+
+                // Now switch to single selection mode
+                selectionModel.SingleSelect = true;
+
+                // Verify that no SelectionChanged event was raised
+                Verify.AreEqual(0, selectionChangedFiredCount, "SelectionChanged event should have not been raised as only one item was selected");
+
+                // Second test: this time switching from multiple to single selection mode with more than one selected item
+                selectionModel.SelectionChanged -= IncreaseCountIfRaisedSelectionChanged;
+                selectionModel.SingleSelect = false;
+                selectionModel.Select(5);
+                selectionModel.SelectionChanged += IncreaseCountIfRaisedSelectionChanged;
+
+                // Now switch to single selection mode
+                selectionModel.SingleSelect = true;
+
+                // Verify that the SelectionChanged was raised 
+                Verify.AreEqual(1, selectionChangedFiredCount, "SelectionChanged event should have been raised as the selection changed");
+
+                void IncreaseCountIfRaisedSelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)
+                {
+                    selectionChangedFiredCount++;
+                }
+            });
+        }
+
         private void Select(SelectionModel manager, int index, bool select)
         {
             Log.Comment((select ? "Selecting " : "DeSelecting ") + index);

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1147,7 +1147,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 selectionModel.SingleSelect = true;
 
-                // Verify that the item at IndexPath 4 is still selected 
+                // Verify that the item at index 4 is still selected 
                 Verify.IsTrue(selectionModel.SelectedIndex.CompareTo(Path(4)) == 0, "Item at index 4 should have still been selected");
 
                 // Second test: this time switching from multiple to single selection mode with more than one selected item
@@ -1160,7 +1160,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 // Verify that 
                 // - only one item is currently selected
-                // - the currently selected item was among the previously selected items
+                // - the currently selected item was among the previously selected items in multiple selection mode
                 Verify.AreEqual(1, selectionModel.SelectedIndices.Count,
                     "Exactly one item should have been selected now after we switched from Multiple to Single selection mode");
                 Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0);
@@ -1201,7 +1201,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 // Now switch to single selection mode
                 selectionModel.SingleSelect = true;
 
-                // Verify that the SelectionChanged was raised 
+                // Verify that the SelectionChanged event was raised 
                 Verify.AreEqual(1, selectionChangedFiredCount, "SelectionChanged event should have been raised as the selection changed");
 
                 void IncreaseCountIfRaisedSelectionChanged(SelectionModel sender, SelectionModelSelectionChangedEventArgs args)

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1163,7 +1163,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 // - the currently selected item is the item with the lowest index in the Multiple selection list
                 Verify.AreEqual(1, selectionModel.SelectedIndices.Count,
                     "Exactly one item should have been selected now after we switched from Multiple to Single selection mode");
-                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0);
+                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0,
+                    "SelectedIndex and SelectedIndices should have been identical");
                 Verify.IsTrue(selectionModel.SelectedIndex.CompareTo(Path(4)) == 0, "The currently selected item should have been the first item in the Multiple selection list");
             });
         }

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1163,8 +1163,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 // - the currently selected item is the item with the lowest index in the Multiple selection list
                 Verify.AreEqual(1, selectionModel.SelectedIndices.Count,
                     "Exactly one item should have been selected now after we switched from Multiple to Single selection mode");
-                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0,
-                    "The currently selected item should have been the first item in the Multiple selection list");
+                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0);
+                Verify.IsTrue(selectionModel.SelectedIndex.CompareTo(Path(4)) == 0, "The currently selected item should have been the first item in the Multiple selection list");
             });
         }
 

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1170,7 +1170,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        public void ValidateSelectionChangedEventOnSwitchFromMultipleSelectionToSingleSelection()
+        public void ValidateSelectionModeChangeFromMultipleToSingleSelectionChangedEvent()
         {
             RunOnUIThread.Execute(() =>
             {

--- a/dev/Repeater/APITests/SelectionModelTests.cs
+++ b/dev/Repeater/APITests/SelectionModelTests.cs
@@ -1160,15 +1160,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
                 // Verify that 
                 // - only one item is currently selected
-                // - the currently selected item was among the previously selected items in multiple selection mode
+                // - the currently selected item is the item with the lowest index in the Multiple selection list
                 Verify.AreEqual(1, selectionModel.SelectedIndices.Count,
                     "Exactly one item should have been selected now after we switched from Multiple to Single selection mode");
-                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0);
-                Verify.IsTrue(
-                    selectionModel.SelectedIndex.CompareTo(Path(4)) == 0
-                    || selectionModel.SelectedIndex.CompareTo(Path(5)) == 0
-                    || selectionModel.SelectedIndex.CompareTo(Path(6)) == 0,
-                    "The currently selected item should have been one of the previously selected items");
+                Verify.IsTrue(selectionModel.SelectedIndices[0].CompareTo(selectionModel.SelectedIndex) == 0,
+                    "The currently selected item should have been the first item in the Multiple selection list");
             });
         }
 

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -60,15 +60,17 @@ void SelectionModel::SingleSelect(bool value)
     {
         m_singleSelect = value;
         auto selectedIndices = SelectedIndices();
-        if (value && selectedIndices && selectedIndices.Size() > 0)
+
+        // Only update selection and raise SelectionChanged event when:
+        // - we switch from SelectionMode::Multiple to SelectionMode::Single and
+        // - more than one item was selected at the time of the switch
+        if (value && selectedIndices && selectedIndices.Size() > 1)
         {
             // We want to be single select, so make sure there is only 
             // one selected item.
             auto firstSelectionIndexPath = selectedIndices.GetAt(0);
             ClearSelection(true /* resetAnchor */, false /*raiseSelectionChanged */);
-            SelectWithPathImpl(firstSelectionIndexPath, true /* select */, false /* raiseSelectionChanged */);
-            // Setting SelectedIndex will raise SelectionChanged event.
-            SelectedIndex(firstSelectionIndexPath);
+            SelectWithPathImpl(firstSelectionIndexPath, true /* select */, true /* raiseSelectionChanged */);
         }
 
         RaisePropertyChanged(L"SingleSelect");


### PR DESCRIPTION
## Description
Fixes the missing SelectionChanged event raise when switching from SelectionMode `Multiple` to `Single` while more than one item is currently selected.

Also added two API tests: 
* One test to cover event raising. This is the API test to cover this specific issue.
* One test to test if the selection is still correct after switching from Multiple to Single selection mode. This test helps in keeping the event test above focused solely on event raise testing.

## Motivation and Context
Fixes #2358. 

## How Has This Been Tested?
Added API test.