### PR TITLE
Add check to only open flyout if a menubaritem has items

### DIFF
--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -214,29 +214,32 @@ void MenuBarItem::OnMenuBarItemAccessKeyInvoked(winrt::IInspectable const& sende
 // Menu Flyout actions
 void MenuBarItem::ShowMenuFlyout()
 {
-    if (auto button = m_button.get())
+    if (Items().Size() != 0)
     {
-        const auto width = static_cast<float>(button.ActualWidth());
-        const auto height = static_cast<float>(button.ActualHeight());
-
-        if (SharedHelpers::IsFlyoutShowOptionsAvailable())
+        if (auto button = m_button.get())
         {
-            // Sets an exclusion rect over the button that generates the flyout so that even if the menu opens upwards
-            // (which is the default in touch mode) it doesn't cover the menu bar button.
-            winrt::FlyoutShowOptions options{};
-            options.Position(winrt::Point(0, height));
-            options.Placement(winrt::FlyoutPlacementMode::Bottom);
-            options.ExclusionRect(winrt::Rect(0, 0, width, height));
-            m_flyout.get().ShowAt(button, options);
-        }
-        else
-        {
-            m_flyout.get().ShowAt(button, winrt::Point(0, height));
-        }
+            const auto width = static_cast<float>(button.ActualWidth());
+            const auto height = static_cast<float>(button.ActualHeight());
 
-        // Attach keyboard event handler
-        auto presenter = winrt::get_self<MenuBarItemFlyout>(m_flyout.get())->m_presenter.get();
-        m_presenterKeyDownRevoker = presenter.KeyDown(winrt::auto_revoke, { this,  &MenuBarItem::OnPresenterKeyDown });
+            if (SharedHelpers::IsFlyoutShowOptionsAvailable())
+            {
+                // Sets an exclusion rect over the button that generates the flyout so that even if the menu opens upwards
+                // (which is the default in touch mode) it doesn't cover the menu bar button.
+                winrt::FlyoutShowOptions options{};
+                options.Position(winrt::Point(0, height));
+                options.Placement(winrt::FlyoutPlacementMode::Bottom);
+                options.ExclusionRect(winrt::Rect(0, 0, width, height));
+                m_flyout.get().ShowAt(button, options);
+            }
+            else
+            {
+                m_flyout.get().ShowAt(button, winrt::Point(0, height));
+            }
+
+            // Attach keyboard event handler
+            auto presenter = winrt::get_self<MenuBarItemFlyout>(m_flyout.get())->m_presenter.get();
+            m_presenterKeyDownRevoker = presenter.KeyDown(winrt::auto_revoke, { this,  &MenuBarItem::OnPresenterKeyDown });
+        }
     }
 }
 

