### PR TITLE
Tabview: Fix issue with newly added items not behaving according to TabViews WidthMode

### DIFF
--- a/dev/TabView/APITests/TabViewTests.cs
+++ b/dev/TabView/APITests/TabViewTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -10,7 +10,6 @@ using Windows.UI.Xaml.Media;
 using Common;
 using Microsoft.UI.Xaml.Controls;
 using System.Collections.Generic;
-using System.Threading.Tasks.Dataflow;
 
 #if USING_TAEF
 using WEX.TestExecution;

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -635,6 +635,10 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
         }
         else
         {
+            if (const auto newItem = TabItems().GetAt(args.Index()).try_as<TabViewItem>())
+            {
+                newItem->OnTabViewWidthModeChanged(TabWidthMode());
+            }
             UpdateTabWidths();
         }
     }

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -88,6 +88,7 @@ void TabViewItem::OnApplyTemplate()
     }
 
     UpdateCloseButton();
+    UpdateWidthModeVisualState();
 }
 
 void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added code to ensure that the newly added TabView items know the parents TabView WidthMode and ensure that we update the TabViewItems update their compact sizing visual states on apply template.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2711 Coincidentally, this also fixes #2724 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Fixed existing API test that already "tested" this.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->