### PR TITLE
Add TabView SelectionPattern

### DIFF
--- a/dev/TabView/APITests/TabViewTests.cs
+++ b/dev/TabView/APITests/TabViewTests.cs
@@ -114,29 +114,45 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifyTabViewItemUIABehavior()
         {
+            TabView tabView;
+
+            TabViewItem tvi0 = null;
+            TabViewItem tvi1 = null;
+            TabViewItem tvi2 = null;
             RunOnUIThread.Execute(() =>
             {
-                TabView tabView = new TabView();
+                tabView = new TabView();
                 Content = tabView;
 
-                var tvi0 = CreateTabViewItem("Item 0", Symbol.Add);
-                var tvi1 = CreateTabViewItem("Item 1", Symbol.AddFriend);
-                var tvi2 = CreateTabViewItem("Item 2");
+                tvi0 = CreateTabViewItem("Item 0", Symbol.Add);
+                tvi1 = CreateTabViewItem("Item 1", Symbol.AddFriend);
+                tvi2 = CreateTabViewItem("Item 2");
 
                 tabView.TabItems.Add(tvi0);
                 tabView.TabItems.Add(tvi1);
                 tabView.TabItems.Add(tvi2);
 
+                tabView.SelectedIndex = 0;
+                tabView.SelectedItem = tvi0;
                 Content.UpdateLayout();
+            });
 
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
                 var selectionItemProvider = GetProviderFromTVI(tvi0);
-                Verify.IsTrue(selectionItemProvider.IsSelected,"Item should have been selected");
+                Verify.IsTrue(selectionItemProvider.IsSelected,"Item should be selected");
 
                 selectionItemProvider = GetProviderFromTVI(tvi1);
-                Verify.IsFalse(selectionItemProvider.IsSelected, "Item not should have been selected");
+                Verify.IsFalse(selectionItemProvider.IsSelected, "Item should not be selected");
 
+                Log.Comment("Change selection through automationpeer");
                 selectionItemProvider.Select();
                 Verify.IsTrue(selectionItemProvider.IsSelected, "Item should have been selected");
+                
+                selectionItemProvider = GetProviderFromTVI(tvi0);
+                Verify.IsFalse(selectionItemProvider.IsSelected, "Item should not be selected anymore");
             });
 
             static ISelectionItemProvider GetProviderFromTVI(TabViewItem item)

--- a/dev/TabView/APITests/TabViewTests.cs
+++ b/dev/TabView/APITests/TabViewTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -88,7 +88,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        public void VerifyUIABehavior()
+        public void VerifyTabViewUIABehavior()
         {
             RunOnUIThread.Execute(() =>
             {
@@ -111,6 +111,43 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
+        [TestMethod]
+        public void VerifyTabViewItemUIABehavior()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                TabView tabView = new TabView();
+                Content = tabView;
+
+                var tvi0 = CreateTabViewItem("Item 0", Symbol.Add);
+                var tvi1 = CreateTabViewItem("Item 1", Symbol.AddFriend);
+                var tvi2 = CreateTabViewItem("Item 2");
+
+                tabView.TabItems.Add(tvi0);
+                tabView.TabItems.Add(tvi1);
+                tabView.TabItems.Add(tvi2);
+
+                Content.UpdateLayout();
+
+                var selectionItemProvider = GetProviderFromTVI(tvi0);
+                Verify.IsTrue(selectionItemProvider.IsSelected,"Item should have been selected");
+
+                selectionItemProvider = GetProviderFromTVI(tvi1);
+                Verify.IsFalse(selectionItemProvider.IsSelected, "Item not should have been selected");
+
+                selectionItemProvider.Select();
+                Verify.IsTrue(selectionItemProvider.IsSelected, "Item should have been selected");
+            });
+
+            static ISelectionItemProvider GetProviderFromTVI(TabViewItem item)
+            {
+                var peer = FrameworkElementAutomationPeer.CreatePeerForElement(item);
+                var provider = peer.GetPattern(PatternInterface.SelectionItem)
+                                as ISelectionItemProvider;
+                Verify.IsNotNull(provider);
+                return provider;
+            }
+        }
 
         private static void VerifyTabWidthVisualStates(IList<object> items, bool isCompact)
         {

--- a/dev/TabView/APITests/TabViewTests.cs
+++ b/dev/TabView/APITests/TabViewTests.cs
@@ -10,6 +10,9 @@ using Windows.UI.Xaml.Media;
 using Common;
 using Microsoft.UI.Xaml.Controls;
 using System.Collections.Generic;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Provider;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -83,6 +86,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 VerifyTabWidthVisualStates(tabView.TabItems, false);
             });
         }
