### PR TITLE
Resize tab view items only once the pointer has left the TabViewItem strip

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -161,10 +161,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Close a tab to make room. The scroll buttons should disappear:
                 Log.Comment("Closing a tab:");
                 Button closeButton = FindCloseButton(FindElement.ByName("LongHeaderTab"));
+                closeButton.MovePointer(0, 0);
                 closeButton.InvokeAndWait();
                 VerifyElement.NotFound("LongHeaderTab", FindBy.Name);
 
                 Log.Comment("Scroll buttons should disappear");
+                // Leaving tabstrip with this so the tabs update their width
+                FindElement.ByName<Button>("GetScrollButtonsVisible").MovePointer(0,0);
+                Wait.ForIdle();
                 Verify.IsFalse(AreScrollButtonsVisible(), "Scroll buttons should disappear");
 
                 // Make sure the scroll buttons can show up in 'Equal' sizing mode. 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -656,13 +656,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
 
                 Log.Comment("Verifying sizing behavior when closing a tab");
-                CloseTabAndVerifyWidth("Tab 1", 500,true);
+                CloseTabAndVerifyWidth("Tab 1", 500, "True;False;");
 
-                CloseTabAndVerifyWidth("Tab 2", 500, true);
+                CloseTabAndVerifyWidth("Tab 2", 500, "True;False;");
 
-                CloseTabAndVerifyWidth("Tab 3", 443, false);
+                CloseTabAndVerifyWidth("Tab 3", 500, "False;False;");
 
-                CloseTabAndVerifyWidth("Tab 4", 343, false);
+                CloseTabAndVerifyWidth("Tab 4", 401, "False;False;");
 
                 Log.Comment("Leaving the pointer exited area");
                 var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
@@ -676,21 +676,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - 500) < pixelTolerance);
             }
 
-            void CloseTabAndVerifyWidth(string tabName, int expectedValue, bool expectedScrollButtonVisible)
+            void CloseTabAndVerifyWidth(string tabName, int expectedValue, string expectedScrollbuttonStates)
             {
                 Log.Comment("Closing tab:" + tabName);
                 FindCloseButton(FindElement.ByName(tabName)).Click();
                 Wait.ForIdle();
                 Log.Comment("Verifying TabView width");
                 Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedValue) < pixelTolerance);
-                if(expectedScrollButtonVisible)
-                {
-                    Verify.AreEqual("true;true;", FindElement.ByName("ScrollButtonStatus").GetText());
-                }
-                else
-                {
-                    Verify.AreEqual("false;false;", FindElement.ByName("ScrollButtonStatus").GetText());
-                }
+                Verify.AreEqual(expectedScrollbuttonStates, FindElement.ByName("ScrollButtonStatus").GetText());
 
             }
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -660,9 +660,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 CloseTabAndVerifyWidth("Tab 2", 500, true);
 
