### PR TITLE
Add support for NotifyCollectionChangedAction.Move to ItemsRepeater

### DIFF
--- a/dev/Repeater/APITests/Common/CollectionChangeEventArgsConverters.cs
+++ b/dev/Repeater/APITests/Common/CollectionChangeEventArgsConverters.cs
@@ -87,6 +87,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
                         newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, addedItems, removedItems, oldStartingIndex);
                     }
                     break;
+                case NotifyCollectionChangedAction.Move:
+                    newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, null, newStartingIndex, oldStartingIndex);
+                    break;
                 case NotifyCollectionChangedAction.Reset:
                     newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
                     break;

--- a/dev/Repeater/APITests/Common/CollectionChangeEventArgsConverters.cs
+++ b/dev/Repeater/APITests/Common/CollectionChangeEventArgsConverters.cs
@@ -88,8 +88,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
                     }
                     break;
                 case NotifyCollectionChangedAction.Move:
-                    newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, null, newStartingIndex, oldStartingIndex);
-                    break;
+                    {
+                        List<object> movedItems = new List<object>();
+                        for (int i = 0; i < oldItemsCount; i++)
+                        {
+                            movedItems.Add(null);
+                        }
+                        newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, movedItems, newStartingIndex, oldStartingIndex);
+                    }
+                  break;
                 case NotifyCollectionChangedAction.Reset:
                     newArgs = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
                     break;

--- a/dev/Repeater/APITests/Common/CustomItemsSource.cs
+++ b/dev/Repeater/APITests/Common/CustomItemsSource.cs
@@ -99,6 +99,28 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
             }
         }
 
+        public void Move(int oldIndex, int newIndex, bool reset)
+        {
+
+            var item = Inner[oldIndex];
+            Inner.RemoveAt(oldIndex);
+            Inner.Insert(newIndex, item);
+
+            if (reset)
+            {
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(NotifyCollectionChangedAction.Reset, -1, -1, -1, -1));
+            }
+            else
+            {
+                OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                    NotifyCollectionChangedAction.Move,
+                    oldStartingIndex: oldIndex,
+                    oldItemsCount: 1,
+                    newStartingIndex: newIndex,
+                    newItemsCount: 1));
+            }
+        }
+
         public void Reset()
         {
             Random rand = new Random(123);

--- a/dev/Repeater/APITests/Common/CustomItemsSource.cs
+++ b/dev/Repeater/APITests/Common/CustomItemsSource.cs
@@ -99,12 +99,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
             }
         }
 
-        public void Move(int oldIndex, int newIndex, bool reset)
+        public void Move(int oldIndex, int newIndex, int count, bool reset)
         {
-
-            var item = Inner[oldIndex];
-            Inner.RemoveAt(oldIndex);
-            Inner.Insert(newIndex, item);
+            var items = Inner.GetRange(oldIndex, count);
+            Inner.RemoveRange(oldIndex, count);
+            Inner.InsertRange(newIndex, items);
 
             if (reset)
             {
@@ -115,9 +114,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
                 OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                     NotifyCollectionChangedAction.Move,
                     oldStartingIndex: oldIndex,
-                    oldItemsCount: 1,
+                    oldItemsCount: count,
                     newStartingIndex: newIndex,
-                    newItemsCount: 1));
+                    newItemsCount: count));
             }
         }
 

--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -351,7 +351,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 realized = VerifyRealizedRange(repeater, dataSource);
                 Verify.AreEqual(4, realized);
 
-                Log.Comment("Replace in realized range.");
+                Log.Comment("Move in realized range.");
                 elementsPrepared = 0;
                 elementsCleared = 0;
                 elementsIndexChanged = 0;
@@ -369,7 +369,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 realized = VerifyRealizedRange(repeater, dataSource);
                 Verify.AreEqual(4, realized);
 
-                Log.Comment("Replace after realized range");
+                Log.Comment("Move after realized range");
                 dataSource.Move(oldIndex: 8, newIndex: 9, reset: false);
                 repeater.UpdateLayout();
 