+
+        [TestMethod]
+        public void VerifyUIABehavior()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                TabView tabView = new TabView();
+                Content = tabView;
+
+                tabView.TabItems.Add(CreateTabViewItem("Item 0", Symbol.Add));
+                tabView.TabItems.Add(CreateTabViewItem("Item 1", Symbol.AddFriend));
+                tabView.TabItems.Add(CreateTabViewItem("Item 2"));
+
+                Content.UpdateLayout();
+
+                var tabViewPeer = FrameworkElementAutomationPeer.CreatePeerForElement(tabView);
+                Verify.IsNotNull(tabViewPeer);
+                var tabViewSelectionPattern = tabViewPeer.GetPattern(PatternInterface.Selection);
+                Verify.IsNotNull(tabViewSelectionPattern);
+                var selectionProvider = tabViewSelectionPattern as ISelectionProvider;
+                // Tab controls must require selection
+                Verify.IsTrue(selectionProvider.IsSelectionRequired);
+            });
+        }
+
 
         private static void VerifyTabWidthVisualStates(IList<object> items, bool isCompact)
         {

--- a/dev/TabView/APITests/TabViewTests.cs
+++ b/dev/TabView/APITests/TabViewTests.cs
@@ -114,7 +114,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         [TestMethod]
         public void VerifyTabViewItemUIABehavior()
         {
-            TabView tabView;
+            TabView tabView = null;
 
             TabViewItem tvi0 = null;
             TabViewItem tvi1 = null;
@@ -153,6 +153,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 
                 selectionItemProvider = GetProviderFromTVI(tvi0);
                 Verify.IsFalse(selectionItemProvider.IsSelected, "Item should not be selected anymore");
+
+                Verify.IsNotNull(selectionItemProvider.SelectionContainer);
             });
 
             static ISelectionItemProvider GetProviderFromTVI(TabViewItem item)

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -638,6 +638,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
             if (const auto newItem = TabItems().GetAt(args.Index()).try_as<TabViewItem>())
             {
                 newItem->OnTabViewWidthModeChanged(TabWidthMode());
+                newItem->SetParentTabView(*this);
             }
             UpdateTabWidths();
         }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -638,6 +638,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
             if (const auto newItem = TabItems().GetAt(args.Index()).try_as<TabViewItem>())
             {
                 newItem->OnTabViewWidthModeChanged(TabWidthMode());
+                newItem->SetParentTabView(*this);
             }
             UpdateTabWidths();
         }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -638,7 +638,6 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
             if (const auto newItem = TabItems().GetAt(args.Index()).try_as<TabViewItem>())
             {
                 newItem->OnTabViewWidthModeChanged(TabWidthMode());
-                newItem->SetParentTabView(*this);
             }
             UpdateTabWidths();
         }

--- a/dev/TabView/TabViewAutomationPeer.cpp
+++ b/dev/TabView/TabViewAutomationPeer.cpp
@@ -18,6 +18,10 @@ TabViewAutomationPeer::TabViewAutomationPeer(winrt::TabView const& owner)
 // IAutomationPeerOverrides
 winrt::IInspectable TabViewAutomationPeer::GetPatternCore(winrt::PatternInterface const& patternInterface)
 {
+    if (patternInterface == winrt::PatternInterface::Selection)
+    {
+        return *this;
+    }
     return __super::GetPatternCore(patternInterface);
 }
 
@@ -31,3 +35,27 @@ winrt::AutomationControlType TabViewAutomationPeer::GetAutomationControlTypeCore
     return winrt::AutomationControlType::Tab;
 }
 
+bool TabViewAutomationPeer::CanSelectMultiple()
+{
+    return false;
+}
+
+bool TabViewAutomationPeer::IsSelectionRequired()
+{
+    return true;
+}
+
+winrt::com_array<winrt::Windows::UI::Xaml::Automation::Provider::IRawElementProviderSimple> TabViewAutomationPeer::GetSelection()
+{
+    if (auto tabView = Owner().try_as<TabView>())
+    {
+        if (auto tabViewItem = tabView->ContainerFromIndex(tabView->SelectedIndex()).try_as<winrt::TabViewItem>())
+        {
+            if (auto peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(tabViewItem))
+            {
+                return { ProviderFromPeer(peer) };
+            }
+        }
+    }
+    return {};
+}

