### PR TITLE
Hide NavigationViewItem Chevron if Children is empty

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -144,9 +144,9 @@ void NavigationViewItem::UpdateRepeaterItemsSource()
             }
             return MenuItems().as<winrt::IInspectable>();
         }();
-        m_itemsSourceViewChanged.revoke();
+        m_itemsSourceViewCollectionChangedRevoker.revoke();
         repeater.ItemsSource(itemsSource);
-        m_itemsSourceViewChanged = repeater.ItemsSourceView().CollectionChanged(winrt::auto_revoke, { this, &NavigationViewItem::OnItemsSourceViewChanged });
+        m_itemsSourceViewCollectionChangedRevoker = repeater.ItemsSourceView().CollectionChanged(winrt::auto_revoke, { this, &NavigationViewItem::OnItemsSourceViewChanged });
     }
 }
 
@@ -926,6 +926,7 @@ void NavigationViewItem::UnhookEventsAndClearFields()
     m_repeaterElementPreparedRevoker.revoke();
     m_repeaterElementClearingRevoker.revoke();
     m_isEnabledChangedRevoker.revoke();
+    m_itemsSourceViewCollectionChangedRevoker.revoke();
 
     m_rootGrid.set(nullptr);
     m_navigationViewItemPresenter.set(nullptr);

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -144,8 +144,15 @@ void NavigationViewItem::UpdateRepeaterItemsSource()
             }
             return MenuItems().as<winrt::IInspectable>();
         }();
+        m_itemsSourceViewChanged.revoke();
         repeater.ItemsSource(itemsSource);
+        m_itemsSourceViewChanged = repeater.ItemsSourceView().CollectionChanged(winrt::auto_revoke, { this, &NavigationViewItem::OnItemsSourceViewChanged });
     }
+}
+
+void NavigationViewItem::OnItemsSourceViewChanged(const winrt::IInspectable& sender, const winrt::NotifyCollectionChangedEventArgs& args)
+{
+    UpdateVisualStateForChevron();
 }
  
 winrt::UIElement NavigationViewItem::GetSelectionIndicator() const
@@ -468,7 +475,7 @@ void NavigationViewItem::UpdateVisualStateForChevron()
 
 bool NavigationViewItem::HasChildren()
 {
-    return MenuItems().Size() > 0 || MenuItemsSource() != nullptr || HasUnrealizedChildren();
+    return MenuItems().Size() > 0 || (MenuItemsSource() != nullptr && m_repeater.get().ItemsSourceView().Count() > 0) || HasUnrealizedChildren();
 }
 
 bool NavigationViewItem::ShouldShowIcon()

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -150,7 +150,7 @@ void NavigationViewItem::UpdateRepeaterItemsSource()
     }
 }
 
-void NavigationViewItem::OnItemsSourceViewChanged(const winrt::IInspectable& sender, const winrt::NotifyCollectionChangedEventArgs& args)
+void NavigationViewItem::OnItemsSourceViewChanged(const winrt::IInspectable& /*sender*/, const winrt::NotifyCollectionChangedEventArgs& /*args*/)
 {
     UpdateVisualStateForChevron();
 }

--- a/dev/NavigationView/NavigationViewItem.h
+++ b/dev/NavigationView/NavigationViewItem.h
@@ -125,7 +125,7 @@ private:
 
     winrt::ItemsRepeater::ElementPrepared_revoker m_repeaterElementPreparedRevoker{};
     winrt::ItemsRepeater::ElementClearing_revoker m_repeaterElementClearingRevoker{};
-    winrt::ItemsSourceView::CollectionChanged_revoker m_itemsSourceViewChanged{};
+    winrt::ItemsSourceView::CollectionChanged_revoker m_itemsSourceViewCollectionChangedRevoker{};
 
     winrt::FlyoutBase::Closing_revoker m_flyoutClosingRevoker{};
     winrt::Control::IsEnabledChanged_revoker m_isEnabledChangedRevoker{};

--- a/dev/NavigationView/NavigationViewItem.h
+++ b/dev/NavigationView/NavigationViewItem.h
@@ -100,6 +100,7 @@ private:
     bool HasChildren();
 
     void UpdateRepeaterItemsSource();
+    void OnItemsSourceViewChanged(const winrt::IInspectable& sender, const winrt::NotifyCollectionChangedEventArgs& args);
     void ReparentRepeater();
     void OnFlyoutClosing(const winrt::IInspectable& sender, const winrt::FlyoutBaseClosingEventArgs& args);
     void UpdateItemIndentation();
@@ -124,6 +125,7 @@ private:
 
     winrt::ItemsRepeater::ElementPrepared_revoker m_repeaterElementPreparedRevoker{};
     winrt::ItemsRepeater::ElementClearing_revoker m_repeaterElementClearingRevoker{};
+    winrt::ItemsSourceView::CollectionChanged_revoker m_itemsSourceViewChanged{};
 
     winrt::FlyoutBase::Closing_revoker m_flyoutClosingRevoker{};
     winrt::Control::IsEnabledChanged_revoker m_isEnabledChangedRevoker{};

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -780,7 +780,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.Width = 1008; // forces the control into Expanded mode so that the menu renders
                 Content.UpdateLayout();
 