--- a/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
+++ b/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
@@ -375,6 +375,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void EmptyMenuBarItemNoPopupTest()
+        {
+            if (PlatformConfiguration.IsDevice(DeviceType.Phone))
+            {
+                Log.Comment("Skipping tests on phone, because menubar is not supported.");
+                return;
+            }
+            using (var setup = new TestSetupHelper("MenuBar Tests"))
+            {
+                FindElement.ByName<Button>("NoChildrenFlyout").Click();
+                VerifyElement.NotFound("Popup",FindBy.Name);
+
+                FindElement.ByName<Button>("OneChildrenFlyout").Click();
+                VerifyElement.Found("Popup", FindBy.Name);
+
+                // Click twice to close flyout
+                FindElement.ByName<Button>("RemoveItemsFromOneChildrenItem").Click();
+                FindElement.ByName<Button>("RemoveItemsFromOneChildrenItem").Click();
+
+                FindElement.ByName<Button>("OneChildrenFlyout").Click();
+                VerifyElement.NotFound("Popup", FindBy.Name);
+            }
+        }
 
         private T GetElement<T>(ref T element, string elementName) where T : UIObject
         {

--- a/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
+++ b/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
@@ -55,6 +55,8 @@
                     <MenuFlyoutItem Text="Word Wrap"/>
                     <MenuFlyoutItem Text="Font..."/>
                 </muxc:MenuBarItem>
+
+                <muxc:MenuBarItem Title="No children"/>
             </muxc:MenuBar>
 
             <TextBlock Text="Custom sized menu bar" Margin="0,6,0,0"/>

--- a/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
+++ b/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
@@ -56,7 +56,10 @@
                     <MenuFlyoutItem Text="Font..."/>
                 </muxc:MenuBarItem>
 
-                <muxc:MenuBarItem Title="No children"/>
+                <muxc:MenuBarItem Title="No children" AutomationProperties.Name="NoChildrenFlyout"/>
+                <muxc:MenuBarItem Title="One children" AutomationProperties.Name="OneChildrenFlyout" x:Name="OneChildrenFlyoutMenuBarItem">
+                    <MenuFlyoutItem Text="Sometext"/>
+                </muxc:MenuBarItem>
             </muxc:MenuBar>
 
             <TextBlock Text="Custom sized menu bar" Margin="0,6,0,0"/>
@@ -80,6 +83,7 @@
             <Button x:Name="AddFlyoutItemButton" AutomationProperties.Name="AddFlyoutItemButton" Click="AddFlyoutItem_Click" Content="Add Flyout Item"/>
             <Button x:Name="RemoveFlyoutItemButton" AutomationProperties.Name="RemoveFlyoutItemButton" Click="RemoveFlyoutItem_Click" Content="Remove Flyout Item"/>
             <Button x:Name="AddItemsToEmptyMenuBar" AutomationProperties.Name="AddItemsToEmptyMenuBar" Click="AddMenuBarToEmptyMenuBarItem_Click" Content="Add a menu item to the empty menu bar"/>
+            <Button x:Name="RemoveItemsFromOneChildrenItem" AutomationProperties.Name="RemoveItemsFromOneChildrenItem" Click="RemoveItemsFromOneChildrenItem_Click" Content="Remove items from One Children item"/>
         </StackPanel>
         <StackPanel Grid.Row="3">
             <TextBlock Text="Test output" Style="{ThemeResource StandardGroupHeader}"/>

--- a/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
+++ b/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml
@@ -50,16 +50,17 @@
                         <MenuFlyoutItem Text="Item 3"/>
                     </MenuFlyoutSubItem>
                 </muxc:MenuBarItem>
+                
+                <muxc:MenuBarItem Title="No children" AutomationProperties.Name="NoChildrenFlyout"/>
+                <muxc:MenuBarItem Title="One children" AutomationProperties.Name="OneChildrenFlyout" x:Name="OneChildrenFlyoutMenuBarItem">
+                    <MenuFlyoutItem Text="Sometext"/>
+                </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Format">
                     <MenuFlyoutItem Text="Word Wrap"/>
                     <MenuFlyoutItem Text="Font..."/>
                 </muxc:MenuBarItem>
 
-                <muxc:MenuBarItem Title="No children" AutomationProperties.Name="NoChildrenFlyout"/>
-                <muxc:MenuBarItem Title="One children" AutomationProperties.Name="OneChildrenFlyout" x:Name="OneChildrenFlyoutMenuBarItem">
-                    <MenuFlyoutItem Text="Sometext"/>
-                </muxc:MenuBarItem>
             </muxc:MenuBar>
 
             <TextBlock Text="Custom sized menu bar" Margin="0,6,0,0"/>

--- a/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml.cs
+++ b/dev/MenuBar/MenuBar_TestUI/MenuBarPage.xaml.cs
@@ -108,5 +108,9 @@ namespace MUXControlsTestApp
             EmptyMenuBar.Items.Add(mainMenuBarHelp);
         }
 
+        private void RemoveItemsFromOneChildrenItem_Click(object sender, RoutedEventArgs e)
+        {
+            OneChildrenFlyoutMenuBarItem.Items.Clear();
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a check to only open a menubaritems flyout if it has items.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2740 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually:

![gif](https://user-images.githubusercontent.com/16122379/87257603-93b0c800-c49c-11ea-87a5-0acfd95f1594.gif)

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->