### PR TITLE
Fix crash with UniformGridLayout trying to scroll to first item

### DIFF
--- a/dev/Repeater/APITests/LayoutTests.cs
+++ b/dev/Repeater/APITests/LayoutTests.cs
@@ -39,6 +39,7 @@ using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutC
 using ElementRealizationOptions = Microsoft.UI.Xaml.Controls.ElementRealizationOptions;
 using LayoutContext = Microsoft.UI.Xaml.Controls.LayoutContext;
 using LayoutPanel = Microsoft.UI.Xaml.Controls.LayoutPanel;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
@@ -251,6 +252,50 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Verify.IsNotNull(child);
                 }
             });
+        }
+
+        [TestMethod]
+        public void VerifyUniformGridLayoutDoesntCrashWhenTryingToScrollToEnd()
+        {
+
+            ItemsRepeater repeater = null;
+            ScrollViewer scrollViewer = null;
+            RunOnUIThread.Execute(() =>
+            {
+                repeater = new ItemsRepeater {
+                    ItemsSource = Enumerable.Range(0, 1000).Select(i => new Border {
+                        Background = new SolidColorBrush(Colors.Blue),
+                        Child = new TextBlock { Text = "#" + i }
+                    }).ToArray(),
+                    Layout = new UniformGridLayout {
+                        MinItemWidth = 100,
+                        MinItemHeight = 40,
+                        MinRowSpacing = 10,
+                        MinColumnSpacing = 10
+                    }
+                };
+                scrollViewer = new ScrollViewer { Content = repeater };
+                Content = scrollViewer;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                scrollViewer.ChangeView(0, repeater.ActualHeight, null);
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                scrollViewer.ChangeView(0, 0, null);
+            });
+
+            IdleSynchronizer.Wait();
+
+            // The test guards against an app crash, so this is enough to verify
+            Verify.IsTrue(true);
         }
 
         private ItemsRepeaterScrollHost CreateAndInitializeRepeater(

--- a/dev/Repeater/UniformGridLayout.cpp
+++ b/dev/Repeater/UniformGridLayout.cpp
@@ -72,10 +72,6 @@ winrt::Size UniformGridLayout::MeasureOverride(
         false /* disableVirtualization */,
         LayoutId());
 
-    // If after Measure the first item is in the realization rect, then we revoke grid state's ownership,
-    // and only use the layout when to clear it when it's done.
-    gridState->EnsureFirstElementOwnership(context);
-
     return { desiredSize.Width, desiredSize.Height };
 }
 
@@ -100,9 +96,6 @@ void UniformGridLayout::OnItemsChangedCore(
     GetFlowAlgorithm(context).OnItemsSourceChanged(source, args, context);
     // Always invalidate layout to keep the view accurate.
     InvalidateLayout();
-
-    auto gridState = GetAsGridState(context.LayoutState());
-    gridState->ClearElementOnDataSourceChange(context, args);
 }
 #pragma endregion
 

--- a/dev/Repeater/UniformGridLayoutState.cpp
+++ b/dev/Repeater/UniformGridLayoutState.cpp
@@ -41,30 +41,21 @@ void UniformGridLayoutState::EnsureElementSize(
 
     if (context.ItemCount() > 0)
     {
-        // If the first element is realized we don't need to cache it or to get it from the context
+        // If the first element is realized we don't need to get it from the context
         if (auto realizedElement = m_flowAlgorithm.GetElementIfRealized(0))
         {
             realizedElement.Measure(availableSize);
-            m_cachedSize = realizedElement.DesiredSize();
-            SetSize(m_cachedSize, layoutItemWidth, LayoutItemHeight, availableSize, stretch, orientation, minRowSpacing, minColumnSpacing, maxItemsPerLine);
-            hasCachedSize = true;
+            SetSize(realizedElement.DesiredSize(), layoutItemWidth, LayoutItemHeight, availableSize, stretch, orientation, minRowSpacing, minColumnSpacing, maxItemsPerLine);
         }
         else
         {
-            if (!hasCachedSize)
+            // Not realized by flowlayout, so do this now!
+            if (const auto firstElement = context.GetOrCreateElementAt(0, winrt::ElementRealizationOptions::ForceCreate))
             {
-                // we only cache if we aren't realizing it
-                // expensive
-                if (const auto firstElement = context.GetOrCreateElementAt(0, winrt::ElementRealizationOptions::ForceCreate))
-                {
-                    firstElement.Measure(availableSize);
-                    hasCachedSize = true;
-                    m_cachedSize = firstElement.DesiredSize();
-                    context.RecycleElement(firstElement);
-                }
+                firstElement.Measure(availableSize);
+                SetSize(firstElement.DesiredSize(), layoutItemWidth, LayoutItemHeight, availableSize, stretch, orientation, minRowSpacing, minColumnSpacing, maxItemsPerLine);
+                context.RecycleElement(firstElement);
             }
-
-            SetSize(m_cachedSize, layoutItemWidth, LayoutItemHeight, availableSize, stretch, orientation, minRowSpacing, minColumnSpacing, maxItemsPerLine);
         }
     }
 }

