### PR TITLE
NavigationView ItemInvoked returning incorrect item fix

### DIFF
--- a/dev/NavigationView/NavigationViewItemBase.h
+++ b/dev/NavigationView/NavigationViewItemBase.h
@@ -65,6 +65,9 @@ public:
     void IsTopLevelItem(bool isTopLevelItem) { m_isTopLevelItem = isTopLevelItem; };
     bool IsTopLevelItem() const { return m_isTopLevelItem; };
 
+    void CreatedByNavigationViewItemsFactory(bool createdByNavigationViewItemsFactory) { m_createdByNavigationViewItemsFactory = createdByNavigationViewItemsFactory; };
+    bool CreatedByNavigationViewItemsFactory() { return m_createdByNavigationViewItemsFactory; };
+
 protected:
 
     winrt::weak_ref<winrt::NavigationView> m_navigationView{ nullptr };
@@ -74,4 +77,8 @@ private:
     NavigationViewRepeaterPosition m_position{ NavigationViewRepeaterPosition::LeftNav };
     int m_depth{ 0 };
     bool m_isTopLevelItem{ false };
+
+    // Flag to keep track of whether this item was created by the custom internal NavigationViewItemsFactory.
+    // This is required in order to achieve proper recycling
+    bool m_createdByNavigationViewItemsFactory{ false };
 };

--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -93,6 +93,7 @@ void NavigationViewItemsFactory::RecycleElementCore(winrt::ElementFactoryRecycle
             if (nviImpl->CreatedByNavigationViewItemsFactory())
             {
                 nviImpl->CreatedByNavigationViewItemsFactory(false);
+                UnlinkElementFromParent(args);
                 args.Element(nullptr);
 
                 // Retain the NVI that we created for future re-use
@@ -102,7 +103,7 @@ void NavigationViewItemsFactory::RecycleElementCore(winrt::ElementFactoryRecycle
                 // and update the args correspondingly
                 if (m_itemTemplateWrapper)
                 {
-                    // TODO: Retrieve and element and add to the args
+                    // TODO: Retrieve the element and add to the args
                 }
             }
         }
@@ -113,17 +114,22 @@ void NavigationViewItemsFactory::RecycleElementCore(winrt::ElementFactoryRecycle
         }
         else
         {
-            // We want to unlink the containers from the parent repeater
-            // in case we are required to move it to a different repeater.
-            if (auto panel = args.Parent().try_as<winrt::Panel>())
-            {
-                auto children = panel.Children();
-                unsigned int childIndex = 0;
-                if (children.IndexOf(element, childIndex))
-                {
-                    children.RemoveAt(childIndex);
-                }
-            }
+            UnlinkElementFromParent(args);
+        }
+    }
+}
+
+void NavigationViewItemsFactory::UnlinkElementFromParent(winrt::ElementFactoryRecycleArgs const& args)
+{
+    // We want to unlink the containers from the parent repeater
+    // in case we are required to move it to a different repeater.
+    if (auto panel = args.Parent().try_as<winrt::Panel>())
+    {
+        auto children = panel.Children();
+        unsigned int childIndex = 0;
+        if (children.IndexOf(args.Element(), childIndex))
+        {
+            children.RemoveAt(childIndex);
         }
     }
 }

--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -6,6 +6,7 @@
 #include "NavigationViewItemBase.h"
 #include "NavigationViewItem.h"
 #include "ItemTemplateWrapper.h"
+#include <ElementFactoryRecycleArgs.h>
 
 void NavigationViewItemsFactory::UserElementFactory(winrt::IInspectable const& newValue)
 {
@@ -23,8 +24,12 @@ void NavigationViewItemsFactory::UserElementFactory(winrt::IInspectable const& n
             m_itemTemplateWrapper = winrt::make<ItemTemplateWrapper>(selector);
         }
     }
+
+    navigationViewItemPool = std::vector<winrt::NavigationViewItem>();
 }
 
