### PR TITLE
TabView: Add theme resource to style the tab separator more easily

### DIFF
--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -377,7 +377,6 @@
         </Setter>
     </Style>
 
-
     <Style TargetType="local:TabViewItem">
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
@@ -648,7 +647,7 @@
                             Grid.Column="1"
                             BorderBrush="{ThemeResource TabViewItemSeparator}"
                             BorderThickness="1"
-                            Margin="0,6,0,6"/>
+                            Margin="{ThemeResource TabViewItemSeparatorMargin}"/>
 
                         <Grid x:Name="TabContainer"
                             Grid.Column="1"

--- a/dev/TabView/TabView_themeresources.xaml
+++ b/dev/TabView/TabView_themeresources.xaml
@@ -116,4 +116,6 @@
 
     <x:Double x:Key="TabViewShadowDepth">16</x:Double>
 
+    <Thickness x:Key="TabViewItemSeparatorMargin">0,6,0,6</Thickness>
+
 </ResourceDictionary>


### PR DESCRIPTION
## Description
This PR introduces a theme resource for the TabView's Separator margin to enable easier styling.

## Motivation and Context
Closes #2344

## How Has This Been Tested?
Tested visually

## Additional Note
The theme resource to set the foreground color of the separator is currently named `TabViewItemSeparator`. To follow naming precedences with theme resources and to properly articulate which property of the separator this theme resource controls I propose to rename it to `TabViewItemSeparatorForeground`. While this would be a breaking change I think it's worth it for the reasons state directly above. If approved, I could either do it in this PR or create a new one.