### PR TITLE
Remove legacy EIC style in WinUI

### DIFF
--- a/dev/MenuFlyout/MenuFlyout_themeresources.xaml
+++ b/dev/MenuFlyout/MenuFlyout_themeresources.xaml
@@ -88,7 +88,6 @@
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushPointerOver" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushSubMenuOpened" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <Thickness x:Key="LanguageSwitcherMenuFlyoutItemPlaceholderThemeThickness">44,0,0,0</Thickness>
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
@@ -172,7 +171,6 @@
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushPointerOver" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushSubMenuOpened" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <Thickness x:Key="LanguageSwitcherMenuFlyoutItemPlaceholderThemeThickness">44,0,0,0</Thickness>
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
@@ -256,7 +254,6 @@
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushPointerOver" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushSubMenuOpened" ResourceKey="SystemControlTransparentRevealBorderBrush" />
             <StaticResource x:Key="MenuFlyoutSubItemRevealBorderBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <Thickness x:Key="LanguageSwitcherMenuFlyoutItemPlaceholderThemeThickness">44,0,0,0</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -309,10 +306,6 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>
-
-    <Style TargetType="MenuFlyoutPresenter" x:Key="LanguageSwitcherMenuFlyoutPresenterStyle" BasedOn="{StaticResource DefaultMenuFlyoutPresenterStyle}">
-        <Setter Property="Margin" Value="{ThemeResource MenuFlyoutScrollerMargin}" />
     </Style>
 
     <Style TargetType="MenuFlyoutItem" x:Key="MenuFlyoutItemRevealStyle">
@@ -600,214 +593,6 @@
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
                 </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style TargetType="MenuFlyoutItem" x:Key="LanguageSwitcherMenuFlyoutSettingsRowStyle">