+// Retrieve the element that will be displayed for a specific data item.
+// If the resolved element is not derived from NavigationViewItemBase, wrap in a NavigationViewItem before returning.
 winrt::UIElement NavigationViewItemsFactory::GetElementCore(winrt::ElementFactoryGetArgs const& args)
 {
     auto const newContent = [itemTemplateWrapper = m_itemTemplateWrapper, args]() {
@@ -35,34 +40,90 @@ winrt::UIElement NavigationViewItemsFactory::GetElementCore(winrt::ElementFactor
         return args.Data();
     }();
 
+    // Element is already of expected type, just return it
     if (auto const newItem = newContent.try_as<winrt::NavigationViewItemBase>())
     {
         return newItem;
     }
 
-    // Create a wrapping container for the data
-    auto nvi = winrt::make_self<NavigationViewItem>();
-    nvi->Content(newContent);
-    return *nvi;
+    // Get or create a wrapping container for the data
+    auto const nvi = [this]() {
+        if (navigationViewItemPool.size() > 0)
+        {
+            auto nvi = navigationViewItemPool.back();
+            navigationViewItemPool.pop_back();
+            return nvi;
+        }
+        return winrt::make_self<NavigationViewItem>().try_as<winrt::NavigationViewItem>();
+    }();
+
+    auto const nviImpl = winrt::get_self<NavigationViewItem>(nvi);
+    nviImpl->CreatedByNavigationViewItemsFactory(true);
+
+    // If a user provided item template exists, just pass the template and data down to the ContentPresenter of the NavigationViewItem
+    if (m_itemTemplateWrapper)
+    {
+        if (auto itemTemplateWrapper = m_itemTemplateWrapper.try_as<ItemTemplateWrapper>())
+        {
+            // Recycle newContent
+            auto const tempArgs = winrt::make_self<ElementFactoryRecycleArgs>();
+            tempArgs->Element(newContent.try_as<winrt::UIElement>());
+            m_itemTemplateWrapper.RecycleElement(static_cast<winrt::ElementFactoryRecycleArgs>(*tempArgs));
+
+
+            nviImpl->Content(args.Data());
+            nviImpl->ContentTemplate(itemTemplateWrapper->Template());
+            nviImpl->ContentTemplateSelector(itemTemplateWrapper->TemplateSelector());
+            return *nviImpl;
+        }
+    }
+
+    nviImpl->Content(newContent);
+    return *nviImpl;
 }
 
 void NavigationViewItemsFactory::RecycleElementCore(winrt::ElementFactoryRecycleArgs const& args)
 {
-    if (m_itemTemplateWrapper)
+    if (auto element = args.Element())
     {
-        m_itemTemplateWrapper.RecycleElement(args);
-    }
-    else
-    {
-        // We want to unlink the containers from the parent repeater
-        // in case we are required to move it to a different repeater.
-        if (auto panel = args.Parent().try_as<winrt::Panel>())
+        if (auto nvi = element.try_as<winrt::NavigationViewItem>())
         {
-            auto children = panel.Children();
-            unsigned int childIndex = 0;
-            if (children.IndexOf(args.Element(), childIndex))
+            auto const nviImpl = winrt::get_self<NavigationViewItem>(nvi);
+            // Check whether we wrapped the element in a NavigationViewItem ourselves.
+            // If yes, we are responsible for recycling it.
+            if (nviImpl->CreatedByNavigationViewItemsFactory())
             {
-                children.RemoveAt(childIndex);
+                nviImpl->CreatedByNavigationViewItemsFactory(false);
+                args.Element(nullptr);
+
+                // Retain the NVI that we created for future re-use
+                navigationViewItemPool.push_back(nvi);
+
+                // Retrieve the proper element that requires recycling for a user defined item template
+                // and update the args correspondingly
+                if (m_itemTemplateWrapper)
+                {
+                    // TODO: Retrieve and element and add to the args
+                }
+            }
+        }
+
+        if (m_itemTemplateWrapper)
+        {
+            m_itemTemplateWrapper.RecycleElement(args);
+        }
+        else
+        {
+            // We want to unlink the containers from the parent repeater
+            // in case we are required to move it to a different repeater.
+            if (auto panel = args.Parent().try_as<winrt::Panel>())
+            {
+                auto children = panel.Children();
+                unsigned int childIndex = 0;
+                if (children.IndexOf(element, childIndex))
+                {
+                    children.RemoveAt(childIndex);
+                }
             }
         }
     }

--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -54,9 +54,8 @@ winrt::UIElement NavigationViewItemsFactory::GetElementCore(winrt::ElementFactor
             navigationViewItemPool.pop_back();
             return nvi;
         }
-        return winrt::make_self<NavigationViewItem>().try_as<winrt::NavigationViewItem>();
+        return winrt::make<NavigationViewItem>();
     }();
-
     auto const nviImpl = winrt::get_self<NavigationViewItem>(nvi);
     nviImpl->CreatedByNavigationViewItemsFactory(true);
 

--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -6,7 +6,7 @@
 #include "NavigationViewItemBase.h"
 #include "NavigationViewItem.h"
 #include "ItemTemplateWrapper.h"
-#include <ElementFactoryRecycleArgs.h>
+#include "ElementFactoryRecycleArgs.h"
 
 void NavigationViewItemsFactory::UserElementFactory(winrt::IInspectable const& newValue)
 {

--- a/dev/NavigationView/NavigationViewItemsFactory.h
+++ b/dev/NavigationView/NavigationViewItemsFactory.h
@@ -21,4 +21,5 @@ private:
     winrt::IElementFactoryShim m_itemTemplateWrapper{ nullptr };
     std::vector<winrt::NavigationViewItem> navigationViewItemPool;
 
+    void UnlinkElementFromParent(winrt::ElementFactoryRecycleArgs const& args);
 };

--- a/dev/NavigationView/NavigationViewItemsFactory.h
+++ b/dev/NavigationView/NavigationViewItemsFactory.h
@@ -19,5 +19,6 @@ public:
 
 private:
     winrt::IElementFactoryShim m_itemTemplateWrapper{ nullptr };
+    std::vector<winrt::NavigationViewItem> navigationViewItemPool;
 
 };

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -1598,5 +1598,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                 }
             }
         }
