### PR TITLE
RadioButtons: Fix selected radio button not being focused on tab navigation when first element in TAB navigation

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsFocusTestPageElements.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsFocusTestPageElements.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+using System;
+using System.Numerics;
+using Common;
+
+#if USING_TAEF
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+using WEX.Logging.Interop;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+#endif
+
+using Microsoft.Windows.Apps.Test.Automation;
+using Microsoft.Windows.Apps.Test.Foundation.Controls;
+using Microsoft.Windows.Apps.Test.Foundation.Waiters;
+using Microsoft.Windows.Apps.Test.Foundation;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
+{
+    class RadioButtonsFocusTestPageElements
+    {
+        public UIObject GetTestRadioButtons1()
+        {
+            return GetElement(ref TestRadioButtons1, "TestRadioButtons1");
+        }
+        private UIObject TestRadioButtons1;
+
+        public UIObject GetTestRadioButtons2()
+        {
+            return GetElement(ref TestRadioButtons2, "TestRadioButtons2");
+        }
+        private UIObject TestRadioButtons2;
+
+        public TextBlock GetSelectedIndexTextBlock1()
+        {
+            return GetElement(ref SelectedIndexTextBlock1, "SelectedIndexTextBlock1");
+        }
+        private TextBlock SelectedIndexTextBlock1;
+
+        public TextBlock GetSelectedIndexTextBlock2()
+        {
+            return GetElement(ref SelectedIndexTextBlock2, "SelectedIndexTextBlock2");
+        }
+        private TextBlock SelectedIndexTextBlock2;
+
+        public TextBlock GetFocusedIndexTextBlock1()
+        {
+            return GetElement(ref FocusedIndexTextBlock1, "FocusedIndexTextBlock1");
+        }
+        private TextBlock FocusedIndexTextBlock1;
+
+        public TextBlock GetFocusedIndexTextBlock2()
+        {
+            return GetElement(ref FocusedIndexTextBlock2, "FocusedIndexTextBlock2");
+        }
+        private TextBlock FocusedIndexTextBlock2;
+
+        public CheckBox GetRadioButtons1HasFocusCheckBox()
+        {
+            return GetElement(ref RadioButtons1HasFocusCheckBox, "TestRadioButtons1HasFocusCheckBox");
+        }
+        private CheckBox RadioButtons1HasFocusCheckBox;
+
+        public CheckBox GetRadioButtons2HasFocusCheckBox()
+        {
+            return GetElement(ref RadioButtons2HasFocusCheckBox, "TestRadioButtons2HasFocusCheckBox");
+        }
+        private CheckBox RadioButtons2HasFocusCheckBox;
+
+        public Edit GetIndexToSelectTextBox1()
+        {
+            return GetElement(ref IndexToSelectTextBox1, "IndexToSelectTextBox1");
+        }
+        private Edit IndexToSelectTextBox1;
+
+        public Edit GetIndexToSelectTextBox2()
+        {
+            return GetElement(ref IndexToSelectTextBox2, "IndexToSelectTextBox2");
+        }
+        private Edit IndexToSelectTextBox2;
+
+        public Button GetSelectByIndexButton1()
+        {
+            return GetElement(ref SelectByIndexButton, "SelectByIndexButton1");
+        }
+        private Button SelectByIndexButton;
+
+        public Button GetSelectByIndexButton2()
+        {
+            return GetElement(ref SelectByIndexButton2, "SelectByIndexButton2");
+        }
+        private Button SelectByIndexButton2;
+
+        private T GetElement<T>(ref T element, string elementName) where T : UIObject
+        {
+            if (element == null)
+            {
+                Log.Comment("Find the " + elementName);
+                element = FindElement.ByNameOrId<T>(elementName);
+                Verify.IsNotNull(element);
+            }
+            return element;
+        }
+    }
+}

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTestPageElements.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTestPageElements.cs
@@ -1,4 +1,7 @@
-﻿using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 using System;
 using System.Numerics;

