### PR TITLE
Disable multi-proc build for lab machines

### DIFF
--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -251,7 +251,7 @@
       <Optimization Condition="'$(Configuration)'=='Release'">MinSpace</Optimization>
       <ConformanceMode>true</ConformanceMode>
       <!-- Disable multi-proc building on low powered machines, such as the lab machines -->
-      <MultiProcessorCompilation Condition="'$(NUMBER_OF_PROCESSORS)'=='2'">false</MultiProcessorCompilation>
+      <MultiProcessorCompilation Condition="'$(TF_BUILD)'=='True'">false</MultiProcessorCompilation>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The recent change to disable multi-proc builds on the lab machines using NUMBER_OF_PROCESSORS didn't work, since some of the lab machines have 4 processors.

Using TF_Build should reliably determine if we are building in the lab.