### PR TITLE
TreeView: Set IsExpanded when last child has been removed

### DIFF
--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -667,6 +667,48 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
+        [TestMethod]
+        public void RemovingLastChildrenSetsIsExpandedToFalse()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var treeViewNode1 = new TreeViewNode();
+                var treeViewNode2 = new TreeViewNode();
+                var treeViewNode3 = new TreeViewNode();
+                var treeViewNode4 = new TreeViewNode();
+                var treeViewNode5 = new TreeViewNode();
+
+                treeViewNode1.Children.Add(treeViewNode2);
+                treeViewNode1.Children.Add(treeViewNode3);
+                treeViewNode1.Children.Add(treeViewNode4);
+                treeViewNode1.Children.Add(treeViewNode5);
+
+                var treeView = new TreeView();
+                Content = treeView;
+                Content.UpdateLayout();
+                
+                treeViewNode1.IsExpanded = true;
+                Verify.IsTrue(treeViewNode1.IsExpanded);
+
+                treeViewNode1.Children.Clear();
+                Verify.IsFalse(treeViewNode1.IsExpanded);
+
+                treeViewNode1.Children.Add(treeViewNode2);
+                treeViewNode1.IsExpanded = true;
+                Verify.IsTrue(treeViewNode1.IsExpanded);
+
+                treeViewNode1.Children.Remove(treeViewNode2);
+                Verify.IsFalse(treeViewNode1.IsExpanded);
+
+                treeViewNode1.Children.Add(treeViewNode2);
+                treeViewNode1.IsExpanded = true;
+                Verify.IsTrue(treeViewNode1.IsExpanded);
+
+                treeViewNode1.Children.RemoveAt(0);
+                Verify.IsFalse(treeViewNode1.IsExpanded);
+            });
+        }
+
         private bool IsMultiSelectCheckBoxChecked(TreeView tree, TreeViewNode node)
         {
             var treeViewItem = tree.ContainerFromNode(node) as TreeViewItem;

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -672,21 +672,22 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             RunOnUIThread.Execute(() =>
             {
+                var treeViewRoot = new TreeViewNode();
                 var treeViewNode1 = new TreeViewNode();
                 var treeViewNode2 = new TreeViewNode();
                 var treeViewNode3 = new TreeViewNode();
                 var treeViewNode4 = new TreeViewNode();
                 var treeViewNode5 = new TreeViewNode();
 
+                // Need root since in TreeView we otherwise 
+                // could collapse whole tree and hide it forever
+                treeViewRoot.Children.Add(treeViewNode1);
+
                 treeViewNode1.Children.Add(treeViewNode2);
                 treeViewNode1.Children.Add(treeViewNode3);
                 treeViewNode1.Children.Add(treeViewNode4);
                 treeViewNode1.Children.Add(treeViewNode5);
 
-                var treeView = new TreeView();
-                Content = treeView;
-                Content.UpdateLayout();
-                
                 treeViewNode1.IsExpanded = true;
                 Verify.IsTrue(treeViewNode1.IsExpanded);
 

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -402,6 +402,15 @@ void TreeViewNodeVector::RemoveAt(unsigned int index, bool updateItemsSource)
             source.RemoveAt(index);
         }
     }
+
+    // No children, so close parent
+    if (inner->Size() == 0)
+    {
+        if (auto&& ownerNode = m_parent.get())
+        {
+            ownerNode.IsExpanded(false);
+        }
+    }
 }
 
 void TreeViewNodeVector::RemoveAtEnd(bool updateItemsSource)
@@ -457,6 +466,11 @@ void TreeViewNodeVector::Clear(bool updateItemsSource)
                 itemsSource.Clear();
             }
         }
+    }
+
+    if (auto&& ownerNode = m_parent.get())
+    {
+        ownerNode.IsExpanded(false);
     }
 }
 

--- a/dev/TreeView/TreeViewNode.h
+++ b/dev/TreeView/TreeViewNode.h
@@ -109,8 +109,8 @@ public:
     void Append(winrt::TreeViewNode const& item, bool updateItemsSource = true);   
     void InsertAt(unsigned int index, winrt::TreeViewNode const& item, bool updateItemsSource = true);
     void SetAt(unsigned int index, winrt::TreeViewNode const& item, bool updateItemsSource = true);   
-    void RemoveAt(unsigned int index, bool updateItemsSource = true);
+    void RemoveAt(unsigned int index, bool updateItemsSource = true, bool updateIsExpanded = true);
     void RemoveAtEnd(bool updateItemsSource = true);
     void ReplaceAll(winrt::array_view<winrt::TreeViewNode const> values, bool updateItemsSource = true);    
-    void Clear(bool updateItemsSource = true);
+    void Clear(bool updateItemsSource = true, bool updateIsExpanded = true);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add code that set's the IsExpanded of a node to false when it's last child has been removed.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2332 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add new API test
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->