### PR TITLE
Adding public ScrollView.CurrentAnchor read-only property

### DIFF
--- a/dev/ScrollPresenter/APITests/ScrollPresenterAnchoringTests.cs
+++ b/dev/ScrollPresenter/APITests/ScrollPresenterAnchoringTests.cs
@@ -196,11 +196,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ViewChanged - HorizontalOffset={0}, VerticalOffset={1}, ZoomFactor={2}",
                             sender.HorizontalOffset, sender.VerticalOffset, sender.ZoomFactor);
+                        Log.Comment("ViewChanged - CurrentAnchor is " + (sender.CurrentAnchor == null ? "null" : "non-null"));
                         if ((orientation == Orientation.Vertical && expectedFinalOffset == sender.VerticalOffset) ||
                             (orientation == Orientation.Horizontal && expectedFinalOffset == sender.HorizontalOffset))
                         {
                             scrollPresenterViewChangedEvent.Set();
-                        }                        
+                        }
+                    };
+
+                    scrollPresenter.AnchorRequested += delegate (ScrollPresenter sender, ScrollingAnchorRequestedEventArgs args)
+                    {
+                        Log.Comment("AnchorRequested - AnchorCandidates.Count={0}", args.AnchorCandidates.Count);
                     };
 
                     Log.Comment("Inserting child at far edge");
@@ -238,6 +244,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Log.Comment("ScrollPresenter offset change expected");
                     Verify.AreEqual(scrollPresenter.HorizontalOffset, horizontalOffset);
                     Verify.AreEqual(scrollPresenter.VerticalOffset, verticalOffset);
+
+                    Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNull(scrollPresenter.CurrentAnchor);
                 });
             }
         }
@@ -309,7 +318,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ViewChanged - HorizontalOffset={0}, VerticalOffset={1}, ZoomFactor={2}",
                             sender.HorizontalOffset, sender.VerticalOffset, sender.ZoomFactor);
+                        Log.Comment("ViewChanged - CurrentAnchor is " + (sender.CurrentAnchor == null ? "null" : "non-null"));
                         scrollPresenterViewChangedEvent.Set();
+                    };
+
+                    scrollPresenter.AnchorRequested += delegate (ScrollPresenter sender, ScrollingAnchorRequestedEventArgs args)
+                    {
+                        Log.Comment("AnchorRequested - AnchorCandidates.Count={0}", args.AnchorCandidates.Count);
                     };
 
                     if (orientation == Orientation.Vertical)
@@ -341,6 +356,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Log.Comment("ScrollPresenter offset change expected");
                     Verify.AreEqual(scrollPresenter.HorizontalOffset, horizontalOffset);
                     Verify.AreEqual(scrollPresenter.VerticalOffset, verticalOffset);
+
+                    Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNull(scrollPresenter.CurrentAnchor);
                 });
             }
         }
@@ -390,6 +408,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ViewChanged - HorizontalOffset={0}, VerticalOffset={1}, ZoomFactor={2}",
                             sender.HorizontalOffset, sender.VerticalOffset, sender.ZoomFactor);
+                        Log.Comment("ViewChanged - CurrentAnchor is " + (sender.CurrentAnchor == null ? "null" : "non-null"));
                         scrollPresenterViewChangedEvent.Set();
                     };
 
@@ -411,6 +430,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Verify.AreEqual(127.0, scrollPresenter.HorizontalOffset);
                     }
+
+                    Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNotNull(scrollPresenter.CurrentAnchor);
                 });
             }
         }
@@ -488,6 +510,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Verify.AreEqual(scrollPresenter.HorizontalOffset, horizontalOffset);
                     }
+
+                    Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNotNull(scrollPresenter.CurrentAnchor);
                 });
             }
         }
@@ -556,6 +581,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ViewChanged - HorizontalOffset={0}, VerticalOffset={1}, ZoomFactor={2}",
                             sender.HorizontalOffset, sender.VerticalOffset, sender.ZoomFactor);
+                        Log.Comment("ViewChanged - CurrentAnchor is " + (sender.CurrentAnchor == null ? "null" : "non-null"));
                         scrollPresenterViewChangedEvent.Set();
                     };
 
@@ -587,6 +613,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Verify.AreEqual(scrollPresenter.HorizontalOffset, horizontalOffset - viewportSizeChange / 2.0);
                     }
