### PR TITLE
TabView workaround for Issues #2455 and #2457

### DIFF
--- a/dev/Generated/TabView.properties.cpp
+++ b/dev/Generated/TabView.properties.cpp
@@ -167,7 +167,7 @@ void TabViewProperties::EnsureProperties()
                 winrt::name_of<winrt::TabView>(),
                 false /* isAttached */,
                 ValueHelper<winrt::IInspectable>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnTabItemsSourcePropertyChanged));
     }
     if (!s_TabItemTemplateProperty)
     {
@@ -292,6 +292,14 @@ void TabViewProperties::OnSelectedItemPropertyChanged(
 {
     auto owner = sender.as<winrt::TabView>();
     winrt::get_self<TabView>(owner)->OnSelectedItemPropertyChanged(args);
+}
+
+void TabViewProperties::OnTabItemsSourcePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::TabView>();
+    winrt::get_self<TabView>(owner)->OnTabItemsSourcePropertyChanged(args);
 }
 
 void TabViewProperties::OnTabWidthModePropertyChanged(

--- a/dev/Generated/TabView.properties.h
+++ b/dev/Generated/TabView.properties.h
@@ -145,6 +145,10 @@ public:
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 
+    static void OnTabItemsSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
     static void OnTabWidthModePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -66,12 +66,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 selectItemButton.InvokeAndWait();
 
                 TextBlock selectedIndexTextBlock = FindElement.ByName<TextBlock>("SelectedIndexTextBlock");
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "1");
+                Verify.AreEqual("1", selectedIndexTextBlock.DocumentText);
 
                 Log.Comment("Verify that setting SelectedIndex changes selection.");
                 Button selectIndexButton = FindElement.ByName<Button>("SelectIndexButton");
                 selectIndexButton.InvokeAndWait();
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
+                Verify.AreEqual("2", selectedIndexTextBlock.DocumentText);
 
                 Log.Comment("Verify that ctrl-click on tab selects it.");
                 UIObject firstTab = FindElement.ByName("FirstTab");
@@ -79,14 +79,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 firstTab.Click();
                 KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
                 Wait.ForIdle();
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
+                Verify.AreEqual("0", selectedIndexTextBlock.DocumentText);
 
                 Log.Comment("Verify that ctrl-click on tab does not deselect.");
                 KeyboardHelper.PressDownModifierKey(ModifierKey.Control);
                 firstTab.Click();
                 KeyboardHelper.ReleaseModifierKey(ModifierKey.Control);
                 Wait.ForIdle();
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
+                Verify.AreEqual("0", selectedIndexTextBlock.DocumentText);
             }
         }
 
@@ -234,19 +234,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(closeButton);
 
                 TextBlock selectedIndexTextBlock = FindElement.ByName<TextBlock>("SelectedIndexTextBlock");
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
+                Verify.AreEqual("0", selectedIndexTextBlock.DocumentText);
 
                 Log.Comment("When the selected tab is closed, selection should move to the next one.");
                 // Use Tab's close button:
                 closeButton.InvokeAndWait();
                 VerifyElement.NotFound("FirstTab", FindBy.Name);
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "0");
+                Verify.AreEqual("0", selectedIndexTextBlock.DocumentText);
 
                 Log.Comment("Select last tab.");
                 UIObject lastTab = FindElement.ByName("LastTab");
                 lastTab.Click();
                 Wait.ForIdle();
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "3");
+                Verify.AreEqual("3", selectedIndexTextBlock.DocumentText);
 
                 Log.Comment("When the selected tab is last and is closed, selection should move to the previous item.");
 
@@ -254,7 +254,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 lastTab.Click(PointerButtons.Middle);
                 Wait.ForIdle();
                 VerifyElement.NotFound("LastTab", FindBy.Name);
-                Verify.AreEqual(selectedIndexTextBlock.DocumentText, "2");
+                Verify.AreEqual("2", selectedIndexTextBlock.DocumentText);
             }
         }
 
@@ -341,6 +341,53 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Home tab content should be visible.");
                 UIObject tabContent = FindElement.ByName("FirstTabContent");
                 Verify.IsNotNull(tabContent);
