### PR TITLE
NavigationViewItem input handling fixes

### DIFF
--- a/dev/Generated/NavigationViewItemBase.properties.cpp
+++ b/dev/Generated/NavigationViewItemBase.properties.cpp
@@ -31,13 +31,21 @@ void NavigationViewItemBaseProperties::EnsureProperties()
                 winrt::name_of<winrt::NavigationViewItemBase>(),
                 false /* isAttached */,
                 ValueHelper<bool>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnIsSelectedPropertyChanged));
     }
 }
 
 void NavigationViewItemBaseProperties::ClearProperties()
 {
     s_IsSelectedProperty = nullptr;
+}
+
+void NavigationViewItemBaseProperties::OnIsSelectedPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::NavigationViewItemBase>();
+    winrt::get_self<NavigationViewItemBase>(owner)->OnPropertyChanged(args);
 }
 
 void NavigationViewItemBaseProperties::IsSelected(bool value)

--- a/dev/Generated/NavigationViewItemBase.properties.h
+++ b/dev/Generated/NavigationViewItemBase.properties.h
@@ -18,4 +18,8 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnIsSelectedPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -93,8 +93,6 @@ public:
 
 private:
 
-    void OnRepeaterGettingFocus(const winrt::IInspectable& sender, const winrt::GettingFocusEventArgs& args);
-
     // Selection handling functions
     void OnNavigationViewItemIsSelectedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void OnSelectionModelSelectionChanged(const winrt::SelectionModel& selectionModel, const winrt::SelectionModelSelectionChangedEventArgs& e);
@@ -261,7 +259,6 @@ private:
     void OnNavigationViewItemOnGotFocus(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& e);
     void OnNavigationViewItemExpandedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
 
-    void OnOverflowItemSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
     void RaiseSelectionChangedEvent(winrt::IInspectable const& nextItem, 
         bool isSettingsItem,
         NavigationRecommendedTransitionDirection recommendedDirection = NavigationRecommendedTransitionDirection::Default);

--- a/dev/NavigationView/NavigationView.idl
+++ b/dev/NavigationView/NavigationView.idl
@@ -301,12 +301,15 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
 [webhosthidden]
 [WUXC_INTERFACE_NAME("INavigationViewItemBase", edf04eb1-37d1-471f-8570-3829ee5b2bc6)]
 [WUXC_CONSTRUCTOR_NAME("INavigationViewItemBaseFactory", eb014cef-7890-4ebb-8245-02e8510f321d)]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 [default_interface]
 unsealed runtimeclass NavigationViewItemBase : Windows.UI.Xaml.Controls.ContentControl
 {
     [WUXC_VERSION_MUXONLY]
     {
+        [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
         Boolean IsSelected{ get; set; };
+
         static Windows.UI.Xaml.DependencyProperty IsSelectedProperty { get; };
     }
 }

--- a/dev/NavigationView/NavigationViewHelper.h
+++ b/dev/NavigationView/NavigationViewHelper.h
@@ -36,7 +36,7 @@ public:
     {
     }
 
-    winrt::UIElement GetSelectionIndicator() { return m_selectionIndicator.get(); }
+    winrt::UIElement GetSelectionIndicator() const { return m_selectionIndicator.get(); }
 
     void Init(const winrt::IControlProtected & controlProtected)
     {

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -27,15 +27,15 @@ static constexpr auto c_chevronHidden = L"ChevronHidden"sv;
 static constexpr auto c_chevronVisibleOpen = L"ChevronVisibleOpen"sv;
 static constexpr auto c_chevronVisibleClosed = L"ChevronVisibleClosed"sv;
 
+NavigationViewItem::NavigationViewItem()
+{
+    SetDefaultStyleKey(this);
+    SetValue(s_MenuItemsProperty, winrt::make<Vector<winrt::IInspectable>>());
+}
+
 void NavigationViewItem::UpdateVisualStateNoTransition()
 {
     UpdateVisualState(false /*useTransition*/);
-}
-
-void NavigationViewItem::OnNavigationViewRepeaterPositionChanged()
-{
-    UpdateVisualStateNoTransition();
-    ReparentRepeater();
 }
 
 void NavigationViewItem::OnNavigationViewItemBaseDepthChanged()
@@ -44,17 +44,38 @@ void NavigationViewItem::OnNavigationViewItemBaseDepthChanged()
     PropagateDepthToChildren(Depth() + 1);
 }
 
-NavigationViewItem::NavigationViewItem()
+void NavigationViewItem::OnNavigationViewItemBaseIsSelectedChanged()
 {
-    SetDefaultStyleKey(this);
-    SetValue(s_MenuItemsProperty, winrt::make<Vector<winrt::IInspectable>>());
+    UpdateVisualStateForPointer();
+}
+
+void NavigationViewItem::OnNavigationViewItemBasePositionChanged()
+{
+    UpdateVisualStateNoTransition();
+    ReparentRepeater();
 }
 
 void NavigationViewItem::OnApplyTemplate()
 {
-    // Stop UpdateVisualState before template is applied. Otherwise the visual may not the same as we expect
+    // Stop UpdateVisualState before template is applied. Otherwise the visuals may be unexpected
     m_appliedTemplate = false;
- 
+
+    UnhookInputEvents();
+
+    m_flyoutClosingRevoker.revoke();
+    m_splitViewIsPaneOpenChangedRevoker.revoke();
+    m_splitViewDisplayModeChangedRevoker.revoke();
+    m_splitViewCompactPaneLengthChangedRevoker.revoke();
+    m_repeaterElementPreparedRevoker.revoke();
+    m_repeaterElementClearingRevoker.revoke();
+    m_isEnabledChangedRevoker.revoke();
+
+    m_rootGrid.set(nullptr);
+    m_navigationViewItemPresenter.set(nullptr);
+    m_toolTip.set(nullptr);
+    m_repeater.set(nullptr);
+    m_flyoutContentGrid.set(nullptr);
+
     NavigationViewItemBase::OnApplyTemplate();
 
     // Find selection indicator
@@ -70,26 +91,11 @@ void NavigationViewItem::OnApplyTemplate()
         {
             m_flyoutClosingRevoker = flyoutBase.Closing(winrt::auto_revoke, { this, &NavigationViewItem::OnFlyoutClosing });
         }
-
     }
 
-    winrt::UIElement const presenter = [this, controlProtected]()
-    {
-        if (auto presenter = GetTemplateChildT<winrt::NavigationViewItemPresenter>(c_navigationViewItemPresenterName, controlProtected))
-        {
-            m_navigationViewItemPresenter.set(presenter);
-            return presenter.try_as<winrt::UIElement>();
-        }
-        // We don't have a presenter, so we are our own presenter.
-        return this->try_as<winrt::UIElement>();
-    }();
+    HookInputEvents(controlProtected);
 
-    m_presenterPointerPressedRevoker = presenter.PointerPressed(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerPressed });
-    m_presenterPointerReleasedRevoker = presenter.PointerReleased(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerReleased });
-    m_presenterPointerEnteredRevoker = presenter.PointerEntered(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerEntered });
-    m_presenterPointerExitedRevoker = presenter.PointerExited(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerExited });
-    m_presenterPointerCanceledRevoker = presenter.PointerCanceled(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCanceled });
-    m_presenterPointerCaptureLostRevoker = presenter.PointerCaptureLost(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerCaptureLost });
+    m_isEnabledChangedRevoker = IsEnabledChanged(winrt::auto_revoke, { this,  &NavigationViewItem::OnIsEnabledChanged });
 
     m_toolTip.set(GetTemplateChildT<winrt::ToolTip>(L"ToolTip"sv, controlProtected));
 
