### PR TITLE
TeachingTip: Fix scrollbar being visible without content to scroll

### DIFF
--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -550,7 +550,8 @@
                                             Child="{TemplateBinding HeroContent}"
                                             Background="{TemplateBinding Background}"/>
                                     <Grid x:Name="NonHeroContentRootGrid" Grid.Row="1">
-                                        <ScrollViewer Foreground="{TemplateBinding Foreground}">
+                                        <ScrollViewer Foreground="{TemplateBinding Foreground}"
+                                                      VerticalScrollBarVisibility="Auto">
                                             <StackPanel Margin="{StaticResource TeachingTipContentMargin}">
                                                 <Grid Grid.Row="0">
                                                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
## Description
This PR fixes a TeachingTip issue where the scrollbar would become visible when moving the mouse to the right side of the content in the TeachingTip.

## Motivation and Context
Fixes #2747.

## How Has This Been Tested?
Tested visually.