### PR TITLE
Roadmap: Update link to State of the Union session

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ Conceptual overview of WinUI 3:
 ![WinUI 3 platform](roadmap_winui3.png)
 
 > You can watch the Build 2019 conference session *State of the Union: The Windows Presentation Platform* for more details:
-https://mybuild.techcommunity.microsoft.com/sessions/77008
+https://www.youtube.com/watch?v=hKMzFjGfoy0
 
 The existing UWP Xaml APIs that ship as part of the OS will no longer receive new feature updates. They will still receive security updates and critical fixes according to the Windows 10 support lifecycle.
 


### PR DESCRIPTION
The original link in the roadmap gave me a "Page not found". Updated the link to point to the offical youtube video with the "State of the Union: The Windows Presentation Platform" session.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->