### PR TITLE
Set InputScope property to Number in NumberBox's input TextBox

### DIFF
--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -106,6 +106,7 @@
 
                         <TextBox x:Name="InputBox"
                             Grid.Row="1"
+                            InputScope="Number"
                             PlaceholderText="{TemplateBinding PlaceholderText}"
                             contract7Present:SelectionFlyout="{TemplateBinding SelectionFlyout}"
                             SelectionHighlightColor="{TemplateBinding SelectionHighlightColor}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set NumberBox's Input TextBox's InputScope="Number" per #1912 

The current NumberBox ControlTemplate does not set the "InputBox" TextBox's InputScope. This means the system will handle it using defaults. It's better to add InputScope="Number" in XAML to ensure the system will handle numerical entry better within the NumberBox. 

## Motivation and Context

Fixes #1912

This is especially helpful for virtual keyboards on the desktop and mobile.