-        <Setter Property="Background" Value="{ThemeResource MenuFlyoutItemRevealBackground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource MenuFlyoutItemRevealBorderBrush}" />
-        <Setter Property="BorderThickness" Value="{ThemeResource MenuFlyoutItemRevealBorderThickness}" />
-        <Setter Property="Foreground" Value="{ThemeResource MenuFlyoutItemForeground}" />
-        <Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />
-        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-        <contract6Present:Setter Property="KeyboardAcceleratorPlacementMode" Value="Hidden" />
-        <Setter Property="AllowFocusOnInteraction" Value="False" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="MenuFlyoutItem">
-                    <Grid x:Name="LayoutRoot"
-                        Padding="{TemplateBinding Padding}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}" >
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="PaddingSizeStates">
-                                <VisualState x:Name="DefaultPadding" />
-                                <VisualState x:Name="NarrowPadding">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Padding">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource MenuFlyoutItemThemePaddingNarrow}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Button x:Name="LanguageSwitcherSettingsLanguageSettingsButton"
-                            Background="{ThemeResource MenuFlyoutItemBackground}"
-                            Grid.Column="0"
-                            HorizontalAlignment="Left"
-                            Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8C1;" />
-                        </Button>
-                        <Button x:Name="LanguageSwitcherSettingsPenAndInkSettingsButton"
-                            Background="{ThemeResource MenuFlyoutItemBackground}"
-                            Grid.Column="1"
-                            HorizontalAlignment="Center"
-                            Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;" />
-                        </Button>
-                        <Button x:Name="LanguageSwitcherSettingsHelpButton"
-                            Background="{ThemeResource MenuFlyoutItemBackground}"
-                            Grid.Column="2"
-                            HorizontalAlignment="Right"
-                            Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE9CE;" />
-                        </Button>
-                    </Grid>
-                 </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-    
-    <Style TargetType="MenuFlyoutItem" x:Key="LanguageSwitcherMenuFlyoutItemStyle">
-        <Setter Property="Background" Value="{ThemeResource MenuFlyoutItemRevealBackground}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource MenuFlyoutItemRevealBorderBrush}" />
-        <Setter Property="BorderThickness" Value="{ThemeResource MenuFlyoutItemRevealBorderThickness}" />
-        <Setter Property="Foreground" Value="{ThemeResource MenuFlyoutItemForeground}" />
-        <Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />
-        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-        <contract6Present:Setter Property="KeyboardAcceleratorPlacementMode" Value="Hidden" />
-        <Setter Property="AllowFocusOnInteraction" Value="False" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="MenuFlyoutItem">
-                    <Grid x:Name="LayoutRoot"
-                        Padding="{TemplateBinding Padding}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}" >
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal">
-                                    <Storyboard>
-                                        <PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="PointerOver">
-                                    <VisualState.Setters>
-                                        <Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="PointerOver" />
-                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource MenuFlyoutItemRevealBackgroundPointerOver}" />
-                                        <Setter Target="LayoutRoot.BorderBrush" Value="{ThemeResource MenuFlyoutItemRevealBorderBrushPointerOver}" />
-                                        <Setter Target="IconContent.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundPointerOver}" />
-                                        <Setter Target="TextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundPointerOver}" />
-                                        <contract6Present:Setter Target="KeyboardAcceleratorTextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver}" />
-                                    </VisualState.Setters>
-                                    <Storyboard>
-                                        <PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Pressed">
-                                    <VisualState.Setters>
-                                        <Setter Target="LayoutRoot.(media:RevealBrush.State)" Value="Pressed" />
-                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource MenuFlyoutItemRevealBackgroundPressed}" />
-                                        <Setter Target="LayoutRoot.BorderBrush" Value="{ThemeResource MenuFlyoutItemRevealBorderBrushPressed}" />
-                                        <Setter Target="IconContent.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundPressed}" />
-                                        <Setter Target="TextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundPressed}" />
-                                        <contract6Present:Setter Target="KeyboardAcceleratorTextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
-                                    </VisualState.Setters>
-                                    <Storyboard>
-                                        <PointerDownThemeAnimation Storyboard.TargetName="LayoutRoot" />
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="LayoutRoot.Background" Value="{ThemeResource MenuFlyoutItemRevealBackgroundDisabled}" />
-                                        <Setter Target="LayoutRoot.BorderBrush" Value="{ThemeResource MenuFlyoutItemRevealBorderBrushDisabled}" />
-                                        <Setter Target="IconContent.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundDisabled}" />
-                                        <Setter Target="TextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundDisabled}" />
-                                        <contract6Present:Setter Target="KeyboardAcceleratorTextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="CheckPlaceholderStates">
-                                <VisualState x:Name="NoPlaceholder" />
-                                <VisualState x:Name="CheckPlaceholder">
-                                    <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="IconPlaceholder">
-                                    <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource LanguageSwitcherMenuFlyoutItemPlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="CheckAndIconPlaceholder">
-                                    <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="PaddingSizeStates">
-                                <VisualState x:Name="DefaultPadding" />
-                                <VisualState x:Name="NarrowPadding">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot" Storyboard.TargetProperty="Padding">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource MenuFlyoutItemThemePaddingNarrow}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <contract6Present:VisualStateGroup x:Name="KeyboardAcceleratorTextVisibility">
-                                <VisualState x:Name="KeyboardAcceleratorTextCollapsed" />
-                                <VisualState x:Name="KeyboardAcceleratorTextVisible">
-                                    <VisualState.Setters>
-                                        <Setter Target="KeyboardAcceleratorTextBlock.Visibility" Value="Visible" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </contract6Present:VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Viewbox x:Name="IconRoot"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Center"
-                            Width="32"
-                            Height="32"
-                            Visibility="Collapsed">
-                            <ContentPresenter x:Name="IconContent"
-                                Content="{TemplateBinding Icon}"/>
-                        </Viewbox>
-                        <TextBlock x:Name="TextBlock"
-                            Text="{TemplateBinding Text}"
-                            TextTrimming="Clip"
-                            Foreground="{TemplateBinding Foreground}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                        <contract6Present:TextBlock x:Name="KeyboardAcceleratorTextBlock"
-                            Grid.Column="1"
-                            Style="{ThemeResource CaptionTextBlockStyle}"
-                            Text="{TemplateBinding KeyboardAcceleratorTextOverride}"
-                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.KeyboardAcceleratorTextMinWidth}"
-                            Margin="24,0,0,0"
-                            Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Visibility="Collapsed"
-                            AutomationProperties.AccessibilityView="Raw" />
-                    </Grid>
-                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove legacy EIC(embedded inking control) style in WinUI

## Description
<!--- Describe your changes in detail -->
In the OS side, we improve the EIC language panel in all version XAML code. But we found the WinUI style hasn't updated. No matter how we change on the OS side, the WinUI will use old-style to override new style.

We have two options:
1. Copy the new style to WinUI
2. Remove the old EIC style

I choose option 2.  Because EIC hasn't undocked. And these styles already define under the OS side, so delete them is safe enough.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

Deploy to the latest VM, make sure the UI show as we plan.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

![image](https://user-images.githubusercontent.com/36372831/88118694-1d365900-cb73-11ea-81c7-34c0a8178fed.png)
