### PR TITLE
Make wasPressing const

### DIFF
--- a/dev/Interactions/ButtonInteraction/ButtonInteraction.cpp
+++ b/dev/Interactions/ButtonInteraction/ButtonInteraction.cpp
@@ -156,7 +156,7 @@ void ButtonInteraction::OnPointerReleased(winrt::UIElement const& sender, winrt:
     auto target = sender;
     auto pointerArgs = args;
 
-    bool wasPressing = m_isPressing;
+    const bool wasPressing = m_isPressing;
 
     UpdateIsPressing(false);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Very minor change, but makes the intention more clear.

## Description
<!--- Describe your changes in detail -->
Because wasPressed is used to capture a previous value before the m_isPressed updates, it should be const.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Unit Tests

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->