### PR TITLE
Remove [Mobile] device form factor from bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -47,11 +47,10 @@ Examples
 <!-- Which device form factors did you see the issue on? Leave blank if you didn't try that device. -->
 | Device form factor | Saw the problem? |
 | :-------------------- | :------------------- |
-| Desktop                 | <!-- Yes/No? -->   |
-| Mobile                   | <!-- Yes/No? -->   |
-| Xbox                      | <!-- Yes/No? -->   |
-| Surface Hub          | <!-- Yes/No? -->    |
-| IoT                         | <!-- Yes/No? -->    |
+| Desktop               | <!-- Yes/No? -->   |
+| Xbox                  | <!-- Yes/No? -->   |
+| Surface Hub           | <!-- Yes/No? -->    |
+| IoT                   | <!-- Yes/No? -->    |
 
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -46,11 +46,11 @@ Examples
 
 <!-- Which device form factors did you see the issue on? Leave blank if you didn't try that device. -->
 | Device form factor | Saw the problem? |
-| :-------------------- | :------------------- |
-| Desktop               | <!-- Yes/No? -->   |
-| Xbox                  | <!-- Yes/No? -->   |
-| Surface Hub           | <!-- Yes/No? -->    |
-| IoT                   | <!-- Yes/No? -->    |
+| :----------------- | :--------------- |
+| Desktop            | <!-- Yes/No? --> |
+| Xbox               | <!-- Yes/No? --> |
+| Surface Hub        | <!-- Yes/No? --> |
+| IoT                | <!-- Yes/No? --> |
 
 
 **Additional context**


### PR DESCRIPTION
## Description
It was suggested in https://github.com/microsoft/microsoft-ui-xaml/issues/2507 by @StephenLPeters that the [Mobile] device form factor in the bug report issue template could "probably" be removed.

## Motivation and Context
Windows 10 Mobile support ended completely in January this year. The WinUI team is no longer providing support for Windows 10 Mobile specific bug reports.
