### PR TITLE
Update ShouldSkipPRBuild to include .png and .PNG

### DIFF
--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -5,7 +5,7 @@ function AllChangedFilesAreSkippable
 {
     Param($files)
 
-    $skipExts = @(".md")
+    $skipExts = @(".md", ".png", ".PNG")
     $allFilesAreSkippable = $true
 
     foreach($file in $files)


### PR DESCRIPTION
The ShouldSkipPRBuild.ps1 script checks if the change contains only .md files and if so causes the system to skip building and testing the product. I've updated the script to include .png files as many of the .md file changes and additions come with pictures as well.