-                UIElement chevronUIElement = (UIElement)FindVisualChildByName(parentItem, "ExpandCollapseChevron");
+                UIElement chevronUIElement = (UIElement)VisualTreeUtils.FindVisualChildByName(parentItem, "ExpandCollapseChevron");
                 Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem has no children");
 
                 // Add a child to our NavigationView parentItem. This should make the chevron visible.
@@ -795,33 +795,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem no longer has children");
             });
-        }
-
-        private static DependencyObject FindVisualChildByName(FrameworkElement parent, string name)
-        {
-            if (parent.Name == name)
-            {
-                return parent;
-            }
-
-            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
-
-            for (int i = 0; i < childrenCount; i++)
-            {
-                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
-
-                if (childAsFE != null)
-                {
-                    DependencyObject result = FindVisualChildByName(childAsFE, name);
-
-                    if (result != null)
-                    {
-                        return result;
-                    }
-                }
-            }
-
-            return null;
         }
 
     }

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -759,5 +759,70 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.IsTrue(true);
             });
         }
+
+        [TestMethod]
+        public void VerifyExpandCollapseChevronVisibility()
+        {
+            NavigationView navView = null;
+            NavigationViewItem parentItem = null;
+            ObservableCollection<string> children = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                navView = new NavigationView();
+                Content = navView;
+
+                children = new ObservableCollection<string>();
+                parentItem = new NavigationViewItem() { Content = "ParentItem", MenuItemsSource = children };
+
+                navView.MenuItems.Add(parentItem);
+
+                navView.Width = 1008; // forces the control into Expanded mode so that the menu renders
+                Content.UpdateLayout();
+
+                UIElement chevronUIElement = (UIElement)FindVisualChildByName(parentItem, "ExpandCollapseChevron");
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem has no children");
+
+                // Add a child to our NavigationView parentItem. This should make the chevron visible.
+                children.Add("Undo");
+                Content.UpdateLayout();
+
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Visible, "chevron should have been visible as NavViewItem now has children");
+
+                // Remove all children from our NavigationView parentItem. This should collapse the chevron
+                children.Clear();
+                Content.UpdateLayout();
+
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem no longer has children");
+            });
+        }
+
+        private static DependencyObject FindVisualChildByName(FrameworkElement parent, string name)
+        {
+            if (parent.Name == name)
+            {
+                return parent;
+            }
+
+            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+
+            for (int i = 0; i < childrenCount; i++)
+            {
+                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
+
+                if (childAsFE != null)
+                {
+                    DependencyObject result = FindVisualChildByName(childAsFE, name);
+
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            return null;
+        }
+
     }
 }

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -783,14 +783,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 UIElement chevronUIElement = (UIElement)VisualTreeUtils.FindVisualChildByName(parentItem, "ExpandCollapseChevron");
                 Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem has no children");
 
-                // Add a child to our NavigationView parentItem. This should make the chevron visible.
-                children.Add("Undo");
+                // Add a child to parentItem through the MenuItemsSource API. This should make the chevron visible.
+                children.Add("Child 1");
                 Content.UpdateLayout();
 
                 Verify.IsTrue(chevronUIElement.Visibility == Visibility.Visible, "chevron should have been visible as NavViewItem now has children");
 
-                // Remove all children from our NavigationView parentItem. This should collapse the chevron
+                // Remove all children of parentItem. This should collapse the chevron
                 children.Clear();
+                Content.UpdateLayout();
+
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem no longer has children");
+
+                // Add a child to parentItem and set the MenuItemsSource as null. This should collapse the chevron
+                children.Add("Child 2");
+                parentItem.MenuItemsSource = null;
+                Content.UpdateLayout();
+
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem no longer has children");
+
+                // Add a child to parentItem through the MenuItems API. This should make the chevron visible.
+                parentItem.MenuItems.Add(new NavigationViewItem() { Content = "Child 3" });
+                Content.UpdateLayout();
+
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Visible, "chevron should have been visible as NavViewItem now has children");
+
+                // Remove all children of parentItem. This should collapse the chevron
+                parentItem.MenuItems.Clear();
                 Content.UpdateLayout();
 
                 Verify.IsTrue(chevronUIElement.Visibility == Visibility.Collapsed, "chevron should have been collapsed as NavViewItem no longer has children");

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -797,6 +797,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 // Add a child to parentItem and set the MenuItemsSource as null. This should collapse the chevron
                 children.Add("Child 2");
+                Content.UpdateLayout();
+
+                // we are doing this so that when we set MenuItemsSource as null, we can check if the chevron's visibility really changes
+                Verify.IsTrue(chevronUIElement.Visibility == Visibility.Visible, "chevron should have been visible as NavViewItem now has children");
+
                 parentItem.MenuItemsSource = null;
                 Content.UpdateLayout();
 


### PR DESCRIPTION
Attach a CollectionChanged to ItemsRepeater ItemsViewSource
whenever the MenuItems or MenuItemsSource changes.
Add check to MenuItemsSource count when checking for children.

Fixes #2743

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->