-                // Scroll buttons are not visible after closing this tab.
-                // However the TabCloseRequested event get's raised before the scroll buttons dissappear.
-                // This results in every call essentially verifiying the scroll button state of the previous tab closing.
                 CloseTabAndVerifyWidth("Tab 3", 443, false);
 
                 CloseTabAndVerifyWidth("Tab 4", 343, false);

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -648,10 +648,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void VerifySizingBehaviorOnTabClose()
+        public void VerifySizingBehaviorOnTabCloseComingFromScroll()
         {
             int pixelTolerance = 10;
-            
+
             using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
             {
 
@@ -662,13 +662,66 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 CloseTabAndVerifyWidth("Tab 3", 500, "False;False;");
 
+                CloseTabAndVerifyWidth("Tab 5", 401, "False;False;");
+
                 CloseTabAndVerifyWidth("Tab 4", 401, "False;False;");
 
                 Log.Comment("Leaving the pointer exited area");
                 var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
                 readTabViewWidthButton.Click();
                 Wait.ForIdle();
-                
+
+                readTabViewWidthButton.Click();
+                Wait.ForIdle();
+
+                Log.Comment("Verify correct TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - 283) < pixelTolerance);
+            }
+
+            void CloseTabAndVerifyWidth(string tabName, int expectedValue, string expectedScrollbuttonStates)
+            {
+                Log.Comment("Closing tab:" + tabName);
+                FindCloseButton(FindElement.ByName(tabName)).Click();
+                Wait.ForIdle();
+                Log.Comment("Verifying TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedValue) < pixelTolerance);
+                Verify.AreEqual(expectedScrollbuttonStates, FindElement.ByName("ScrollButtonStatus").GetText());
+
+            }
+
+            double GetActualTabViewWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewWidth"));
+
+                return Double.Parse(tabviewWidth.GetText());
+            }
+        }
+
+        [TestMethod]
+        public void VerifySizingBehaviorOnTabCloseComingFromNonScroll()
+        {
+            int pixelTolerance = 10;
+
+            using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
+            {
+
+                Log.Comment("Verifying sizing behavior when closing a tab");
+                CloseTabAndVerifyWidth("Tab 1", 500, "True;False;");
+
+                CloseTabAndVerifyWidth("Tab 2", 500, "True;False;");
+
+                CloseTabAndVerifyWidth("Tab 3", 500, "False;False;");
+
+                var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
+                readTabViewWidthButton.Click();
+                Wait.ForIdle();
+
+                CloseTabAndVerifyWidth("Tab 5", 500, "False;False;");
+
+                CloseTabAndVerifyWidth("Tab 4", 500, "False;False;");
+
+                Log.Comment("Leaving the pointer exited area");
+
                 readTabViewWidthButton.Click();
                 Wait.ForIdle();
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Log.Comment("Scroll buttons should disappear");
                 // Leaving tabstrip with this so the tabs update their width
-                FindElement.ByName<Button>("GetScrollButtonsVisible").MovePointer(0,0);
+                FindElement.ByName<Button>("IsClosableCheckBox").MovePointer(0,0);
                 Wait.ForIdle();
                 Verify.IsFalse(AreScrollButtonsVisible(), "Scroll buttons should disappear");
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -647,6 +647,64 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void VerifySizingBehaviorOnTabClose()
+        {
+            int pixelTolerance = 10;
+            
+            using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
+            {
+
+                Log.Comment("Verifying sizing behavior when closing a tab");
+                CloseTabAndVerifyWidth("Tab 1", 500,true);
+
+                CloseTabAndVerifyWidth("Tab 2", 500, true);
+
+                // Scroll buttons are not visible after closing this tab.
+                // However the TabCloseRequested event get's raised before the scroll buttons dissappear.
+                // This results in every call essentially verifiying the scroll button state of the previous tab closing.
+                CloseTabAndVerifyWidth("Tab 3", 443, false);
+
+                CloseTabAndVerifyWidth("Tab 4", 343, false);
+
+                Log.Comment("Leaving the pointer exited area");
+                var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
+                readTabViewWidthButton.Click();
+                Wait.ForIdle();
+                
+                readTabViewWidthButton.Click();
+                Wait.ForIdle();
+
+                Log.Comment("Verify correct TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - 500) < pixelTolerance);
+            }
+
+            void CloseTabAndVerifyWidth(string tabName, int expectedValue, bool expectedScrollButtonVisible)
+            {
+                Log.Comment("Closing tab:" + tabName);
+                FindCloseButton(FindElement.ByName(tabName)).Click();
+                Wait.ForIdle();
+                Log.Comment("Verifying TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedValue) < pixelTolerance);
+                if(expectedScrollButtonVisible)
+                {
+                    Verify.AreEqual("true;true;", FindElement.ByName("ScrollButtonStatus").GetText());
+                }
+                else
+                {
+                    Verify.AreEqual("false;false;", FindElement.ByName("ScrollButtonStatus").GetText());
+                }
+
+            }
+
+            double GetActualTabViewWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewWidth"));
+
+                return Double.Parse(tabviewWidth.GetText());
+            }
+        }
+
         public void PressButtonAndVerifyText(String buttonName, String textBlockName, String expectedText)
         {
             Button button = FindElement.ByName<Button>(buttonName);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -486,6 +486,13 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
                         }
                     } while (index != startIndex);
                 }
+
+            }
+            // Last item removed, update sizes
+            // The index of the last element is "Size() - 1", but in TabItems, it is already removed.
+            if (args.Index() == TabItems().Size())
+            {
+                UpdateTabWidths();
             }
         }
         else

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -641,6 +641,7 @@ void TabView::RequestCloseTab(winrt::TabViewItem const& container)
             internalTabViewItem->RaiseRequestClose(*args);
         }
     }
+    UpdateTabWidths(false);
 }
 
 void TabView::OnScrollDecreaseClick(const winrt::IInspectable&, const winrt::RoutedEventArgs&)
@@ -670,7 +671,7 @@ winrt::Size TabView::MeasureOverride(winrt::Size const& availableSize)
     return __super::MeasureOverride(availableSize);
 }
 
