### PR TITLE
CommandBar closes itself when buttons with flyouts are clicked.

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyout.cpp
@@ -271,7 +271,7 @@ void CommandBarFlyout::SetSecondaryCommandsToCloseWhenExecuted()
         auto button = element.try_as<winrt::AppBarButton>();
         auto toggleButton = element.try_as<winrt::AppBarToggleButton>();
 
-        if (button)
+        if (button && !button.Flyout())
         {
             m_secondaryButtonClickRevokerByIndexMap[i] = button.Click(winrt::auto_revoke, closeFlyoutFunc);
         }

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -189,6 +189,39 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void CanTapOnSecondaryItemWithFlyoutWithoutClosing()
+        {
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with sub-menu");
+                ToggleButton isFlyoutOpenCheckBox = FindElement.ById<ToggleButton>("IsFlyoutOpenCheckBox");
+
+                Action openCommandBarAction = () =>
+                {
+                    Log.Comment("Tapping on a button to show the CommandBarFlyout.");
+                    InputHelper.Tap(showCommandBarFlyoutButton);
+
+                    // Pre-RS5, CommandBarFlyouts always open expanded,
+                    // so we don't need to tap on the more button in that case.
+                    if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
+                    {
+                        Log.Comment("Expanding the CommandBar by invoking the more button.");
+                        FindElement.ById<Button>("MoreButton").InvokeAndWait();
+                    }
+                };
+
+                Log.Comment("Opening the CommandBar and invoking the first button in the secondary commands list.");
+                openCommandBarAction();
+
+
+                setup.ExecuteAndWaitForEvents(() => FindElement.ById<Button>("ProofingButton").Invoke(), new List<string>() { "ProofingButton clicked" });
+
+
+                Verify.IsTrue(isFlyoutOpenCheckBox.ToggleState == ToggleState.On);
+            }
+        }
+
+        [TestMethod]
         public void VerifyTabNavigationBetweenPrimaryAndSecondaryCommands()
         {
             if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))

--- a/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
@@ -95,7 +95,7 @@
                 <AppBarButton x:Name="ItalicButton5" AutomationProperties.AutomationId="ItalicButton5" Label="Italic" Icon="Italic" Click="OnElementClicked" />
                 <AppBarButton x:Name="UnderlineButton5" AutomationProperties.AutomationId="UnderlineButton5" Label="Underline" Icon="Underline" Click="OnElementClicked" />
                 <muxc:CommandBarFlyout.SecondaryCommands>
-                    <AppBarButton Label="Proofing">
+                    <AppBarButton x:Name="ProofingButton" AutomationProperties.AutomationId="ProofingButton" Label="Proofing" Click="OnElementClicked">
                         <AppBarButton.Flyout>
                             <MenuFlyout>
                                 <MenuFlyoutItem Text="talk" />


### PR DESCRIPTION
Fixes #2040 CommandBar closes itself when buttons with flyouts are clicked. 

## Description
We have logic that excludes buttons with flyouts from the commands which close the command bar. However it wasn't being applied in all cases, this change fixes that.

## How Has This Been Tested?
A new interaction test.