+            }
+        }
+
+        [TestMethod]
+        public void ReorderItemsTest()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone5))
+            {
+                // TODO 19727004: Re-enable this on versions below RS5 after fixing the bug where mouse click-and-drag doesn't work.
+                Log.Warning("This test relies on touch input, the injection of which is only supported in RS5 and up. Test is disabled.");
+                return;
+            }
+
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Button tabItemsSourcePageButton = FindElement.ByName<Button>("TabViewTabItemsSourcePageButton");
+                tabItemsSourcePageButton.InvokeAndWait();
+
+                UIObject sourceTab = null;
+                int attempts = 0;
+
+                do
+                {
+                    Wait.ForMilliseconds(100);
+                    ElementCache.Refresh();
+
+                    sourceTab = FindElement.ByName("tabViewItem0");
+                    attempts++;
+                }
+                while (sourceTab == null && attempts < 4);
+
+                Verify.IsNotNull(sourceTab);
+
+                UIObject dropTab = FindElement.ByName("tabViewItem2");
+                Verify.IsNotNull(dropTab);
+
+                Log.Comment("Reordering tabs with drag-drop operation...");
+                InputHelper.DragToTarget(sourceTab, dropTab);
+                Wait.ForIdle();
+                ElementCache.Refresh();
+                Log.Comment("...reordering done. Expecting a TabView.TabItemsChanged event was raised with CollectionChange=ItemInserted and Index=1.");
+
+                TextBlock tblIVectorChangedEventArgsCollectionChange = FindElement.ByName<TextBlock>("tblIVectorChangedEventArgsCollectionChange");
+                Verify.AreEqual("ItemInserted", tblIVectorChangedEventArgsCollectionChange.DocumentText);
+
+                TextBlock tblIVectorChangedEventArgsIndex = FindElement.ByName<TextBlock>("tblIVectorChangedEventArgsIndex");
+                Verify.AreEqual("1", tblIVectorChangedEventArgsIndex.DocumentText);
             }
         }
 
@@ -480,7 +527,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 closeUnselectedButton = FindCloseButton(FindElement.ByName("LongHeaderTab"));
                 Verify.IsNotNull(closeUnselectedButton);
                 Verify.IsNotNull(closeSelectedButton);
-
             }
         } 
 
@@ -526,7 +572,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
                 TextBlock dragOutsideTextBlock = FindElement.ByName<TextBlock>("TabDroppedOutsideTextBlock");
-                Verify.AreEqual(dragOutsideTextBlock.DocumentText, "");
+                Verify.AreEqual("", dragOutsideTextBlock.DocumentText);
 
                 Log.Comment("Drag tab out");
                 UIObject firstTab = TryFindElement.ByName("FirstTab");
@@ -534,7 +580,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Wait.ForIdle();
 
                 Log.Comment("Verify event fired");
