### PR TITLE
Fix issue with ContentDialog not respecting BorderThickness property set

### DIFF
--- a/dev/ContentDialog/ContentDialog_themeresources.xaml
+++ b/dev/ContentDialog/ContentDialog_themeresources.xaml
@@ -98,6 +98,7 @@
     <Style x:Key="DefaultContentDialogStyle" TargetType="ContentDialog">
         <Setter Property="Foreground" Value="{ThemeResource ContentDialogForeground}" />
         <Setter Property="Background" Value="{ThemeResource ContentDialogBackground}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ContentDialogBorderWidth}" />
         <Setter Property="BorderBrush" Value="{ThemeResource ContentDialogBorderBrush}" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="PrimaryButtonStyle" Value="{ThemeResource DefaultButtonStyle}" />
@@ -276,7 +277,7 @@
                                 x:Name="BackgroundElement"
                                 Background="{TemplateBinding Background}"
                                 FlowDirection="{TemplateBinding FlowDirection}"
-                                BorderThickness="{ThemeResource ContentDialogBorderWidth}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                                 contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}"

--- a/dev/ContentDialog/TestUI/ContentDialogPage.xaml
+++ b/dev/ContentDialog/TestUI/ContentDialogPage.xaml
@@ -9,8 +9,8 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-
     <StackPanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
         <Button Content="Click to open simple ContentDialog" Click="ShowDialog_Click"/>
+        <Button Content="Border thickness test dialog" Click="ShowBorderThickness_Click"/>
     </StackPanel>
 </local:TestPage>

--- a/dev/ContentDialog/TestUI/ContentDialogPage.xaml.cs
+++ b/dev/ContentDialog/TestUI/ContentDialogPage.xaml.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 namespace MUXControlsTestApp
 {
@@ -17,6 +19,19 @@ namespace MUXControlsTestApp
         private void ShowDialog_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new ContentDialog { Title = "Title", Content = "Content", IsPrimaryButtonEnabled = true, PrimaryButtonText = "PrimaryButton", SecondaryButtonText = "SecondaryButton", CloseButtonText = "CloseButton" };
+            _ = dialog.ShowAsync();
+        }
+
+        private void ShowBorderThickness_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new ContentDialog {
+                Title = "Title",
+                Content = "I am testing border thickness",
+                IsPrimaryButtonEnabled = true,
+                BorderThickness = new Thickness(10, 20, 10, 20),
+                CloseButtonText = "CloseButton",
+                BorderBrush = new SolidColorBrush(Color.FromArgb(255, 255, 0, 0))
+            };
             _ = dialog.ShowAsync();
         }
     }

--- a/test/MUXControlsTestApp/master/ContentDialog-5.xml
+++ b/test/MUXControlsTestApp/master/ContentDialog-5.xml
@@ -16,7 +16,7 @@
   [Windows.UI.Xaml.Controls.ContentDialog]
       Padding=0,0,0,0
       Foreground=#FF000000
-      BorderThickness=0,0,0,0
+      BorderThickness=1,1,1,1
       BorderBrush=#33000000
       Background=#FFF2F2F2
       Margin=0,0,0,0

--- a/test/MUXControlsTestApp/master/ContentDialog-7.xml
+++ b/test/MUXControlsTestApp/master/ContentDialog-7.xml
@@ -16,7 +16,7 @@
   [Windows.UI.Xaml.Controls.ContentDialog]
       Padding=0,0,0,0
       Foreground=#FF000000
-      BorderThickness=0,0,0,0
+      BorderThickness=1,1,1,1
       BorderBrush=#33000000
       Background=#FFFFFFFF
       CornerRadius=4,4,4,4

--- a/test/MUXControlsTestApp/master/ContentDialog.xml
+++ b/test/MUXControlsTestApp/master/ContentDialog.xml
@@ -16,7 +16,7 @@
   [Windows.UI.Xaml.Controls.ContentDialog]
       Padding=0,0,0,0
       Foreground=#FF000000
-      BorderThickness=0,0,0,0
+      BorderThickness=1,1,1,1
       BorderBrush=#33000000
       Background=#FFF2F2F2
       MaxWidth=548


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When setting the BorderThickness property of a ContentDialog, it was not respected since we were not template binding to the BorderThickness of the ContentDialog.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2525 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually:

![image](https://user-images.githubusercontent.com/16122379/84602320-c3ad8100-ae86-11ea-9d77-9ea7c73c4bbe.png)


## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->