+
+                    Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNotNull(scrollPresenter.CurrentAnchor);
                 });
             }
         }
@@ -753,6 +782,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ViewChanged - HorizontalOffset={0}, VerticalOffset={1}, ZoomFactor={2}",
                             sender.HorizontalOffset, sender.VerticalOffset, sender.ZoomFactor);
+                        Log.Comment("ViewChanged - CurrentAnchor is " + (sender.CurrentAnchor == null ? "null" : "non-null"));
                         if ((reduceAnchorOffset && sender.VerticalOffset == 400) ||
                             (!reduceAnchorOffset && sender.VerticalOffset == 500))
                         {
@@ -762,7 +792,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                     scrollPresenter.AnchorRequested += delegate (ScrollPresenter sender, ScrollingAnchorRequestedEventArgs args)
                     {
-                        Log.Comment("ScrollPresenter.AnchorRequested event handler. Forcing the red Border to be the ScrollPresenter anchor.");
+                        Log.Comment("AnchorRequested - Forcing the red Border to be the ScrollPresenter anchor.");
                         args.AnchorElement = anchorElement;
                         scrollPresenterAnchorRequestedEvent.Set();
                     };
@@ -797,6 +827,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 RunOnUIThread.Execute(() =>
                 {
                     Verify.AreEqual(reduceAnchorOffset ? 400 : 500, scrollPresenter.VerticalOffset);
+
+                    Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNotNull(scrollPresenter.CurrentAnchor);
                 });
             }
         }
@@ -869,6 +902,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ScrollPresenter offset change expected");
                         Verify.AreEqual(250.0, scrollPresenter.VerticalOffset);
+
+                        Log.Comment("ScrollPresenter CurrentAnchor is " + (scrollPresenter.CurrentAnchor == null ? "null" : "non-null"));
+                        Verify.IsNotNull(scrollPresenter.CurrentAnchor);
                     });
                 }
             }

--- a/dev/ScrollPresenter/ScrollPresenter.h
+++ b/dev/ScrollPresenter/ScrollPresenter.h
@@ -250,9 +250,6 @@ public:
     void OnPropertyChanged(
         const winrt::DependencyPropertyChangedEventArgs& args);
 
-    void OnContentSizeChanged(
-        const winrt::IInspectable& sender,
-        const winrt::SizeChangedEventArgs& args);
     void OnContentPropertyChanged(
         const winrt::DependencyObject& sender,
         const winrt::DependencyProperty& args);

--- a/dev/ScrollPresenter/ScrollPresenterPrimitives.idl
+++ b/dev/ScrollPresenter/ScrollPresenterPrimitives.idl
@@ -216,7 +216,9 @@ interface IScrollController
 [contentproperty("Content")]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
