### PR TITLE
NavigationView: Add theme resources to enable easy flyout padding customization

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -292,7 +292,7 @@
                                                 ElementSoundMode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ElementSoundMode}">
                                                 <Flyout.FlyoutPresenterStyle>
                                                     <Style TargetType="FlyoutPresenter">
-                                                        <Setter Property="Padding" Value="0,8" />
+                                                        <Setter Property="Padding" Value="{ThemeResource TopNavigationViewOverflowMenuPadding}" />
                                                         <!-- Set negative top margin to make the flyout align exactly with the button -->
                                                         <Setter Property="Margin" Value="0,-4,0,0" />
                                                     </Style>
@@ -614,7 +614,7 @@
                                     contract7Present:Placement="RightEdgeAlignedTop">
                                 <Flyout.FlyoutPresenterStyle>
                                     <Style TargetType="FlyoutPresenter">
-                                        <Setter Property="Padding" Value="0,8" />
+                                        <Setter Property="Padding" Value="{ThemeResource NavigationViewItemChildrenMenuFlyoutPadding}" />
                                         <!-- Set negative top margin to make the flyout align exactly with the button -->
                                         <Setter Property="Margin" Value="0,-4,0,0" />
                                     </Style>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -257,7 +257,11 @@
     <Thickness x:Key="TopNavigationViewItemOnOverflowNoIconContentPresenterMargin">16,0,20,0</Thickness>
     <Thickness x:Key="TopNavigationViewItemOnOverflowExpandChevronMargin">-4,0,6,0</Thickness>
     <Thickness x:Key="TopNavigationViewItemOnOverflowExpandChevronPadding">12,0,12,0</Thickness>
-    
+
+    <!-- The two resources below must be defined at the app level in order to take effect. -->
+    <Thickness x:Key="TopNavigationViewOverflowMenuPadding">0,8</Thickness>
+    <Thickness x:Key="NavigationViewItemChildrenMenuFlyoutPadding">0,8</Thickness>
+
     <x:String x:Key="NavigationViewItemExpandedGlyph">&#xE70D;</x:String>
 
     <Style x:Key="PaneToggleButtonStyle" TargetType="Button">


### PR DESCRIPTION
## Description
This PR adds two theme resources to the NavigationView to provide easy padding customization for 
* the overflow menu in **Top** PaneDisplayMode and 
* the NavigationViewItem children flyout in the hierarchical NavigationView

## Motivation and Context
Closes #2718.

## How Has This Been Tested?
Tested visually.

## Screenshots:
The following XAML
```xml
<Application.Resources>
    <Thickness x:Key="TopNavigationViewOverflowMenuPadding">0,24</Thickness>
    <Thickness x:Key="NavigationViewItemChildrenMenuFlyoutPadding">0</Thickness>
</Application.Resources>
```
gives the following resulting look:

##### Overflow Menu in Top PaneDisplayMode
![image](https://user-images.githubusercontent.com/1398851/85854156-27537a80-b7b4-11ea-95eb-409b75b2900e.png)

##### NavigationViewItem children flyout
![image](https://user-images.githubusercontent.com/1398851/85854185-35a19680-b7b4-11ea-8a5d-d1a4097e3e5e.png)

For reference, here is how the flyout padding looks by default (children flyout shown here, same padding used in the overflow menu):
![image](https://user-images.githubusercontent.com/1398851/85854248-52d66500-b7b4-11ea-862a-0def23ef0486.png)