-void TabView::UpdateTabWidths()
+void TabView::UpdateTabWidths(bool shouldUpdateWidths)
 {
     double tabWidth = std::numeric_limits<double>::quiet_NaN();
 
@@ -763,18 +764,22 @@ void TabView::UpdateTabWidths()
         }
     }
 
-    for (auto item : TabItems())
-    {
-        // Set the calculated width on each tab.
-        auto tvi = item.try_as<winrt::TabViewItem>();
-        if (!tvi)
-        {
-            tvi = ContainerFromItem(item).as<winrt::TabViewItem>();
-        }
 
-        if (tvi)
+    if (shouldUpdateWidths)
+    {
+        for (auto item : TabItems())
         {
-            tvi.Width(tabWidth);
+            // Set the calculated width on each tab.
+            auto tvi = item.try_as<winrt::TabViewItem>();
+            if (!tvi)
+            {
+                tvi = ContainerFromItem(item).as<winrt::TabViewItem>();
+            }
+
+            if (tvi)
+            {
+                tvi.Width(tabWidth);
+            }
         }
     }
 }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -80,7 +80,11 @@ void TabView::OnApplyTemplate()
     m_addButtonColumn.set(GetTemplateChildT<winrt::ColumnDefinition>(L"AddButtonColumn", controlProtected));
     m_rightContentColumn.set(GetTemplateChildT<winrt::ColumnDefinition>(L"RightContentColumn", controlProtected));
 
-    m_tabContainerGrid.set(GetTemplateChildT<winrt::Grid>(L"TabContainerGrid", controlProtected));
+    if (const auto& containerGrid = GetTemplateChildT<winrt::Grid>(L"TabContainerGrid", controlProtected))
+    {
+        m_tabContainerGrid.set(containerGrid);
+        m_tabStripPointerExitedRevoker = containerGrid.PointerExited(winrt::auto_revoke, { this,&TabView::OnTabStripPointerExited });
+    }
 
     m_shadowReceiver.set(GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected));
 
@@ -89,7 +93,6 @@ void TabView::OnApplyTemplate()
         if (listView)
         {
             m_listViewLoadedRevoker = listView.Loaded(winrt::auto_revoke, { this, &TabView::OnListViewLoaded });
-            m_listViewPointerExitedRevoker = listView.PointerExited(winrt::auto_revoke, { this,&TabView::OnListViewPointerExited });
             m_listViewSelectionChangedRevoker = listView.SelectionChanged(winrt::auto_revoke, { this, &TabView::OnListViewSelectionChanged });
 
             m_listViewDragItemsStartingRevoker = listView.DragItemsStarting(winrt::auto_revoke, { this, &TabView::OnListViewDragItemsStarting });
@@ -342,7 +345,7 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
     }
 }
 
-void TabView::OnListViewPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void TabView::OnTabStripPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
 {
     if (updateTabWidthOnPointerLeave)
     {

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -447,6 +447,7 @@ void TabView::OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, con
     {
         // Presenter size didn't change because of item being removed, so update manually
         UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
+        UpdateTabWidths();
     }
 }
 
@@ -497,9 +498,13 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
             }
             // Last item removed, update sizes
             // The index of the last element is "Size() - 1", but in TabItems, it is already removed.
-            if (args.Index() == TabItems().Size())
+            if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
             {
-                UpdateTabWidths(true,false);
+                updateTabWidthOnPointerLeave = true;
+                if (args.Index() == TabItems().Size())
+                {
+                    UpdateTabWidths(true,false);
+                }
             }
         }
         else
@@ -805,7 +810,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
                             winrt::FxScrollViewer::SetHorizontalScrollBarVisibility(listview, visible
                                 ? winrt::Windows::UI::Xaml::Controls::ScrollBarVisibility::Visible
                                 : winrt::Windows::UI::Xaml::Controls::ScrollBarVisibility::Hidden);
-                            if (visible && shouldUpdateWidths)
+                            if (visible)
                             {
                                 UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
                             }
@@ -817,7 +822,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
     }
 
 
