### PR TITLE
Fix background of MenuFlyout in white high contrast

### DIFF
--- a/dev/MenuFlyout/MenuFlyout_themeresources.xaml
+++ b/dev/MenuFlyout/MenuFlyout_themeresources.xaml
@@ -136,7 +136,7 @@
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseMediumBrush" />
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed" ResourceKey="SystemControlHighlightAltBaseMediumBrush" />
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+            <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlBackgroundBaseHighBrush" />
             <contract7NotPresent:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <contract7NotPresent:StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Swap out the brush we use for high contrast for MenuFlyout background to a brush that adheres more to the background of the app.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2432
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
High contrast 1
![image](https://user-images.githubusercontent.com/16122379/81966290-a08a7a00-9619-11ea-934e-bb7ee4eb7653.png)

High contrast 2
![image](https://user-images.githubusercontent.com/16122379/81966315-aa13e200-9619-11ea-81cc-8c59b4847c0f.png)

High contrast black
![image](https://user-images.githubusercontent.com/16122379/81966337-b4ce7700-9619-11ea-990d-456d03cfab99.png)

High contrast white
![image](https://user-images.githubusercontent.com/16122379/81966378-c44dc000-9619-11ea-87fd-792eea5208d7.png)

