### PR TITLE
Add missing templatebindings to NumberBox

### DIFF
--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -99,6 +99,8 @@
                             FontWeight="Normal"
                             Foreground="{ThemeResource TextControlHeaderForeground}"
                             Margin="{ThemeResource TextBoxTopHeaderMargin}"
+                            FontSize="{TemplateBinding FontSize}"
+                            FontFamily="{TemplateBinding FontFamily}"
                             TextWrapping="Wrap"
                             VerticalAlignment="Top"
                             Visibility="Collapsed"
@@ -111,6 +113,9 @@
                             SelectionHighlightColor="{TemplateBinding SelectionHighlightColor}"
                             TextReadingOrder="{TemplateBinding TextReadingOrder}"
                             PreventKeyboardDisplayOnProgrammaticFocus="{TemplateBinding PreventKeyboardDisplayOnProgrammaticFocus}"
+                            FontSize="{TemplateBinding FontSize}"
+                            FontWeight="{TemplateBinding FontWeight}"
+                            FontFamily="{TemplateBinding FontFamily}"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
 
                         <Popup x:Name="UpDownPopup"

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <local:TestPage
     x:Class="MUXControlsTestApp.NumberBoxPage"
     x:Name="NumberBoxTestPage"
@@ -146,6 +146,9 @@
                     </controls:NumberBox>
                     <controls:NumberBox x:Name="HeaderTemplateTestingNumberBox"/>
                 </StackPanel>
+
+                <!-- FontSize propagation -->
+                <controls:NumberBox Header="Header text" FontSize="50"/>
             </StackPanel>
         </Grid>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the TemplateBinding to NumberBox, that are necessary to customize FontSize, FontFamily and FontWeight.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2603
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually:

![image](https://user-images.githubusercontent.com/16122379/84576659-bcb73d80-adb6-11ea-8c4e-879cf29485f2.png)

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->