-                Verify.AreEqual(dragOutsideTextBlock.DocumentText, "Home");
+                Verify.AreEqual("Home", dragOutsideTextBlock.DocumentText);
             }
         }
 

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -178,7 +178,7 @@ void TabView::OnListViewGettingFocus(const winrt::IInspectable& sender, const wi
         auto newItem = args.NewFocusedElement().try_as<winrt::TabViewItem>();
         if (oldItem && newItem)
         {
-            if (auto listView = m_listView.get())
+            if (auto&& listView = m_listView.get())
             {
                 bool oldItemIsFromThisTabView = listView.IndexFromContainer(oldItem) != -1;
                 bool newItemIsFromThisTabView = listView.IndexFromContainer(newItem) != -1;
@@ -236,7 +236,7 @@ void TabView::UpdateListViewItemContainerTransitions()
 {
     if (TabItemsSource())
     {
-        if (auto listView = m_listView.get())
+        if (auto&& listView = m_listView.get())
         {
             if (listView.CanReorderItems() && listView.AllowDrop())
             {
@@ -388,7 +388,7 @@ void TabView::OnLoaded(const winrt::IInspectable&, const winrt::RoutedEventArgs&
 
 void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEventArgs& args)
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         // Now that ListView exists, we can start using its Items collection.
         if (auto const lvItems = listView.Items())
@@ -533,18 +533,36 @@ void TabView::UpdateScrollViewerDecreaseAndIncreaseButtonsViewState()
 
         if (abs(horizontalOffset - scrollableWidth) < minThreshold)
         {
-            decreaseButton.IsEnabled(true);
-            increaseButton.IsEnabled(false);
+            if (decreaseButton)
+            {
+                decreaseButton.IsEnabled(true);
+            }
+            if (increaseButton)
+            {
+                increaseButton.IsEnabled(false);
+            }
         }
         else if (abs(horizontalOffset) < minThreshold)
         {
-            decreaseButton.IsEnabled(false);
-            increaseButton.IsEnabled(true);
+            if (decreaseButton)
+            {
+                decreaseButton.IsEnabled(false);
+            }
+            if (increaseButton)
+            {
+                increaseButton.IsEnabled(true);
+            }
         }
         else
         {
-            decreaseButton.IsEnabled(true);
-            increaseButton.IsEnabled(true);
+            if (decreaseButton)
+            {
+                decreaseButton.IsEnabled(true);
+            }
+            if (increaseButton)
+            {
+                increaseButton.IsEnabled(true);
+            }
         }
     }
 }
@@ -625,7 +643,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
 
 void TabView::OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args)
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         SelectedIndex(listView.SelectedIndex());
         SelectedItem(listView.SelectedItem());
@@ -703,7 +721,7 @@ void TabView::OnListViewDragItemsCompleted(const winrt::IInspectable& sender, co
 
 void TabView::UpdateTabContent()
 {
-    if (auto tabContentPresenter = m_tabContentPresenter.get())
+    if (auto&& tabContentPresenter = m_tabContentPresenter.get())
     {
         if (!SelectedItem())
         {
@@ -760,7 +778,7 @@ void TabView::UpdateTabContent()
 
 void TabView::RequestCloseTab(winrt::TabViewItem const& container)
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         auto args = winrt::make_self<TabViewTabCloseRequestedEventArgs>(listView.ItemFromContainer(container), container);
             
@@ -776,7 +794,7 @@ void TabView::RequestCloseTab(winrt::TabViewItem const& container)
 
 void TabView::OnScrollDecreaseClick(const winrt::IInspectable&, const winrt::RoutedEventArgs&)
 {
-    if (auto scrollViewer = m_scrollViewer.get())
+    if (auto&& scrollViewer = m_scrollViewer.get())
     {
         scrollViewer.ChangeView(std::max(0.0, scrollViewer.HorizontalOffset() - c_scrollAmount), nullptr, nullptr);
     }
@@ -784,7 +802,7 @@ void TabView::OnScrollDecreaseClick(const winrt::IInspectable&, const winrt::Rou
 
 void TabView::OnScrollIncreaseClick(const winrt::IInspectable&, const winrt::RoutedEventArgs&)
 {
-    if (auto scrollViewer = m_scrollViewer.get())
+    if (auto&& scrollViewer = m_scrollViewer.get())
     {
         scrollViewer.ChangeView(std::min(scrollViewer.ScrollableWidth(), scrollViewer.HorizontalOffset() + c_scrollAmount), nullptr, nullptr);
     }
@@ -805,21 +823,21 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
 {
     double tabWidth = std::numeric_limits<double>::quiet_NaN();
 
-    if (auto tabGrid = m_tabContainerGrid.get())
+    if (auto&& tabGrid = m_tabContainerGrid.get())
     {
         // Add up width taken by custom content and + button
         double widthTaken = 0.0;
-        if (auto leftContentColumn = m_leftContentColumn.get())
+        if (auto&& leftContentColumn = m_leftContentColumn.get())
         {
             widthTaken += leftContentColumn.ActualWidth();
         }
-        if (auto addButtonColumn = m_addButtonColumn.get())
+        if (auto&& addButtonColumn = m_addButtonColumn.get())
         {
             widthTaken += addButtonColumn.ActualWidth();
         }
         if (auto&& rightContentColumn = m_rightContentColumn.get())
         {
-            if (auto rightContentPresenter = m_rightContentPresenter.get())
+            if (auto&& rightContentPresenter = m_rightContentPresenter.get())
             {
                 winrt::Size rightContentSize = rightContentPresenter.DesiredSize();
                 rightContentColumn.MinWidth(rightContentSize.Width);
@@ -827,7 +845,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
             }
         }
 
-        if (auto tabColumn = m_tabColumn.get())
+        if (auto&& tabColumn = m_tabColumn.get())
         {
             // Note: can be infinite
             auto availableWidth = previousAvailableSize.Width - widthTaken;
@@ -879,7 +897,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
                     if (requiredWidth >= availableWidth)
                     {
                         tabColumn.Width(winrt::GridLengthHelper::FromPixels(availableWidth));
-                        if (auto listview = m_listView.get())
+                        if (auto&& listview = m_listView.get())
                         {
                             winrt::FxScrollViewer::SetHorizontalScrollBarVisibility(listview, winrt::Windows::UI::Xaml::Controls::ScrollBarVisibility::Visible);
                             UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
@@ -888,7 +906,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
                     else
                     {
                         tabColumn.Width(winrt::GridLengthHelper::FromValueAndType(1.0, winrt::GridUnitType::Auto));
-                        if (auto listview = m_listView.get())
+                        if (auto&& listview = m_listView.get())
                         {
                             if (shouldUpdateWidths && fillAllAvailableSpace)
                             {
@@ -896,8 +914,14 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
                             }
                             else
                             {
-                                m_scrollDecreaseButton.get().IsEnabled(false);
-                                m_scrollIncreaseButton.get().IsEnabled(false);
+                                if (auto&& decreaseButton = m_scrollDecreaseButton.get())
+                                {
+                                    decreaseButton.IsEnabled(false);
+                                }
+                                if (auto&& increaseButton = m_scrollIncreaseButton.get())
+                                {
+                                    increaseButton.IsEnabled(false);
+                                }
                             }
                         }
                     }
@@ -907,12 +931,12 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
                     // Case: TabWidthMode "Compact" or "FitToContent"
                     tabColumn.MaxWidth(availableWidth);
                     tabColumn.Width(winrt::GridLengthHelper::FromValueAndType(1.0, winrt::GridUnitType::Auto));
-                    if (auto listview = m_listView.get())
+                    if (auto&& listview = m_listView.get())
                     {
                         listview.MaxWidth(availableWidth);
 
                         // Calculate if the scroll buttons should be visible.
-                        if (auto itemsPresenter = m_itemsPresenter.get())
+                        if (auto&& itemsPresenter = m_itemsPresenter.get())
                         {
                             auto visible = itemsPresenter.ActualWidth() > availableWidth;
                             winrt::FxScrollViewer::SetHorizontalScrollBarVisibility(listview, visible
@@ -951,7 +975,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
 
 void TabView::UpdateSelectedItem()
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         auto tvi = SelectedItem().try_as<winrt::TabViewItem>();
         if (!tvi)
@@ -972,7 +996,7 @@ void TabView::UpdateSelectedItem()
 
 void TabView::UpdateSelectedIndex()
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         listView.SelectedIndex(SelectedIndex());
     }
@@ -980,7 +1004,7 @@ void TabView::UpdateSelectedIndex()
 
 winrt::DependencyObject TabView::ContainerFromItem(winrt::IInspectable const& item)
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         return listView.ContainerFromItem(item);
     }
@@ -989,7 +1013,7 @@ winrt::DependencyObject TabView::ContainerFromItem(winrt::IInspectable const& it
 
 winrt::DependencyObject TabView::ContainerFromIndex(int index)
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         return listView.ContainerFromIndex(index);
     }
@@ -998,7 +1022,7 @@ winrt::DependencyObject TabView::ContainerFromIndex(int index)
 
 winrt::IInspectable TabView::ItemFromContainer(winrt::DependencyObject const& container)
 {
-    if (auto listView = m_listView.get())
+    if (auto&& listView = m_listView.get())
     {
         return listView.ItemFromContainer(container);
     }

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -104,6 +104,7 @@ public:
 
     // Internal
     void OnCloseButtonOverlayModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnTabItemsSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnTabWidthModePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnSelectedIndexPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnSelectedItemPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
@@ -147,7 +148,9 @@ private:
     void UpdateTabWidths();
 
     void UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
+    void UpdateListViewItemContainerTransitions();
 
+    void OnListViewDraggingPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void OnListViewGettingFocus(const winrt::IInspectable& sender, const winrt::GettingFocusEventArgs& args);
 
     int GetItemCount();
@@ -174,6 +177,9 @@ private:
     winrt::ListView::Loaded_revoker m_listViewLoadedRevoker{};
     winrt::Selector::SelectionChanged_revoker m_listViewSelectionChangedRevoker{};
     winrt::UIElement::GettingFocus_revoker m_listViewGettingFocusRevoker{};
+
+    PropertyChanged_revoker m_listViewCanReorderItemsPropertyChangedRevoker{};
+    PropertyChanged_revoker m_listViewAllowDropPropertyChangedRevoker{};
 
     winrt::ListView::DragItemsStarting_revoker m_listViewDragItemsStartingRevoker{};
     winrt::ListView::DragItemsCompleted_revoker m_listViewDragItemsCompletedRevoker{};

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -89,6 +89,7 @@ unsealed runtimeclass TabView : Windows.UI.Xaml.Controls.Control
     event Windows.Foundation.TypedEventHandler<TabView, Windows.Foundation.Collections.IVectorChangedEventArgs> TabItemsChanged;
 
     // From ListView
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Object TabItemsSource;
     Windows.Foundation.Collections.IVector<Object> TabItems{ get; };
 

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -243,7 +243,7 @@ void TabViewItem::OnHeaderPropertyChanged(const winrt::DependencyPropertyChanged
         }
     }
 
-    if (auto toolTip = m_toolTip.get())
+    if (auto&& toolTip = m_toolTip.get())
     {
         // Update tooltip text to new header text
         auto headerContent = Header();

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -153,8 +153,10 @@
 
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
-                            <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
-                            <Button x:Name="TabViewTabItemsSourcePageButton" AutomationProperties.Name="TabViewTabItemsSourcePageButton" Margin="8" Click="TabViewTabItemsSourcePageButton_Click" FontSize="20">TabView TabItemsSource Page</Button>
+                            <StackPanel Orientation="Horizontal">
+                                <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
+                                <Button x:Name="TabViewTabItemsSourcePageButton" AutomationProperties.Name="TabViewTabItemsSourcePageButton" Margin="8" Click="TabViewTabItemsSourcePageButton_Click" FontSize="20">TabView TabItemsSource Page</Button>
+                            </StackPanel>
                         </StackPanel>
                     </controls:TabViewItem>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <local:TestPage
     x:Class="MUXControlsTestApp.TabViewPage"
     x:Name="TabViewTestPage"
@@ -154,6 +154,7 @@
                         <StackPanel x:Name="FirstTabContent" AutomationProperties.Name="FirstTabContent">
                             <Button x:Name="FirstTabButton" AutomationProperties.Name="FirstTabButton" Margin="8" FontSize="20">Home Button</Button>
                             <Button x:Name="TabViewSizingPageButton" AutomationProperties.Name="TabViewSizingPageButton" Margin="8" Click="TabViewSizingPageButton_Click" FontSize="20">TabView Sizing Page</Button>
+                            <Button x:Name="TabViewTabItemsSourcePageButton" AutomationProperties.Name="TabViewTabItemsSourcePageButton" Margin="8" Click="TabViewTabItemsSourcePageButton_Click" FontSize="20">TabView TabItemsSource Page</Button>
                         </StackPanel>
                     </controls:TabViewItem>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -394,6 +394,11 @@ namespace MUXControlsTestApp
             this.Frame.Navigate(typeof(TabViewSizingPage));
         }
 
+        private void TabViewTabItemsSourcePageButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.Frame.Navigate(typeof(TabViewTabItemsSourcePage));
+        }
+
         private void ShortLongTextButton_Click(object sender, RoutedEventArgs e)
         {
             FirstTab.Header = "s";

--- a/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml
+++ b/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml
@@ -34,6 +34,13 @@
             <CheckBox x:Name="chkCanReorderItems" Content="ListView.CanReorderItems?" IsChecked="True" Checked="ChkCanReorderItems_Checked" Unchecked="ChkCanReorderItems_Unchecked"/>
             <CheckBox x:Name="chkCanDrag" Content="ListView.CanDrag?" IsChecked="False" Checked="ChkCanDrag_Checked" Unchecked="ChkCanDrag_Unchecked"/>
             <CheckBox x:Name="chkAllowDrop" Content="ListView.AllowDrop?" IsChecked="True" Checked="ChkAllowDrop_Checked" Unchecked="ChkAllowDrop_Unchecked"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Last TabItemsChanged Info - " Margin="2"/>
+                <TextBlock Text="CollectionChange:" Margin="2"/>
+                <TextBlock x:Name="tblIVectorChangedEventArgsCollectionChange" AutomationProperties.Name="tblIVectorChangedEventArgsCollectionChange" Text="-" Margin="2"/>
+                <TextBlock Text=", Index:" Margin="2"/>
+                <TextBlock x:Name="tblIVectorChangedEventArgsIndex" AutomationProperties.Name="tblIVectorChangedEventArgsIndex" Text="-" Margin="2"/>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </Page>

--- a/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml
+++ b/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml
@@ -1,0 +1,39 @@
+﻿<Page
+    x:Class="MUXControlsTestApp.TabViewTabItemsSourcePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <controls:TabView x:Name="TabViewItemsSourceSample"
+            Margin="5"
+            SelectedIndex="0"
+            MinHeight="200"
+            TabItemsSource="{x:Bind myDatas, Mode=OneWay}"
+            AddTabButtonClick="TabViewItemsSourceSample_AddTabButtonClick"
+            TabCloseRequested="TabViewItemsSourceSample_TabCloseRequested">
+            <controls:TabView.TabItemTemplate>
+                <DataTemplate x:DataType="local:MyData">
+                    <controls:TabViewItem
+                        Header="{x:Bind DataHeader}"
+                        IconSource="{x:Bind DataIconSource}"
+                        Content="{x:Bind DataContent}"/>
+                </DataTemplate>
+            </controls:TabView.TabItemTemplate>
+        </controls:TabView>
+        <StackPanel Margin="5" Grid.Row="1">
+            <CheckBox x:Name="chkCanDragItems" Content="ListView.CanDragItems?" IsChecked="False" Checked="ChkCanDragItems_Checked" Unchecked="ChkCanDragItems_Unchecked"/>
+            <CheckBox x:Name="chkCanReorderItems" Content="ListView.CanReorderItems?" IsChecked="True" Checked="ChkCanReorderItems_Checked" Unchecked="ChkCanReorderItems_Unchecked"/>
+            <CheckBox x:Name="chkCanDrag" Content="ListView.CanDrag?" IsChecked="False" Checked="ChkCanDrag_Checked" Unchecked="ChkCanDrag_Unchecked"/>
+            <CheckBox x:Name="chkAllowDrop" Content="ListView.AllowDrop?" IsChecked="True" Checked="ChkAllowDrop_Checked" Unchecked="ChkAllowDrop_Unchecked"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.UI.Xaml.Controls;
 using MUXControlsTestApp.Utilities;
 using System.Collections.ObjectModel;
+using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
 
 namespace MUXControlsTestApp
@@ -15,6 +17,7 @@ namespace MUXControlsTestApp
 
     public sealed partial class TabViewTabItemsSourcePage : Page
     {
+        const int initialTabsCount = 3;
         ListView innerListView = null;
         ObservableCollection<MyData> myDatas;
 
@@ -23,13 +26,31 @@ namespace MUXControlsTestApp
             this.InitializeComponent();
 
             Loaded += TabViewTabItemsSourcePage_Loaded;
+            TabViewItemsSourceSample.TabItemsChanged += TabViewItemsSourceSample_TabItemsChanged;
 
             InitializeDataBindingSampleData();
+        }
+
+        private void TabViewItemsSourceSample_TabItemsChanged(TabView sender, IVectorChangedEventArgs args)
+        {
+            tblIVectorChangedEventArgsCollectionChange.Text = args.CollectionChange.ToString();
+            tblIVectorChangedEventArgsIndex.Text = args.Index.ToString();
         }
 
         private void TabViewTabItemsSourcePage_Loaded(object sender, RoutedEventArgs e)
         {
             innerListView = TabViewItemsSourceSample.FindElementOfTypeInSubtree<ListView>();
+
+            for (int tabIndex = 0; tabIndex < initialTabsCount; tabIndex++)
+            {
+                var tabViewItem = TabViewItemsSourceSample.ContainerFromIndex(tabIndex) as TabViewItem;
+
+                if (tabViewItem != null)
+                {
+                    tabViewItem.Name = "tabViewItem" + tabIndex;
+                    AutomationProperties.SetName(tabViewItem, tabViewItem.Name);
+                }
+            }
         }
 
         private void ChkCanDragItems_Checked(object sender, RoutedEventArgs e)
@@ -100,7 +121,7 @@ namespace MUXControlsTestApp
         {
             myDatas = new ObservableCollection<MyData>();
 
-            for (int index = 0; index < 3; index++)
+            for (int index = 0; index < initialTabsCount; index++)
             {
                 myDatas.Add(CreateNewMyData(index));
             }

--- a/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml.cs
@@ -1,0 +1,136 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp.Utilities;
+using System.Collections.ObjectModel;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace MUXControlsTestApp
+{
+    public class MyData
+    {
+        public string DataHeader { get; set; }
+        public Microsoft.UI.Xaml.Controls.IconSource DataIconSource { get; set; }
+        public object DataContent { get; set; }
+    }
+
+    public sealed partial class TabViewTabItemsSourcePage : Page
+    {
+        ListView innerListView = null;
+        ObservableCollection<MyData> myDatas;
+
+        public TabViewTabItemsSourcePage()
+        {
+            this.InitializeComponent();
+
+            Loaded += TabViewTabItemsSourcePage_Loaded;
+
+            InitializeDataBindingSampleData();
+        }
+
+        private void TabViewTabItemsSourcePage_Loaded(object sender, RoutedEventArgs e)
+        {
+            innerListView = TabViewItemsSourceSample.FindElementOfTypeInSubtree<ListView>();
+        }
+
+        private void ChkCanDragItems_Checked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.CanDragItems = true;
+            }
+        }
+
+        private void ChkCanDragItems_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.CanDragItems = false;
+            }
+        }
+
+        private void ChkCanReorderItems_Checked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.CanReorderItems = true;
+            }
+        }
+
+        private void ChkCanReorderItems_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.CanReorderItems = false;
+            }
+        }
+
+        private void ChkCanDrag_Checked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.CanDrag = true;
+            }
+        }
+
+        private void ChkCanDrag_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.CanDrag = false;
+            }
+        }
+
+        private void ChkAllowDrop_Checked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.AllowDrop = true;
+            }
+        }
+
+        private void ChkAllowDrop_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (innerListView != null)
+            {
+                innerListView.AllowDrop = false;
+            }
+        }
+
+        private void InitializeDataBindingSampleData()
+        {
+            myDatas = new ObservableCollection<MyData>();
+
+            for (int index = 0; index < 3; index++)
+            {
+                myDatas.Add(CreateNewMyData(index));
+            }
+        }
+
+        private MyData CreateNewMyData(int index)
+        {
+            var textBlock = new TextBlock();
+            textBlock.Text = "Sample" + index;
+
+            var newData = new MyData
+            {
+                DataHeader = $"MyData {index}",
+                DataIconSource = new Microsoft.UI.Xaml.Controls.SymbolIconSource() { Symbol = Symbol.Caption + index },
+                DataContent = textBlock
+            };
+
+            return newData;
+        }
+
+        private void TabViewItemsSourceSample_AddTabButtonClick(TabView sender, object args)
+        {
+            // Add a new MyData item to the collection. TabView automatically generates a TabViewItem.
+            myDatas.Add(CreateNewMyData(myDatas.Count));
+        }
+
+        private void TabViewItemsSourceSample_TabCloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)
+        {
+            // Remove the requested MyData object from the collection. 
+            myDatas.Remove(args.Item as MyData);
+        }
+    }
+}

--- a/dev/TabView/TestUI/TabView_TestUI.projitems
+++ b/dev/TabView/TestUI/TabView_TestUI.projitems
@@ -10,6 +10,10 @@
     <Import_RootNamespace>TabView_TestUI</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)TabViewTabItemsSourcePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)TabViewSizingPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -20,6 +24,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)TabViewTabItemsSourcePage.xaml.cs">
+      <DependentUpon>TabViewTabItemsSourcePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)TabViewSizingPage.xaml.cs">
       <DependentUpon>TabViewSizingPage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Fixes #2455 
Fixes #2457 

Instead of having apps like the XamlControlsGallery implement a workaround described in https://github.com/microsoft/Xaml-Controls-Gallery/pull/457, we can put in a workaround in the TabView control as follows:

When the TabView.TabItemsSource property is set, and the underlying ListView can be reordered (i.e. CanReorderItems and AllowDrop are True), we replace the ItemContainerTransitions collection with a clone that does not include AddDeleteThemeTransition / ContentThemeTransition instances.

This is done regardless of the nature of the new TabView.TabItemsSource, and we never try to revert the collection changes.

Adding a new regression test that reorders tab items.