--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
@@ -50,7 +50,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void SelectionTest()
         {
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 SetItemType(RadioButtonsSourceType.RadioButton);
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires TrySetNewFocusedElement from RS4");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 SetItemType(RadioButtonsSourceType.RadioButton);
@@ -118,29 +118,90 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires TrySetNewFocusedElement from RS4");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtonsFocus Test" }))
             {
-                elements = new RadioButtonsTestPageElements();
-                SetItemType(RadioButtonsSourceType.RadioButton);
-                foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
+                var elements = new RadioButtonsFocusTestPageElements();        
+
+                // Select items
+                SelectByIndex(1, false);
+                SelectByIndex(2, true);
+
+                // Verify selection
+                VerifySelectedIndex(1, false);
+                VerifySelectedIndex(2, true);
+
+                VerifyRadioButtonsHasFocus(true, false);
+
+                // Move focus to second RadioButtons control by pressing TAB
+                KeyboardHelper.PressKey(Key.Tab);
+
+                // Verify that 
+                // - the first RadioButtons control no longer has focus and
+                // - the third radio button of the second RadioButtons control now has focus
+                VerifyRadioButtonsHasFocus(false, false);
+                VerifySelectedFocusedIndex(2, true);
+
+                // Move focus to the first RadioButtons control by pressing TAB again
+                KeyboardHelper.PressKey(Key.Tab);
+
+                // Verify that the second radio button is still selected and now has focus
+                VerifySelectedFocusedIndex(1, false);
+
+                void SelectByIndex(int index, bool checkRadioButtons2)
                 {
-                    SetSource(location);
+                    if (checkRadioButtons2)
+                    {
+                        elements.GetIndexToSelectTextBox2().SetValue(index.ToString());
+                        elements.GetSelectByIndexButton2().Click();
+                    }
+                    else
+                    {
+                        elements.GetIndexToSelectTextBox1().SetValue(index.ToString());
+                        elements.GetSelectByIndexButton1().Click();
+                    }
+                }
 
-                    TapOnItem(3);
-                    VerifySelectedFocusedIndex(3);
-                    RadioButton item3 = FindElement.ByName<RadioButton>("Radio Button 3");
-                    Verify.IsTrue(item3.IsSelected);
+                void VerifySelectedIndex(int index, bool checkRadioButtons2)
+                {
+                    if (checkRadioButtons2)
+                    {
+                        Verify.AreEqual(index, Int32.Parse(elements.GetSelectedIndexTextBlock2().DocumentText), $"RadioButton with index {index} should have been selected.");
+                    }
+                    else
+                    {
+                        Verify.AreEqual(index, Int32.Parse(elements.GetSelectedIndexTextBlock1().DocumentText), $"RadioButton with index {index} should have been selected.");
+                    }
+                }
 
-                    KeyboardHelper.PressKey(Key.Tab);
-                    VerifyRadioButtonsHasFocus(false);
-                    Verify.IsTrue(item3.IsSelected);
+                void VerifyRadioButtonsHasFocus(bool hasFocus, bool checkRadioButtons2)
+                {
+                    if (checkRadioButtons2)
+                    {
+                        Verify.AreEqual(hasFocus, elements.GetRadioButtons2HasFocusCheckBox().ToggleState == ToggleState.On);
+                    }
+                    else
+                    {
+                        Verify.AreEqual(hasFocus, elements.GetRadioButtons1HasFocusCheckBox().ToggleState == ToggleState.On);
+                    }
+                }
 
-                    KeyboardHelper.PressDownModifierKey(ModifierKey.Shift);
-                    KeyboardHelper.PressKey(Key.Tab);
-                    KeyboardHelper.ReleaseModifierKey(ModifierKey.Shift);
-                    VerifySelectedFocusedIndex(3);
-                    Verify.IsTrue(item3.IsSelected);
+                void VerifyFocusedIndex(int index, bool checkRadioButtons2)
+                {
+                    if (checkRadioButtons2)
+                    {
+                        Verify.AreEqual(index, Int32.Parse(elements.GetFocusedIndexTextBlock2().DocumentText), $"RadioButton with index {index} should have focus.");
+                    }
+                    else
+                    {
+                        Verify.AreEqual(index, Int32.Parse(elements.GetFocusedIndexTextBlock1().DocumentText), $"RadioButton with index {index} should have focus.");
+                    }
+                    
+                }
 
+                void VerifySelectedFocusedIndex(int index, bool checkRadioButtons2)
+                {
+                    VerifySelectedIndex(index, checkRadioButtons2);
+                    VerifyFocusedIndex(index, checkRadioButtons2);
                 }
             }
         }
