### PR TITLE
NumberBox: Fix deselecting text when opening context menu

### DIFF
--- a/dev/NumberBox/InteractionTests/NumberBoxTests.cs
+++ b/dev/NumberBox/InteractionTests/NumberBoxTests.cs
@@ -581,6 +581,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void VerifyRightClickForContextMenuDoesNotDeselectText()
+        {
+            using (var setup = new TestSetupHelper("NumberBox Tests"))
+            {
+                RangeValueSpinner numBox = FindElement.ByName<RangeValueSpinner>("TestNumberBox");
+                numBox.SetValue(0);
+
+                Log.Comment("Verify that focusing the NumberBox selects the text");
+                numBox.SetFocus();
+                Wait.ForIdle();
+                Wait.ForSeconds(3);
+                Edit edit = FindTextBox(numBox);
+                Verify.AreEqual("0", edit.GetTextSelection());
+
+                Log.Comment("Verify that right-clicking on the NumberBox's input field (to bring up the context menu) does not clear the selection");
+                // (15, 15): Just some offset large enough to make sure the right-click below will actually bring up the context menu
+                InputHelper.RightClick(edit, 15, 15);
+                Wait.ForIdle();
+
+                Verify.AreEqual("0", edit.GetTextSelection());
+            }
+        }
+
 
         Button FindButton(UIObject parent, string buttonName)
         {

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -549,6 +549,10 @@ void NumberBox::StepValue(double change)
         }
 
         Value(newVal);
+
+        // We don't want the caret to move to the front of the text for example when using the up/down arrows
+        // to change the numberbox value.
+        MoveCaretToTextEnd();
     }
 }
 
@@ -575,9 +579,6 @@ void NumberBox::UpdateTextToValue()
         });
         m_textUpdating = true;
         Text(newText.data());
-
-        // This places the caret at the end of the text.
-        textBox.Select(static_cast<int32_t>(newText.size()), 0);
     }
 }
 
@@ -676,5 +677,14 @@ void NumberBox::UpdateHeaderPresenterState()
     if (auto&& headerPresenter = m_headerPresenter.get())
     {
         headerPresenter.Visibility(shouldShowHeader ? winrt::Visibility::Visible : winrt::Visibility::Collapsed);
+    }
+}
+
+void NumberBox::MoveCaretToTextEnd()
+{
+    if (auto&& textBox = m_textBox.get())
+    {
+        // This places the caret at the end of the text.
+        textBox.Select(static_cast<int32_t>(textBox.Text().size()), 0);
     }
 }

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -682,7 +682,7 @@ void NumberBox::UpdateHeaderPresenterState()
 
 void NumberBox::MoveCaretToTextEnd()
 {
-    if (auto&& textBox = m_textBox.get())
+    if (auto && textBox = m_textBox.get())
     {
         // This places the caret at the end of the text.
         textBox.Select(static_cast<int32_t>(textBox.Text().size()), 0);

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -53,7 +53,6 @@ public:
     void OnMinimumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnSmallChangePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnLargeChangePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnIsWrapEnabledPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
     void OnNumberFormatterPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -86,6 +86,8 @@ private:
 
     bool IsInBounds(double value);
 
+    void MoveCaretToTextEnd();
+
     bool m_valueUpdating{ false };
     bool m_textUpdating{ false };
 


### PR DESCRIPTION
## Description
This PR fixes an issue with the NumberBox where right-clicking to bring up the context menu would deselect the selected NumberBox text, thus preventing context menu operations such as *Cut* and *Copy* from working as expected.

## Motivation and Context
Fixes #1978.

## How Has This Been Tested?
Tested manually.

## Gif:
![numberbox-ctxmenu](https://user-images.githubusercontent.com/1398851/85908135-28b48f80-b814-11ea-999f-1baa2e31f873.gif)

## Additional Note
I noticed that there is a missing function definition for
https://github.com/microsoft/microsoft-ui-xaml/blob/865e4fcc00e8649baeaec1ba7daeca398671aa72/dev/NumberBox/NumberBox.h#L56
in NumberBox.cpp. Looking at the overall NumberBox API I don't think we will have to do anything special when the `NumberBox.LargeChange` value is changed any time soon - so I think we can just remove it. Your thoughts, @teaP?
