### PR TITLE
Fix issue with TextCommandBarFlyout not opening when using custom button

### DIFF
--- a/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
@@ -648,6 +648,26 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void VerifyTextCommandBarRemainsOpenWithItems()
+        {
+            using (var setup = new TestSetupHelper(new[] { "CommandBarFlyout Tests", "Extra CommandBarFlyout Tests" }))
+            {
+                Log.Comment("Clear the clipboard.");
+                FindElement.ById<Button>("ClearClipboardContentsButton").InvokeAndWait();
+
+                Log.Comment("Right-click on the text box with additional items.");
+                FindElement.ByName("TextBoxWithAdditionalItems").Click(PointerButtons.Secondary, 20, 20);
+
+                Wait.ForIdle();
+
+                Log.Comment("Count the number of open popups.");
+                FindElement.ById<Button>("CountPopupsButton").InvokeAndWait();
+
+                Verify.AreEqual("1", FindElement.ById<Edit>("CustomButtonsOpenCount").Value);
+            }
+        }
+
         private void OpenFlyoutOn(string textControlName, bool asTransient)
         {
             Log.Comment("Opening text control flyout on the {0} in {1} mode.", textControlName, asTransient ? "transient" : "standard");

--- a/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml
@@ -20,8 +20,8 @@
         <TextBlock Text="Demo controls" Style="{ThemeResource StandardGroupHeader}"/>
         <StackPanel Orientation="Horizontal">
             <TextBox x:Name="TextBox1" AutomationProperties.AutomationId="TextBox" ContextFlyout="{x:Bind TextCommandBarContextFlyout}"
-                     MinWidth="200" SelectionFlyout="{x:Bind TextCommandBarSelectionFlyout}" />
-            <RichTextBlock x:Name="RichTextBlock1" AutomationProperties.AutomationId="RichTextBlock" Margin="10" OverflowContentTarget="{x:Bind RichTextBlockOverflow1}" ContextFlyout="{x:Bind TextCommandBarContextFlyout}" SelectionFlyout="{x:Bind TextCommandBarSelectionFlyout}" Width="100" Height="50" HorizontalAlignment="Center">
+                     MinWidth="200" />
+            <RichTextBlock x:Name="RichTextBlock1" AutomationProperties.AutomationId="RichTextBlock" Margin="10" OverflowContentTarget="{x:Bind RichTextBlockOverflow1}" ContextFlyout="{x:Bind TextCommandBarContextFlyout}" Width="100" Height="50" HorizontalAlignment="Center">
                 <RichTextBlock.Blocks>
                     <Paragraph>
                         <Run>This is a very, very long string that cannot possibly fit within the RichTextBlock's bounds, so it overflows.</Run>

--- a/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml
@@ -58,11 +58,13 @@
         </StackPanel>
         <TextBlock Text="Actions" Style="{ThemeResource StandardGroupHeader}" Margin="0,24,0,8"/>
         <Button AutomationProperties.AutomationId="ClearClipboardContentsButton" Content="Clear clipboard" Click="OnClearClipboardContentsClicked" />
+        <TextBox x:Name="tb" Loaded="tbloaded" Unloaded="tbunloaded" AutomationProperties.Name="TextBoxWithAdditionalItems"/>
 
         <TextBlock Text="Status" Style="{ThemeResource StandardGroupHeader}" Margin="0,24,0,8"/>
         <StackPanel Orientation="Horizontal">
             <Button AutomationProperties.AutomationId="CountPopupsButton" Content="Count popups" Click="OnCountPopupsClicked" Margin="0,0,8,0"/>
             <TextBox x:Name="PopupCountTextBox" AutomationProperties.AutomationId="PopupCountTextBox" IsReadOnly="True" />
+            <TextBox x:Name="CustomButtonsOpenCount" AutomationProperties.AutomationId="CustomButtonsOpenCount" IsReadOnly="True" />
         </StackPanel>
     </StackPanel>
 </local:TestPage>

--- a/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml.cs
+++ b/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml.cs
@@ -22,6 +22,8 @@ namespace MUXControlsTestApp
 {
     public sealed partial class ExtraCommandBarFlyoutPage : TestPage
     {
+        private int customButtonsFlyoutOpenCount = 0;
+
         public ExtraCommandBarFlyoutPage()
         {
             this.InitializeComponent();
@@ -76,6 +78,33 @@ namespace MUXControlsTestApp
         private void OnCountPopupsClicked(object sender, object args)
         {
             PopupCountTextBox.Text = VisualTreeHelper.GetOpenPopups(Window.Current).Count.ToString();
+            CustomButtonsOpenCount.Text = customButtonsFlyoutOpenCount.ToString();
+        }
+
+        private void tbloaded(object sender, RoutedEventArgs e)
+        {
+            tb.ContextFlyout = new Microsoft.UI.Xaml.Controls.TextCommandBarFlyout();
+            tb.ContextFlyout.Opening += ContextFlyout_Opening;
+            tb.ContextFlyout.Closed += ContextFlyout_Closed;
+        }
+
+        private void tbunloaded(object sender, RoutedEventArgs e)
+        {
+            tb.ContextFlyout.Opening -= ContextFlyout_Opening;
+        }
+
+        private void ContextFlyout_Opening(object sender, object e)
+        {
+            customButtonsFlyoutOpenCount++;
+            var flyout = (sender as Microsoft.UI.Xaml.Controls.TextCommandBarFlyout);
+            flyout.PrimaryCommands.Add(new AppBarButton() {
+                Command = new StandardUICommand(StandardUICommandKind.Close) //Just used as an example, doesn't matter what the UICommand is. Behavior is the same
+            });
+        }
+
+        private void ContextFlyout_Closed(object sender, object e)
+        {
+            customButtonsFlyoutOpenCount--;
         }
     }
 }

--- a/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml.cs
+++ b/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml.cs
@@ -51,7 +51,7 @@ namespace MUXControlsTestApp
                 TextBox1.ContextFlyout = TextCommandBarContextFlyout;
                 RichTextBlock1.ContextFlyout = TextCommandBarContextFlyout;
             }
-            
+
             try
             {
                 if (ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Controls.TextBox", "SelectionFlyout"))
@@ -98,7 +98,7 @@ namespace MUXControlsTestApp
             customButtonsFlyoutOpenCount++;
             var flyout = (sender as Microsoft.UI.Xaml.Controls.TextCommandBarFlyout);
             flyout.PrimaryCommands.Add(new AppBarButton() {
-                Command = new StandardUICommand(StandardUICommandKind.Close) //Just used as an example, doesn't matter what the UICommand is. Behavior is the same
+                Content = new TextBlock() { Text = "Test" }
             });
         }
 

--- a/dev/CommandBarFlyout/TextCommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/TextCommandBarFlyout.cpp
@@ -18,7 +18,12 @@ TextCommandBarFlyout::TextCommandBarFlyout()
         [this](auto const&, auto const&)
         {
             UpdateButtons();
+        }
+    });
 
+    Opened({
+        [this](auto const&, auto const&)
+        {
             // If there aren't any primary commands and we aren't opening expanded,
             // or if there are just no commands at all, then we'll have literally no UI to show. 
             // We'll just close the flyout in that case - nothing should be opening us


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issue with TextCommandBarFlyout closing immediatly even when there are buttons that were added manually.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2950
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new interaction test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->