--- a/dev/TabView/TabViewAutomationPeer.h
+++ b/dev/TabView/TabViewAutomationPeer.h
@@ -7,7 +7,9 @@
 #include "TabViewAutomationPeer.g.h"
 
 class TabViewAutomationPeer :
-    public ReferenceTracker<TabViewAutomationPeer, winrt::implementation::TabViewAutomationPeerT>
+    public ReferenceTracker<TabViewAutomationPeer,
+    winrt::implementation::TabViewAutomationPeerT,
+    winrt::ISelectionProvider>
 {
 
 public:
@@ -17,4 +19,9 @@ public:
     winrt::IInspectable GetPatternCore(winrt::PatternInterface const& patternInterface);
     hstring GetClassNameCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
+
+    // ISelectionProvider
+    bool CanSelectMultiple();
+    bool IsSelectionRequired();
+    winrt::com_array<winrt::Windows::UI::Xaml::Automation::Provider::IRawElementProviderSimple> GetSelection();
 };

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -146,6 +146,16 @@ void TabViewItem::OnCloseButtonOverlayModeChanged(winrt::TabViewCloseButtonOverl
     UpdateCloseButton();
 }
 
+winrt::TabView TabViewItem::GetParentTabView()
+{
+    return m_parentTabView.get();
+}
+
+void TabViewItem::SetParentTabView(winrt::TabView const& tabView)
+{
+    m_parentTabView = winrt::make_weak(tabView);
+}
+
 void TabViewItem::OnTabViewWidthModeChanged(winrt::TabViewWidthMode const& mode)
 {
     m_tabViewWidthMode = mode;

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -93,6 +93,11 @@ void TabViewItem::OnApplyTemplate()
 
 void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
 {
+    if (const auto peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(*this))
+    {
+        peer.RaiseAutomationEvent(winrt::AutomationEvents::SelectionItemPatternOnElementSelected);
+    }
+
     if (IsSelected())
     {
         SetValue(winrt::Canvas::ZIndexProperty(),box_value(20));

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -151,16 +151,6 @@ void TabViewItem::OnCloseButtonOverlayModeChanged(winrt::TabViewCloseButtonOverl
     UpdateCloseButton();
 }
 
-winrt::TabView TabViewItem::GetParentTabView()
-{
-    return m_parentTabView.get();
-}
-
-void TabViewItem::SetParentTabView(winrt::TabView const& tabView)
-{
-    m_parentTabView = winrt::make_weak(tabView);
-}
-
 void TabViewItem::OnTabViewWidthModeChanged(winrt::TabViewWidthMode const& mode)
 {
     m_tabViewWidthMode = mode;

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -151,6 +151,16 @@ void TabViewItem::OnCloseButtonOverlayModeChanged(winrt::TabViewCloseButtonOverl
     UpdateCloseButton();
 }
 
+winrt::TabView TabViewItem::GetParentTabView()
+{
+    return m_parentTabView.get();
+}
+
+void TabViewItem::SetParentTabView(winrt::TabView const& tabView)
+{
+    m_parentTabView = winrt::make_weak(tabView);
+}
+
 void TabViewItem::OnTabViewWidthModeChanged(winrt::TabViewWidthMode const& mode)
 {
     m_tabViewWidthMode = mode;

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -41,9 +41,6 @@ public:
     void OnTabViewWidthModeChanged(winrt::TabViewWidthMode const& mode);
     void OnCloseButtonOverlayModeChanged(winrt::TabViewCloseButtonOverlayMode const& mode);
 
-    winrt::TabView GetParentTabView();
-    void SetParentTabView(winrt::TabView const& tabView);
-
  private:
     tracker_ref<winrt::Button> m_closeButton{ this };
     tracker_ref<winrt::ToolTip> m_toolTip{ this };
@@ -75,6 +72,4 @@ public:
 
     void UpdateShadow();
     winrt::IInspectable m_shadow{ nullptr };
-
-    winrt::weak_ref<winrt::TabView> m_parentTabView{ nullptr };
 };

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -41,6 +41,9 @@ public:
     void OnTabViewWidthModeChanged(winrt::TabViewWidthMode const& mode);
     void OnCloseButtonOverlayModeChanged(winrt::TabViewCloseButtonOverlayMode const& mode);
 
+    winrt::TabView GetParentTabView();
+    void SetParentTabView(winrt::TabView const& tabView);
+
  private:
     tracker_ref<winrt::Button> m_closeButton{ this };
     tracker_ref<winrt::ToolTip> m_toolTip{ this };
@@ -72,4 +75,6 @@ public:
 
     void UpdateShadow();
     winrt::IInspectable m_shadow{ nullptr };
+
+    winrt::weak_ref<winrt::TabView> m_parentTabView{ nullptr };
 };

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -66,7 +66,10 @@ winrt::IRawElementProviderSimple TabViewItemAutomationPeer::SelectionContainer()
 {
     if (const auto parent = GetParentTabView())
     {
-        return ProviderFromPeer(winrt::FrameworkElementAutomationPeer::CreatePeerForElement(parent));
+        if (const auto peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(parent))
+        {
+            return ProviderFromPeer(peer);
+        }
     }
     return nullptr;
 }
@@ -87,4 +90,16 @@ void TabViewItemAutomationPeer::Select()
     {
         owner->IsSelected(true);
     }
+}
+
+winrt::TabView TabViewItemAutomationPeer::GetParentTabView()
+{
+    winrt::TabView parentTabView{ nullptr };
+
+    winrt::TabViewItem tabViewItem = Owner().try_as<winrt::TabViewItem>();
+    if (tabViewItem)
+    {
+        parentTabView = winrt::get_self<TabViewItem>(tabViewItem)->GetParentTabView();
+    }
+    return parentTabView;
 }

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -80,19 +80,8 @@ void TabViewItemAutomationPeer::RemoveFromSelection()
 
 void TabViewItemAutomationPeer::Select()
 {
-    if (auto tabView = GetParenTabView().try_as<TabView>())
+    if (auto owner = Owner().try_as<TabViewItem>().get())
     {
-        // Set selection by getting the item from the container
-        // and setting that as the new selected item.
-        tabView->SelectedItem(tabView->ItemFromContainer(Owner()));
+        owner->IsSelected(true);
     }
-}
-
-winrt::TabView TabViewItemAutomationPeer::GetParenTabView()
-{
-    if (auto tvi = Owner().try_as<winrt::TabViewItem>())
-    {
-        return winrt::get_self<TabViewItem>(tvi)->GetParentTabView();
-    }
-    return nullptr;
 }

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -17,6 +17,15 @@ TabViewItemAutomationPeer::TabViewItemAutomationPeer(winrt::TabViewItem const& o
 }
 
 // IAutomationPeerOverrides
+winrt::IInspectable TabViewItemAutomationPeer::GetPatternCore(winrt::PatternInterface const& patternInterface)
+{
+    if (patternInterface == winrt::PatternInterface::SelectionItem)
+    {
+        return *this;
+    }
+    return __super::GetPatternCore(patternInterface);
+}
+
 hstring TabViewItemAutomationPeer::GetClassNameCore()
 {
     return winrt::hstring_name_of<winrt::TabViewItem>();
@@ -46,6 +55,11 @@ winrt::hstring TabViewItemAutomationPeer::GetNameCore()
 
 bool TabViewItemAutomationPeer::IsSelected()
 {
+    if (auto tvi = Owner().try_as<TabViewItem>())
+    {
+        const bool returnValue = tvi->IsSelected();
+        return returnValue;
+    }
     return false;
 }
 
@@ -56,14 +70,22 @@ winrt::IRawElementProviderSimple TabViewItemAutomationPeer::SelectionContainer()
 
 void TabViewItemAutomationPeer::AddToSelection()
 {
+    Select();
 }
 
 void TabViewItemAutomationPeer::RemoveFromSelection()
 {
+    // Can't unselect in a TabView without knowing next selection
 }
 
 void TabViewItemAutomationPeer::Select()
 {
+    if (auto tabView = GetParenTabView().try_as<TabView>())
+    {
+        // Set selection by getting the item from the container
+        // and setting that as the new selected item.
+        tabView->SelectedItem(tabView->ItemFromContainer(Owner()));
+    }
 }
 
 winrt::TabView TabViewItemAutomationPeer::GetParenTabView()

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -57,14 +57,17 @@ bool TabViewItemAutomationPeer::IsSelected()
 {
     if (auto tvi = Owner().try_as<TabViewItem>())
     {
-        const bool returnValue = tvi->IsSelected();
-        return returnValue;
+        return tvi->IsSelected();
     }
     return false;
 }
 
 winrt::IRawElementProviderSimple TabViewItemAutomationPeer::SelectionContainer()
 {
+    if (const auto parent = GetParentTabView())
+    {
+        return ProviderFromPeer(winrt::FrameworkElementAutomationPeer::CreatePeerForElement(parent));
+    }
     return nullptr;
 }
 

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -27,7 +27,6 @@ winrt::AutomationControlType TabViewItemAutomationPeer::GetAutomationControlType
     return winrt::AutomationControlType::TabItem;
 }
 
-
 winrt::hstring TabViewItemAutomationPeer::GetNameCore()
 {
     winrt::hstring returnHString = __super::GetNameCore();
@@ -42,4 +41,36 @@ winrt::hstring TabViewItemAutomationPeer::GetNameCore()
     }
 
     return returnHString;
+}
+
+
+bool TabViewItemAutomationPeer::IsSelected()
+{
+    return false;
+}
+
+winrt::IRawElementProviderSimple TabViewItemAutomationPeer::SelectionContainer()
+{
+    return nullptr;
+}
+
+void TabViewItemAutomationPeer::AddToSelection()
+{
+}
+
+void TabViewItemAutomationPeer::RemoveFromSelection()
+{
+}
+
+void TabViewItemAutomationPeer::Select()
+{
+}
+
+winrt::TabView TabViewItemAutomationPeer::GetParenTabView()
+{
+    if (auto tvi = Owner().try_as<winrt::TabViewItem>())
+    {
+        return winrt::get_self<TabViewItem>(tvi)->GetParentTabView();
+    }
+    return nullptr;
 }

--- a/dev/TabView/TabViewItemAutomationPeer.h
+++ b/dev/TabView/TabViewItemAutomationPeer.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
@@ -7,7 +7,9 @@
 #include "TabViewItemAutomationPeer.g.h"
 
 class TabViewItemAutomationPeer :
-    public ReferenceTracker<TabViewItemAutomationPeer, winrt::implementation::TabViewItemAutomationPeerT>
+    public ReferenceTracker < TabViewItemAutomationPeer,
+    winrt::implementation::TabViewItemAutomationPeerT,
+    winrt::ISelectionItemProvider >
 {
 
 public:
@@ -17,4 +19,14 @@ public:
     winrt::hstring GetNameCore();
     hstring GetClassNameCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
+
+    // ISelectionItemProvider
+    bool IsSelected();
+    winrt::IRawElementProviderSimple SelectionContainer();
+    void AddToSelection();
+    void RemoveFromSelection();
+    void Select();
+
+private:
+    winrt::TabView GetParenTabView();
 };

--- a/dev/TabView/TabViewItemAutomationPeer.h
+++ b/dev/TabView/TabViewItemAutomationPeer.h
@@ -27,4 +27,7 @@ public:
     void AddToSelection();
     void RemoveFromSelection();
     void Select();
+
+private:
+    winrt::TabView GetParentTabView();
 };

