### PR TITLE
Automation Peer fix for Hierarchical NavigationView

### DIFF
--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -84,6 +84,7 @@ public:
     winrt::ItemsRepeater LeftNavRepeater();
     winrt::NavigationViewItem GetSelectedContainer();
     winrt::ItemsRepeater GetParentItemsRepeaterForContainer(const winrt::NavigationViewItemBase& nvib);
+    winrt::IndexPath GetIndexPathForContainer(const winrt::NavigationViewItemBase& nvib);
 
     // Hierarchical related functions
     void Expand(const winrt::NavigationViewItem& item);
@@ -108,7 +109,6 @@ private:
     int GetIndexFromItem(const winrt::ItemsRepeater& ir, const winrt::IInspectable& data);
     static winrt::IInspectable GetItemFromIndex(const winrt::ItemsRepeater& ir, int index);
     winrt::IndexPath GetIndexPathOfItem(const winrt::IInspectable& data);
-    winrt::IndexPath GetIndexPathForContainer(const winrt::NavigationViewItemBase& nvib);
     winrt::UIElement GetContainerForIndex(int index);
     winrt::NavigationViewItemBase GetContainerForIndexPath(const winrt::IndexPath& ip);
     winrt::NavigationViewItemBase GetContainerForIndexPath(const winrt::UIElement& firstContainer, const winrt::IndexPath& ip);

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -83,6 +83,7 @@ public:
     // Used in AutomationPeer
     winrt::ItemsRepeater LeftNavRepeater();
     winrt::NavigationViewItem GetSelectedContainer();
+    winrt::ItemsRepeater GetParentItemsRepeaterForContainer(const winrt::NavigationViewItemBase& nvib);
 
     // Hierarchical related functions
     void Expand(const winrt::NavigationViewItem& item);
@@ -118,7 +119,6 @@ private:
     winrt::IndexPath SearchEntireTreeForIndexPath(const winrt::NavigationViewItem& parentContainer, const winrt::IInspectable& data, const winrt::IndexPath& ip);
 
     winrt::ItemsRepeater GetChildRepeaterForIndexPath(const winrt::IndexPath& ip);
