### PR TITLE
TabView: Add tooltips to its scrolling buttons.

### DIFF
--- a/dev/ResourceHelper/ResourceAccessor.h
+++ b/dev/ResourceHelper/ResourceAccessor.h
@@ -157,6 +157,8 @@ public:
 #define SR_TabViewCloseButtonName L"TabViewCloseButtonName"
 #define SR_TabViewCloseButtonTooltip L"TabViewCloseButtonTooltip"
 #define SR_TabViewCloseButtonTooltipWithKA L"TabViewCloseButtonTooltipWithKA"
+#define SR_TabViewScrollDecreaseButtonTooltip L"TabViewScrollDecreaseButtonTooltip"
+#define SR_TabViewScrollIncreaseButtonTooltip L"TabViewScrollIncreaseButtonTooltip"
 #define SR_NumberBoxUpSpinButtonName L"NumberBoxUpSpinButtonName"
 #define SR_NumberBoxDownSpinButtonName L"NumberBoxDownSpinButtonName"
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -630,7 +630,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 PressButtonAndVerifyText("GetScrollDecreaseButtonToolTipButton", "ScrollDecreaseButtonToolTipTextBlock", "Scroll tab list backward");
                 PressButtonAndVerifyText("GetScrollIncreaseButtonToolTipButton", "ScrollIncreaseButtonToolTipTextBlock", "Scroll tab list forward");
-
             }
         }
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -623,6 +623,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void ScrollButtonToolTipTest()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                PressButtonAndVerifyText("GetScrollDecreaseButtonToolTipButton", "ScrollDecreaseButtonToolTipTextBlock", "Scroll tab list backward");
+                PressButtonAndVerifyText("GetScrollIncreaseButtonToolTipButton", "ScrollIncreaseButtonToolTipTextBlock", "Scroll tab list forward");
+
+            }
+        }
+
         public void PressButtonAndVerifyText(String buttonName, String textBlockName, String expectedText)
         {
             Button button = FindElement.ByName<Button>(buttonName);

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -640,7 +640,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             button.InvokeAndWait();
 
             TextBlock textBlock = FindElement.ByName<TextBlock>(textBlockName);
-            Verify.AreEqual(textBlock.DocumentText, expectedText);
+            Verify.AreEqual(expectedText, textBlock.DocumentText);
         }
 
         Button FindCloseButton(UIObject tabItem)

--- a/dev/TabView/Strings/en-us/Resources.resw
+++ b/dev/TabView/Strings/en-us/Resources.resw
@@ -137,4 +137,12 @@
     <value>Close tab (Ctrl+F4)</value>
     <comment>Tooltip for the close button on each tab (with keyboard accelerator).</comment>
   </data>
