### PR TITLE
README: Update WinUI 2 Version support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ The Microsoft.UI.Xaml 2.4 NuGet package requires your project to have TargetPlat
 
 Your app's users can be on any of the following supported Windows 10 versions:
 
-* Windows 10 1703 (Creators Update aka "Redstone 2") and newer (including Windows Insider Previews)
+* Windows 10 1703 - Build 15063 (Creators Update aka "Redstone 2") and newer (including Windows Insider Previews)
 
-Some features may have a reduced or slightly different user experience on older versions, particularly on Windows 10 versions before 1703. This should not impact overall usability.
+Some features may have a reduced or slightly different user experience on older versions.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ The Microsoft.UI.Xaml 2.4 NuGet package requires your project to have TargetPlat
 
 Your app's users can be on any of the following supported Windows 10 versions:
 
-* Windows Insider Previews
-* Windows 10 1703 (Creators Update) and newer
+* Windows 10 1703 (Creators Update) and newer (including Windows Insider Previews)
 
 Some features may have a reduced or slightly different user experience on older versions, particularly on Windows 10 versions before 1703. This should not impact overall usability.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The Microsoft.UI.Xaml 2.4 NuGet package requires your project to have TargetPlat
 
 Your app's users can be on any of the following supported Windows 10 versions:
 
-* Windows 10 1703 (Creators Update) and newer (including Windows Insider Previews)
+* Windows 10 1703 (Creators Update aka "Redstone 2") and newer (including Windows Insider Previews)
 
 Some features may have a reduced or slightly different user experience on older versions, particularly on Windows 10 versions before 1703. This should not impact overall usability.
 

--- a/README.md
+++ b/README.md
@@ -81,18 +81,14 @@ You don't need version checks or conditional XAML markup to use WinUI controls o
 
 ### Version support
 
-The Microsoft.UI.Xaml 2.3 NuGet package requires your project to have TargetPlatformVersion &gt;= 10.0.18362.0 and TargetPlatformMinVersion &gt;= 10.0.15063.0 when building. 
+The Microsoft.UI.Xaml 2.4 NuGet package requires your project to have TargetPlatformVersion &gt;= 10.0.18362.0 and TargetPlatformMinVersion &gt;= 10.0.15063.0 when building. 
 
 Your app's users can be on any of the following supported Windows 10 versions:
 
 * Windows Insider Previews
-* May 2019 Update (18362 aka "19H1")
-* October 2018 Update (17763 aka "Redstone 5")
-* April 2018 Update (17134 aka "Redstone 4")
-* Fall Creators Update (16299 aka "Redstone 3")
-* Creators Update (15063 aka "Redstone 2")
+* Windows 10 1703 (Creators Update) and newer
 
-Some features may have a reduced or slightly different user experience on older versions, particularly on builds before 15063. This should not impact overall usability.
+Some features may have a reduced or slightly different user experience on older versions, particularly on Windows 10 versions before 1703. This should not impact overall usability.
 
 ## Roadmap
 


### PR DESCRIPTION
## Description
This PR updates the [WinUI 2 Version support] section of the README to include Windows 10 2004 as a supported Windows 10 version. It also presents the information conveyed (that all Windows 10 versions since 1703 are supported) in a more compact way without the loss of precision. Lastly, it switches out Windows 10 build numbers with the more widely used Windows 10 Version terms. With this change, developers won't have to "translate" build numbers or marketing terms to actual Windows 10 versions like 1903 - and is is these supported Windows versions that are of actual interest here. This also matches the [supported versions documentation](https://microsoft.github.io/microsoft-ui-xaml/about.html#controls) on the WinUI website:
![image](https://user-images.githubusercontent.com/1398851/86256299-759fb980-bbb8-11ea-8428-32f57df5e16e.png)

## Motivation and Context
* Keeps the WinUI github frontpage up-to-date.
* Uses the Windows 10 Version terms instead of Windows 10 build numbers to easier see the Windows 10 versions supported by WinUI.

## How Has This Been Tested?
Checked Readme after changes.