### PR TITLE
Fix issue with SplitButton overriding every flyout placement

### DIFF
--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -217,15 +217,9 @@ void SplitButton::OpenFlyout()
             winrt::FlyoutShowOptions options{};
 
             // Flyout should only be at the bottom of the splitbutton so let's enforce it
-            if (flyout.Placement() == winrt::FlyoutPlacementMode::Top
-                || flyout.Placement() == winrt::FlyoutPlacementMode::TopEdgeAlignedLeft
-                || flyout.Placement() == winrt::FlyoutPlacementMode::TopEdgeAlignedRight
-                || flyout.Placement() == winrt::FlyoutPlacementMode::Left
-                || flyout.Placement() == winrt::FlyoutPlacementMode::LeftEdgeAlignedBottom
-                || flyout.Placement() == winrt::FlyoutPlacementMode::LeftEdgeAlignedTop
-                || flyout.Placement() == winrt::FlyoutPlacementMode::Right
-                || flyout.Placement() == winrt::FlyoutPlacementMode::RightEdgeAlignedBottom
-                || flyout.Placement() == winrt::FlyoutPlacementMode::RightEdgeAlignedTop)
+            if (!(flyout.Placement() == winrt::FlyoutPlacementMode::Bottom
+                || flyout.Placement() == winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft
+                || flyout.Placement() == winrt::FlyoutPlacementMode::BottomEdgeAlignedRight))
             {
                 options.Placement(winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft);
             }

--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -215,7 +215,20 @@ void SplitButton::OpenFlyout()
         if (SharedHelpers::IsFlyoutShowOptionsAvailable())
         {
             winrt::FlyoutShowOptions options{};
-            options.Placement(winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft);
+
+            // Flyout should only be at the bottom of the splitbutton so let's enforce it
+            if (flyout.Placement() == winrt::FlyoutPlacementMode::Top
+                || flyout.Placement() == winrt::FlyoutPlacementMode::TopEdgeAlignedLeft
+                || flyout.Placement() == winrt::FlyoutPlacementMode::TopEdgeAlignedRight
+                || flyout.Placement() == winrt::FlyoutPlacementMode::Left
+                || flyout.Placement() == winrt::FlyoutPlacementMode::LeftEdgeAlignedBottom
+                || flyout.Placement() == winrt::FlyoutPlacementMode::LeftEdgeAlignedTop
+                || flyout.Placement() == winrt::FlyoutPlacementMode::Right
+                || flyout.Placement() == winrt::FlyoutPlacementMode::RightEdgeAlignedBottom
+                || flyout.Placement() == winrt::FlyoutPlacementMode::RightEdgeAlignedTop)
+            {
+                options.Placement(winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft);
+            }
             flyout.ShowAt(*this, options);
         }
         else

--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -215,14 +215,6 @@ void SplitButton::OpenFlyout()
         if (SharedHelpers::IsFlyoutShowOptionsAvailable())
         {
             winrt::FlyoutShowOptions options{};
-
-            // Flyout should only be at the bottom of the splitbutton so let's enforce it
-            if (!(flyout.Placement() == winrt::FlyoutPlacementMode::Bottom
-                || flyout.Placement() == winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft
-                || flyout.Placement() == winrt::FlyoutPlacementMode::BottomEdgeAlignedRight))
-            {
-                options.Placement(winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft);
-            }
             flyout.ShowAt(*this, options);
         }
         else

--- a/dev/SplitButton/TestUI/SplitButtonPage.xaml
+++ b/dev/SplitButton/TestUI/SplitButtonPage.xaml
@@ -91,7 +91,7 @@
 
                     <util:ControlStateViewer x:Name="ToggleControlStateViewer" Margin="0,6,0,0"/>
 
-                    <controls:SplitButton Content="Bottom center flyout (allowed)">
+                    <controls:SplitButton Content="Bottom center flyout">
                         <controls:SplitButton.Flyout>
                             <MenuFlyout Placement="Bottom">
                                 <MenuFlyoutItem Text="SubAction 1" />
@@ -100,7 +100,7 @@
                         </controls:SplitButton.Flyout>
                     </controls:SplitButton>
 
-                    <controls:SplitButton Content="Top aligned flyout (not allowed)">
+                    <controls:SplitButton Content="Top aligned flyout">
                         <controls:SplitButton.Flyout>
                             <MenuFlyout Placement="Top">
                                 <MenuFlyoutItem Text="SubAction 1" />

--- a/dev/SplitButton/TestUI/SplitButtonPage.xaml
+++ b/dev/SplitButton/TestUI/SplitButtonPage.xaml
@@ -91,7 +91,7 @@
 
                     <util:ControlStateViewer x:Name="ToggleControlStateViewer" Margin="0,6,0,0"/>
 
-                    <controls:SplitButton Content="Bottom Left aligned flyout (allowed)">
+                    <controls:SplitButton Content="Bottom center flyout (allowed)">
                         <controls:SplitButton.Flyout>
                             <MenuFlyout Placement="Bottom">
                                 <MenuFlyoutItem Text="SubAction 1" />

--- a/dev/SplitButton/TestUI/SplitButtonPage.xaml
+++ b/dev/SplitButton/TestUI/SplitButtonPage.xaml
@@ -90,6 +90,25 @@
                     <util:ControlStateViewer x:Name="ControlStateViewer" Margin="0,16,0,0"/>
 
                     <util:ControlStateViewer x:Name="ToggleControlStateViewer" Margin="0,6,0,0"/>
+
+                    <controls:SplitButton Content="Bottom Left aligned flyout (allowed)">
+                        <controls:SplitButton.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="SubAction 1" />
+                                <MenuFlyoutItem Text="SubAction2" />
+                            </MenuFlyout>
+                        </controls:SplitButton.Flyout>
+                    </controls:SplitButton>
+
+                    <controls:SplitButton Content="Top aligned flyout (not allowed)">
+                        <controls:SplitButton.Flyout>
+                            <MenuFlyout Placement="Top">
+                                <MenuFlyoutItem Text="SubAction 1" />
+                                <MenuFlyoutItem Text="SubAction2" />
+                            </MenuFlyout>
+                        </controls:SplitButton.Flyout>
+                    </controls:SplitButton>
+                    
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The splitbutton now checks what placement the flyout has before overriding it allowing any placement that is below the SplitButton but overriding any placement to the side or the top of the splitbutton.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2797
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually, updated test UI.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->