--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -314,9 +314,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             ScrollViewer scrollViewer = null;
             ItemsRepeater repeater = null;
             var viewChangedEvent = new ManualResetEvent(false);
-            int elementsCleared = 0;
-            int elementsPrepared = 0;
-            int elementsIndexChanged = 0;
 
             RunOnUIThread.Execute(() =>
             {
@@ -328,12 +325,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         viewChangedEvent.Set();
                     }
                 };
-
-                repeater.ElementPrepared += (sender, args) => { elementsPrepared++; };
-                repeater.ElementIndexChanged += (sender, args) => { elementsIndexChanged++; };
-                repeater.ElementClearing += (sender, args) => { elementsCleared++; };
-
-                scrollViewer.ChangeView(null, 300, null, true);
+                scrollViewer.ChangeView(null, 400, null, true);
             });
 
             Verify.IsTrue(viewChangedEvent.WaitOne(DefaultWaitTime), "Waiting for ViewChanged.");
@@ -345,32 +337,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 Verify.AreEqual(4, realized);
 
                 Log.Comment("Move before realized range.");
-                dataSource.Move(oldIndex: 0, newIndex: 1, reset: false);
+                dataSource.Move(oldIndex: 0, newIndex: 1, count: 2, reset: false);
                 repeater.UpdateLayout();
 
                 realized = VerifyRealizedRange(repeater, dataSource);
                 Verify.AreEqual(4, realized);
 
                 Log.Comment("Move in realized range.");
-                elementsPrepared = 0;
-                elementsCleared = 0;
-                elementsIndexChanged = 0;
-                dataSource.Move(oldIndex: 5, newIndex: 6, reset: false);
+                dataSource.Move(oldIndex: 3, newIndex: 5, count: 2, reset: false);
                 repeater.UpdateLayout();
-
-                Log.Comment(elementsIndexChanged.ToString());
-                Log.Comment(elementsPrepared.ToString());
-                Log.Comment(elementsCleared.ToString());
-
-                Verify.AreEqual(0, elementsIndexChanged);
-                Verify.AreEqual(1, elementsPrepared);
-                Verify.AreEqual(1, elementsCleared);
 
                 realized = VerifyRealizedRange(repeater, dataSource);
                 Verify.AreEqual(4, realized);
 
                 Log.Comment("Move after realized range");
-                dataSource.Move(oldIndex: 8, newIndex: 9, reset: false);
+                dataSource.Move(oldIndex: 7, newIndex: 8, count: 2, reset: false);
                 repeater.UpdateLayout();
 
                 realized = VerifyRealizedRange(repeater, dataSource);

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -314,8 +314,9 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             break;
 
         case winrt::NotifyCollectionChangedAction::Move:
-            OnItemsRemoved(args.OldStartingIndex(), 1);
-            OnItemsAdded(args.NewStartingIndex(), 1);
+            int size = args.OldItems() != NULL ? args.OldItems().Size() : 1;
+            OnItemsRemoved(args.OldStartingIndex(), size);
+            OnItemsAdded(args.NewStartingIndex(), size);
             break;
         }
     }

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -314,14 +314,8 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             break;
 
         case winrt::NotifyCollectionChangedAction::Move:
-            auto oldIndex = args.OldStartingIndex();
-            auto newIndex = args.NewStartingIndex();
-            OnItemsRemoved(oldIndex, 1);
-            auto insertionIndex = newIndex;
-            if (newIndex > oldIndex) {
-                insertionIndex -= 1;
-            }
-            OnItemsAdded(insertionIndex, 1);
+            OnItemsRemoved(args.OldStartingIndex(), 1);
+            OnItemsAdded(args.NewStartingIndex(), 1);
             break;
         }
     }

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -278,7 +278,7 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             if (oldSize == newSize &&
                 oldStartIndex == newStartIndex &&
                 IsDataIndexRealized(oldStartIndex) &&
-                IsDataIndexRealized(oldStartIndex + oldSize -1))
+                IsDataIndexRealized(oldStartIndex + oldSize - 1))
             {
                 // Straight up replace of n items within the realization window.
                 // Removing and adding might causes us to lose the anchor causing us
@@ -314,7 +314,14 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             break;
 
         case winrt::NotifyCollectionChangedAction::Move:
-            throw winrt::hresult_not_implemented();
+            auto oldIndex = args.OldStartingIndex();
+            auto newIndex = args.NewStartingIndex();
+            OnItemsRemoved(oldIndex, 1);
+            auto insertionIndex = newIndex;
+            if (newIndex > oldIndex) {
+                insertionIndex -= 1;
+            }
+            OnItemsAdded(insertionIndex, 1);
             break;
         }
     }

--- a/dev/Repeater/TestUI/Samples/ItemsSourceSamples/CollectionChangeDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/ItemsSourceSamples/CollectionChangeDemo.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!--  Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information.  -->
 <Page
     x:Class="MUXControlsTestApp.Samples.CollectionChangeDemo"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -8,9 +8,13 @@
 
     <Page.Resources>
         <controls:RecyclePool x:Key="RecyclePool" />
-        <controls:RecyclingElementFactory x:Name="elementFactory"  RecyclePool="{StaticResource RecyclePool}">
+        <controls:RecyclingElementFactory x:Name="elementFactory" RecyclePool="{StaticResource RecyclePool}">
             <DataTemplate x:Key="Item" x:DataType="x:String">
-                <Button Content="{x:Bind}" Width="100" Height="100"  Click="OnItemClicked"/>
+                <Button
+                    Width="100"
+                    Height="100"
+                    Click="OnItemClicked"
+                    Content="{x:Bind}" />
             </DataTemplate>
         </controls:RecyclingElementFactory>
     </Page.Resources>
@@ -30,7 +34,7 @@
                 <TextBlock>OldStartingIndex:</TextBlock>
                 <TextBox x:Name="oldStartIndex" Text="0" />
                 <TextBlock>OldCount:</TextBlock>
-                <TextBox x:Name="oldCount" Text="0"/>
+                <TextBox x:Name="oldCount" Text="0" />
                 <TextBlock>NewStartingIndex:</TextBlock>
                 <TextBox x:Name="newStartIndex" Text="0" />
                 <TextBlock>NewCount:</TextBlock>
@@ -41,15 +45,20 @@
                 <Button x:Name="insertButton">Insert</Button>
                 <Button x:Name="removeButton">Remove</Button>
                 <Button x:Name="replaceButton">Replace</Button>
+                <Button x:Name="moveButton">Move</Button>
                 <Button x:Name="resetButton">Reset</Button>
             </StackPanel>
         </StackPanel>
 
-        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1" >
+        <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1">
             <ScrollViewer x:Name="scrollViewer">
                 <controls:ItemsRepeater x:Name="repeater">
                     <controls:ItemsRepeater.Layout>
-                        <controls:UniformGridLayout MinItemWidth="150" MinItemHeight="150" MinRowSpacing="10" MinColumnSpacing="10" />
+                        <controls:UniformGridLayout
+                            MinColumnSpacing="10"
+                            MinItemHeight="150"
+                            MinItemWidth="150"
+                            MinRowSpacing="10" />
                     </controls:ItemsRepeater.Layout>
                     <controls:ItemsRepeater.Animator>
                         <utils:DefaultElementAnimator />
@@ -57,13 +66,21 @@
                 </controls:ItemsRepeater>
             </ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
-        
-        <controls:ItemsRepeater ItemsSource="{x:Bind ResettingListItems}" Grid.Row="2" x:Name="ResettingCollectionRepeater">
+
+        <controls:ItemsRepeater
+            x:Name="ResettingCollectionRepeater"
+            Grid.Row="2"
+            ItemsSource="{x:Bind ResettingListItems}">
             <controls:ItemsRepeater.ItemTemplate>
                 <DataTemplate>
                     <Grid Width="300" HorizontalAlignment="Left">