-    if (shouldUpdateWidths)
+    if (shouldUpdateWidths || TabWidthMode() != winrt::TabViewWidthMode::Equal)
     {
         for (auto item : TabItems())
         {

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -127,7 +127,7 @@ private:
     void OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
 
     void OnListViewLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
-    void OnListViewPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnTabStripPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
     void OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
 
     void OnListViewDragItemsStarting(const winrt::IInspectable& sender, const winrt::DragItemsStartingEventArgs& args);
@@ -176,7 +176,7 @@ private:
     tracker_ref<winrt::Grid> m_shadowReceiver{ this };
 
     winrt::ListView::Loaded_revoker m_listViewLoadedRevoker{};
-    winrt::ListView::PointerExited_revoker m_listViewPointerExitedRevoker{};
+    winrt::ListView::PointerExited_revoker m_tabStripPointerExitedRevoker{};
     winrt::Selector::SelectionChanged_revoker m_listViewSelectionChangedRevoker{};
     winrt::UIElement::GettingFocus_revoker m_listViewGettingFocusRevoker{};
 

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -145,7 +145,7 @@ private:
     void UpdateSelectedItem();
     void UpdateSelectedIndex();
 
-    void UpdateTabWidths();
+    void UpdateTabWidths(bool shouldUpdateWidths=true);
 
     void UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
 

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -145,7 +145,7 @@ private:
     void UpdateSelectedItem();
     void UpdateSelectedIndex();
 
-    void UpdateTabWidths(bool shouldUpdateWidths=true);
+    void UpdateTabWidths(bool shouldUpdateWidths=true, bool fillAllAvailableSpace=true);
 
     void UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
 

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -89,7 +89,7 @@ public:
 
     // IFrameworkElement
     void OnApplyTemplate();
-    winrt::Size MeasureOverride(winrt::Size const& availableSize); 
+    winrt::Size MeasureOverride(winrt::Size const& availableSize);
 
     // IUIElement
     winrt::AutomationPeer OnCreateAutomationPeer();
@@ -127,6 +127,7 @@ private:
     void OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
 
     void OnListViewLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
+    void OnListViewPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
     void OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
 
     void OnListViewDragItemsStarting(const winrt::IInspectable& sender, const winrt::DragItemsStartingEventArgs& args);
@@ -152,6 +153,9 @@ private:
 
     int GetItemCount();
 
+    bool updateTabWidthOnPointerLeave{ false };
+
+
     winrt::TabViewItem FindTabViewItemFromDragItem(const winrt::IInspectable& item);
 
     tracker_ref<winrt::ColumnDefinition> m_leftContentColumn{ this };
@@ -172,6 +176,7 @@ private:
     tracker_ref<winrt::Grid> m_shadowReceiver{ this };
 
     winrt::ListView::Loaded_revoker m_listViewLoadedRevoker{};
+    winrt::ListView::PointerExited_revoker m_listViewPointerExitedRevoker{};
     winrt::Selector::SelectionChanged_revoker m_listViewSelectionChangedRevoker{};
     winrt::UIElement::GettingFocus_revoker m_listViewGettingFocusRevoker{};
 

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -153,7 +153,12 @@
 
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
-                            <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
+                            <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton"
+                                    Margin="8" Click="TabViewSizingPageButton_Click"
+                                    FontSize="20">TabView Sizing Page</Button>
+                            <Button x:Name="TabViewTabClosingBehaviorButton" AutomationProperties.Name="TabViewTabClosingBehaviorButton"
+                                    Margin="8" Click="TabViewTabClosingBehaviorButton_Click"
+                                    FontSize="20">TabView Tab Closing behavior Page</Button>
                         </StackPanel>
                     </controls:TabViewItem>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
@@ -392,6 +392,12 @@ namespace MUXControlsTestApp
         private void TabViewSizingPageButton_Click(object sender, RoutedEventArgs e)
         {
             this.Frame.Navigate(typeof(TabViewSizingPage));
+        }
+
+        
+        private void TabViewTabClosingBehaviorButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.Frame.Navigate(typeof(TabViewTabClosingBehaviorPage));
         }
 
         private void ShortLongTextButton_Click(object sender, RoutedEventArgs e)

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml
@@ -1,0 +1,44 @@
+﻿<Page
+    x:Class="MUXControlsTestApp.TabViewTabClosingBehaviorPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
+        <StackPanel Orientation="Horizontal">
+            <Grid MaxWidth="500">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <muxc:TabView
+                    MaxWidth="500"
+                    x:Name="Tabs"
+                    TabCloseRequested="TabViewTabCloseRequested"
+                    AddTabButtonClick="AddButtonClick">
+
+                    <muxc:TabViewItem Header="Tab 0" AutomationProperties.Name="Tab 0"/>
+                    <muxc:TabViewItem Header="Tab 1" AutomationProperties.Name="Tab 1"/>
+                    <muxc:TabViewItem Header="Tab 2" AutomationProperties.Name="Tab 2"/>
+                    <muxc:TabViewItem Header="Tab 3" AutomationProperties.Name="Tab 3"/>
+                    <muxc:TabViewItem Header="Tab 4" AutomationProperties.Name="Tab 4"/>
+                    <muxc:TabViewItem Header="Tab 5" AutomationProperties.Name="Tab 5"/>
+                </muxc:TabView>
+            </Grid>
+            <StackPanel>
+                <TextBlock Text="Actual width"/>
+                <TextBlock x:Name="TabViewWidth" AutomationProperties.Name="TabViewWidth"/>
+                <TextBlock Text="Scroll buttons status"/>
+                <TextBlock x:Name="ScrollButtonStatus" AutomationProperties.Name="ScrollButtonStatus" />
+            </StackPanel>
+            <StackPanel>
+                <Button AutomationProperties.Name="GetActualWidthButton"
+                        Click="GetActualWidthsButton_Click"
+                        Content="Get actual TabView width"/>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace MUXControlsTestApp
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class TabViewTabClosingBehaviorPage : Page
+    {
+        private int _newTabNumber = 0;
+
+        public TabViewTabClosingBehaviorPage()
+        {
+            this.InitializeComponent();
+        }
+
+        public void AddButtonClick(object sender, object e)
+        {
+            if (Tabs != null)
+            {
+                TabViewItem item = new TabViewItem();
+                item.Header = "New Tab " + _newTabNumber;
+                item.Content = item.Header;
+
+                Tabs.TabItems.Add(item);
+
+                _newTabNumber++;
+            }
+        }
+
+        private void TabViewTabCloseRequested(object sender, Microsoft.UI.Xaml.Controls.TabViewTabCloseRequestedEventArgs e)
+        {
+            Tabs.TabItems.Remove(e.Tab);
+
+            TabViewWidth.Text = Tabs.ActualWidth.ToString();
+
+            var scrollButtonStateValue = "";
+
+            var scrollIncreaseButton = VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollIncreaseButton") as RepeatButton;
+            var scrollDecreaseButton = VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollDecreaseButton") as RepeatButton;
+
+            scrollButtonStateValue += scrollIncreaseButton.Visibility == Visibility.Visible ? "true;" : "false;";
+            scrollButtonStateValue += scrollDecreaseButton.Visibility == Visibility.Visible ? "true;" : "false;";
+
+            ScrollButtonStatus.Text = scrollButtonStateValue;
+        }
+
+        public void GetActualWidthsButton_Click(object sender, RoutedEventArgs e)
+        {
+            // This is the smallest width that fits our content without any scrolling.
+            TabViewWidth.Text = Tabs.ActualWidth.ToString();
+        }
+
+    }
+}

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
@@ -56,8 +56,8 @@ namespace MUXControlsTestApp
             var scrollIncreaseButton = VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollIncreaseButton") as RepeatButton;
             var scrollDecreaseButton = VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollDecreaseButton") as RepeatButton;
 
