### PR TITLE
RS4 and lower: Cannot find a Resource with the Name/Key CalendarDatePickerTopHeaderMargin #2719

### DIFF
--- a/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
+++ b/dev/CalendarDatePicker/CalendarDatePicker_themeresources.xaml
@@ -73,6 +73,8 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
+    <Thickness x:Key="CalendarDatePickerTopHeaderMargin">0,0,0,4</Thickness>
+
     <Style TargetType="CalendarDatePicker" BasedOn="{StaticResource DefaultCalendarDatePicker}" />
 
     <Style x:Key="DefaultCalendarDatePicker" TargetType="CalendarDatePicker">


### PR DESCRIPTION
On RS4 and lower, this xaml will hit an error:

`<CalendarDatePicker Header="MyHeader" />`

`Cannot find a Resource with the Name/Key CalendarDatePickerTopHeaderMargin`

In my testing, I was not directly hitting an app crash due to this issue. The error gets swallowed along the way due to the fact that the header element is a defer load element in the tree. But it does result in a stowed exception and it causes the Header not to appear.

In some cases this may have knock on effect that cause a crash. Tipa in #2583 reported seeing a crash due to this error.

The issue is due to the fact that DefaultCalendarDatePicker in CalendarDatePicker_themeresources.xaml references the resource CalendarDatePickerTopHeaderMargin which was added to the OS in RS5.

The fix is to include the resource directly in WinUI so that it is not dependent on the resource being available in the OS.