### PR TITLE
Improve readability of AccentButton style on High Contrast

### DIFF
--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -10,7 +10,7 @@
             <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemAccentColorLight1" />
             <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemAccentColorDark1" />
             <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
+            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlForegroundAccentBrush" />
             <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
@@ -43,15 +43,15 @@
             <SolidColorBrush x:Key="ButtonPressedForegroundThemeBrush" Color="#FF000000" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="AccentButtonBackground" ResourceKey="SystemControlBackgroundAccentBrush" />
+            <StaticResource x:Key="AccentButtonBackground" ResourceKey="SystemControlHighlightAccentBrush" />
             <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemControlForegroundAccentBrush" />
             <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
             <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
+            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlHighlightAltAccentBrush" />
             <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="SystemControlHighlightBaseHighBrush" />
             <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <StaticResource x:Key="AccentButtonBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush" />
+            <StaticResource x:Key="AccentButtonBorderBrush" ResourceKey="SystemControlHighlightAccentBrush" />
             <StaticResource x:Key="AccentButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
             <StaticResource x:Key="AccentButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
             <StaticResource x:Key="AccentButtonBorderBrushDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
@@ -84,7 +84,7 @@
             <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemAccentColorLight1" />
             <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemAccentColorDark1" />
             <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
+            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlForegroundAccentBrush" />
             <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />


### PR DESCRIPTION
The AccentButton style has a couple problems in High Contrast mode:
* When HighContrastAdjustment is `None`, the text is completely unreadable.
* When HighContrastAdjustment is `Auto`, an accented button is indistinguishable from a regular button (unless you have a mouse and hover the pointer over it)

Here are some screenshots.  The left column is the current code as-is, and the right column shows the effects of this PR.  The screenshot shows a normal button (no special styles) on the left and an accented button (`Style="{StaticResource AccentButtonStyle}"`) on the right.  The mouse hovers over the button, then clicks it.

| Mode | Current | Proposed |
| --- | --- | --- |
| HC Black, Auto | ![oldhcblackauto](https://user-images.githubusercontent.com/10259764/80933862-49171f00-8d7a-11ea-91e6-7ba51175ce0e.gif) | ![newhcblackauto](https://user-images.githubusercontent.com/10259764/80935112-fb051a00-8d7f-11ea-95cb-92debf54a680.gif) |
| HC Black, None | ![oldhcblacknone](https://user-images.githubusercontent.com/10259764/80933872-57fdd180-8d7a-11ea-9d61-1a643ed6c1d2.gif) | ![newhcblacknone](https://user-images.githubusercontent.com/10259764/80935117-03f5eb80-8d80-11ea-847b-382be6caa4ec.gif) |
| HC White, Auto | ![oldhcwhiteauto](https://user-images.githubusercontent.com/10259764/80933879-65b35700-8d7a-11ea-8784-3f1ccd707acd.gif) | ![newhcwhiteauto](https://user-images.githubusercontent.com/10259764/80935128-0a846300-8d80-11ea-816d-09a33ca91748.gif) |
| HC White, None | ![oldhcwhitenone](https://user-images.githubusercontent.com/10259764/80933889-6d72fb80-8d7a-11ea-943e-906d6f89e99d.gif) | ![newhcwhitenone](https://user-images.githubusercontent.com/10259764/80935132-12440780-8d80-11ea-9be1-7082be54935f.gif) |
| Light theme | ![oldlight](https://user-images.githubusercontent.com/10259764/80933834-26850600-8d7a-11ea-8062-ac39c41e5c83.gif) | [no change] |
| Dark theme | ![olddark](https://user-images.githubusercontent.com/10259764/80933842-3270c800-8d7a-11ea-8309-2bda25b9a1d8.gif) | [no change, although shouldn't the hover background get darker, not lighter?] |

Note that this PR undoes #1509.  The problem is that that change had made `Auto` look a little better, at the cost of completely breaking the `None` mode.  I'd argue that the correct fix is for the app that reported the original issue to opt into `None` mode -- that's the general solution to making your app look great on High Contrast.  As long as the app is stuck in `Auto` mode, a variety of controls will have ugly -- but functional -- automatic backplating.  Including accent buttons.

It seems like there is a testing gap here, where the MUX test app doesn't let you try things in `None` mode.  I also raised #2378 to add that as an option.