-unsealed runtimeclass ScrollPresenter : Windows.UI.Xaml.FrameworkElement
+unsealed runtimeclass ScrollPresenter :
+    Windows.UI.Xaml.FrameworkElement,
+    Windows.UI.Xaml.Controls.IScrollAnchorProvider
 {
     ScrollPresenter();
 

--- a/dev/ScrollPresenter/TestUI/ScrollPresenterRepeaterAnchoringPage.xaml
+++ b/dev/ScrollPresenter/TestUI/ScrollPresenterRepeaterAnchoringPage.xaml
@@ -62,6 +62,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -82,28 +83,32 @@
             <Button x:Name="btnGetVerticalAnchorRatio" Content="G" Margin="1" Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetVerticalAnchorRatio_Click"/>
             <Button x:Name="btnSetVerticalAnchorRatio" Content="S" Margin="1" Grid.Row="2" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetVerticalAnchorRatio_Click"/>
 
-            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="3" Grid.Column="0"/>
-            <TextBlock Text="AnchorElement:" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbAnchorElement" Width="75" Margin="1" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
+            <TextBlock Text="CurrentAnchor:" Grid.Row="3" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCurrentAnchor" Grid.Row="3" Grid.Column="1" Margin="1" IsReadOnly="True" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetCurrentAnchor" Content="G" Margin="1" Grid.Row="3" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetCurrentAnchor_Click"/>
+
+            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="4" Grid.Column="0"/>
+            <TextBlock Text="AnchorElement:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbAnchorElement" Width="75" Margin="1" Grid.Row="4" Grid.Column="1" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
                 <ComboBoxItem>Null</ComboBoxItem>
                 <ComboBoxItem>External</ComboBoxItem>
                 <ComboBoxItem>Collapsed</ComboBoxItem>
                 <ComboBoxItem>Border</ComboBoxItem>
                 <ComboBoxItem>Item</ComboBoxItem>
             </ComboBox>
-            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
-            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
+            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
+            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
 
-            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
-            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
 
-            <TextBlock Text="ScrollPresenter Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="5" Margin="0,4,0,0"/>
+            <TextBlock Text="ScrollPresenter Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="6" Margin="0,4,0,0"/>
 
-            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="6" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
+            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="7" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
 
-            <TextBlock Text="ItemsRepeater Properties" Grid.Row="7" Grid.ColumnSpan="4" Foreground="Red" Margin="0,4,0,0"/>
+            <TextBlock Text="ItemsRepeater Properties" Grid.Row="8" Grid.ColumnSpan="4" Foreground="Red" Margin="0,4,0,0"/>
 
-            <CheckBox x:Name="chkUseAnimator" Content="Use Animator?" Grid.Row="8" Grid.ColumnSpan="4" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" 
+            <CheckBox x:Name="chkUseAnimator" Content="Use Animator?" Grid.Row="9" Grid.ColumnSpan="4" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" 
                       Checked="ChkUseAnimator_Checked" Unchecked="ChkUseAnimator_Unchecked"/>
         </Grid>
 

--- a/dev/ScrollPresenter/TestUI/ScrollPresenterRepeaterAnchoringPage.xaml.cs
+++ b/dev/ScrollPresenter/TestUI/ScrollPresenterRepeaterAnchoringPage.xaml.cs
@@ -349,8 +349,11 @@ namespace MUXControlsTestApp
             }
             catch (Exception ex)
             {
-                txtExceptionReport.Text = ex.ToString();
-                lstScrollPresenterEvents.Items.Add(ex.ToString());
+                if (string.IsNullOrEmpty(txtExceptionReport.Text))
+                {
+                    txtExceptionReport.Text = ex.ToString();
+                    lstScrollPresenterEvents.Items.Add(ex.ToString());
+                }
             }
         }
 