@@ -126,6 +132,7 @@ void NavigationViewItem::OnApplyTemplate()
     m_flyoutContentGrid.set(GetTemplateChildT<winrt::Grid>(c_flyoutContentGrid, controlProtected));
 
     m_appliedTemplate = true;
+
     UpdateItemIndentation();
     UpdateVisualStateNoTransition();
     ReparentRepeater();
@@ -155,7 +162,7 @@ void NavigationViewItem::UpdateRepeaterItemsSource()
     }
 }
  
-winrt::UIElement NavigationViewItem::GetSelectionIndicator()
+winrt::UIElement NavigationViewItem::GetSelectionIndicator() const
 {
     auto selectIndicator = m_helper.GetSelectionIndicator(); 
     if (auto presenter = GetPresenter())
@@ -267,23 +274,6 @@ void NavigationViewItem::OnMenuItemsSourcePropertyChanged(const winrt::Dependenc
 void NavigationViewItem::OnHasUnrealizedChildrenPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
     UpdateVisualStateForChevron();
-}
-
-bool NavigationViewItem::ShowSelectionIndicatorIfRequired()
-{
-    if (!IsSelected())
-    {
-        if (!IsRepeaterVisible() && IsChildSelected())
-        {
-            ShowSelectionIndicator(true);
-            return true;
-        }
-        else
-        {
-            ShowSelectionIndicator(false);
-        }
-    }
-    return false;
 }
 
 void NavigationViewItem::ShowSelectionIndicator(bool visible)
@@ -433,15 +423,14 @@ void NavigationViewItem::UpdateVisualStateForPointer()
     // update the states for the item itself.
     if (auto const presenter = m_navigationViewItemPresenter.get())
     {
-        winrt::VisualStateManager::GoToState(m_navigationViewItemPresenter.get(), enabledStateValue, true);
-        winrt::VisualStateManager::GoToState(m_navigationViewItemPresenter.get(), selectedStateValue, true);
+        winrt::VisualStateManager::GoToState(presenter, enabledStateValue, true);
+        winrt::VisualStateManager::GoToState(presenter, selectedStateValue, true);
     }
     else
     {
         winrt::VisualStateManager::GoToState(*this, enabledStateValue, true);
         winrt::VisualStateManager::GoToState(*this, selectedStateValue, true);
     }
-
 }
 
 void NavigationViewItem::UpdateVisualState(bool useTransitions)
@@ -461,7 +450,7 @@ void NavigationViewItem::UpdateVisualState(bool useTransitions)
         if (auto const presenter = m_navigationViewItemPresenter.get())
         {
             // Backward Compatibility with RS4-, new implementation prefer IconOnLeft/IconOnly/ContentOnly
-            winrt::VisualStateManager::GoToState(m_navigationViewItemPresenter.get(), shouldShowIcon ? L"IconVisible" : L"IconCollapsed", useTransitions);
+            winrt::VisualStateManager::GoToState(presenter, shouldShowIcon ? L"IconVisible" : L"IconCollapsed", useTransitions);
         }
     } 
    
@@ -480,7 +469,7 @@ void NavigationViewItem::UpdateVisualStateForChevron()
     if (auto const presenter = m_navigationViewItemPresenter.get())
     {
         auto const chevronState = HasChildren() && !(m_isClosedCompact && ShouldRepeaterShowInFlyout()) ? ( IsExpanded() ? c_chevronVisibleOpen : c_chevronVisibleClosed) : c_chevronHidden;
-        winrt::VisualStateManager::GoToState(m_navigationViewItemPresenter.get(), chevronState, true);
+        winrt::VisualStateManager::GoToState(presenter, chevronState, true);
     }
 }
 
@@ -494,7 +483,7 @@ bool NavigationViewItem::ShouldShowIcon()
     return static_cast<bool>(Icon());
 }
 
-bool NavigationViewItem::ShouldEnableToolTip()
+bool NavigationViewItem::ShouldEnableToolTip() const
 {
     // We may enable Tooltip for IconOnly in the future, but not now
     return IsOnLeftNav() && m_isClosedCompact;
@@ -505,19 +494,32 @@ bool NavigationViewItem::ShouldShowContent()
     return static_cast<bool>(Content());
 }
 
-bool NavigationViewItem::IsOnLeftNav()
+bool NavigationViewItem::IsOnLeftNav() const
 {
     return Position() == NavigationViewRepeaterPosition::LeftNav;
 }
 
-bool NavigationViewItem::IsOnTopPrimary()
+bool NavigationViewItem::IsOnTopPrimary() const
 {
     return Position() == NavigationViewRepeaterPosition::TopPrimary;
 }
 
-NavigationViewItemPresenter * NavigationViewItem::GetPresenter()
+winrt::UIElement const NavigationViewItem::GetPresenterOrItem() const
 {
-    NavigationViewItemPresenter * presenter = nullptr;
+    if (m_navigationViewItemPresenter)
+    {
+        auto navigationViewItemPresenter = m_navigationViewItemPresenter.get();
+        return navigationViewItemPresenter ? navigationViewItemPresenter.try_as<winrt::UIElement>() : nullptr;
+    }
+    else
+    {
+        return this->try_as<winrt::UIElement>();
+    }
+}
+
+NavigationViewItemPresenter* NavigationViewItem::GetPresenter() const
+{
+    NavigationViewItemPresenter* presenter = nullptr;
     if (m_navigationViewItemPresenter)
     {
         presenter = winrt::get_self<NavigationViewItemPresenter>(m_navigationViewItemPresenter.get());
@@ -590,14 +592,18 @@ void NavigationViewItem::ReparentRepeater()
     }
 }
 
