### PR TITLE
Fix issue with item that just got uncollapsed not showing selection

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -1851,7 +1851,17 @@ winrt::UIElement NavigationView::FindSelectionIndicator(const winrt::IInspectabl
     {
         if (auto const container = NavigationViewItemOrSettingsContentFromData(item))
         {
-            return winrt::get_self<NavigationViewItem>(container)->GetSelectionIndicator();
+            if (const auto indicator = winrt::get_self<NavigationViewItem>(container)->GetSelectionIndicator())
+            {
+                return indicator;
+            }
+            else
+            {
+                // Indicator was not found, so maybe the layout hasn't updated yet.
+                // So let's do that now.
+                container.UpdateLayout();
+                return winrt::get_self<NavigationViewItem>(container)->GetSelectionIndicator();
+            }
         }
     }
     return nullptr;

--- a/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml
@@ -16,9 +16,11 @@
             x:Name="NavView" 
             AutomationProperties.Name="NavView" 
             AutomationProperties.AutomationId="NavView"
+            ItemInvoked="NavigationView_ItemInvoked"
             PaneTitle="NavView Test"
             IsPaneOpen="False">
             <muxcontrols:NavigationView.MenuItems>
+                <muxcontrols:NavigationViewItem x:Name="CollapsedItem" Content="Hidden" Icon="Home" Visibility="Collapsed"/>
                 <muxcontrols:NavigationViewItem x:Name="HomeItem" Content="Home" Icon="Home"/>
                 <muxcontrols:NavigationViewItem x:Name="AppsItem" Content="Apps" Icon="Shop" />
             </muxcontrols:NavigationView.MenuItems>

--- a/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml
+++ b/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml
@@ -20,6 +20,8 @@
             PaneTitle="NavView Test"
             IsPaneOpen="False">
             <muxcontrols:NavigationView.MenuItems>
+                <!-- This NavigationViewItem can be used to check whether selecting an item right after showing it still shows the selection indicator -->
+                <!-- See https://github.com/microsoft/microsoft-ui-xaml/issues/2941 for context  -->
                 <muxcontrols:NavigationViewItem x:Name="CollapsedItem" Content="Hidden" Icon="Home" Visibility="Collapsed"/>
                 <muxcontrols:NavigationViewItem x:Name="HomeItem" Content="Home" Icon="Home"/>
                 <muxcontrols:NavigationViewItem x:Name="AppsItem" Content="Apps" Icon="Shop" />

--- a/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.UI.Xaml.Controls;
+
 namespace MUXControlsTestApp
 {
     public sealed partial class NavigationViewIsPaneOpenPage : TestPage
@@ -8,6 +10,17 @@ namespace MUXControlsTestApp
         public NavigationViewIsPaneOpenPage()
         {
             this.InitializeComponent();
+
+        }
+
+        private void NavigationView_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
+        {
+            if((args.InvokedItem as string) == "Apps")
+            {
+                CollapsedItem.Visibility = Windows.UI.Xaml.Visibility.Visible;
+
+                NavView.SelectedItem = CollapsedItem;
+            }
         }
     }
 }

--- a/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml.cs
+++ b/dev/NavigationView/TestUI/NavigationViewIsPaneOpenPage.xaml.cs
@@ -13,6 +13,8 @@ namespace MUXControlsTestApp
 
         }
 
+        // This NavigationViewItem can be used to check whether selecting an item right after showing it still shows the selection indicator
+        // See https://github.com/microsoft/microsoft-ui-xaml/issues/2941 for context
         private void NavigationView_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
         {
             if((args.InvokedItem as string) == "Apps")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The root issue is that when the selected item changes, the template might not have been applied yet, resulting in the animation not rendering, and as soon as we apply the template, for some reason, the selection indicator is not ready yet.

Only after calling `UpdateLayout` on the NavigationViewItem, we can be sure that either the template just does not have a selection indicator, or that if it has one, we will get it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2941 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

Update the `IsPaneOpen` test page to include the code necessary to show the faulty behavior. We could add an API test or interaction test, however I don't think that it would be that useful, given that we would have to dig quite deeply into the template to verify the selection indicator got shown.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->