@@ -154,7 +215,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -198,7 +259,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -261,7 +322,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 SetItemType(RadioButtonsSourceType.RadioButton);
@@ -333,7 +394,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 SetItemType(RadioButtonsSourceType.RadioButton);
@@ -396,7 +457,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS2 keyboarding behavior");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -447,7 +508,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void GamepadCanEscapeAndDoesNotSelectWithFocus()
         {
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -506,7 +567,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test fails on RS2 because of a repeater bug: #1447");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -532,7 +593,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void ColumnsTest()
         {
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -579,7 +640,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void UIAProperties()
         {
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 SetItemType(RadioButtonsSourceType.RadioButton);
@@ -622,7 +683,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void InsertedCheckedRadioButtonGetsSelection()
         {
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 SetItemType(RadioButtonsSourceType.RadioButton);
@@ -645,7 +706,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test is disabled on RS2 because it requires RS3+ keyboarding behavior.");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))
@@ -678,7 +739,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS3+ keyboarding behavior");
                 return;
             }
-            using (var setup = new TestSetupHelper("RadioButtons Tests"))
+            using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))
             {
                 elements = new RadioButtonsTestPageElements();
                 foreach (RadioButtonsSourceLocation location in Enum.GetValues(typeof(RadioButtonsSourceLocation)))

--- a/dev/RadioButtons/InteractionTests/RadioButtons_InteractionTests.projitems
+++ b/dev/RadioButtons/InteractionTests/RadioButtons_InteractionTests.projitems
@@ -10,6 +10,7 @@
     <Import_RootNamespace>RadioButtons_InteractionTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)RadioButtonsFocusTestPageElements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonsTestPageElements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonsTests.cs" />
   </ItemGroup>

--- a/dev/RadioButtons/TestUI/RadioButtonsCaseBundle.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsCaseBundle.xaml
@@ -1,0 +1,29 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="RadioButtons_TestUI.RadioButtonsCaseBundle"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <VariableSizedWrapGrid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            Orientation="Horizontal">
+        <VariableSizedWrapGrid.Resources>
+            <Style TargetType="StackPanel">
+                <Setter Property="Margin" Value="4"/>
+                <Setter Property="MaxWidth" Value="400" />
+                <Setter Property="MinWidth" Value="200" />
+            </Style>
+        </VariableSizedWrapGrid.Resources>
+
+        <StackPanel>
+            <TextBlock Text="Common Tests"/>
+            <Button x:Name="RadioButtonsPage" AutomationProperties.Name="RadioButtons Test" Margin="2" HorizontalAlignment="Stretch">RadioButtons Test</Button>
+            <TextBlock Text="Special Tests" />
+            <Button x:Name="RadioButtonsFocusPage" AutomationProperties.Name="RadioButtonsFocus Test" Margin="2" HorizontalAlignment="Stretch">RadioButtons Focus Test</Button>
+        </StackPanel>
+    </VariableSizedWrapGrid>
+</local:TestPage>

--- a/dev/RadioButtons/TestUI/RadioButtonsCaseBundle.xaml.cs
+++ b/dev/RadioButtons/TestUI/RadioButtonsCaseBundle.xaml.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MUXControlsTestApp;
+using Windows.UI.Xaml.Controls;
+
+namespace RadioButtons_TestUI
+{
+    [TopLevelTestPage(Name = "RadioButtons", Icon = "RadioButton.png")]
+    public sealed partial class RadioButtonsCaseBundle : TestPage
+    {
+        public RadioButtonsCaseBundle()
+        {
+            this.InitializeComponent();
+
+            RadioButtonsPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(RadioButtonsPage), 0); };
+            RadioButtonsFocusPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(RadioButtonsFocusPage), 0); };
+        }
+    }
+}