+
+        [TestMethod]
+        public void VerifyNoCrashWhenSwitchingPaneDisplayModeWithAutoWrappedElements()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView ItemTemplate Test" }))
+            {
+                Log.Comment("Verify that switching pane mode to auto does not crash.");
+                var flipOrientationButton = new Button(FindElement.ByName("FlipOrientationButton"));
+                flipOrientationButton.Invoke();
+                Wait.ForIdle();
+            }
+        }
+
+
     }
 }

--- a/dev/NavigationView/NavigationView_InteractionTests/EventTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/EventTests.cs
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Init Test" }))
             {
                 const string navigationViewItemType = "Microsoft.UI.Xaml.Controls.NavigationViewItem";
-                const string stringType = "System.String";
+                const string itemType = "System.String";
 
                 var itemInvokedItemType = new Edit(FindElement.ById("ItemInvokedItemType"));
                 var itemInvokedItemContainerType = new Edit(FindElement.ById("ItemInvokedItemContainerType"));
@@ -134,11 +134,39 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                 Wait.ForIdle();
 
                 Log.Comment("Verify that item invoked returns expected parameters.");
-                Verify.IsTrue(itemInvokedItemType.Value == stringType);
+                Verify.IsTrue(itemInvokedItemType.Value == itemType);
                 Verify.IsTrue(itemInvokedItemContainerType.Value == navigationViewItemType);
 
                 Log.Comment("Verify that selection changed event returns expected parameters");
-                Verify.IsTrue(selectionChangedItemtype.Value == stringType);
+                Verify.IsTrue(selectionChangedItemtype.Value == itemType);
+                Verify.IsTrue(selectionChangedItemContainerType.Value == navigationViewItemType);
+            }
+        }
+
+        [TestMethod]
+        public void VerifyEventsReturnExpectedDataTypesItemTemplate()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView ItemTemplate Test" }))
+            {
+                const string navigationViewItemType = "Microsoft.UI.Xaml.Controls.NavigationViewItem";
+                const string itemType = "MUXControlsTestApp.Customer";
+
+                var itemInvokedItemType = new Edit(FindElement.ById("ItemInvokedItemType"));
+                var itemInvokedItemContainerType = new Edit(FindElement.ById("ItemInvokedItemContainerType"));
+                var selectionChangedItemtype = new Edit(FindElement.ById("SelectionChangedItemType"));
+                var selectionChangedItemContainerType = new Edit(FindElement.ById("SelectionChangedItemContainerType"));
+
+                Log.Comment("Click Michael item");
+                var menuItem = FindElement.ByName("Michael");
+                InputHelper.LeftClick(menuItem);
+                Wait.ForIdle();
+
+                Log.Comment("Verify that item invoked returns expected parameters.");
+                Verify.IsTrue(itemInvokedItemType.Value == itemType);
+                Verify.IsTrue(itemInvokedItemContainerType.Value == navigationViewItemType);
+
+                Log.Comment("Verify that selection changed event returns expected parameters");
+                Verify.IsTrue(selectionChangedItemtype.Value == itemType);
                 Verify.IsTrue(selectionChangedItemContainerType.Value == navigationViewItemType);
             }
         }