--- a/dev/Repeater/UniformGridLayoutState.h
+++ b/dev/Repeater/UniformGridLayoutState.h
@@ -46,12 +46,4 @@ private:
         double minRowSpacing,
         double minColumnSpacing,
         unsigned int maxItemsPerLine);
-
-    // We need to measure the element at index 0 to know what size to measure all other items.
-    // If FlowlayoutAlgorithm has already realized element 0 then we can use that.
-    // If it does not, then we need to do context.GetElement(0) at which point we have requested an element and are on point to clear it.
-    // If we are responsible for clearing element 0 we keep m_cachedFirstElement valid.
-    // If we are not (because FlowLayoutAlgorithm is holding it for us) then we just null out this field and use the one from FlowLayoutAlgorithm.
-    bool hasCachedSize = false;
-    winrt::Size m_cachedSize;
 };

--- a/dev/Repeater/UniformGridLayoutState.h
+++ b/dev/Repeater/UniformGridLayoutState.h
@@ -21,9 +21,6 @@ public:
     double EffectiveItemWidth() { return m_effectiveItemWidth; }
     double EffectiveItemHeight() { return m_effectiveItemHeight; }
 
-    // If it's realized then we shouldn't be caching it
-    void EnsureFirstElementOwnership(winrt::VirtualizingLayoutContext const& context);
-
     void EnsureElementSize(
         const winrt::Size availableSize,
         const winrt::VirtualizingLayoutContext& context,
@@ -34,14 +31,13 @@ public:
         double minRowSpacing,
         double minColumnSpacing,
         unsigned int maxItemsPerLine);
-    void ClearElementOnDataSourceChange(winrt::VirtualizingLayoutContext const& context, winrt::NotifyCollectionChangedEventArgs const& args);
 
 private:
     ::FlowLayoutAlgorithm m_flowAlgorithm{ this };
     double m_effectiveItemWidth{ 0.0 };
     double m_effectiveItemHeight{ 0.0 };
 
-    void SetSize(const winrt::UIElement& UIElement,
+    void SetSize(const winrt::Size& desiredItemSize,
         const double itemWidth,
         const double itemHeight,
         const winrt::Size availableSize,
@@ -56,5 +52,6 @@ private:
     // If it does not, then we need to do context.GetElement(0) at which point we have requested an element and are on point to clear it.
     // If we are responsible for clearing element 0 we keep m_cachedFirstElement valid.
     // If we are not (because FlowLayoutAlgorithm is holding it for us) then we just null out this field and use the one from FlowLayoutAlgorithm.
-    winrt::UIElement m_cachedFirstElement = nullptr;
+    bool hasCachedSize = false;
+    winrt::Size m_cachedSize;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue is that we didn't managed to properly recycle the first item, even though the UniformGridLayout was the owner. That resulted in the ElementManager trying to move ownership to realize that it isn't the actual owner, which resulted in the crash.

The behavior changed to only cache the item's desired size (which is the only information we needed), and let the ElementManager take care of managing.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #535 and closes #2834
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add API test for #2834, tested #535 manually (code not included in this PR)
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->