### PR TITLE
Fix issue with settings button in top mode not receiving pointer events

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -73,27 +73,23 @@ void NavigationViewItem::OnApplyTemplate()
 
     }
 
-    if (auto presenter = GetTemplateChildT<winrt::NavigationViewItemPresenter>(c_navigationViewItemPresenterName, controlProtected))
+    winrt::UIElement const presenter = [this, controlProtected]()
     {
-        m_navigationViewItemPresenter.set(presenter);
-
-        m_presenterPointerPressedRevoker = presenter.PointerPressed(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerPressed });
-        m_presenterPointerReleasedRevoker = presenter.PointerReleased(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerReleased });
-        m_presenterPointerEnteredRevoker = presenter.PointerEntered(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerEntered });
-        m_presenterPointerExitedRevoker = presenter.PointerExited(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerExited });
-        m_presenterPointerCanceledRevoker = presenter.PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
-        m_presenterPointerCaptureLostRevoker = presenter.PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
-    }
-    else
-    {
+        if (auto presenter = GetTemplateChildT<winrt::NavigationViewItemPresenter>(c_navigationViewItemPresenterName, controlProtected))
+        {
+            m_navigationViewItemPresenter.set(presenter);
+            return presenter.try_as<winrt::UIElement>();
+        }
         // We don't have a presenter, so we are our own presenter.
-        m_presenterPointerPressedRevoker = this->PointerPressed(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerPressed });
-        m_presenterPointerReleasedRevoker = this->PointerReleased(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerReleased });
-        m_presenterPointerEnteredRevoker = this->PointerEntered(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerEntered });
-        m_presenterPointerExitedRevoker = this->PointerExited(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerExited });
-        m_presenterPointerCanceledRevoker = this->PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
-        m_presenterPointerCaptureLostRevoker = this->PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
-    }
+        return this->try_as<winrt::UIElement>();
+    }();
+
+    m_presenterPointerPressedRevoker = presenter.PointerPressed(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerPressed });
+    m_presenterPointerReleasedRevoker = presenter.PointerReleased(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerReleased });
+    m_presenterPointerEnteredRevoker = presenter.PointerEntered(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerEntered });
+    m_presenterPointerExitedRevoker = presenter.PointerExited(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerExited });
+    m_presenterPointerCanceledRevoker = presenter.PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
+    m_presenterPointerCaptureLostRevoker = presenter.PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
 
     m_toolTip.set(GetTemplateChildT<winrt::ToolTip>(L"ToolTip"sv, controlProtected));
 

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -84,6 +84,17 @@ void NavigationViewItem::OnApplyTemplate()
         m_presenterPointerCanceledRevoker = presenter.PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
         m_presenterPointerCaptureLostRevoker = presenter.PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
     }
+    else
+    {
+        // We don't have a presenter, so we are our own presenter.
+        m_presenterPointerPressedRevoker = this->PointerPressed(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerPressed });
+        m_presenterPointerReleasedRevoker = this->PointerReleased(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerReleased });
+        m_presenterPointerEnteredRevoker = this->PointerEntered(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerEntered });
+        m_presenterPointerExitedRevoker = this->PointerExited(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerExited });
+        m_presenterPointerCanceledRevoker = this->PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
+        m_presenterPointerCaptureLostRevoker = this->PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
+
+    }
 
     m_toolTip.set(GetTemplateChildT<winrt::ToolTip>(L"ToolTip"sv, controlProtected));
 

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -93,7 +93,6 @@ void NavigationViewItem::OnApplyTemplate()
         m_presenterPointerExitedRevoker = this->PointerExited(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerExited });
         m_presenterPointerCanceledRevoker = this->PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
         m_presenterPointerCaptureLostRevoker = this->PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
-
     }
 
     m_toolTip.set(GetTemplateChildT<winrt::ToolTip>(L"ToolTip"sv, controlProtected));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There is a regression that was introduced with #2004 where the settings button didn't receive any visual states for pointer events. Now we subscribe to the item's pointer events if it does not have a NavigationViewItemPresenter as children, which would handle this normally.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2431 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

![gif](https://user-images.githubusercontent.com/16122379/81831304-7b283e00-953d-11ea-98f0-9df4d12513c8.gif)