--- a/dev/NavigationView/TestUI/NavigationViewItemTemplatePage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewItemTemplatePage.xaml
@@ -22,8 +22,9 @@
         <controls:NavigationView 
             x:Name="NavView" 
             PaneDisplayMode="Top"
-            SelectionChanged="NavView_SelectionChanged"
             MenuItemsSource="{StaticResource customers}"
+            ItemInvoked="NavView_ItemInvoked"
+            SelectionChanged="NavView_SelectionChanged"
             Grid.Row="1">
             <controls:NavigationView.MenuItemTemplate>
               <DataTemplate>
@@ -37,6 +38,18 @@
             <StackPanel Orientation="Vertical" Margin="8,0,0,0">
                 <Button x:Name="FlipOrientation" AutomationProperties.Name="FlipOrientationButton" Content="Flip Orientation" Click="FlipOrientation_Click"/>
                 <TextBlock x:Name="SelectionEventResult" AutomationProperties.Name="SelectionEventResult"></TextBlock>
+                <StackPanel Orientation="Vertical">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center">ItemInvoked Arguments (InvokedItem | InvokedItemContainer):</TextBlock>
+                        <TextBox Margin="42,0,0,0" x:Name="ItemInvokedItemType" AutomationProperties.Name="ItemInvokedItemType" Text="N/A"/>
+                        <TextBox x:Name="ItemInvokedItemContainerType" AutomationProperties.Name="ItemInvokedItemContainerType" Text="N/A"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Margin="5" HorizontalAlignment="Center" VerticalAlignment="Center">SelectionChanged Arguments (SelectedItem | SelectedItemContainer):</TextBlock>
+                        <TextBox x:Name="SelectionChangedItemType" AutomationProperties.Name="SelectionChangedItemType" Text="N/A"/>
+                        <TextBox x:Name="SelectionChangedItemContainerType" AutomationProperties.Name="SelectionChangedItemContainerType" Text="N/A"/>
+                    </StackPanel>
+                </StackPanel>
             </StackPanel>
         </controls:NavigationView>
     </Grid>

--- a/dev/NavigationView/TestUI/NavigationViewItemTemplatePage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewItemTemplatePage.xaml.cs
@@ -12,6 +12,9 @@ using Windows.UI.Xaml.Navigation;
 
 using NavigationViewPaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode;
 using MaterialHelperTestApi = Microsoft.UI.Private.Media.MaterialHelperTestApi;