-    winrt::ItemsRepeater GetParentItemsRepeaterForContainer(const winrt::NavigationViewItemBase& nvib);
     winrt::NavigationViewItem GetParentNavigationViewItemForContainer(const winrt::NavigationViewItemBase& nvib);
     bool IsContainerTheSelectedItemInTheSelectionModel(const winrt::NavigationViewItemBase& nvib);
     bool IsContainerInOverflow(const winrt::NavigationViewItemBase& nvib);

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -320,16 +320,7 @@ int32_t NavigationViewItemAutomationPeer::GetPositionOrSetCountInLeftNavHelper(A
                             {
                                 returnValue++;
 
-                                auto nvipSelf = static_cast<winrt::FrameworkElementAutomationPeer>(*this);
-                                auto nameSelf = nvipSelf.GetName();
-
-                                auto nviCurrentName = navviewItem.Name();
-
-                                auto nvipCurrent = winrt::FrameworkElementAutomationPeer::FromElement(navviewItem);
-                                auto nameCurrent = nvipCurrent.GetName();
-
-                                //if (winrt::FrameworkElementAutomationPeer::FromElement(navviewItem) == static_cast<winrt::NavigationViewItemAutomationPeer>(*this))
-                                if (nvipSelf == nvipCurrent)
+                                if (winrt::FrameworkElementAutomationPeer::FromElement(navviewItem) == static_cast<winrt::NavigationViewItemAutomationPeer>(*this))
                                 {
                                     if (automationOutput == AutomationOutput::Position)
                                     {
@@ -363,38 +354,41 @@ int32_t NavigationViewItemAutomationPeer::GetPositionOrSetCountInTopNavHelper(Au
 
     if (auto const parentRepeater = GetParentRepeater())
     {
-        auto numberOfElements = parentRepeater.ItemsSourceView().Count();
-
-        for (int32_t i = 0; i < numberOfElements; i++)
+        if (auto const itemsSourceView = parentRepeater.ItemsSourceView())
         {
-            if (auto child = parentRepeater.TryGetElement(i))
-            {
-                if (child.try_as<winrt::NavigationViewItemHeader>())
-                {
-                    if (automationOutput == AutomationOutput::Size && itemFound)
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        returnValue = 0;
-                    }
-                }
-                else if (auto const navviewitem = child.try_as<winrt::NavigationViewItem>())
-                {
-                    if (navviewitem.Visibility() == winrt::Visibility::Visible)
-                    {
-                        returnValue++;
+            auto numberOfElements = itemsSourceView.Count();
 
-                        if (winrt::FrameworkElementAutomationPeer::FromElement(navviewitem) == static_cast<winrt::NavigationViewItemAutomationPeer>(*this))
+            for (int32_t i = 0; i < numberOfElements; i++)
+            {
+                if (auto child = parentRepeater.TryGetElement(i))
+                {
+                    if (child.try_as<winrt::NavigationViewItemHeader>())
+                    {
+                        if (automationOutput == AutomationOutput::Size && itemFound)
                         {
-                            if (automationOutput == AutomationOutput::Position)
+                            break;
+                        }
+                        else
+                        {
+                            returnValue = 0;
+                        }
+                    }
+                    else if (auto const navviewitem = child.try_as<winrt::NavigationViewItem>())
+                    {
+                        if (navviewitem.Visibility() == winrt::Visibility::Visible)
+                        {
+                            returnValue++;
+
+                            if (winrt::FrameworkElementAutomationPeer::FromElement(navviewitem) == static_cast<winrt::NavigationViewItemAutomationPeer>(*this))
                             {
-                                break;
-                            }
-                            else
-                            {
-                                itemFound = true;
+                                if (automationOutput == AutomationOutput::Position)
+                                {
+                                    break;
+                                }
+                                else
+                                {
+                                    itemFound = true;
+                                }
                             }
                         }
                     }

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -8,6 +8,7 @@
 #include "NavigationView.h"
 #include "NavigationViewItemBase.h"
 #include "SharedHelpers.h"
+#include "NavigationViewHelper.h"
 
 
 #include "NavigationViewItemAutomationPeer.properties.cpp"
@@ -123,9 +124,23 @@ int32_t NavigationViewItemAutomationPeer::GetSizeOfSetCore()
 int32_t NavigationViewItemAutomationPeer::GetLevelCore()
 {
     int32_t level = 0;
-    if (winrt::NavigationViewItemBase navigationViewItem = Owner().try_as<winrt::NavigationViewItemBase>())
+    if (winrt::NavigationViewItemBase nvib = Owner().try_as<winrt::NavigationViewItemBase>())
     {
-        return winrt::get_self<NavigationViewItemBase>(navigationViewItem)->Depth();
+        auto const nvibImpl = winrt::get_self<NavigationViewItemBase>(nvib);
+        if (nvibImpl->IsTopLevelItem())
+        {
+            return 1;
+        }
+        else
+        {
+            if (auto const navView = GetParentNavigationView())
+            {
+                if (auto const indexPath = winrt::get_self<NavigationView>(navView)->GetIndexPathForContainer(nvib))
+                {
+                    return indexPath.GetSize();
+                }
+            }
+        }
     }
 
     return level;

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -84,7 +84,6 @@ int32_t NavigationViewItemAutomationPeer::GetPositionInSetCore()
 
     if (IsSettingsItem())
     {
-
         return 1;
     }
 
@@ -123,7 +122,6 @@ int32_t NavigationViewItemAutomationPeer::GetSizeOfSetCore()
 
 int32_t NavigationViewItemAutomationPeer::GetLevelCore()
 {
-    int32_t level = 0;
     if (winrt::NavigationViewItemBase nvib = Owner().try_as<winrt::NavigationViewItemBase>())
     {
         auto const nvibImpl = winrt::get_self<NavigationViewItemBase>(nvib);
@@ -143,7 +141,7 @@ int32_t NavigationViewItemAutomationPeer::GetLevelCore()
         }
     }
 
-    return level;
+    return 0;
 }
 
 void NavigationViewItemAutomationPeer::Invoke()

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.h
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.h
@@ -52,6 +52,7 @@ private:
     };
 
     winrt::NavigationView GetParentNavigationView();
+    winrt::ItemsRepeater GetParentRepeater();
     bool IsOnTopNavigation();
     bool IsOnTopNavigationOverflow();
     bool IsSettingsItem();

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.h
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.h
@@ -60,6 +60,6 @@ private:
     int32_t GetNavigationViewItemCountInPrimaryList();
     int32_t GetNavigationViewItemCountInTopNav();
     int32_t GetPositionOrSetCountInLeftNavHelper(AutomationOutput automationOutput);
-    int32_t GetPositionOrSetCountInTopNavHelper(winrt::IVector<winrt::IInspectable> navigationViewElements, AutomationOutput automationOutput);
+    int32_t GetPositionOrSetCountInTopNavHelper(AutomationOutput automationOutput);
     void ChangeSelection(bool isSelected);
 };

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -814,7 +814,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        public void HierarchyItemsAccessibilitySetTest()
+        public void HierarchyItemsAccessibilitySetAndLevelTest()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView Markup Test" }))
             {
@@ -826,9 +826,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                 AutomationElement ae = AutomationElement.FocusedElement;
                 int positionInSet = (int)ae.GetCurrentPropertyValue(AutomationElement.PositionInSetProperty);
                 int sizeOfSet = (int)ae.GetCurrentPropertyValue(AutomationElement.SizeOfSetProperty);
+                int itemLevel = (int)ae.GetCurrentPropertyValue(AutomationElement.LevelProperty);
 
                 Verify.AreEqual(4, positionInSet, "Position in set");
                 Verify.AreEqual(15, sizeOfSet, "Size of set");
+                Verify.AreEqual(1, itemLevel, "Level of item");
 
                 Log.Comment("Expanding Menu Item 15.");
                 InputHelper.LeftClick(menuItem15);
@@ -842,9 +844,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                 ae = AutomationElement.FocusedElement;
                 positionInSet = (int)ae.GetCurrentPropertyValue(AutomationElement.PositionInSetProperty);
                 sizeOfSet = (int)ae.GetCurrentPropertyValue(AutomationElement.SizeOfSetProperty);
+                itemLevel = (int)ae.GetCurrentPropertyValue(AutomationElement.LevelProperty);
 
                 Verify.AreEqual(2, positionInSet, "Position in set, not including separator/header");
                 Verify.AreEqual(3, sizeOfSet, "Size of set");
+                Verify.AreEqual(2, itemLevel, "Level of item");
             }
         }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -814,6 +814,41 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
+        public void HierarchyItemsAccessibilitySetTest()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView Markup Test" }))
+            {
+                Log.Comment("Setting focus to Menu Item 15");
+                UIObject menuItem15 = FindElement.ByName("Menu Item 15");
+                menuItem15.SetFocus();
+                Wait.ForIdle();
+
+                AutomationElement ae = AutomationElement.FocusedElement;
+                int positionInSet = (int)ae.GetCurrentPropertyValue(AutomationElement.PositionInSetProperty);
+                int sizeOfSet = (int)ae.GetCurrentPropertyValue(AutomationElement.SizeOfSetProperty);
+
+                Verify.AreEqual(4, positionInSet, "Position in set");
+                Verify.AreEqual(15, sizeOfSet, "Size of set");
+
+                Log.Comment("Expanding Menu Item 15.");
+                InputHelper.LeftClick(menuItem15);
+                Wait.ForIdle();
+
+                Log.Comment("Setting focus to Menu Item 17");
+                UIObject menuItem17 = FindElement.ByName("Menu Item 17");
+                menuItem17.SetFocus();
+                Wait.ForIdle();
+
+                ae = AutomationElement.FocusedElement;
+                positionInSet = (int)ae.GetCurrentPropertyValue(AutomationElement.PositionInSetProperty);
+                sizeOfSet = (int)ae.GetCurrentPropertyValue(AutomationElement.SizeOfSetProperty);
+
+                Verify.AreEqual(2, positionInSet, "Position in set, not including separator/header");
+                Verify.AreEqual(3, sizeOfSet, "Size of set");
+            }
+        }
+
+        [TestMethod]
         public void ItemsSourceAccessibilitySetTest()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Init Test" }))


### PR DESCRIPTION
## Description
1. Updates the automation peer to properly report size and position for hierarchy.
2. Updates the automation peer to report correct item level (was being 0-indexed previously, but to keep consistent with TreeView it should start at level one)

## Motivation and Context
Fixes #2560  

## How Has This Been Tested?
Added interaction test and manually tested.