-                        <Button Width="140" Height="40" HorizontalAlignment="Right" AutomationProperties.Name="{Binding}"
-                                Click="ResettingCollectionRemoveItemButton_ItemClick" Content="{Binding}"/>
+                        <Button
+                            Width="140"
+                            Height="40"
+                            HorizontalAlignment="Right"
+                            AutomationProperties.Name="{Binding}"
+                            Click="ResettingCollectionRemoveItemButton_ItemClick"
+                            Content="{Binding}" />
                     </Grid>
                 </DataTemplate>
             </controls:ItemsRepeater.ItemTemplate>

--- a/dev/Repeater/TestUI/Samples/ItemsSourceSamples/CollectionChangeDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ItemsSourceSamples/CollectionChangeDemo.xaml.cs
@@ -25,7 +25,7 @@ namespace MUXControlsTestApp.Samples
             insertButton.Click += delegate { _dataSource.Insert(int.Parse(newStartIndex.Text), int.Parse(newCount.Text), resetMode.IsChecked ?? false); };
             removeButton.Click += delegate { _dataSource.Remove(int.Parse(oldStartIndex.Text), int.Parse(oldCount.Text), resetMode.IsChecked ?? false); };
             replaceButton.Click += delegate { _dataSource.Replace(int.Parse(oldStartIndex.Text), int.Parse(oldCount.Text), int.Parse(newCount.Text), resetMode.IsChecked ?? false); };
-            moveButton.Click += delegate { _dataSource.Move(int.Parse(oldStartIndex.Text), int.Parse(newStartIndex.Text), resetMode.IsChecked ?? false); };
+            moveButton.Click += delegate { _dataSource.Move(int.Parse(oldStartIndex.Text), int.Parse(newStartIndex.Text), int.Parse(oldCount.Text), resetMode.IsChecked ?? false); };
             resetButton.Click += delegate { _dataSource.Reset(); };
 
             repeater.ItemTemplate = elementFactory;
@@ -158,11 +158,11 @@ namespace MUXControlsTestApp.Samples
                 }
             }
 
-            public void Move(int oldIndex, int newIndex, bool reset)
+            public void Move(int oldIndex, int newIndex, int count, bool reset)
             {
-                var item = Inner[oldIndex];
-                Inner.RemoveAt(oldIndex);
-                Inner.Insert(newIndex, item);
+                var items = Inner.GetRange(oldIndex, count);
+                Inner.RemoveRange(oldIndex, count);
+                Inner.InsertRange(newIndex, items);
 
                 if (reset)
                 {
@@ -173,9 +173,9 @@ namespace MUXControlsTestApp.Samples
                     OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
                         NotifyCollectionChangedAction.Move,
                         oldStartingIndex: oldIndex,
-                        oldItemsCount: 1,
+                        oldItemsCount: count,
                         newStartingIndex: newIndex,
-                        newItemsCount: 1));
+                        newItemsCount: count));
                 }
             }
 

