### PR TITLE
ProgressBar: Update indicator size when Padding changes.

### DIFF
--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -18,10 +18,10 @@ ProgressBar::ProgressBar()
 
     // NOTE: This is necessary only because Value isn't one of OUR properties, it's implemented in RangeBase.
     // If it was one of ProgressBar's properties, defined in the IDL, you'd do it differently (see IsIndeterminate).
-    RegisterPropertyChangedCallback(winrt::RangeBase::ValueProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
-    RegisterPropertyChangedCallback(winrt::RangeBase::MinimumProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
-    RegisterPropertyChangedCallback(winrt::RangeBase::MaximumProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
-    RegisterPropertyChangedCallback(winrt::Control::PaddingProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
+    RegisterPropertyChangedCallback(winrt::RangeBase::ValueProperty(), { this, &ProgressBar::OnIndicatorWidthComponentChanged });
+    RegisterPropertyChangedCallback(winrt::RangeBase::MinimumProperty(), { this, &ProgressBar::OnIndicatorWidthComponentChanged });
+    RegisterPropertyChangedCallback(winrt::RangeBase::MaximumProperty(), { this, &ProgressBar::OnIndicatorWidthComponentChanged });
+    RegisterPropertyChangedCallback(winrt::Control::PaddingProperty(), { this, &ProgressBar::OnIndicatorWidthComponentChanged });
 
     SetValue(s_TemplateSettingsProperty, winrt::make<::ProgressBarTemplateSettings>());
 }
@@ -53,7 +53,7 @@ void ProgressBar::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspec
     UpdateWidthBasedTemplateSettings();
 }
 
-void ProgressBar::OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
+void ProgressBar::OnIndicatorWidthComponentChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
 {
     // NOTE: This hits when the Value property changes, because we called RegisterPropertyChangedCallback.
     SetProgressBarIndicatorWidth();

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -21,6 +21,7 @@ ProgressBar::ProgressBar()
     RegisterPropertyChangedCallback(winrt::RangeBase::ValueProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
     RegisterPropertyChangedCallback(winrt::RangeBase::MinimumProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
     RegisterPropertyChangedCallback(winrt::RangeBase::MaximumProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
+    RegisterPropertyChangedCallback(winrt::Control::PaddingProperty(), { this, &ProgressBar::OnRangeBasePropertyChanged });
 
     SetValue(s_TemplateSettingsProperty, winrt::make<::ProgressBarTemplateSettings>());
 }
@@ -62,7 +63,7 @@ void ProgressBar::OnIsIndeterminatePropertyChanged(const winrt::DependencyProper
 {
     // NOTE: This hits when IsIndeterminate changes because we set MUX_PROPERTY_CHANGED_CALLBACK to true in the idl.
     SetProgressBarIndicatorWidth();
-    UpdateStates(); 
+    UpdateStates();
 }
 
 void ProgressBar::OnShowPausedPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -120,7 +121,7 @@ void ProgressBar::SetProgressBarIndicatorWidth()
 
             // Adds "Updating" state in between to trigger RepositionThemeAnimation Visual Transition
             // in ProgressBar.xaml when reverting back to previous state
-            winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true); 
+            winrt::VisualStateManager::GoToState(*this, s_UpdatingStateName, true);
 
             if (IsIndeterminate())
             {
@@ -149,7 +150,7 @@ void ProgressBar::SetProgressBarIndicatorWidth()
             {
                 determinateProgressBarIndicator.Width(0); // Error
             }
-           
+
             UpdateStates(); // Reverts back to previous state
         }
     }

--- a/dev/ProgressBar/ProgressBar.h
+++ b/dev/ProgressBar/ProgressBar.h
@@ -29,7 +29,7 @@ public:
     void OnShowPausedPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
 private:
-    void OnRangeBasePropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
+    void OnIndicatorWidthComponentChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
 
     void SetProgressBarIndicatorWidth();
     void UpdateStates();


### PR DESCRIPTION
Changing the `Padding` on a `<winui:ProgressBar>` were not updating the size of the indicator.

## Motivation and Context
When the `Padding` dynamically, the indicator size were not properly updated. This change should fix the problem.