--- a/dev/RadioButtons/TestUI/RadioButtonsFocusPage.xaml
+++ b/dev/RadioButtons/TestUI/RadioButtonsFocusPage.xaml
@@ -1,0 +1,124 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="RadioButtons_TestUI.RadioButtonsFocusPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- RadioButtons test group 1 -->
+        <controls:RadioButtons x:Name="TestRadioButtons1" Grid.Row="0" Grid.Column="0"
+                               Header="TestRadioButtons"
+                               SelectionChanged="TestRadioButtons_SelectionChanged"
+                               GotFocus="TestRadioButtons_GotFocus"
+                               LostFocus="TestRadioButtons_LostFocus">
+            <x:String>Item 1</x:String>
+            <x:String>Item 2</x:String>
+            <x:String>Item 3</x:String>
+        </controls:RadioButtons>
+
+        <!-- Selected Index/Item and focus info UI -->
+        <Grid Grid.Row="0" Grid.Column="1" Margin="10,0,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0">Selected Index:</TextBlock>
+            <TextBlock x:Name="SelectedIndexTextBlock1" AutomationProperties.Name="SelectedIndexTextBlock1" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left">-1</TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="0">Selected Item:</TextBlock>
+            <TextBlock x:Name="SelectedItemTextBlock1" AutomationProperties.Name="SelectedItemTextBlock1" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left">null</TextBlock>
+
+            <TextBlock Grid.Row="2" Grid.Column="0">Focused Index:</TextBlock>
+            <TextBlock x:Name="FocusedIndexTextBlock1" AutomationProperties.Name="FocusedIndexTextBlock1" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left">-1</TextBlock>
+
+            <TextBlock Grid.Row="3" Grid.Column="0">Has Focus:</TextBlock>
+            <CheckBox x:Name="TestRadioButtons1HasFocusCheckBox" AutomationProperties.Name="TestRadioButtons1HasFocusCheckBox" Grid.Row="3" Grid.Column="1" IsTabStop="False"/>
+        </Grid>
+
+        <!-- Select by index UI -->
+        <Grid Grid.Row="0" Grid.Column="2" Margin="10,0,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0">Index to select:</TextBlock>
+            <TextBox x:Name="IndexToSelectTextBox1" AutomationProperties.Name="IndexToSelectTextBox1" Grid.Column="1" Text="-1" Margin="5,0,0,0" VerticalAlignment="Top"
+                     IsTabStop="False"/>
+            <Button x:Name="SelectByIndexButton1" AutomationProperties.Name="SelectByIndexButton1" Grid.Column="2" IsTabStop="False" Click="SelectByIndexButton1_Click"
+                    Margin="5,0,0,0" VerticalAlignment="Top">Select by index</Button>
+        </Grid>
+
+        <!-- RadioButtons test group 2 -->
+        <controls:RadioButtons x:Name="TestRadioButtons2" Grid.Row="1" Grid.Column="0"
+                               Header="TestRadioButtons2" Margin="0,10,0,0"
+                               SelectionChanged="TestRadioButtons2_SelectionChanged"
+                               GotFocus="TestRadioButtons2_GotFocus"
+                               LostFocus="TestRadioButtons2_LostFocus">
+            <x:String>Item 1</x:String>
+            <x:String>Item 2</x:String>
+            <x:String>Item 3</x:String>
+        </controls:RadioButtons>
+
+        <!-- Selected Index/Item and focus info UI -->
+        <Grid Grid.Row="1" Grid.Column="1" Margin="10,10,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0">Selected Index:</TextBlock>
+            <TextBlock x:Name="SelectedIndexTextBlock2" AutomationProperties.Name="SelectedIndexTextBlock2" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left">-1</TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="0">Selected Item:</TextBlock>
+            <TextBlock x:Name="SelectedItemTextBlock2" AutomationProperties.Name="SelectedItemTextBlock2" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left">null</TextBlock>
+
+            <TextBlock Grid.Row="2" Grid.Column="0">Focused Index:</TextBlock>
+            <TextBlock x:Name="FocusedIndexTextBlock2" AutomationProperties.Name="FocusedIndexTextBlock2" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left">-1</TextBlock>
+
+            <TextBlock Grid.Row="3" Grid.Column="0">Has Focus:</TextBlock>
+            <CheckBox x:Name="TestRadioButtons2HasFocusCheckBox" AutomationProperties.Name="TestRadioButtons2HasFocusCheckBox" Grid.Row="3" Grid.Column="1" IsTabStop="False"/>
+        </Grid>
+
+        <!-- Select by index UI -->
+        <Grid Grid.Row="1" Grid.Column="2" Margin="10,0,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Column="0">Index to select:</TextBlock>
+            <TextBox x:Name="IndexToSelectTextBox2" AutomationProperties.Name="IndexToSelectTextBox2" Grid.Column="1" Margin="5,0,0,0" VerticalAlignment="Top" Text="-1"
+                     IsTabStop="False"/>
+            <Button x:Name="SelectByIndexButton2" AutomationProperties.Name="SelectByIndexButton2" Grid.Column="2" IsTabStop="False" Click="SelectByIndexButton2_Click"
+                    Margin="5,0,0,0" VerticalAlignment="Top">Select by index</Button>
+        </Grid>
+    </Grid>
+</local:TestPage>

