### PR TITLE
Run Code Analysis in the lab only on debug

### DIFF
--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -181,7 +181,6 @@
   <PropertyGroup>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\..\build\PrefastWarnings.ruleset</CodeAnalysisRuleSet>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
We are hitting errors in the build lab due to Code Analysis failing spuriously on code in the Arm build.

We had originally set up Code Analysis to only run in the lab on debug builds to reduce the impact on the build time. A recent change enabled in unconditionally. Restoring the conditional logic, which will hopefully solve the build lab issue.

Test CI build running here:
https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=93193&view=results