### PR TITLE
Add fix for NavViewItems in footer crashing

### DIFF
--- a/dev/NavigationView/NavigationViewItemPresenter.cpp
+++ b/dev/NavigationView/NavigationViewItemPresenter.cpp
@@ -44,7 +44,7 @@ void NavigationViewItemPresenter::OnApplyTemplate()
         // We probably switched displaymode, so restore width now, otherwise the next time we will restore is when the CompactPaneLength changes
         if(auto&& navigationView = navigationViewItem->GetNavigationView())
         {
-            if (navigationViewItem->GetNavigationView().PaneDisplayMode() != winrt::NavigationViewPaneDisplayMode::Top)
+            if (navigationView.PaneDisplayMode() != winrt::NavigationViewPaneDisplayMode::Top)
             {
                 UpdateCompactPaneLength(m_compactPaneLengthValue, true);
             }

--- a/dev/NavigationView/NavigationViewItemPresenter.cpp
+++ b/dev/NavigationView/NavigationViewItemPresenter.cpp
@@ -38,14 +38,16 @@ void NavigationViewItemPresenter::OnApplyTemplate()
             m_expandCollapseChevron.set(expandCollapseChevron);
             m_expandCollapseChevronTappedToken = expandCollapseChevron.Tapped({ navigationViewItem, &NavigationViewItem::OnExpandCollapseChevronTapped });
         }
-
         navigationViewItem->UpdateVisualStateNoTransition();
 
 
         // We probably switched displaymode, so restore width now, otherwise the next time we will restore is when the CompactPaneLength changes
-        if (navigationViewItem->GetNavigationView().PaneDisplayMode() != winrt::NavigationViewPaneDisplayMode::Top)
+        if(auto&& navigationView = navigationViewItem->GetNavigationView())
         {
-            UpdateCompactPaneLength(m_compactPaneLengthValue, true);
+            if (navigationViewItem->GetNavigationView().PaneDisplayMode() != winrt::NavigationViewPaneDisplayMode::Top)
+            {
+                UpdateCompactPaneLength(m_compactPaneLengthValue, true);
+            }
         }
     }
 

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -683,6 +683,27 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Verify.IsFalse(menuItem1.IsSelected);
                 Verify.AreEqual(null, navView.SelectedItem, "SelectedItem should have been [null] as no item is selected");
+            });
+        }
+
+        [TestMethod]
+        public void VerifyNavigationViewItemInFooterDoesNotCrash()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var navView = new NavigationView();
+
+                Content = navView;
+
+                var navViewItem = new NavigationViewItem() { Content = "Footer item" };
+
+                navView.PaneFooter = navViewItem;
+
+                navView.Width = 1008; // forces the control into Expanded mode so that the menu renders
+                Content.UpdateLayout();
+
+                // If we don't get here, app has crashed. This verify is just making sure code got run
+                Verify.IsTrue(true);
             });
         }
     }

--- a/dev/NavigationView/TestUI/NavigationViewCompactPaneLengthTestPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewCompactPaneLengthTestPage.xaml
@@ -36,6 +36,9 @@
                 <AutoSuggestBox QueryIcon="Find" AutomationProperties.Name="PaneAutoSuggestBox"/>
             </muxc:NavigationView.AutoSuggestBox>
 
+            <muxc:NavigationView.PaneFooter>
+                <muxc:NavigationViewItem Content="Footer item"/>
+            </muxc:NavigationView.PaneFooter>
             
             <muxc:NavigationView.Content>
                 <StackPanel Padding="50" Orientation="Horizontal">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add null check to handle when NavigationViewItems are not rooted in the NavigationView menuitems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2388 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add API test and add NavigationVIewItem to footer of a testpage.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->