+using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
+using NavigationViewItemInvokedEventArgs = Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs;
+using NavigationViewSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs;
 
 namespace MUXControlsTestApp
 {
@@ -67,6 +70,37 @@ namespace MUXControlsTestApp
             else
             {
                 SelectionEventResult.Text = "Failed";
+        private void NavView_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+        {
+            // Reset argument type indicatiors
+            ItemInvokedItemType.Text = "null";
+            ItemInvokedItemContainerType.Text = "null";
+
+            if (args.InvokedItem != null)
+            {
+                ItemInvokedItemType.Text = args.InvokedItem.GetType().ToString();
+            }
+
+            if (args.InvokedItemContainer != null)
+            {
+                ItemInvokedItemContainerType.Text = args.InvokedItemContainer.GetType().ToString();
+            }
+        }
+
+        private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+        {
+            // Reset argument type indicatiors
+            SelectionChangedItemType.Text = "null";
+            SelectionChangedItemContainerType.Text = "null";
+
+            if (args.SelectedItem != null)
+            {
+                SelectionChangedItemType.Text = args.SelectedItem.GetType().ToString();
+            }
+
+            if (args.SelectedItemContainer != null)
+            {
+                SelectionChangedItemContainerType.Text = args.SelectedItemContainer.GetType().ToString();
             }
         }
     }

--- a/dev/NavigationView/TestUI/NavigationViewItemTemplatePage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewItemTemplatePage.xaml.cs
@@ -61,15 +61,33 @@ namespace MUXControlsTestApp
 
         private void NavView_SelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
         {
-            var children = (StackPanel)args.SelectedItemContainer.Content;
+            var children = (Customer)args.SelectedItemContainer.Content;
             var customer = (Customer)args.SelectedItem;
-            if(children != null && customer != null)
+            if (children != null && customer != null)
             {
                 SelectionEventResult.Text = "Passed";
             }
             else
             {
                 SelectionEventResult.Text = "Failed";
+            }
+
+            // Reset argument type indicatiors
+            SelectionChangedItemType.Text = "null";
+            SelectionChangedItemContainerType.Text = "null";
+
+            // Update argument type indicators
+            if (args.SelectedItem != null)
+            {
+                SelectionChangedItemType.Text = args.SelectedItem.GetType().ToString();
+            }
+
+            if (args.SelectedItemContainer != null)
+            {
+                SelectionChangedItemContainerType.Text = args.SelectedItemContainer.GetType().ToString();
+            }
+        }
+
         private void NavView_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
             // Reset argument type indicatiors
@@ -84,23 +102,6 @@ namespace MUXControlsTestApp
             if (args.InvokedItemContainer != null)
             {
                 ItemInvokedItemContainerType.Text = args.InvokedItemContainer.GetType().ToString();
-            }
-        }
-
-        private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
-        {
-            // Reset argument type indicatiors
-            SelectionChangedItemType.Text = "null";
-            SelectionChangedItemContainerType.Text = "null";
-
-            if (args.SelectedItem != null)
-            {
-                SelectionChangedItemType.Text = args.SelectedItem.GetType().ToString();
-            }
-
-            if (args.SelectedItemContainer != null)
-            {
-                SelectionChangedItemContainerType.Text = args.SelectedItemContainer.GetType().ToString();
             }
         }
     }


### PR DESCRIPTION
## Description
In the scenario where MenuItemTemplate/MenuItemTemplateSelector returns a `UIElement` that is not derived from `NavigationViewItemBase`, the ItemInvoked callback returns the `UIElement` instead of the expected data item provided via `MenuItemsSource`.

This is because in the `ItemsRepeater` NV implementation, we internally wrap this `UIElement` in a `NavigationViewItem`. This is done by setting the content property of a `NavigationViewItem` to the returned `UIElement`. This breaks expectation from the `ListView` implementation as the content property should be set to the actual data item.

Fixed this issue by updating the wrapping logic to pass down the content and ItemTemplate down to the NavigationViewItem's content presenter to resolve.

_Note:_
I still have to figure out the best way to recycle the returned `UIElement`, so for now I left it as a todo. Depending on when I find a good way to do this, I will either update this PR or file a new issue.

## Motivation and Context
Fixes #2520 

## How Has This Been Tested?
Added new interaction test