### PR TITLE
Treeview: Fix Background API not being applied to TreeView UI.

### DIFF
--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Content = treeView;
                 Content.UpdateLayout();
-                var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                var listControl = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                 // Verify TreeViewNode::SetAt
                 TreeViewNode setAtChildCheckNode = new TreeViewNode() { Content = "Set At Child" };
                 TreeViewNode setAtRootCheckNode = new TreeViewNode() { Content = "Set At Root" };
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var treeView = new TreeView();
                 Content = treeView;
                 Content.UpdateLayout();
-                var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                var listControl = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                 treeView.RootNodes.Add(treeViewNode1);
                 Verify.AreEqual(listControl.Items.Count, 1);
 
@@ -278,7 +278,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Content = treeView;
                 Content.UpdateLayout();
-                var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                var listControl = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                 treeView.RootNodes.Add(treeViewNode1);
                 var children = (treeViewNode1.Children as IObservableVector<TreeViewNode>);
                 children.VectorChanged += (vector, args) =>
@@ -335,7 +335,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     treeView.ItemTemplate = dataTemplate;
                     var node = new TreeViewNode();
                     treeView.RootNodes.Add(node);
-                    var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                    var listControl = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                     var treeViewItem = listControl.ContainerFromItem(node) as TreeViewItem;
                     Verify.AreEqual(treeViewItem.ContentTemplate, dataTemplate);
                 };
@@ -376,7 +376,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     treeView.ItemContainerStyle = style;
                     var node = new TreeViewNode();
                     treeView.RootNodes.Add(node);
-                    var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                    var listControl = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                     var treeViewItem = listControl.ContainerFromItem(node) as TreeViewItem;
                     Verify.AreEqual(treeViewItem.Style, style);
                 };
@@ -398,7 +398,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     treeView.ItemContainerTransitions = transition;
                     var node = new TreeViewNode();
                     treeView.RootNodes.Add(node);
-                    var listControl = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                    var listControl = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
                     var treeViewItem = listControl.ContainerFromItem(node) as TreeViewItem;
                     Verify.AreEqual(treeViewItem.ContentTransitions, transition);
                 };
@@ -720,7 +720,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Content = treeView;
                 Content.UpdateLayout();
 
-                var treeViewList = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+                var treeViewList = VisualTreeUtils.FindVisualChildByName(treeView, "ListControl") as TreeViewList;
 
                 // Make sure the TreeViewList does not already have the background color we are using for this test.
                 bool testCondition = treeViewList.Background is SolidColorBrush brush && brush.Color == Colors.Green;
@@ -738,35 +738,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         private bool IsMultiSelectCheckBoxChecked(TreeView tree, TreeViewNode node)
         {
             var treeViewItem = tree.ContainerFromNode(node) as TreeViewItem;
-            var checkBox = FindVisualChildByName(treeViewItem, "MultiSelectCheckBox") as CheckBox;
+            var checkBox = VisualTreeUtils.FindVisualChildByName(treeViewItem, "MultiSelectCheckBox") as CheckBox;
             return checkBox.IsChecked == true;
-        }
-
-        public static DependencyObject FindVisualChildByName(FrameworkElement parent, string name)
-        {
-            if (parent.Name == name)
-            {
-                return parent;
-            }
-
-            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
-
-            for (int i = 0; i < childrenCount; i++)
-            {
-                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
-
-                if (childAsFE != null)
-                {
-                    DependencyObject result = FindVisualChildByName(childAsFE, name);
-
-                    if (result != null)
-                    {
-                        return result;
-                    }
-                }
-            }
-
-            return null;
         }
 
         public ObservableCollection<TreeViewItemSource> CreateTreeViewItemsSource()

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -710,6 +710,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
+        [TestMethod]
+        public void TreeViewBackgroundTest()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var treeView = new TreeView();
+
+                Content = treeView;
+                Content.UpdateLayout();
+
+                var treeViewList = FindVisualChildByName(treeView, "ListControl") as TreeViewList;
+
+                // Make sure the TreeViewList does not already have the background color we are using for this test.
+                bool testCondition = treeViewList.Background is SolidColorBrush brush && brush.Color == Colors.Green;
+                Verify.IsFalse(testCondition, "The default TreeView background color should not match the test color used.");
+
+                // Check if the Background API affects the TreeView control.
+                treeView.Background = new SolidColorBrush(Colors.Green);
+                Content.UpdateLayout();
+
+                testCondition = treeViewList.Background is SolidColorBrush brush2 && brush2.Color == Colors.Green;
+                Verify.IsTrue(testCondition, "The TreeView background UI should have matched the specified test color.");
+            });
+        }
+
         private bool IsMultiSelectCheckBoxChecked(TreeView tree, TreeViewNode node)
         {
             var treeViewItem = tree.ContainerFromNode(node) as TreeViewItem;

--- a/dev/TreeView/TreeView.xaml
+++ b/dev/TreeView/TreeView.xaml
@@ -36,6 +36,7 @@
                 <ControlTemplate TargetType="local:TreeView">
                     <local:TreeViewList
                         x:Name="ListControl"
+                        Background="{TemplateBinding Background}"
                         ItemTemplate="{TemplateBinding ItemTemplate}"
                         ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                         ItemContainerStyle="{TemplateBinding ItemContainerStyle}"


### PR DESCRIPTION
## Description
This PR fixes the `TreeView.Background` API not being applied to the TreeView UI.

While adding an API test, I also cleaned up the TreeView API tests code to use the `VisualTreeUtils.FindVisualChildByName()` method instead of a local implementation.

## Motivation and Context
Fixes #3012.

## How Has This Been Tested?
Tested visually and added API test.

## Screenshots:
```xml
<TreeView Background="BlueViolet" 
    Width="200" Height="200"/>
```
![image](https://user-images.githubusercontent.com/1398851/88914514-05419200-d263-11ea-94b4-3b4d596e885f.png)

