### PR TITLE
Simplify obtaining the CoreDispatcher from a thread

### DIFF
--- a/dev/inc/DispatcherHelper.h
+++ b/dev/inc/DispatcherHelper.h
@@ -4,26 +4,6 @@
 #pragma once
 #include "SharedHelpers.h"
 
-// To avoid having to call a potentially throwing cppwinrt api, we call directly through the abi.
-// We don't want to include the entirety of the abi headers, so we just reproduce the single interface
-// that we need.
-namespace ABI::Windows::ApplicationModel::Core
-{
-    MIDL_INTERFACE("0AACF7A4-5E1D-49DF-8034-FB6A68BC5ED1")
-    ICoreApplication : public IInspectable
-    {
-        virtual HRESULT STDMETHODCALLTYPE get_Id(HSTRING* value) = 0;
-        virtual HRESULT STDMETHODCALLTYPE add_Suspending(void* handler, EventRegistrationToken* token) = 0;
-        virtual HRESULT STDMETHODCALLTYPE remove_Suspending(EventRegistrationToken token) = 0;
-        virtual HRESULT STDMETHODCALLTYPE add_Resuming(void* handler, EventRegistrationToken* token) = 0;
-        virtual HRESULT STDMETHODCALLTYPE remove_Resuming(EventRegistrationToken token) = 0;
-        virtual HRESULT STDMETHODCALLTYPE get_Properties(void** value) = 0;
-        virtual HRESULT STDMETHODCALLTYPE GetCurrentView(void** value) = 0;
-        virtual HRESULT STDMETHODCALLTYPE Run(void* viewSource) = 0;
-        virtual HRESULT STDMETHODCALLTYPE RunWithActivationFactories(void* activationFactoryCallback) = 0;
-    };
-}
-
 class DispatcherHelper
 {
 public:
@@ -41,22 +21,11 @@ public:
             {
                 coreDispatcher = dependencyObject.Dispatcher();
             }
-            else if (auto currentView = TryGetCoreApplicationCurrentView())
+            else if (auto window = winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread())
             {
-                coreDispatcher = currentView.Dispatcher();
+                coreDispatcher = window.Dispatcher();
             }
         }
-    }
-
-    winrt::CoreApplicationView TryGetCoreApplicationCurrentView()
-    {
-        // We could call winrt::CoreApplication::GetCurrentView() here, but that can throw in some cases. Even if we catch, it will still
-        // generate exception noise in the debugger.
-        winrt::CoreApplicationView view{ nullptr };
-        auto coreApplication = winrt::get_activation_factory<winrt::CoreApplication, ABI::Windows::ApplicationModel::Core::ICoreApplication>();
-        auto ignorehr = coreApplication->GetCurrentView(winrt::put_abi(view));
-
-        return view;
     }
 
     void RunAsync(std::function<void()> func, bool fallbackToThisThread = false) const


### PR DESCRIPTION
## Description
Improvement to #1434 by switching from CoreApplicationView::GetForCurrentThread to CoreWindow::GetForCurrentThread. The difference is that CoreApplicationView::GetForCurrentThread throws if not called on a UI thread, whereas CoreWindow::GetForCurrentThread just returns null. The CoreWindow and CoreApplicationView have the same dispatcher, and switching to CoreWindow removes the need to work around the CoreApplicationView behavior.

## Motivation and Context
Functionally equivalent to existing code, but much simpler. Avoids having to drop to lower-level C++/WinRT code.

## How Has This Been Tested?
Bespoke testing of underlying algorithm.