--- a/dev/RadioButtons/TestUI/RadioButtonsFocusPage.xaml.cs
+++ b/dev/RadioButtons/TestUI/RadioButtonsFocusPage.xaml.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp;
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+
+namespace RadioButtons_TestUI
+{
+    public sealed partial class RadioButtonsFocusPage : TestPage
+    {
+        public RadioButtonsFocusPage()
+        {
+            this.InitializeComponent();
+
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            ChangeTestFrameVisibility(Visibility.Collapsed);
+        }
+
+        private void ChangeTestFrameVisibility(Visibility visibility)
+        {
+            var testFrame = Window.Current.Content as TestFrame;
+            testFrame.ChangeBarVisibility(visibility);
+        }
+
+        private void TestRadioButtons_SelectionChanged(object sender, Windows.UI.Xaml.Controls.SelectionChangedEventArgs e)
+        {
+            var index = TestRadioButtons1.SelectedIndex;
+            SelectedIndexTextBlock1.Text = index.ToString();
+            if (TestRadioButtons1.SelectedItem != null)
+            {
+                SelectedItemTextBlock1.Text = TestRadioButtons1.SelectedItem.ToString();
+            }
+            else
+            {
+                SelectedItemTextBlock1.Text = "null";
+            }
+
+        }
+
+        private void TestRadioButtons2_SelectionChanged(object sender, Windows.UI.Xaml.Controls.SelectionChangedEventArgs e)
+        {
+            var index = TestRadioButtons2.SelectedIndex;
+            SelectedIndexTextBlock2.Text = index.ToString();
+            if (TestRadioButtons2.SelectedItem != null)
+            {
+                SelectedItemTextBlock2.Text = TestRadioButtons2.SelectedItem.ToString();
+            }
+            else
+            {
+                SelectedItemTextBlock2.Text = "null";
+            }
+
+        }
+
+        private void TestRadioButtons_GotFocus(object sender, RoutedEventArgs e)
+        {
+            var stackPanel = VisualTreeHelper.GetChild(TestRadioButtons1, 0);
+            var repeater = (ItemsRepeater)VisualTreeHelper.GetChild(stackPanel, 1);
+            FocusedIndexTextBlock1.Text = repeater.GetElementIndex((UIElement)e.OriginalSource).ToString();
+            TestRadioButtons1HasFocusCheckBox.IsChecked = true;
+        }
+
+        private void TestRadioButtons_LostFocus(object sender, RoutedEventArgs e)
+        {
+            FocusedIndexTextBlock1.Text = "-1";
+            TestRadioButtons1HasFocusCheckBox.IsChecked = false;
+        }
+
+        private void TestRadioButtons2_GotFocus(object sender, RoutedEventArgs e)
+        {
+            var stackPanel = VisualTreeHelper.GetChild(TestRadioButtons2, 0);
+            var repeater = (ItemsRepeater)VisualTreeHelper.GetChild(stackPanel, 1);
+            FocusedIndexTextBlock2.Text = repeater.GetElementIndex((UIElement)e.OriginalSource).ToString();
+            TestRadioButtons2HasFocusCheckBox.IsChecked = true;
+        }
+
+        private void TestRadioButtons2_LostFocus(object sender, RoutedEventArgs e)
+        {
+            FocusedIndexTextBlock2.Text = "-1";
+            TestRadioButtons2HasFocusCheckBox.IsChecked = false;
+        }
+
+        private void SelectByIndexButton1_Click(object sender, RoutedEventArgs e)
+        {
+            var index = getIndexToSelect(false);
+            if (index != -2)
+            {
+                TestRadioButtons1.SelectedIndex = index;
+            }
+        }
+
+        private void SelectByIndexButton2_Click(object sender, RoutedEventArgs e)
+        {
+            var index = getIndexToSelect(true);
+            if (index != -2)
+            {
+                TestRadioButtons2.SelectedIndex = index;
+            }
+        }
+
+        private int getIndexToSelect(bool selectRadioButtons2)
+        {
+            int value;
+            bool success;
+            if (selectRadioButtons2)
+            {
+                success = Int32.TryParse(IndexToSelectTextBox2.Text, out value);
+            }
+            else
+            {
+                success = Int32.TryParse(IndexToSelectTextBox1.Text, out value);
+            }
+
+            if (success)
+            {
+                if (value >= 3)
+                {
+                    return 1;
+                }
+                if (value < -1)
+                {
+                    return -2;
+                }
+                return value;
+            }
+            return -2;
+        }
+    }
+}

