### PR TITLE
Add missed Slider dependency to ColorPicker InnerLoop

### DIFF
--- a/FeatureAreas.props
+++ b/FeatureAreas.props
@@ -45,6 +45,7 @@
   </PropertyGroup>
     <!-- Dependencies for ColorPicker -->
   <PropertyGroup Condition="Exists('InnerLoopAreas.props') And $(SolutionName) == 'MUXControlsInnerLoop' And $(FeatureColorPickerEnabled) == 'true'">
+    <FeatureSliderEnabled>productOnly</FeatureSliderEnabled>
   </PropertyGroup>
     <!-- Dependencies for ComboBox -->
   <PropertyGroup Condition="Exists('InnerLoopAreas.props') And $(SolutionName) == 'MUXControlsInnerLoop' And $(FeatureComboBoxEnabled) == 'true'">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As described in https://github.com/microsoft/microsoft-ui-xaml/issues/2804, MUXControlsTestApp app crashes in InnerLoop configuration with ColorPicker only enabled.
This PR adds missed dependency, so Slider resources will be included in ColorPicker-only configuration.

## Motivation and Context
Fixex #2804

## How Has This Been Tested?
Tested manually.

## Screenshots (if appropriate):