--- a/dev/TabView/TabViewItemAutomationPeer.h
+++ b/dev/TabView/TabViewItemAutomationPeer.h
@@ -16,6 +16,7 @@ public:
     TabViewItemAutomationPeer(winrt::TabViewItem const& owner);
 
     // IAutomationPeerOverrides
+    winrt::IInspectable GetPatternCore(winrt::PatternInterface const& patternInterface);
     winrt::hstring GetNameCore();
     hstring GetClassNameCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();

--- a/dev/TabView/TabViewItemAutomationPeer.h
+++ b/dev/TabView/TabViewItemAutomationPeer.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #pragma once
@@ -27,7 +27,4 @@ public:
     void AddToSelection();
     void RemoveFromSelection();
     void Select();
-
-private:
-    winrt::TabView GetParenTabView();
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the SelectionPattern to the TabViewAutomationPeer.
I am not using the internals ListView pattern since we plan to switch that out at some point, and then we would need to do all of that ourselves anyway.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2847 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add API test
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

## Open questions
Given that the TabView now has the SelectionPattern, should the TabViewItems also have the SelectionItemPattern?

There is also a way to run Accessibility Insights as a test through the [Axe package](https://github.com/microsoft/axe-windows). Maybe we could leverage that to prevent those errors in the future? Given that the MUXControlsTestApp is a bit special compared to a regular app, maybe this could be done with the XCG, after all it contains a lot of samples for the controls.
@stmoy FYI