+  <data name="TabViewScrollDecreaseButtonTooltip" xml:space="preserve">
+    <value>Scroll tab list backward</value>
+    <comment>Tooltip for the tab list scroll decrease button.</comment>
+  </data>
+  <data name="TabViewScrollIncreaseButtonTooltip" xml:space="preserve">
+    <value>Scroll tab list forward</value>
+    <comment>Tooltip for the tab list scroll increase button.</comment>
+  </data>
 </root>

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -345,13 +345,41 @@ void TabView::OnScrollViewerLoaded(const winrt::IInspectable&, const winrt::Rout
 {
     if (auto&& scrollViewer = m_scrollViewer.get())
     {
-        auto decreaseButton = SharedHelpers::FindInVisualTreeByName(scrollViewer, L"ScrollDecreaseButton").as<winrt::RepeatButton>();
-        m_scrollDecreaseButton.set(decreaseButton);
-        m_scrollDecreaseClickRevoker = decreaseButton.Click(winrt::auto_revoke, { this, &TabView::OnScrollDecreaseClick });
+        m_scrollDecreaseButton.set([this, scrollViewer]() {
+            const auto decreaseButton = SharedHelpers::FindInVisualTreeByName(scrollViewer, L"ScrollDecreaseButton").as<winrt::RepeatButton>();
+            if (decreaseButton)
+            {
+                // Do localization for the scroll decrease button
+                const auto toolTip = winrt::ToolTipService::GetToolTip(decreaseButton);
+                if (!toolTip)
+                {
+                    const auto tooltip = winrt::ToolTip();
+                    tooltip.Content(box_value(ResourceAccessor::GetLocalizedStringResource(SR_TabViewScrollDecreaseButtonTooltip)));
+                    winrt::ToolTipService::SetToolTip(decreaseButton, tooltip);
+                }
 
-        auto increaseButton = SharedHelpers::FindInVisualTreeByName(scrollViewer, L"ScrollIncreaseButton").as<winrt::RepeatButton>();
-        m_scrollIncreaseButton.set(increaseButton);
-        m_scrollIncreaseClickRevoker = increaseButton.Click(winrt::auto_revoke, { this, &TabView::OnScrollIncreaseClick });
+                m_scrollDecreaseClickRevoker = decreaseButton.Click(winrt::auto_revoke, { this, &TabView::OnScrollDecreaseClick });
+            }
+            return decreaseButton;
+        }());
+
+        m_scrollIncreaseButton.set([this, scrollViewer]() {
+            const auto increaseButton = SharedHelpers::FindInVisualTreeByName(scrollViewer, L"ScrollIncreaseButton").as<winrt::RepeatButton>();
+            if (increaseButton)
+            {
+                // Do localization for the scroll increase button
+                const auto toolTip = winrt::ToolTipService::GetToolTip(increaseButton);
+                if (!toolTip)
+                {
+                    const auto tooltip = winrt::ToolTip();
+                    tooltip.Content(box_value(ResourceAccessor::GetLocalizedStringResource(SR_TabViewScrollIncreaseButtonTooltip)));
+                    winrt::ToolTipService::SetToolTip(increaseButton, tooltip);
+                }
+
+                m_scrollIncreaseClickRevoker = increaseButton.Click(winrt::auto_revoke, { this, &TabView::OnScrollIncreaseClick });
+            }
+            return increaseButton;
+        }());
 
         m_scrollViewerViewChangedRevoker = scrollViewer.ViewChanged(winrt::auto_revoke, { this, &TabView::OnScrollViewerViewChanged });
     }

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -99,6 +99,16 @@
                     <Button x:Name="GetFirstTabLocationButton" AutomationProperties.Name="GetFirstTabLocationButton" Content="FirstTab" Click="GetFirstTabLocationButton_Click"/>
                     <TextBlock x:Name="FirstTabLocationTextBlock" AutomationProperties.Name="FirstTabLocationTextBlock" Margin="4,0,0,0" Text=""/>
                 </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="GetScrollDecreaseButtonToolTipButton" AutomationProperties.Name="GetScrollDecreaseButtonToolTipButton" Content="TooltipScrollDecreaseButton" Click="GetScrollDecreaseButtonToolTipButton_Click"/>
+                    <TextBlock x:Name="ScrollDecreaseButtonToolTipTextBlock" AutomationProperties.Name="ScrollDecreaseButtonToolTipTextBlock" Margin="4,0,0,0" Text=""/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="GetScrollIncreaseButtonToolTipButton" AutomationProperties.Name="GetScrollIncreaseButtonToolTipButton" Content="TooltipScrollIncreaseButton" Click="GetScrollIncreaseButtonToolTipButton_Click"/>
+                    <TextBlock x:Name="ScrollIncreaseButtonToolTipTextBlock" AutomationProperties.Name="ScrollIncreaseButtonToolTipTextBlock" Margin="4,0,0,0" Text=""/>
+                </StackPanel>
             </StackPanel>
 
             <Grid Grid.Column="1">

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -142,15 +142,15 @@ namespace MUXControlsTestApp
 
         public void GetTab0ToolTipButton_Click(object sender, RoutedEventArgs e)
         {
-            GetToolTipStringForTab(FirstTab, Tab0ToolTipTextBlock);
+            GetToolTipStringForUIElement(FirstTab, Tab0ToolTipTextBlock);
         }
 
         public void GetTab1ToolTipButton_Click(object sender, RoutedEventArgs e)
         {
-            GetToolTipStringForTab(SecondTab, Tab1ToolTipTextBlock);
+            GetToolTipStringForUIElement(SecondTab, Tab1ToolTipTextBlock);
         }
 
-        public void GetToolTipStringForTab(TabViewItem item, TextBlock textBlock)
+        public void GetToolTipStringForUIElement(UIElement item, TextBlock textBlock)
         {
             var tooltip = ToolTipService.GetToolTip(item);
             if (tooltip is ToolTip)
@@ -398,6 +398,22 @@ namespace MUXControlsTestApp
         {
             FirstTab.Header = "s";
             LongHeaderTab.Header = "long long long long long long long long";
+        }
+
+        private void GetScrollDecreaseButtonToolTipButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollDecreaseButton") is RepeatButton scrollDecreaseButton)
+            {
+                GetToolTipStringForUIElement(scrollDecreaseButton, ScrollDecreaseButtonToolTipTextBlock);
+            }
+        }
+
+        private void GetScrollIncreaseButtonToolTipButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollIncreaseButton") is RepeatButton scrollIncreaseButton)
+            {
+                GetToolTipStringForUIElement(scrollIncreaseButton, ScrollIncreaseButtonToolTipTextBlock);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds tooltips to the TabView's tab list scrolling buttons. Note: Not yet localized.

## Motivation and Context
Closes #2345.

## How Has This Been Tested?
Tested visually.

## Screenshots
![image](https://user-images.githubusercontent.com/1398851/80839164-f6632900-8bfa-11ea-99c9-37b4628b91d7.png) 

![image](https://user-images.githubusercontent.com/1398851/80839191-0418ae80-8bfb-11ea-9e2a-c9ca9837446d.png)

