### PR TITLE
Set TeachingTip's ActionButton and CloseButton styles DPs

### DIFF
--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -13,6 +13,8 @@
         <Setter Property="Foreground" Value="{ThemeResource TeachingTipForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource TeachingTipBorderBrush}"/>
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+        <Setter Property="ActionButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>
+        <Setter Property="CloseButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TeachingTip">


### PR DESCRIPTION
Fixes #2411

What was happening here is the system sees that that the teaching tip buttons had an assigned style so it would not do the style lookup. However the assigned style was null so when the property was applied it grabbed the button style from generic.xaml  This process skipped over the proper style lookup and results in the DefaultButtonStyle in the Winui CommonStyles gets skipped over.