@@ -382,6 +385,28 @@ namespace MUXControlsTestApp
             try
             {
                 scrollPresenter.VerticalAnchorRatio = Convert.ToDouble(txtVerticalAnchorRatio.Text);
+            }
+            catch (Exception ex)
+            {
+                txtExceptionReport.Text = ex.ToString();
+                lstScrollPresenterEvents.Items.Add(ex.ToString());
+            }
+        }
+
+        private void BtnGetCurrentAnchor_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (scrollPresenter.CurrentAnchor == null)
+                {
+                    txtCurrentAnchor.Text = "null";
+                }
+                else
+                {
+                    FrameworkElement currentAnchorAsFE = scrollPresenter.CurrentAnchor as FrameworkElement;
+
+                    txtCurrentAnchor.Text = currentAnchorAsFE == null ? "UIElement" : currentAnchorAsFE.Name;
+                }
             }
             catch (Exception ex)
             {

--- a/dev/ScrollPresenter/TestUI/ScrollPresenterStackPanelAnchoringPage.xaml
+++ b/dev/ScrollPresenter/TestUI/ScrollPresenterStackPanelAnchoringPage.xaml
@@ -53,6 +53,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -83,41 +84,45 @@
             <Button x:Name="btnGetHeight" Content="G" Margin="1" Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetHeight_Click"/>
             <Button x:Name="btnSetHeight" Content="S" Margin="1" Grid.Row="4" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetHeight_Click"/>
 
-            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="5" Grid.Column="0"/>
-            <TextBlock Text="AnchorElement:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbAnchorElement" Grid.Row="5" Grid.Column="1" Margin="1,0,1,0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
+            <TextBlock Text="CurrentAnchor:" Grid.Row="5" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCurrentAnchor" Grid.Row="5" Grid.Column="1" Margin="1" IsReadOnly="True" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetCurrentAnchor" Content="G" Margin="1" Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetCurrentAnchor_Click"/>
+
+            <TextBlock x:Name="tblCollapsedAnchorElement" Grid.Row="6" Grid.Column="0"/>
+            <TextBlock Text="AnchorElement:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbAnchorElement" Grid.Row="6" Grid.Column="1" Margin="1,0,1,0" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectedIndex="0" SelectionChanged="CmbAnchorElement_SelectionChanged">
                 <ComboBoxItem>Null</ComboBoxItem>
                 <ComboBoxItem>External</ComboBoxItem>
                 <ComboBoxItem>Collapsed</ComboBoxItem>
                 <ComboBoxItem>Border</ComboBoxItem>
                 <ComboBoxItem>Item</ComboBoxItem>
             </ComboBox>
-            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="5" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
-            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="5" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
+            <Button x:Name="btnGetAnchorElement" Content="G" Margin="1" Grid.Row="6" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetAnchorElement_Click"/>
+            <Button x:Name="btnSetAnchorElement" Content="S" Margin="1" Grid.Row="6" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetAnchorElement_Click"/>
 
-            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
-            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBlock x:Name="tblItemIndex" Text="Item Index:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center" Visibility="Collapsed"/>
+            <TextBox x:Name="txtItemIndex" Text="0" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Margin="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Visibility="Collapsed"/>
 
-            <TextBlock Text="ScrollPresenter Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="7" Margin="0,4,0,0"/>
+            <TextBlock Text="ScrollPresenter Methods" Grid.ColumnSpan="4" Foreground="Red" Grid.Row="8" Margin="0,4,0,0"/>
 
-            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="8" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
+            <Button x:Name="btnInvalidateArrange" Content="InvalidateArrange" Margin="1" Grid.Row="9" Grid.ColumnSpan="4" HorizontalAlignment="Stretch" VerticalAlignment="Center" Click="BtnInvalidateArrange_Click"/>
 
-            <TextBlock Text="ScrollTo Options" Grid.Row="9" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
-            <TextBlock Text="Offset:" Grid.Column="0" Grid.Row="10" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtCOAO" Text="0" Grid.Column="1" Grid.Row="10" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
-            <TextBlock Text="Duration override (msec):" Grid.Column="0" Grid.Row="11" VerticalAlignment="Center"/>
-            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="11" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+            <TextBlock Text="ScrollTo Options" Grid.Row="10" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
+            <TextBlock Text="Offset:" Grid.Column="0" Grid.Row="11" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCOAO" Text="0" Grid.Column="1" Grid.Row="11" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
+            <TextBlock Text="Duration override (msec):" Grid.Column="0" Grid.Row="12" VerticalAlignment="Center"/>
+            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.ColumnSpan="3" Grid.Row="12" HorizontalAlignment="Stretch" VerticalAlignment="Center">
                 <TextBox x:Name="txtStockOffsetsChangeDuration" IsReadOnly="True" Margin="1"/>
                 <TextBox x:Name="txtOverriddenOffsetsChangeDuration" Margin="1"/>
             </StackPanel>
-            <Button x:Name="btnScrollTo" Content="ScrollTo" Grid.ColumnSpan="4" Grid.Row="12" Margin="1" HorizontalAlignment="Stretch" Click="BtnScrollTo_Click"/>
+            <Button x:Name="btnScrollTo" Content="ScrollTo" Grid.ColumnSpan="4" Grid.Row="13" Margin="1" HorizontalAlignment="Stretch" Click="BtnScrollTo_Click"/>
 
-            <TextBlock Text="AddScrollVelocity Options" Grid.Row="13" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
-            <TextBlock Text="Velocity:" Grid.Column="0" Grid.Row="14" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtCOWAVAV" Text="0" Grid.Column="1" Grid.Row="14" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
-            <TextBlock Text="InertiaDecayRate:" Grid.Column="0" Grid.Row="15" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtCOWAVAIDR" Text="null" Grid.Column="1" Grid.Row="15" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
-            <Button x:Name="btnAddScrollVelocity" Content="AddScrollVelocity" Grid.ColumnSpan="4" Grid.Row="16" Margin="1" HorizontalAlignment="Stretch" Click="BtnAddScrollVelocity_Click"/>
+            <TextBlock Text="AddScrollVelocity Options" Grid.Row="14" Grid.ColumnSpan="4" Margin="0,4,0,0"/>
+            <TextBlock Text="Velocity:" Grid.Column="0" Grid.Row="15" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCOWAVAV" Text="0" Grid.Column="1" Grid.Row="15" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
+            <TextBlock Text="InertiaDecayRate:" Grid.Column="0" Grid.Row="16" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCOWAVAIDR" Text="null" Grid.Column="1" Grid.Row="16" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="1"/>
+            <Button x:Name="btnAddScrollVelocity" Content="AddScrollVelocity" Grid.ColumnSpan="4" Grid.Row="17" Margin="1" HorizontalAlignment="Stretch" Click="BtnAddScrollVelocity_Click"/>
         </Grid>
 
         <Grid Grid.Row="1" Grid.Column="2" Margin="1" Padding="6">

--- a/dev/ScrollPresenter/TestUI/ScrollPresenterStackPanelAnchoringPage.xaml.cs
+++ b/dev/ScrollPresenter/TestUI/ScrollPresenterStackPanelAnchoringPage.xaml.cs
@@ -672,6 +672,28 @@ namespace MUXControlsTestApp
             }
         }
 