-            scrollButtonStateValue += scrollIncreaseButton.Visibility == Visibility.Visible ? "true;" : "false;";
-            scrollButtonStateValue += scrollDecreaseButton.Visibility == Visibility.Visible ? "true;" : "false;";
+            scrollButtonStateValue += scrollIncreaseButton.IsEnabled + ";";
+            scrollButtonStateValue += scrollDecreaseButton.IsEnabled + ";";
 
             ScrollButtonStatus.Text = scrollButtonStateValue;
         }

--- a/dev/TabView/TestUI/TabView_TestUI.projitems
+++ b/dev/TabView/TestUI/TabView_TestUI.projitems
@@ -18,6 +18,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)TabViewTabClosingBehaviorPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)TabViewSizingPage.xaml.cs">
@@ -25,6 +29,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)TabViewPage.xaml.cs">
       <DependentUpon>TabViewPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)TabViewTabClosingBehaviorPage.xaml.cs">
+      <DependentUpon>TabViewTabClosingBehaviorPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move the resizing of TabViewItems to a PointerExited event of the TabItemStrip container grid.. The scroll buttons are updated after every item to disable them once the number of items is low enough to make scrolling unecessary.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2417
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add new interaction test and testpage.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![gif](https://user-images.githubusercontent.com/16122379/83297619-2e0dc280-a1f3-11ea-82bd-ed221bff8ca5.gif)
