### PR TITLE
Revert change to default AccentForegroundBrush

### DIFF
--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -84,7 +84,7 @@
             <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemAccentColorLight1" />
             <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemAccentColorDark1" />
             <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlForegroundAccentBrush" />
+            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />

--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -10,7 +10,7 @@
             <StaticResource x:Key="AccentButtonBackgroundPointerOver" ResourceKey="SystemAccentColorLight1" />
             <StaticResource x:Key="AccentButtonBackgroundPressed" ResourceKey="SystemAccentColorDark1" />
             <StaticResource x:Key="AccentButtonBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlForegroundAccentBrush" />
+            <StaticResource x:Key="AccentButtonForeground" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPointerOver" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundPressed" ResourceKey="SystemControlBackgroundChromeWhiteBrush" />
             <StaticResource x:Key="AccentButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert the AccentForeGround resource to a the previous value as the new value was a regression.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

Fixes regression with Accent buttons

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

Tested manually:
Before:
![image](https://user-images.githubusercontent.com/16122379/81753131-6606cd00-94b3-11ea-81cb-ef417c16ffb6.png)

![image](https://user-images.githubusercontent.com/16122379/81753114-5c7d6500-94b3-11ea-8a7b-f16d233e1e38.png)

After:
![image](https://user-images.githubusercontent.com/16122379/81455375-59226a80-918f-11ea-87f2-19207488d5a0.png)
![image](https://user-images.githubusercontent.com/16122379/81455382-5d4e8800-918f-11ea-85d9-4672a26aee2c.png)


## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->