+        private void BtnGetCurrentAnchor_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (scrollPresenter.CurrentAnchor == null)
+                {
+                    txtCurrentAnchor.Text = "null";
+                }
+                else
+                {
+                    FrameworkElement currentAnchorAsFE = scrollPresenter.CurrentAnchor as FrameworkElement;
+
+                    txtCurrentAnchor.Text = currentAnchorAsFE == null ? "UIElement" : currentAnchorAsFE.Name;
+                }
+            }
+            catch (Exception ex)
+            {
+                txtExceptionReport.Text = ex.ToString();
+                lstScrollPresenterEvents.Items.Add(ex.ToString());
+            }
+        }
+
         private void BtnGetAnchorElement_Click(object sender, RoutedEventArgs e)
         {
             try

--- a/dev/ScrollView/APITests/ScrollViewTests.cs
+++ b/dev/ScrollView/APITests/ScrollViewTests.cs
@@ -87,6 +87,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Log.Comment("Verifying ScrollView default property values");
                 Verify.IsNull(scrollView.Content);
+                Verify.IsNull(scrollView.CurrentAnchor);
                 Verify.IsNull(ScrollViewTestHooks.GetScrollPresenterPart(scrollView));
 #if USE_SCROLLMODE_AUTO
                 Verify.AreEqual(c_defaultComputedHorizontalScrollMode, scrollView.ComputedHorizontalScrollMode);
@@ -227,6 +228,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 {
                     Log.Comment("Verifying ScrollView property values after Loaded event");
                     Verify.AreEqual(rectangleScrollViewContent, scrollView.Content);
+                    Verify.IsNull(scrollView.CurrentAnchor);
                     Verify.IsNotNull(ScrollViewTestHooks.GetScrollPresenterPart(scrollView));
                     Verify.AreEqual(rectangleScrollViewContent, ScrollViewTestHooks.GetScrollPresenterPart(scrollView).Content);
                     Verify.AreEqual(c_defaultUIScrollViewContentWidth, scrollView.ExtentWidth);
@@ -491,6 +493,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     {
                         Log.Comment("ScrollView.AnchorRequested event handler. args.AnchorCandidates.Count: " + args.AnchorCandidates.Count);
                         Verify.IsNull(args.AnchorElement);
+                        Verify.IsNull(sender.CurrentAnchor);
                         Verify.AreEqual(expectedAnchorCandidatesCount, args.AnchorCandidates.Count);
                         scrollViewAnchorRequestedEvent.Set();
                     };
@@ -524,6 +527,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 });
 
                 WaitForEvent("Waiting for AnchorRequested event", scrollViewAnchorRequestedEvent);
+
+                RunOnUIThread.Execute(() =>
+                {
+                    Log.Comment("ScrollView CurrentAnchor is " + (scrollView.CurrentAnchor == null ? "null" : "non-null"));
+                    Verify.IsNull(scrollView.CurrentAnchor);
+                    Verify.AreEqual(scrollView.CurrentAnchor, scrollPresenter.CurrentAnchor);
+                });
             }
         }
 

--- a/dev/ScrollView/ScrollView.cpp
+++ b/dev/ScrollView/ScrollView.cpp
@@ -40,6 +40,19 @@ ScrollView::~ScrollView()
 
 #pragma region IScrollView
 
