### PR TITLE
Fix issue with NavigationViewItem announcing collapsed when not having children

### DIFF
--- a/dev/NavigationView/NavigationViewItem.h
+++ b/dev/NavigationView/NavigationViewItem.h
@@ -58,6 +58,7 @@ public:
     void RotateExpandCollapseChevron(bool isExpanded);
     bool IsRepeaterVisible() const;
     void PropagateDepthToChildren(int depth);
+    bool HasChildren();
 
 private:
     winrt::UIElement const GetPresenterOrItem() const;
@@ -97,7 +98,6 @@ private:
     bool ShouldEnableToolTip() const;
     bool IsOnLeftNav() const;
     bool IsOnTopPrimary() const;
-    bool HasChildren();
 
     void UpdateRepeaterItemsSource();
     void ReparentRepeater();

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -48,7 +48,8 @@ winrt::IInspectable NavigationViewItemAutomationPeer::GetPatternCore(winrt::Patt
 {
     if (pattern == winrt::PatternInterface::SelectionItem ||
         pattern == winrt::PatternInterface::Invoke ||
-        pattern == winrt::PatternInterface::ExpandCollapse)
+        // Only provide expand collapse pattern if we have children!
+        (pattern == winrt::PatternInterface::ExpandCollapse && HasChildren()))
     {
         return *this;
     }
@@ -456,4 +457,13 @@ void NavigationViewItemAutomationPeer::ChangeSelection(bool isSelected)
     {
         nvi.IsSelected(isSelected);
     }
+}
+
+bool NavigationViewItemAutomationPeer::HasChildren()
+{
+    if (const auto& navigationViewItem = Owner().try_as<NavigationViewItem>())
+    {
+        return navigationViewItem->HasChildren();
+    }
+    return false;
 }

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.h
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.h
@@ -62,4 +62,5 @@ private:
     int32_t GetPositionOrSetCountInLeftNavHelper(AutomationOutput automationOutput);
     int32_t GetPositionOrSetCountInTopNavHelper(AutomationOutput automationOutput);
     void ChangeSelection(bool isSelected);
+    bool HasChildren();
 };

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -536,6 +536,37 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        public void VerifyAutomationPeerExpandCollapsePatternBehavior()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+
+                var menuItem1 = new NavigationViewItem();
+                var menuItem2 = new NavigationViewItem();
+                var menuItem3 = new NavigationViewItem();
+                var menuItem4 = new NavigationViewItem();
+                menuItem1.Content = "Item 1";
+                menuItem2.Content = "Item 2";
+                menuItem3.Content = "Item 3";
+                menuItem4.Content = "Item 4";
+
+                menuItem2.MenuItems.Add(menuItem3);
+                menuItem4.HasUnrealizedChildren = true;
+
+                var expandPeer = NavigationViewItemAutomationPeer.CreatePeerForElement(menuItem1).GetPattern(PatternInterface.ExpandCollapse);
+
+                Verify.IsNull(expandPeer,"Verify NavigationViewItem with no children has no ExpandCollapse pattern");
+
+                expandPeer = NavigationViewItemAutomationPeer.CreatePeerForElement(menuItem2).GetPattern(PatternInterface.ExpandCollapse);
+                Verify.IsNotNull(expandPeer,"Verify NavigationViewItem with children has an ExpandCollapse pattern provided");
+
+                expandPeer = NavigationViewItemAutomationPeer.CreatePeerForElement(menuItem4).GetPattern(PatternInterface.ExpandCollapse);
+                Verify.IsNotNull(expandPeer,"Verify NavigationViewItem without children but with UnrealizedChildren set to true has an ExpandCollapse pattern provided");
+            });
+        }
+
+
+        [TestMethod]
         public void VerifySettingsItemToolTip()
         {
             RunOnUIThread.Execute(() =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a check to the NavigationViewItemAutomationPeer whether the NavViewItem it represents has children or not. If the item has no children, we don't return that as the automation peer for the ExpandCollapse pattern.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2598 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new API test, tested manually with narrator
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->