-bool NavigationViewItem::ShouldRepeaterShowInFlyout()
+bool NavigationViewItem::ShouldRepeaterShowInFlyout() const
 {
     return (m_isClosedCompact && IsTopLevelItem()) || IsOnTopPrimary();
 }
 
-bool NavigationViewItem::IsRepeaterVisible()
+bool NavigationViewItem::IsRepeaterVisible() const
 {
-    return m_repeater.get().Visibility() == winrt::Visibility::Visible;
+    if (auto const repeater = m_repeater.get())
+    {
+        return repeater.Visibility() == winrt::Visibility::Visible;
+    }
+    return false;
 }
 
 void NavigationViewItem::UpdateItemIndentation()
@@ -690,48 +696,222 @@ void NavigationViewItem::OnLostFocus(winrt::RoutedEventArgs const& e)
     }
 }
 
-void NavigationViewItem::OnPresenterPointerPressed(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void NavigationViewItem::ResetTrackedPointerId()
 {
+    m_trackedPointerId = 0;
+}
+
+// Returns False when the provided pointer Id matches the currently tracked Id.
+// When there is no currently tracked Id, sets the tracked Id to the provided Id and returns False.
+// Returns True when the provided pointer Id does not match the currently tracked Id.
+bool NavigationViewItem::IgnorePointerId(const winrt::PointerRoutedEventArgs& args)
+{
+    uint32_t pointerId = args.Pointer().PointerId();
+
+    if (m_trackedPointerId == 0)
+    {
+        m_trackedPointerId = pointerId;
+    }
+    else if (m_trackedPointerId != pointerId)
+    {
+        return true;
+    }
+    return false;
+}
+
+void NavigationViewItem::OnPresenterPointerPressed(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
+{
+    if (IgnorePointerId(args))
+    {
+        return;
+    }
+
+    MUX_ASSERT(!m_isPressed);
+    MUX_ASSERT(!m_capturedPointer);
+
     // TODO: Update to look at presenter instead
     auto pointerProperties = args.GetCurrentPoint(*this).Properties();
     m_isPressed = pointerProperties.IsLeftButtonPressed() || pointerProperties.IsRightButtonPressed();
 
+    auto pointer = args.Pointer();
+    auto presenter = GetPresenterOrItem();
+
+    MUX_ASSERT(presenter);
+
+    if (presenter.CapturePointer(pointer))
+    {
+        m_capturedPointer = pointer;
+    }
+
     UpdateVisualState(true);
 }
 
-void NavigationViewItem::OnPresenterPointerReleased(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void NavigationViewItem::OnPresenterPointerReleased(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
 {
-    m_isPressed = false;
-    UpdateVisualState(true);
+    if (IgnorePointerId(args))
+    {
+        return;
+    }
+
+    if (m_isPressed)
+    {
+        m_isPressed = false;
+
+        if (m_capturedPointer)
+        {
+            auto presenter = GetPresenterOrItem();
+
+            MUX_ASSERT(presenter);
+
+            presenter.ReleasePointerCapture(m_capturedPointer);
+        }
+
+        UpdateVisualState(true);
+    }
 }
 
-void NavigationViewItem::OnPresenterPointerEntered(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void NavigationViewItem::OnPresenterPointerEntered(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
 {
-    m_isPointerOver = true;
-    UpdateVisualState(true);
+    ProcessPointerOver(args);
 }
 
-void NavigationViewItem::OnPresenterPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void NavigationViewItem::OnPresenterPointerMoved(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
 {
+    ProcessPointerOver(args);
+}
+
+void NavigationViewItem::OnPresenterPointerExited(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
+{
+    if (IgnorePointerId(args))
+    {
+        return;
+    }
+
     m_isPointerOver = false;
+
+    if (!m_capturedPointer)
+    {
+        ResetTrackedPointerId();
+    }
+
     UpdateVisualState(true);
 }
 
-void NavigationViewItem::OnPresenterPointerCanceled(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void NavigationViewItem::OnPresenterPointerCanceled(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
 {
-    m_isPressed = false;
-    m_isPointerOver = false;
-    UpdateVisualState(true);
+    ProcessPointerCanceled(args);
 }
 
-void NavigationViewItem::OnPresenterPointerCaptureLost(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+void NavigationViewItem::OnPresenterPointerCaptureLost(const winrt::IInspectable&, const winrt::PointerRoutedEventArgs& args)
 {
-    m_isPressed = false;
-    m_isPointerOver = false;
+    ProcessPointerCanceled(args);
+}
+
+void NavigationViewItem::OnIsEnabledChanged(const winrt::IInspectable&, const winrt::DependencyPropertyChangedEventArgs&)
+{
+    if (!IsEnabled())
+    {
+        m_isPressed = false;
+        m_isPointerOver = false;
+
+        if (m_capturedPointer)
+        {
+            auto presenter = GetPresenterOrItem();
+
+            MUX_ASSERT(presenter);
+
+            presenter.ReleasePointerCapture(m_capturedPointer);
+            m_capturedPointer = nullptr;
+        }
+
+        ResetTrackedPointerId();
+    }
+
     UpdateVisualState(true);
 }
 
 void NavigationViewItem::RotateExpandCollapseChevron(bool isExpanded)
 {
-    winrt::get_self<NavigationViewItemPresenter>(m_navigationViewItemPresenter.get())->RotateExpandCollapseChevron(isExpanded);
+    if (auto presenter = GetPresenter())
+    {
+        presenter->RotateExpandCollapseChevron(isExpanded);
+    }
+}
+
+void NavigationViewItem::ProcessPointerCanceled(const winrt::PointerRoutedEventArgs& args)
+{
+    if (IgnorePointerId(args))
+    {
+        return;
+    }
+
+    m_isPressed = false;
+    m_isPointerOver = false;
+    m_capturedPointer = nullptr;
+    ResetTrackedPointerId();
+    UpdateVisualState(true);
+}
+
+void NavigationViewItem::ProcessPointerOver(const winrt::PointerRoutedEventArgs& args)
+{
+    if (IgnorePointerId(args))
+    {
+        return;
+    }
+
+    if (!m_isPointerOver)
+    {
+        m_isPointerOver = true;
+        UpdateVisualState(true);
+    }
+}
+
+void NavigationViewItem::HookInputEvents(const winrt::IControlProtected& controlProtected)
+{
+    winrt::UIElement const presenter = [this, controlProtected]()
+    {
+        if (auto presenter = GetTemplateChildT<winrt::NavigationViewItemPresenter>(c_navigationViewItemPresenterName, controlProtected))
+        {
+            m_navigationViewItemPresenter.set(presenter);
+            return presenter.try_as<winrt::UIElement>();
+        }
+        // We don't have a presenter, so we are our own presenter.
+        return this->try_as<winrt::UIElement>();
+    }();
+
+    MUX_ASSERT(presenter);
+
+    // Handlers that set flags are skipped when args.Handled is already True.
+    m_presenterPointerPressedRevoker = presenter.PointerPressed(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerPressed });
+    m_presenterPointerEnteredRevoker = presenter.PointerEntered(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerEntered });
+    m_presenterPointerMovedRevoker = presenter.PointerMoved(winrt::auto_revoke, { this, &NavigationViewItem::OnPresenterPointerMoved });
+
+    // Handlers that reset flags are not skipped when args.Handled is already True to avoid broken states.
+    m_presenterPointerReleasedRevoker = AddRoutedEventHandler<RoutedEventType::PointerReleased>(
+        presenter,
+        { this, &NavigationViewItem::OnPresenterPointerReleased },
+        true /*handledEventsToo*/);
+    m_presenterPointerExitedRevoker = AddRoutedEventHandler<RoutedEventType::PointerExited>(
+        presenter,
+        { this, &NavigationViewItem::OnPresenterPointerExited },
+        true /*handledEventsToo*/);
+    m_presenterPointerCanceledRevoker = AddRoutedEventHandler<RoutedEventType::PointerCanceled>(
+        presenter,
+        { this, &NavigationViewItem::OnPresenterPointerCanceled },
+        true /*handledEventsToo*/);
+    m_presenterPointerCaptureLostRevoker = AddRoutedEventHandler<RoutedEventType::PointerCaptureLost>(
+        presenter,
+        { this, &NavigationViewItem::OnPresenterPointerCaptureLost },
+        true /*handledEventsToo*/);
+}
+
+void NavigationViewItem::UnhookInputEvents()
+{
+    m_presenterPointerPressedRevoker.revoke();
+    m_presenterPointerEnteredRevoker.revoke();
+    m_presenterPointerMovedRevoker.revoke();
+    m_presenterPointerReleasedRevoker.revoke();
+    m_presenterPointerExitedRevoker.revoke();
+    m_presenterPointerCanceledRevoker.revoke();
+    m_presenterPointerCaptureLostRevoker.revoke();
 }

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -60,21 +60,7 @@ void NavigationViewItem::OnApplyTemplate()
     // Stop UpdateVisualState before template is applied. Otherwise the visuals may be unexpected
     m_appliedTemplate = false;
 
-    UnhookInputEvents();
-
-    m_flyoutClosingRevoker.revoke();
-    m_splitViewIsPaneOpenChangedRevoker.revoke();
-    m_splitViewDisplayModeChangedRevoker.revoke();
-    m_splitViewCompactPaneLengthChangedRevoker.revoke();
-    m_repeaterElementPreparedRevoker.revoke();
-    m_repeaterElementClearingRevoker.revoke();
-    m_isEnabledChangedRevoker.revoke();
-
-    m_rootGrid.set(nullptr);
-    m_navigationViewItemPresenter.set(nullptr);
-    m_toolTip.set(nullptr);
-    m_repeater.set(nullptr);
-    m_flyoutContentGrid.set(nullptr);
+    UnhookEventsAndClearFields();
 
     NavigationViewItemBase::OnApplyTemplate();
 
@@ -506,10 +492,9 @@ bool NavigationViewItem::IsOnTopPrimary() const
 
 winrt::UIElement const NavigationViewItem::GetPresenterOrItem() const
 {
-    if (m_navigationViewItemPresenter)
+    if (auto const presenter = m_navigationViewItemPresenter.get())
     {
-        auto navigationViewItemPresenter = m_navigationViewItemPresenter.get();
-        return navigationViewItemPresenter ? navigationViewItemPresenter.try_as<winrt::UIElement>() : nullptr;
+        return presenter.try_as<winrt::UIElement>();
     }
     else
     {
@@ -914,4 +899,23 @@ void NavigationViewItem::UnhookInputEvents()
     m_presenterPointerExitedRevoker.revoke();
     m_presenterPointerCanceledRevoker.revoke();
     m_presenterPointerCaptureLostRevoker.revoke();
+}
+
+void NavigationViewItem::UnhookEventsAndClearFields()
+{
+    UnhookInputEvents();
+
+    m_flyoutClosingRevoker.revoke();
+    m_splitViewIsPaneOpenChangedRevoker.revoke();
+    m_splitViewDisplayModeChangedRevoker.revoke();
+    m_splitViewCompactPaneLengthChangedRevoker.revoke();
+    m_repeaterElementPreparedRevoker.revoke();
+    m_repeaterElementClearingRevoker.revoke();
+    m_isEnabledChangedRevoker.revoke();
+
+    m_rootGrid.set(nullptr);
+    m_navigationViewItemPresenter.set(nullptr);
+    m_toolTip.set(nullptr);
+    m_repeater.set(nullptr);
+    m_flyoutContentGrid.set(nullptr);
 }

--- a/dev/NavigationView/NavigationViewItem.h
+++ b/dev/NavigationView/NavigationViewItem.h
@@ -108,6 +108,7 @@ private:
     void ProcessPointerOver(const winrt::PointerRoutedEventArgs& args);
     void HookInputEvents(const winrt::IControlProtected& controlProtected);
     void UnhookInputEvents();
+    void UnhookEventsAndClearFields();
 
     PropertyChanged_revoker m_splitViewIsPaneOpenChangedRevoker{};
     PropertyChanged_revoker m_splitViewDisplayModeChangedRevoker{};

--- a/dev/NavigationView/NavigationViewItem.h
+++ b/dev/NavigationView/NavigationViewItem.h
@@ -32,8 +32,7 @@ public:
     void OnMenuItemsSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnHasUnrealizedChildrenPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
-    winrt::UIElement GetSelectionIndicator();
-    winrt::ToolTip GetToolTip();
+    winrt::UIElement GetSelectionIndicator() const;
 
     // IUIElement / IUIElementOverridesHelper
     winrt::AutomationPeer OnCreateAutomationPeer() override;
@@ -50,35 +49,37 @@ public:
     // It provides a chance for NavigationViewItemPresenter to request visualstate refresh
     void UpdateVisualStateNoTransition();
 
-    void OnPresenterPointerPressed(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-    void OnPresenterPointerReleased(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-    void OnPresenterPointerEntered(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-    void OnPresenterPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-    void OnPresenterPointerCanceled(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-    void OnPresenterPointerCaptureLost(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
-
     void ShowHideChildren();
-    bool ShouldRepeaterShowInFlyout();
+    bool ShouldRepeaterShowInFlyout() const;
 
-    winrt::ItemsRepeater GetRepeater() { return m_repeater.get(); };
-
-    NavigationViewItemPresenter* GetPresenter();
+    winrt::ItemsRepeater GetRepeater() const { return m_repeater.get(); };
 
     void OnExpandCollapseChevronTapped(const winrt::IInspectable& sender, const winrt::TappedRoutedEventArgs& args);
-    bool ShowSelectionIndicatorIfRequired();
     void RotateExpandCollapseChevron(bool isExpanded);
-    bool IsRepeaterVisible();
+    bool IsRepeaterVisible() const;
     void PropagateDepthToChildren(int depth);
 
 private:
+    winrt::UIElement const GetPresenterOrItem() const;
+    NavigationViewItemPresenter* GetPresenter() const;
+
     void UpdateNavigationViewItemToolTip();
     void SuggestedToolTipChanged(winrt::IInspectable const& newContent);
-    void OnNavigationViewRepeaterPositionChanged() override;
     void OnNavigationViewItemBaseDepthChanged() override;
+    void OnNavigationViewItemBaseIsSelectedChanged() override;
+    void OnNavigationViewItemBasePositionChanged() override;
 
-    void OnLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
-    void OnUnloaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
+    void OnPresenterPointerPressed(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnPresenterPointerReleased(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnPresenterPointerEntered(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnPresenterPointerMoved(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnPresenterPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnPresenterPointerCanceled(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnPresenterPointerCaptureLost(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnIsEnabledChanged(const winrt::IInspectable& sender, const winrt::DependencyPropertyChangedEventArgs& args);
 
+    void ResetTrackedPointerId();
+    bool IgnorePointerId(const winrt::PointerRoutedEventArgs& args);
     void OnSplitViewPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void UpdateCompactPaneLength();
     void UpdateIsClosedCompact();
@@ -93,33 +94,38 @@ private:
     void UpdateVisualState(bool useTransitions);
     bool ShouldShowIcon();
     bool ShouldShowContent();
-    bool ShouldEnableToolTip();
-    bool IsOnLeftNav();
-    bool IsOnTopPrimary();
+    bool ShouldEnableToolTip() const;
+    bool IsOnLeftNav() const;
+    bool IsOnTopPrimary() const;
     bool HasChildren();
 
     void UpdateRepeaterItemsSource();
     void ReparentRepeater();
-    void ReparentContent();
     void OnFlyoutClosing(const winrt::IInspectable& sender, const winrt::FlyoutBaseClosingEventArgs& args);
     void UpdateItemIndentation();
     void ShowSelectionIndicator(bool visible);
+    void ProcessPointerCanceled(const winrt::PointerRoutedEventArgs& args);
+    void ProcessPointerOver(const winrt::PointerRoutedEventArgs& args);
+    void HookInputEvents(const winrt::IControlProtected& controlProtected);
+    void UnhookInputEvents();
 
     PropertyChanged_revoker m_splitViewIsPaneOpenChangedRevoker{};
     PropertyChanged_revoker m_splitViewDisplayModeChangedRevoker{};
     PropertyChanged_revoker m_splitViewCompactPaneLengthChangedRevoker{};
 
     winrt::UIElement::PointerPressed_revoker m_presenterPointerPressedRevoker{};
-    winrt::UIElement::PointerReleased_revoker m_presenterPointerReleasedRevoker{};
     winrt::UIElement::PointerEntered_revoker m_presenterPointerEnteredRevoker{};
-    winrt::UIElement::PointerExited_revoker m_presenterPointerExitedRevoker{};
-    winrt::UIElement::PointerCanceled_revoker m_presenterPointerCanceledRevoker{};
-    winrt::UIElement::PointerCaptureLost_revoker m_presenterPointerCaptureLostRevoker{};
+    winrt::UIElement::PointerMoved_revoker m_presenterPointerMovedRevoker{};
+    RoutedEventHandler_revoker m_presenterPointerReleasedRevoker{};
+    RoutedEventHandler_revoker m_presenterPointerExitedRevoker{};
+    RoutedEventHandler_revoker m_presenterPointerCanceledRevoker{};
+    RoutedEventHandler_revoker m_presenterPointerCaptureLostRevoker{};
 
     winrt::ItemsRepeater::ElementPrepared_revoker m_repeaterElementPreparedRevoker{};
     winrt::ItemsRepeater::ElementClearing_revoker m_repeaterElementClearingRevoker{};
 
     winrt::FlyoutBase::Closing_revoker m_flyoutClosingRevoker{};
+    winrt::Control::IsEnabledChanged_revoker m_isEnabledChangedRevoker{};
 
     tracker_ref<winrt::ToolTip> m_toolTip{ this };
     NavigationViewItemHelper<NavigationViewItem> m_helper{ this };
@@ -135,6 +141,8 @@ private:
     bool m_hasKeyboardFocus{ false };
 
     // Visual state tracking
+    winrt::Pointer m_capturedPointer{ nullptr };
+    uint32_t m_trackedPointerId{ 0 };
     bool m_isPressed{ false };
     bool m_isPointerOver{ false };
 

--- a/dev/NavigationView/NavigationViewItemBase.cpp
+++ b/dev/NavigationView/NavigationViewItemBase.cpp
@@ -7,7 +7,7 @@
 #include "NavigationView.h"
 #include "IndexPath.h"
 
-NavigationViewRepeaterPosition NavigationViewItemBase::Position()
+NavigationViewRepeaterPosition NavigationViewItemBase::Position() const
 {
     return m_position;
 }
@@ -17,27 +17,30 @@ void NavigationViewItemBase::Position(NavigationViewRepeaterPosition value)
     if (m_position != value)
     {
         m_position = value;
-        OnNavigationViewRepeaterPositionChanged();
+        OnNavigationViewItemBasePositionChanged();
     }
 }
 
-winrt::NavigationView NavigationViewItemBase::GetNavigationView()
+winrt::NavigationView NavigationViewItemBase::GetNavigationView() const
 {
     return m_navigationView.get();
 }
 
 void NavigationViewItemBase::Depth(int depth)
 {
-    m_depth = depth;
-    OnNavigationViewItemBaseDepthChanged();
+    if (m_depth != depth)
+    {
+        m_depth = depth;
+        OnNavigationViewItemBaseDepthChanged();
+    }
 }
 
-int NavigationViewItemBase::Depth()
+int NavigationViewItemBase::Depth() const
 {
     return m_depth;
 }
 
-winrt::SplitView NavigationViewItemBase::GetSplitView()
+winrt::SplitView NavigationViewItemBase::GetSplitView() const
 {
     winrt::SplitView splitView{ nullptr };
     auto navigationView = GetNavigationView();
@@ -51,4 +54,12 @@ winrt::SplitView NavigationViewItemBase::GetSplitView()
 void NavigationViewItemBase::SetNavigationViewParent(winrt::NavigationView const& navigationView)
 {
     m_navigationView = winrt::make_weak(navigationView);
+}
+
+void NavigationViewItemBase::OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
+{
+    if (args.Property() == s_IsSelectedProperty)
+    {
+        OnNavigationViewItemBaseIsSelectedChanged();
+    }
 }

--- a/dev/NavigationView/NavigationViewItemBase.h
+++ b/dev/NavigationView/NavigationViewItemBase.h
@@ -43,23 +43,27 @@ public:
         __super::OnLostFocus(e);
     }
 
-    NavigationViewRepeaterPosition Position();
+    void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+
+    NavigationViewRepeaterPosition Position() const;
     void Position(NavigationViewRepeaterPosition value);
-    virtual void OnNavigationViewRepeaterPositionChanged() {}
+    virtual void OnNavigationViewItemBasePositionChanged() {}
 
     void Depth(int depth);
-    int Depth();
+    int Depth() const;
     virtual void OnNavigationViewItemBaseDepthChanged() {}
-    
-    winrt::NavigationView GetNavigationView();
-    winrt::SplitView GetSplitView();
+
+    virtual void OnNavigationViewItemBaseIsSelectedChanged() {}
+
+    winrt::NavigationView GetNavigationView() const;
+    winrt::SplitView GetSplitView() const;
     void SetNavigationViewParent(winrt::NavigationView const& navigationView);
 
-    // TODO: Constant is a temporary mesure. Potentially expose using TemplateSettings.
+    // TODO: Constant is a temporary measure. Potentially expose using TemplateSettings.
     static constexpr int c_itemIndentation = 25;
 
     void IsTopLevelItem(bool isTopLevelItem) { m_isTopLevelItem = isTopLevelItem; };
-    bool IsTopLevelItem() { return m_isTopLevelItem; };
+    bool IsTopLevelItem() const { return m_isTopLevelItem; };
 
 protected:
 

--- a/dev/NavigationView/NavigationViewItemSeparator.cpp
+++ b/dev/NavigationView/NavigationViewItemSeparator.cpp
@@ -26,7 +26,7 @@ void NavigationViewItemSeparator::UpdateVisualState(bool useTransitions)
                 : L"HorizontalLine"sv
             : L"VerticalLine"sv;
 
-        VisualStateUtil::GotToStateIfGroupExists(*this, groupName, stateName, false /*useTransitions*/);
+        VisualStateUtil::GoToStateIfGroupExists(*this, groupName, stateName, false /*useTransitions*/);
     }
 }
 
@@ -56,14 +56,14 @@ void NavigationViewItemSeparator::OnApplyTemplate()
     UpdateItemIndentation();
 }
 
-void NavigationViewItemSeparator::OnNavigationViewRepeaterPositionChanged()
-{
-    UpdateVisualState(false /*useTransition*/);
-}
-
 void NavigationViewItemSeparator::OnNavigationViewItemBaseDepthChanged()
 {
     UpdateItemIndentation();
+}
+
+void NavigationViewItemSeparator::OnNavigationViewItemBasePositionChanged()
+{
+    UpdateVisualState(false /*useTransition*/);
 }
 
 void NavigationViewItemSeparator::OnSplitViewPropertyChanged(const winrt::DependencyObject& /*sender*/, const winrt::DependencyProperty& /*args*/)

--- a/dev/NavigationView/NavigationViewItemSeparator.h
+++ b/dev/NavigationView/NavigationViewItemSeparator.h
@@ -16,7 +16,7 @@ public:
     void OnApplyTemplate() override;
 
 private:
-    void OnNavigationViewRepeaterPositionChanged() override;
+    void OnNavigationViewItemBasePositionChanged() override;
     void OnNavigationViewItemBaseDepthChanged() override;
     void UpdateVisualState(bool useTransitions);
     void UpdateItemIndentation();

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -28,6 +28,7 @@ using NavigationViewItemSeparator = Microsoft.UI.Xaml.Controls.NavigationViewIte
 using NavigationViewBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationViewBackButtonVisible;
 using System.Collections.ObjectModel;
 using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Composition;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -416,13 +417,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifySingleSelection()
         {
+            string navItemPresenter1CurrentState = string.Empty;
+            string navItemPresenter2CurrentState = string.Empty;
+            NavigationView navView = null;
+            NavigationViewItem menuItem1 = null;
+            NavigationViewItem menuItem2 = null;
+
             RunOnUIThread.Execute(() =>
             {
-                var navView = new NavigationView();
+                navView = new NavigationView();
                 Content = navView;
 
-                var menuItem1 = new NavigationViewItem();
-                var menuItem2 = new NavigationViewItem();
+                menuItem1 = new NavigationViewItem();
+                menuItem2 = new NavigationViewItem();
                 menuItem1.Content = "Item 1";
                 menuItem2.Content = "Item 2";
 
@@ -431,23 +438,69 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.Width = 1008; // forces the control into Expanded mode so that the menu renders
                 Content.UpdateLayout();
 
+                var menuItemLayoutRoot = VisualTreeHelper.GetChild(menuItem1, 0) as FrameworkElement;
+                var navItemPresenter = VisualTreeHelper.GetChild(menuItemLayoutRoot, 0) as FrameworkElement;
+                var navItemPresenterLayoutRoot = VisualTreeHelper.GetChild(navItemPresenter, 0) as FrameworkElement;
+                var statesGroups = VisualStateManager.GetVisualStateGroups(navItemPresenterLayoutRoot);
+
+                foreach (var visualStateGroup in statesGroups)
+                {
+                    Log.Comment($"VisualStateGroup1: Name={visualStateGroup.Name}, CurrentState={visualStateGroup.CurrentState.Name}");
+
+                    visualStateGroup.CurrentStateChanged += (object sender, VisualStateChangedEventArgs e) =>
+                    {
+                        Log.Comment($"VisualStateChangedEventArgs1: Name={e.Control.Name}, OldState={e.OldState.Name}, NewState={e.NewState.Name}");
+                        navItemPresenter1CurrentState = e.NewState.Name;
+                    };
+                }
+
+                menuItemLayoutRoot = VisualTreeHelper.GetChild(menuItem2, 0) as FrameworkElement;
+                navItemPresenter = VisualTreeHelper.GetChild(menuItemLayoutRoot, 0) as FrameworkElement;
+                navItemPresenterLayoutRoot = VisualTreeHelper.GetChild(navItemPresenter, 0) as FrameworkElement;
+                statesGroups = VisualStateManager.GetVisualStateGroups(navItemPresenterLayoutRoot);
+
+                foreach (var visualStateGroup in statesGroups)
+                {
+                    Log.Comment($"VisualStateGroup2: Name={visualStateGroup.Name}, CurrentState={visualStateGroup.CurrentState.Name}");
+
+                    visualStateGroup.CurrentStateChanged += (object sender, VisualStateChangedEventArgs e) =>
+                    {
+                        Log.Comment($"VisualStateChangedEventArgs2: Name={e.Control.Name}, OldState={e.OldState.Name}, NewState={e.NewState.Name}");
+                        navItemPresenter2CurrentState = e.NewState.Name;
+                    };
+                }
+
                 Verify.IsFalse(menuItem1.IsSelected);
                 Verify.IsFalse(menuItem2.IsSelected);
-                Verify.AreEqual(navView.SelectedItem, null);
+                Verify.AreEqual(null, navView.SelectedItem);
 
                 menuItem1.IsSelected = true;
                 Content.UpdateLayout();
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual("Selected", navItemPresenter1CurrentState);
+                Verify.AreEqual(string.Empty, navItemPresenter2CurrentState);
 
                 Verify.IsTrue(menuItem1.IsSelected);
                 Verify.IsFalse(menuItem2.IsSelected);
-                Verify.AreEqual(navView.SelectedItem, menuItem1);
+                Verify.AreEqual(menuItem1, navView.SelectedItem);
 
                 menuItem2.IsSelected = true;
                 Content.UpdateLayout();
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual("Normal", navItemPresenter1CurrentState);
+                Verify.AreEqual("Selected", navItemPresenter2CurrentState);
 
                 Verify.IsTrue(menuItem2.IsSelected);
                 Verify.IsFalse(menuItem1.IsSelected, "MenuItem1 should have been deselected when MenuItem2 was selected");
-                Verify.AreEqual(navView.SelectedItem, menuItem2);
+                Verify.AreEqual(menuItem2, navView.SelectedItem);
             });
         }
 

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml
@@ -186,6 +186,7 @@
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">
+                        <CheckBox x:Name="SelectedItemIsEnabledCheckbox" AutomationProperties.Name="SelectedItemIsEnabledCheckbox" Content="SelectedItem IsEnabled" IsChecked="True" Checked="SelectedItemIsEnabledCheckbox_Checked" Unchecked="SelectedItemIsEnabledCheckbox_Unchecked" Margin="5"/>
                         <CheckBox x:Name="SettingsItemVisibilityCheckbox" AutomationProperties.Name="SettingsItemVisibilityCheckbox" Content="Show Settings" Checked="SettingsItemVisibilityCheckbox_Checked" Unchecked="SettingsItemVisibilityCheckbox_Unchecked" Margin="5"/>
                         <CheckBox x:Name="PaneToggleButtonVisiblityCheckbox" AutomationProperties.Name="PaneToggleButtonVisiblityCheckbox" Content="Show Hamburger Button" Checked="PaneToggleButtonVisiblityCheckbox_Checked" Unchecked="PaneToggleButtonVisiblityCheckbox_Unchecked" Margin="5"/>
                         <CheckBox x:Name="AutoSuggestCheckbox" AutomationProperties.Name="AutoSuggestCheckbox" Content="Set AutoSuggestBox" IsChecked="True" Checked="AutoSuggestCheckbox_Checked" Unchecked="AutoSuggestCheckbox_Unchecked" Margin="5"/>

--- a/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewPage.xaml.cs
@@ -202,6 +202,22 @@ namespace MUXControlsTestApp
             }
         }
 
+        private void SelectedItemIsEnabledCheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            if (NavView.SelectedItem != null)
+            {
+                (NavView.SelectedItem as Control).IsEnabled = true;
+            }
+        }
+
+        private void SelectedItemIsEnabledCheckbox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (NavView.SelectedItem != null)
+            {
+                (NavView.SelectedItem as Control).IsEnabled = false;
+            }
+        }
+
         private void SettingsItemVisibilityCheckbox_Checked(object sender, RoutedEventArgs e)
         {
             NavView.IsSettingsVisible = true;
@@ -396,6 +412,15 @@ namespace MUXControlsTestApp
             if (args.SelectedItemContainer != null)
             {
                 SelectionChangedItemContainerType.Text = args.SelectedItemContainer.GetType().ToString();
+            }
+
+            if (NavView.SelectedItem == null)
+            {
+                SelectedItemIsEnabledCheckbox.IsChecked = null;
+            }
+            else
+            {
+                SelectedItemIsEnabledCheckbox.IsChecked = (NavView.SelectedItem as Control).IsEnabled;
             }
         }
 

--- a/dev/ResourceHelper/Utils.cpp
+++ b/dev/ResourceHelper/Utils.cpp
@@ -96,7 +96,7 @@ bool VisualStateUtil::VisualStateGroupExists(const winrt::FrameworkElement& cont
     return static_cast<bool>(GetVisualStateGroup(control, groupName));
 }
 
-void VisualStateUtil::GotToStateIfGroupExists(const winrt::Control& control, const std::wstring_view& groupName, const std::wstring_view& stateName, bool useTransitions)
+void VisualStateUtil::GoToStateIfGroupExists(const winrt::Control& control, const std::wstring_view& groupName, const std::wstring_view& stateName, bool useTransitions)
 {
     auto visualStateGroup = GetVisualStateGroup(control, groupName);
     if (visualStateGroup)

--- a/dev/ResourceHelper/Utils.h
+++ b/dev/ResourceHelper/Utils.h
@@ -25,7 +25,7 @@ class VisualStateUtil
 public:
     static winrt::VisualStateGroup GetVisualStateGroup(const winrt::FrameworkElement& control, const std::wstring_view& groupName);
     static bool VisualStateGroupExists(const winrt::FrameworkElement& control, const std::wstring_view& groupName);
-    static void GotToStateIfGroupExists(const winrt::Control& control, const std::wstring_view& groupName, const std::wstring_view& stateName, bool useTransitions);
+    static void GoToStateIfGroupExists(const winrt::Control& control, const std::wstring_view& groupName, const std::wstring_view& stateName, bool useTransitions);
 };
 
 namespace LayoutUtils

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -153,12 +153,14 @@
 
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
-                            <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton"
-                                    Margin="8" Click="TabViewSizingPageButton_Click"
-                                    FontSize="20">TabView Sizing Page</Button>
-                            <Button x:Name="TabViewTabClosingBehaviorButton" AutomationProperties.Name="TabViewTabClosingBehaviorButton"
-                                    Margin="8" Click="TabViewTabClosingBehaviorButton_Click"
-                                    FontSize="20">TabView Tab Closing behavior Page</Button>
+                            <StackPanel Orientation="Horizontal">
+                                <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton"
+                                        Margin="8" Click="TabViewSizingPageButton_Click"
+                                        FontSize="20">TabView Sizing Page</Button>
+                                <Button x:Name="TabViewTabClosingBehaviorButton" AutomationProperties.Name="TabViewTabClosingBehaviorButton"
+                                        Margin="8" Click="TabViewTabClosingBehaviorButton_Click"
+                                        FontSize="20">TabView Tab Closing behavior Page</Button>
+                            </StackPanel>
                         </StackPanel>
                     </controls:TabViewItem>
 

--- a/dev/inc/RoutedEventHelpers.h
+++ b/dev/inc/RoutedEventHelpers.h
@@ -81,7 +81,11 @@ enum class RoutedEventType
     GettingFocus,
     LosingFocus,
     KeyDown,
-    PointerPressed
+    PointerPressed,
+    PointerReleased,
+    PointerExited,
+    PointerCanceled,
+    PointerCaptureLost
 };
 
 template<RoutedEventType eventType>
@@ -114,6 +118,34 @@ template <>
 struct RoutedEventTraits<RoutedEventType::PointerPressed>
 {
     static winrt::RoutedEvent Event() { return winrt::UIElement::PointerPressedEvent(); }
+    using HandlerT = winrt::PointerEventHandler;
+};
+
+template <>
+struct RoutedEventTraits<RoutedEventType::PointerReleased>
+{
+    static winrt::RoutedEvent Event() { return winrt::UIElement::PointerReleasedEvent(); }
+    using HandlerT = winrt::PointerEventHandler;
+};
+
+template <>
+struct RoutedEventTraits<RoutedEventType::PointerExited>
+{
+    static winrt::RoutedEvent Event() { return winrt::UIElement::PointerExitedEvent(); }
+    using HandlerT = winrt::PointerEventHandler;
+};
+
+template <>
+struct RoutedEventTraits<RoutedEventType::PointerCanceled>
+{
+    static winrt::RoutedEvent Event() { return winrt::UIElement::PointerCanceledEvent(); }
+    using HandlerT = winrt::PointerEventHandler;
+};
+
+template <>
+struct RoutedEventTraits<RoutedEventType::PointerCaptureLost>
+{
+    static winrt::RoutedEvent Event() { return winrt::UIElement::PointerCaptureLostEvent(); }
     using HandlerT = winrt::PointerEventHandler;
 };
 


### PR DESCRIPTION
These changes address a series of bugs in the NavigationViewItem implementation:
#1 NavigationViewItem does not update its visual state when its IsSelected property changed.
-	In WinUI3, often when you tap a NavigationViewItem, it stays dark gray.
-	When you select a NavigationViewItem programmatically, it does not change its visual state.
Fix: Listening to IsSelected change notifications to refresh visual state.

#2 PonterMoved does not update NavigationViewItem visual state in WinUI3.
-	Move mouse cursor over NavigationViewItem A
-	Tap NavigationViewItem B
-	Move mouse cursor a bit --> NavigationViewItem A does not update its visual state.
Fix: Listening to PointerMoved to update visual state when pointer is not thought to be over.

#3 Mouse pointer is not captured in PointerPressed.
-	Mouse button down on NavigationViewItem.
-	Move mouse outside of NavigationViewItem.
-	Release mouse button --> NavigationViewItem does not update its NavigationViewItem visual state. It stays dark gray until you interact with it again.
Fix: Pointer is captured in PointerPressed and released in PointerReleased, or when pointer is lost.

#4 IsEnabled change does not update NavigationViewItem visual state.
Fix: Listening to NavigationViewItem.IsEnabledChanged to clear the state flags and refresh visual state.

#5 Beginning of OnApplyTemplate does not reset template parts, or clear event handlers.
Fix: All control parts and handler are cleared at beginning of OnApplyTemplate to avoid leftover incorrect fields.

#6 Pointer input handlers that reset internal flags are not invoked when args.Handled is true causing bugs.
Fix: Input handlers that reset flags are not skipped thanks to the handledEventsToo=True feature.

#7 Multi finger inputs are not handled properly. Removing second finger clears pressed state for instance.
Fix: Only one pointer Id is tracked for a given NavigationViewItem now. Any newcomer is ignored.

o	Also did some dead code cleanup, and code cleanup in general.
o	Did some ad-hoc testing, expanded controls test app and NavigationView test.

(These changes also address 26317023 once pushed into WinUI)
