### PR TITLE
Fix typo in ProcessHelixFiles

### DIFF
--- a/build/Helix/ProcessHelixFiles.ps1
+++ b/build/Helix/ProcessHelixFiles.ps1
@@ -97,7 +97,7 @@ foreach ($testRun in $testRuns.value)
 
                     $destination = "$visualTreeVerificationFolder\$($verificationFile.Name)"
                     Write-Host "Copying $($verificationFile.Name) to $destination"
-                    $link = "$($masterFile.Link)$accessTokenParam"
+                    $link = "$($verificationFile.Link)$accessTokenParam"
                     $webClient.DownloadFile($link, $destination)
                 }
 


### PR DESCRIPTION
A variable re-name in ProcessHelixFiles.ps1 was missed as part of this PR #2725.

This resulted in occasional Pipeline failures in the ProcessTestResults job sometimes causing PR verifications to fail.