--- a/dev/Repeater/TestUI/Samples/ItemsSourceSamples/CollectionChangeDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ItemsSourceSamples/CollectionChangeDemo.xaml.cs
@@ -17,7 +17,7 @@ namespace MUXControlsTestApp.Samples
     public sealed partial class CollectionChangeDemo : Page
     {
         MyDataSource _dataSource = new MyDataSource(Enumerable.Range(0, 10).Select(i => i.ToString()).ToList());
-        public List<object> ResettingListItems { get; set; } = new List<object> { "item0","item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
+        public List<object> ResettingListItems { get; set; } = new List<object> { "item0", "item1", "item2", "item3", "item4", "item5", "item6", "item7", "item8", "item9" };
         public CollectionChangeDemo()
         {
             this.InitializeComponent();
@@ -25,6 +25,7 @@ namespace MUXControlsTestApp.Samples
             insertButton.Click += delegate { _dataSource.Insert(int.Parse(newStartIndex.Text), int.Parse(newCount.Text), resetMode.IsChecked ?? false); };
             removeButton.Click += delegate { _dataSource.Remove(int.Parse(oldStartIndex.Text), int.Parse(oldCount.Text), resetMode.IsChecked ?? false); };
             replaceButton.Click += delegate { _dataSource.Replace(int.Parse(oldStartIndex.Text), int.Parse(oldCount.Text), int.Parse(newCount.Text), resetMode.IsChecked ?? false); };
+            moveButton.Click += delegate { _dataSource.Move(int.Parse(oldStartIndex.Text), int.Parse(newStartIndex.Text), resetMode.IsChecked ?? false); };
             resetButton.Click += delegate { _dataSource.Reset(); };
 
             repeater.ItemTemplate = elementFactory;
@@ -154,6 +155,27 @@ namespace MUXControlsTestApp.Samples
                         oldItemsCount: oldCount,
                         newStartingIndex: index,
                         newItemsCount: newCount));
+                }
+            }
+
+            public void Move(int oldIndex, int newIndex, bool reset)
+            {
+                var item = Inner[oldIndex];
+                Inner.RemoveAt(oldIndex);
+                Inner.Insert(newIndex, item);
+
+                if (reset)
+                {
+                    OnItemsSourceChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                }
+                else
+                {
+                    OnItemsSourceChanged(CollectionChangeEventArgsConverters.CreateNotifyArgs(
+                        NotifyCollectionChangedAction.Move,
+                        oldStartingIndex: oldIndex,
+                        oldItemsCount: 1,
+                        newStartingIndex: newIndex,
+                        newItemsCount: 1));
                 }
             }
 

--- a/dev/Repeater/UniformGridLayoutState.cpp
+++ b/dev/Repeater/UniformGridLayoutState.cpp
@@ -152,9 +152,10 @@ void UniformGridLayoutState::ClearElementOnDataSourceChange(winrt::VirtualizingL
 {
     if (m_cachedFirstElement)
     {
+        // The first element of UniformGridLayout is special since we use its size to 
+        // determine the size of all the other elements. So if the first item has changed
+        // we will need to clear it and re-evalauate all the items with the new item size.
         bool shouldClear = false;
-        // We should only clear the first element, used by determine the size of all elements,
-        // if it was modified by the action or the whole collection was reset
         switch (args.Action())
         {
         case winrt::NotifyCollectionChangedAction::Add:

--- a/dev/Repeater/UniformGridLayoutState.cpp
+++ b/dev/Repeater/UniformGridLayoutState.cpp
@@ -153,6 +153,8 @@ void UniformGridLayoutState::ClearElementOnDataSourceChange(winrt::VirtualizingL
     if (m_cachedFirstElement)
     {
         bool shouldClear = false;
+        // We should only clear the first element, used by determine the size of all elements,
+        // if it was modified by the action or the whole collection was reset
         switch (args.Action())
         {
         case winrt::NotifyCollectionChangedAction::Add:

--- a/dev/Repeater/UniformGridLayoutState.cpp
+++ b/dev/Repeater/UniformGridLayoutState.cpp
@@ -172,7 +172,7 @@ void UniformGridLayoutState::ClearElementOnDataSourceChange(winrt::VirtualizingL
             break;
 
         case winrt::NotifyCollectionChangedAction::Move:
-            throw winrt::hresult_not_implemented();
+            shouldClear = args.NewStartingIndex() == 0 || args.OldStartingIndex() == 0;
             break;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As described in #2339, ItemsRepeater throws a NotImplementedException after we call Move() in the observable collection it is bound to. This PR adds basic support for handling single-item NotifyCollectionChangedAction::Move.

## Motivation and Context
Fixes #2339 

## How Has This Been Tested?
 - I added a move button to the CollectionChangesDemo page which shows that the list refreshes correctly.
 - I added a new test to FlowLayoutCollectionChangeTests.cs, which shows that the repeater behaves as expected.

## Screenshots (if appropriate):
N/A