### PR TITLE
Update background color of selected ListView item to meet contrast ratio requirement

### DIFF
--- a/dev/Common/Common_themeresources.xaml
+++ b/dev/Common/Common_themeresources.xaml
@@ -9,6 +9,7 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumLowBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.75" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
             <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
@@ -16,6 +17,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumLowBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.75" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
             <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>
@@ -23,6 +25,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="SystemControlTransparentBrush" Color="Transparent" />
+            <SolidColorBrush x:Key="SystemControlHighlightListAccentMediumLowBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <x:Boolean x:Key="UseSystemFocusVisuals">True</x:Boolean>
             <Thickness x:Key="TextControlBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TextControlBorderThemeThicknessFocused">2</Thickness>

--- a/dev/CommonStyles/ListViewItem_themeresources.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources.xaml
@@ -20,7 +20,7 @@
             <StaticResource x:Key="ListViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
-            <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+            <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentMediumLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
             <StaticResource x:Key="ListViewItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -57,7 +57,7 @@
             <StaticResource x:Key="ListViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
-            <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+            <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentMediumLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
             <StaticResource x:Key="ListViewItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
@@ -116,7 +116,7 @@
             <StaticResource x:Key="ListViewItemBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
-            <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+            <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentMediumLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
             <StaticResource x:Key="ListViewItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />

--- a/dev/CommonStyles/ListViewItem_themeresources.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources.xaml
@@ -21,7 +21,7 @@
             <StaticResource x:Key="ListViewItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentMediumLowBrush" />
-            <StaticResource x:Key="ListViewItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
+            <StaticResource x:Key="ListViewItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentLowBrush" />
             <StaticResource x:Key="ListViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
             <StaticResource x:Key="ListViewItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="ListViewItemForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />


### PR DESCRIPTION
## Description
This PR updates the brushes used by the ListView to set the background of selected ListViewItems. A new `SystemControlHighlightListAccentMediumLowBrush` has been added to set the background of a selected ListViewItem in rest state. Additionally, the brush used by `ListViewItemBackgroundSelectedPointerOver` has been updated in Dark mode to create a better visual contrast to the selected rest and selected pressed states.

Here are the current opacities used :
|Selection State|Light|Dark|
|----|-----|-----|
|Selection Rest|0.75 (previously 0.4)|0.75 (previously 0.6)|
|Selection Hover|0.6|0.6 (previously 0.8)
|Selection Pressed|0.7|0.9|

## Motivation and Context
Closes #2669  

## How Has This Been Tested?
Visually (see GIFs below)

## GIFs:
|Light|Dark|
|-----|-----|
|![listviewitem-selected-light](https://user-images.githubusercontent.com/1398851/88043461-c10d0e00-cb4d-11ea-9758-41b93c9a8de9.gif)|![listviewitem-selected-dark](https://user-images.githubusercontent.com/1398851/88043513-cf5b2a00-cb4d-11ea-9236-c2bac1645311.gif)|

And in Highcontrast (only shown in HC black. HC Light is identical just with a different accent color):
![listviewitem-selected-highcontrast-dark](https://user-images.githubusercontent.com/1398851/88043606-f7e32400-cb4d-11ea-8fac-7c2a92d14f1d.gif)

## Remarks:
@YuliKl In light theme, the selected pressed opacity (0.7) is now slightly less than the selected rest opacity (0.75). Previously, the selected pressed color had the highest opacity in Light theme of all three selection state colors (as can be seen in the table above). Here is how it would look like if the were to update the selection pressed opacity in Light theme to 0.9 (and thus matching Dark theme):
![listviewitem-selected-light-selectionpressed-update](https://user-images.githubusercontent.com/1398851/88046739-d0418b00-cb50-11ea-9555-0bfc91eb3e78.gif)

This would also resemble the color scheme used for the `Button` control:
![button-light-theme](https://user-images.githubusercontent.com/1398851/88047015-36c6a900-cb51-11ea-8ddb-a71c9fcb1e3d.gif)

What do you think? Should we update the selection pressed opacity from 0.7 to 0.9 in Light theme? If yes, that would probably require us to introduce a new brush, as the `SystemControlHighlightListAccentHighBrush` used here is defined in Light theme as:
```xml
<SolidColorBrush x:Key="SystemControlHighlightListAccentHighBrush" Color="{ThemeResource SystemAccentColor}" Opacity="0.7" />
```
We likely shouldn't update that brush to 0.9 opacity as that could affect controls besides the ListViewItem. Thus, similar to the newly introduced `SystemControlHighlightListAccentMediumLowBrush` brush as part of this PR, we could introduce a new brush here which will be used by the ListViewItem in Light theme:
```xml
<SolidColorBrush x:Key="SystemControlHighlightListAccent[NewTermHere]Brush" Color="{ThemeResource SystemAccentColor}" Opacity="0.9" />

<ResourceDictionary x:Key="Light">
    <StaticResource x:Key="ListViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccent[NewTermHere]Brush" />
</ResourceDictionary>
```
What would be a good name here for such a brush? Is it even a good idea to introduce a new system-wide brush here which might only be used by the ListView in Light theme mode for now? Or should we use a solution local to the ListView here?