--- a/dev/RadioButtons/TestUI/RadioButtonsPage.xaml.cs
+++ b/dev/RadioButtons/TestUI/RadioButtonsPage.xaml.cs
@@ -21,7 +21,6 @@ using Windows.UI.Xaml.Automation;
 
 namespace MUXControlsTestApp
 {
-    [TopLevelTestPage(Name = "RadioButtons", Icon = "RadioButton.png")]
     public sealed partial class RadioButtonsPage : TestPage
     {
         ObservableCollection<string> m_stringItemCollection;

--- a/dev/RadioButtons/TestUI/RadioButtons_TestUI.projitems
+++ b/dev/RadioButtons/TestUI/RadioButtons_TestUI.projitems
@@ -10,12 +10,26 @@
     <Import_RootNamespace>RadioButtons_TestUI</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)RadioButtonsCaseBundle.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)RadioButtonsFocusPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)RadioButtonsPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)RadioButtonsCaseBundle.xaml.cs">
+      <DependentUpon>RadioButtonsCaseBundle.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)RadioButtonsFocusPage.xaml.cs">
+      <DependentUpon>RadioButtonsFocusPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonsPage.xaml.cs">
       <DependentUpon>RadioButtonsPage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
## Description
This PR fixes issue https://github.com/microsoft/microsoft-ui-xaml/issues/3021 where focus was not set to the selected radio button when re-entering the specific RadioButtons control via TAB navigation. This issue occurs when the RadioButtons control is the *first* control in the TAB navigation route. In that case, GettingFocusEventArgs.OldFocusedElement() returns null, even if the focus was indeed set to another item before (in this case the last item in the TAB navigation route). With this PR, we now also set focus on the selected radio button (if any) when there is no old focused element as per GettingFocusEventArgs.

![radiobuttons-focus](https://user-images.githubusercontent.com/1398851/89440395-da1bde80-d74b-11ea-8043-b5e913b1b451.gif)

In order to properly test this case I had to create a new test page without the Back button and ToggleTheme button typically available on a test page as those buttons come first in the TAB navigation route so GettingFocusEventArgs.OldFocusedElement() would not be null upon tabbing into the RadioButtons control. I did not want to remove those two buttons for the existing RadioButtons test page so my only option was to create a new test page here.

I have modified an existing interaction test - FocusComingFromAnotherRepeaterTest() - to cover this specific case. The modified test is not an exact 1-to-1 re-build as I removed checks like Verify.IsTrue(item3.IsSelected); for easier testing. This should be fine as those checks are covered in the existing SelectionTest().

## Motivation and Context
Fixes #3021.

## How Has This Been Tested?
Tested visually and added interaction test.

## Screenshots:
![image](https://user-images.githubusercontent.com/1398851/89438638-5a8d1000-d749-11ea-85d0-0be2ff8f8ce7.png)
(The new landing page for RadioButtons tests)

![image](https://user-images.githubusercontent.com/1398851/89438643-5c56d380-d749-11ea-9d4e-664e369dada8.png)
(The new special focus test page)