+winrt::UIElement ScrollView::CurrentAnchor()
+{
+    if (auto scrollPresenter = m_scrollPresenter.get())
+    {
+        if (const auto scrollPresenterAsAnchorProvider = scrollPresenter.try_as<winrt::Controls::IScrollAnchorProvider>())
+        {
+            return scrollPresenterAsAnchorProvider.CurrentAnchor();
+        }
+    }
+
+    return nullptr;
+}
+
 winrt::CompositionPropertySet ScrollView::ExpressionAnimationSources()
 {
     if (auto scrollPresenter = m_scrollPresenter.get())

--- a/dev/ScrollView/ScrollView.h
+++ b/dev/ScrollView/ScrollView.h
@@ -47,6 +47,7 @@ public:
 
 #pragma region IScrollView
 
+    winrt::UIElement CurrentAnchor();
     winrt::CompositionPropertySet ExpressionAnimationSources();
 
     double HorizontalOffset();

--- a/dev/ScrollView/ScrollView.idl
+++ b/dev/ScrollView/ScrollView.idl
@@ -20,6 +20,7 @@ unsealed runtimeclass ScrollView : Windows.UI.Xaml.Controls.Control
     ScrollView();
 
     Windows.UI.Xaml.UIElement Content { get; set; };
+    Windows.UI.Xaml.UIElement CurrentAnchor { get; };
     Windows.UI.Composition.CompositionPropertySet ExpressionAnimationSources { get; };
     Double HorizontalOffset { get; };
     Double VerticalOffset { get; };

--- a/dev/ScrollView/TestUI/ScrollViewDynamicPage.xaml
+++ b/dev/ScrollView/TestUI/ScrollViewDynamicPage.xaml
@@ -146,35 +146,39 @@
                 <ComboBoxItem>Viewbox</ComboBoxItem>
             </ComboBox>
 
-            <TextBlock Text="HorizontalScrollBarVisibility:" Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbHorizontalScrollBarVisibility" Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,1,0,1" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionChanged="CmbHorizontalScrollBarVisibility_SelectionChanged">
+            <TextBlock Text="CurrentAnchor:" Grid.Row="5" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtCurrentAnchor" Grid.Row="5" Grid.Column="1" Margin="1" IsReadOnly="True" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetCurrentAnchor" Content="G" Margin="1" Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Center" Click="BtnGetCurrentAnchor_Click"/>
+
+            <TextBlock Text="HorizontalScrollBarVisibility:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbHorizontalScrollBarVisibility" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,1,0,1" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionChanged="CmbHorizontalScrollBarVisibility_SelectionChanged">
                 <ComboBoxItem>Auto</ComboBoxItem>
                 <ComboBoxItem>Visible</ComboBoxItem>
                 <ComboBoxItem>Hidden</ComboBoxItem>
             </ComboBox>
 
-            <TextBlock Text="VerticalScrollBarVisibility:" Grid.Row="6" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbVerticalScrollBarVisibility" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,1,0,1" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionChanged="CmbVerticalScrollBarVisibility_SelectionChanged">
+            <TextBlock Text="VerticalScrollBarVisibility:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbVerticalScrollBarVisibility" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,1,0,1" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionChanged="CmbVerticalScrollBarVisibility_SelectionChanged">
                 <ComboBoxItem>Auto</ComboBoxItem>
                 <ComboBoxItem>Visible</ComboBoxItem>
                 <ComboBoxItem>Hidden</ComboBoxItem>
             </ComboBox>
 
-            <TextBlock Text="Margin:" Grid.Row="7" Grid.Column="0" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtMargin" Grid.Row="7" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetMargin" Content="G" Margin="1" Grid.Row="7" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetMargin_Click"/>
-            <Button x:Name="btnSetMargin" Content="S" Margin="1" Grid.Row="7" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetMargin_Click"/>
+            <TextBlock Text="Margin:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtMargin" Grid.Row="8" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetMargin" Content="G" Margin="1" Grid.Row="8" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetMargin_Click"/>
+            <Button x:Name="btnSetMargin" Content="S" Margin="1" Grid.Row="8" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetMargin_Click"/>
 
-            <TextBlock Text="Padding:" Grid.Row="8" Grid.Column="0" VerticalAlignment="Center"/>
-            <TextBox x:Name="txtPadding" Grid.Row="8" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
-            <Button x:Name="btnGetPadding" Content="G" Margin="1" Grid.Row="8" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetPadding_Click"/>
-            <Button x:Name="btnSetPadding" Content="S" Margin="1" Grid.Row="8" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetPadding_Click"/>
+            <TextBlock Text="Padding:" Grid.Row="9" Grid.Column="0" VerticalAlignment="Center"/>
+            <TextBox x:Name="txtPadding" Grid.Row="9" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center"/>
+            <Button x:Name="btnGetPadding" Content="G" Margin="1" Grid.Row="9" Grid.Column="2" VerticalAlignment="Center" Click="BtnGetPadding_Click"/>
+            <Button x:Name="btnSetPadding" Content="S" Margin="1" Grid.Row="9" Grid.Column="3" VerticalAlignment="Center" Click="BtnSetPadding_Click"/>
 
-            <CheckBox x:Name="chkIsEnabled" Content="IsEnabled?" Grid.Row="9" Grid.ColumnSpan="4" Checked="ChkIsEnabled_Checked" Unchecked="ChkIsEnabled_Unchecked"/>
-            <CheckBox x:Name="chkIsTabStop" Content="IsTabStop?" Grid.Row="10" Grid.ColumnSpan="4" Checked="ChkIsTabStop_Checked" Unchecked="ChkIsTabStop_Unchecked"/>
+            <CheckBox x:Name="chkIsEnabled" Content="IsEnabled?" Grid.Row="10" Grid.ColumnSpan="4" Checked="ChkIsEnabled_Checked" Unchecked="ChkIsEnabled_Unchecked"/>
+            <CheckBox x:Name="chkIsTabStop" Content="IsTabStop?" Grid.Row="11" Grid.ColumnSpan="4" Checked="ChkIsTabStop_Checked" Unchecked="ChkIsTabStop_Unchecked"/>
 
-            <TextBlock Text="XYFocusKeyboardNavigation:" Grid.Row="11" Grid.Column="0" VerticalAlignment="Center"/>
-            <ComboBox x:Name="cmbXYFocusKeyboardNavigation" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,1,0,1" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionChanged="CmbXYFocusKeyboardNavigation_SelectionChanged">
+            <TextBlock Text="XYFocusKeyboardNavigation:" Grid.Row="12" Grid.Column="0" VerticalAlignment="Center"/>
+            <ComboBox x:Name="cmbXYFocusKeyboardNavigation" Grid.Row="12" Grid.Column="1" Grid.ColumnSpan="3" Margin="0,1,0,1" HorizontalAlignment="Stretch" VerticalAlignment="Center" SelectionChanged="CmbXYFocusKeyboardNavigation_SelectionChanged">
                 <ComboBoxItem>Auto</ComboBoxItem>
                 <ComboBoxItem>Enabled</ComboBoxItem>
                 <ComboBoxItem>Disabled</ComboBoxItem>

--- a/dev/ScrollView/TestUI/ScrollViewDynamicPage.xaml.cs
+++ b/dev/ScrollView/TestUI/ScrollViewDynamicPage.xaml.cs
@@ -698,6 +698,28 @@ namespace MUXControlsTestApp
             }
         }
 
+        private void BtnGetCurrentAnchor_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (scrollView.CurrentAnchor == null)
+                {
+                    txtCurrentAnchor.Text = "null";
+                }
+                else
+                {
+                    FrameworkElement currentAnchorAsFE = scrollView.CurrentAnchor as FrameworkElement;
+
+                    txtCurrentAnchor.Text = currentAnchorAsFE == null ? "UIElement" : currentAnchorAsFE.Name;
+                }
+            }
+            catch (Exception ex)
+            {
+                txtExceptionReport.Text = ex.ToString();
+                lstLogs.Items.Add(ex.ToString());
+            }
+        }
+
         private void CmbHorizontalScrollBarVisibility_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             try


### PR DESCRIPTION
These changes add a read-only ScrollView.CurrentAnchor property and have the ScrollPresenter publicly implement Windows.UI.Xaml.Controls.IScrollAnchorProvider (it already privately implemented it).  These gaps were brought up in https://github.com/microsoft/microsoft-ui-xaml/issues/1848. This brings the new ScrollView closer to the old ScrollViewer which exposes that property through its IScrollAnchorProvider implementation.

I updated the ScrollView spec reviewed here https://github.com/microsoft/microsoft-ui-xaml-specs/pull/56 accordingly.
