### PR TITLE
NavigationView incorrectly sizing items as compact on launch

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -4018,7 +4018,10 @@ void NavigationView::OnTitleBarIsVisibleChanged(const winrt::CoreApplicationView
 
 void NavigationView::ClosePaneIfNeccessaryAfterItemIsClicked(const winrt::NavigationViewItem& selectedContainer)
 {
-    if (IsPaneOpen() && DisplayMode() != winrt::NavigationViewDisplayMode::Expanded && !DoesNavigationViewItemHaveChildren(selectedContainer))
+    if (IsPaneOpen() &&
+        DisplayMode() != winrt::NavigationViewDisplayMode::Expanded &&
+        !DoesNavigationViewItemHaveChildren(selectedContainer) &&
+        !m_shouldIgnoreNextSelectionChange)
     {
         ClosePane();
     }


### PR DESCRIPTION
## Description

 NavigationView was launching into expanded mode while the items were being sized as compact.
This is happening due to the pane being closed and opened during the set up. This should not be happening while internal logic is setting up the correct state. Used an existing flag to ensure this.

## Motivation and Context
Fixes #2635 

## How Has This Been Tested?
Manual testing