### PR TITLE
Add support for ReadOnlyList/VectorView and notifycollectionchange

### DIFF
--- a/dev/Repeater/APITests/Common/ReadOnlyNotifyPropertyChangedCollection.cs
+++ b/dev/Repeater/APITests/Common/ReadOnlyNotifyPropertyChangedCollection.cs
@@ -25,12 +25,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 
         public IEnumerator<T> GetEnumerator()
         {
-            return this.Data.GetEnumerator();
+            throw new NotImplementedException("This is not implemented and should not have be used");
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            throw new NotImplementedException("This is not implemented and should not have be used");
         }
 
         #endregion

--- a/dev/Repeater/APITests/Common/ReadOnlyNotifyPropertyChangedCollection.cs
+++ b/dev/Repeater/APITests/Common/ReadOnlyNotifyPropertyChangedCollection.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Text;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
+{
+    public class ReadOnlyNotifyPropertyChangedCollection<T> : IReadOnlyList<T>, INotifyCollectionChanged, IKeyIndexMapping
+    {
+        public ReadOnlyNotifyPropertyChangedCollection() { }
+
+        public ReadOnlyNotifyPropertyChangedCollection(IEnumerable<T> data)
+        {
+            Data = new ObservableCollection<T>(data);
+        }
+
+        #region IReadOnlyList<T>
+
+        public int Count => Data.Count;
+
+        public T this[int index] => Data[index];
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.Data.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+
+        #region INotifyCollectionChanged
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        protected virtual void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            this.CollectionChanged?.Invoke(this, e);
+        }
+
+        #endregion
+
+        public string KeyFromIndex(int index)
+        {
+            return this[index].GetHashCode().ToString();
+        }
+
+        public int IndexFromKey(string key)
+        {
+            throw new Exception();
+        }
+
+        public ObservableCollection<T> Data
+        {
+            get
+            {
+                if (_data == null)
+                {
+                    _data = new ObservableCollection<T>();
+                }
+                return _data;
+            }
+
+            set
+            {
+                if (_data != value)
+                {
+                    // Listen for future changes
+                    if (_data != null)
+                        _data.CollectionChanged -= this.OnCollectionChanged;
+
+                    _data = value;
+
+                    if (_data != null)
+                        _data.CollectionChanged += this.OnCollectionChanged;
+                }
+
+                // Raise a reset event
+                this.OnCollectionChanged(
+                    this,
+                    new NotifyCollectionChangedEventArgs(
+                        NotifyCollectionChangedAction.Reset));
+            }
+        }
+
+        private ObservableCollection<T> _data = null;
+    }
+}

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -205,7 +205,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         {
             RunOnUIThread.Execute(() =>
             {
-                var collection = new ObservableDataSource<object>();
+                var collection = new ReadOnlyNotifyPropertyChangedCollection<object>();
                 var firstItem = "something1";
                 
                 collection.Data = new ObservableCollection<object>();
@@ -232,7 +232,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
             RunOnUIThread.Execute(() =>
             {
-                var collection = new ObservableDataSource<object>();
+                var collection = new ReadOnlyNotifyPropertyChangedCollection<object>();
 
                 var itemsSourceView = new ItemsSourceView(collection);
                 itemsSourceView.CollectionChanged += ItemsSourceView_CollectionChanged;
@@ -449,90 +449,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Index = (uint)index;
                 }
             }
-        }
-
-        public class ObservableDataSource<T> : IReadOnlyList<T>, INotifyCollectionChanged, IKeyIndexMapping
-        {
-            public ObservableDataSource() { }
-
-            public ObservableDataSource(IEnumerable<T> data)
-            {
-                Data = new ObservableCollection<T>(data);
-            }
-
-            #region IReadOnlyList<T>
-
-            public int Count => Data.Count;
-
-            public T this[int index] => Data[index];
-
-            public IEnumerator<T> GetEnumerator()
-            {
-                return this.Data.GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-
-            #endregion
-
-            #region INotifyCollectionChanged
-
-            public event NotifyCollectionChangedEventHandler CollectionChanged;
-
-            protected virtual void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-            {
-                this.CollectionChanged?.Invoke(this, e);
-            }
-
-            #endregion
-
-            public string KeyFromIndex(int index)
-            {
-                return this[index].GetHashCode().ToString();
-            }
-
-            public int IndexFromKey(string key)
-            {
-                throw new Exception();
-            }
-
-            public ObservableCollection<T> Data
-            {
-                get
-                {
-                    if (_data == null)
-                    {
-                        _data = new ObservableCollection<T>();
-                    }
-                    return _data;
-                }
-
-                set
-                {
-                    if (_data != value)
-                    {
-                        // Listen for future changes
-                        if (_data != null)
-                            _data.CollectionChanged -= this.OnCollectionChanged;
-
-                        _data = value;
-
-                        if (_data != null)
-                            _data.CollectionChanged += this.OnCollectionChanged;
-                    }
-
-                    // Raise a reset event
-                    this.OnCollectionChanged(
-                        this,
-                        new NotifyCollectionChangedEventArgs(
-                            NotifyCollectionChangedAction.Reset));
-                }
-            }
-
-            private ObservableCollection<T> _data = null;
         }
 
         class ObservableVectorWithUniqueIds : ObservableCollection<int>, IKeyIndexMapping

--- a/dev/Repeater/APITests/InspectingDataSourceTests.cs
+++ b/dev/Repeater/APITests/InspectingDataSourceTests.cs
@@ -15,7 +15,6 @@ using System;
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using MUXControlsTestApp.Utils;
-using System.Runtime.Serialization;
 
 #if USING_TAEF
 using WEX.TestExecution;

--- a/dev/Repeater/APITests/Repeater_APITests.projitems
+++ b/dev/Repeater/APITests/Repeater_APITests.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Common\CollectionChangeEventArgsConverters.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\CustomItemsSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\CustomItemsSourceView.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\ReadOnlyNotifyPropertyChangedCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ElementAnimatorDerived.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\LayoutExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\FlowLayoutDerived.cs" />

--- a/dev/Repeater/InspectingDataSource.cpp
+++ b/dev/Repeater/InspectingDataSource.cpp
@@ -14,52 +14,32 @@ InspectingDataSource::InspectingDataSource(const winrt::IInspectable& source)
         throw winrt::hresult_invalid_argument(L"Argument 'source' is null.");
     }
 
-    auto vector = source.try_as<winrt::IVector<winrt::IInspectable>>();
-    if (vector)
+    if (const auto vector = source.try_as<winrt::IVector<winrt::IInspectable>>())
     {
         m_vector.set(vector);
         ListenToCollectionChanges();
     }
+    else if (const auto bindableVector = source.try_as<winrt::IBindableVector>())
+    {
+        m_vector.set(reinterpret_cast<const winrt::IVector<winrt::IInspectable>&>(bindableVector));
+        ListenToCollectionChanges();
+    }
+    else if (const auto vectorView = source.try_as<winrt::IVectorView<winrt::IInspectable>>())
+    {
+        m_vectorView.set(vectorView);
+        ListenToCollectionChanges();
+    }
+    else if (const auto iterable = source.try_as<winrt::IIterable<winrt::IInspectable>>())
+    {
+        m_vector.set(WrapIterable(iterable));
+    }
+    else if (const auto bindableIterable = source.try_as<winrt::IBindableIterable>())
+    {
+        m_vector.set(WrapIterable(reinterpret_cast<const winrt::IIterable<winrt::IInspectable>&>(bindableIterable)));
+    }
     else
     {
-        const auto vectorView = source.try_as<winrt::IVectorView<winrt::IInspectable>>();
-        if (vectorView)
-        {
-            m_vectorViewInsteadOfVector = true;
-            m_vectorView.set(vectorView);
-            ListenToCollectionChanges();
-        }
-        else
-        {
-            // The bindable interop interface are abi compatible with the corresponding
-            // WinRT interfaces.
-            auto bindableVector = source.try_as<winrt::IBindableVector>();
-            if (bindableVector)
-            {
-                m_vector.set(reinterpret_cast<const winrt::IVector<winrt::IInspectable>&>(bindableVector));
-                ListenToCollectionChanges();
-            }
-            else
-            {
-                auto iterable = source.try_as<winrt::IIterable<winrt::IInspectable>>();
-                if (iterable)
-                {
-                    m_vector.set(WrapIterable(iterable));
-                }
-                else
-                {
-                    auto bindableIterable = source.try_as<winrt::IBindableIterable>();
-                    if (bindableIterable)
-                    {
-                        m_vector.set(WrapIterable(reinterpret_cast<const winrt::IIterable<winrt::IInspectable>&>(bindableIterable)));
-                    }
-                    else
-                    {
-                        throw winrt::hresult_invalid_argument(L"Argument 'source' is not a supported vector.");
-                    }
-                }
-            }
-        }
+        throw winrt::hresult_invalid_argument(L"Argument 'source' is not a supported vector.");
     }
 
     m_uniqueIdMaping = source.try_as<winrt::IKeyIndexMapping>();
@@ -74,7 +54,7 @@ InspectingDataSource::~InspectingDataSource()
 
 int32_t InspectingDataSource::GetSizeCore()
 {
-    if (m_vectorViewInsteadOfVector)
+    if (m_vectorView)
     {
         return static_cast<int>(m_vectorView.get().Size());
     }
@@ -86,7 +66,7 @@ int32_t InspectingDataSource::GetSizeCore()
 
 winrt::IInspectable InspectingDataSource::GetAtCore(int index)
 {
-    if (m_vectorViewInsteadOfVector)
+    if (m_vectorView)
     {
         return m_vectorView.get().GetAt(static_cast<unsigned>(index));
     }
@@ -128,17 +108,15 @@ int InspectingDataSource::IndexFromKeyCore(winrt::hstring const& id)
 int InspectingDataSource::IndexOfCore(winrt::IInspectable const& value)
 {
     int index = -1;
-    if (m_vectorViewInsteadOfVector)
+    if (m_vectorView)
     {
-        if (m_vectorView)
+        auto v = static_cast<uint32_t>(-1);
+        if (m_vectorView.get().IndexOf(value, v))
         {
-            auto v = static_cast<uint32_t>(-1);
-            if (m_vectorView.get().IndexOf(value, v))
-            {
-                index = static_cast<int>(v);
-            }
+            index = static_cast<int>(v);
         }
-    }else if (m_vector)
+    }
+    else if (m_vector)
     {
         auto v = static_cast<uint32_t>(-1);
         if (m_vector.get().IndexOf(value, v))
@@ -183,7 +161,7 @@ void InspectingDataSource::UnListenToCollectionChanges()
 
 void InspectingDataSource::ListenToCollectionChanges()
 {
-    if (m_vectorViewInsteadOfVector)
+    if (!m_vector)
     {
         MUX_ASSERT(m_vectorView);
     }
@@ -192,7 +170,7 @@ void InspectingDataSource::ListenToCollectionChanges()
         MUX_ASSERT(m_vector);
     }
     const auto incc = [this]() {
-        if (m_vectorViewInsteadOfVector)
+        if (m_vectorView)
         {
             return m_vectorView.try_as<winrt::INotifyCollectionChanged>();
         }

--- a/dev/Repeater/InspectingDataSource.cpp
+++ b/dev/Repeater/InspectingDataSource.cpp
@@ -185,23 +185,15 @@ void InspectingDataSource::ListenToCollectionChanges()
         m_eventToken = incc.CollectionChanged({ this, &InspectingDataSource::OnCollectionChanged });
         m_notifyCollectionChanged.set(incc);
     }
-    else
+    else if (const auto bindableObservableVector = m_vector.try_as<winrt::IBindableObservableVector>())
     {
-        auto bindableObservableVector = m_vector.try_as<winrt::IBindableObservableVector>();
-        if (bindableObservableVector)
-        {
-            m_eventToken = bindableObservableVector.VectorChanged({ this, &InspectingDataSource::OnBindableVectorChanged });
-            m_bindableObservableVector.set(bindableObservableVector);
-        }
-        else
-        {
-            auto observableVector = m_vector.try_as<winrt::IObservableVector<winrt::IInspectable>>();
-            if (observableVector)
-            {
-                m_eventToken = observableVector.VectorChanged({ this, &InspectingDataSource::OnVectorChanged });
-                m_observableVector.set(observableVector);
-            }
-        }
+        m_eventToken = bindableObservableVector.VectorChanged({ this, &InspectingDataSource::OnBindableVectorChanged });
+        m_bindableObservableVector.set(bindableObservableVector);
+
+    }
+    else if(const auto observableVector = m_vector.try_as<winrt::IObservableVector<winrt::IInspectable>>()){
+        m_eventToken = observableVector.VectorChanged({ this, &InspectingDataSource::OnVectorChanged });
+        m_observableVector.set(observableVector);
     }
 }
 

--- a/dev/Repeater/InspectingDataSource.cpp
+++ b/dev/Repeater/InspectingDataSource.cpp
@@ -128,7 +128,7 @@ int InspectingDataSource::IndexFromKeyCore(winrt::hstring const& id)
 int InspectingDataSource::IndexOfCore(winrt::IInspectable const& value)
 {
     int index = -1;
-    if (m_vectorView)
+    if (m_vectorViewInsteadOfVector)
     {
         if (m_vectorView)
         {

--- a/dev/Repeater/InspectingDataSource.h
+++ b/dev/Repeater/InspectingDataSource.h
@@ -43,7 +43,9 @@ private:
         const winrt::Collections::IObservableVector<winrt::IInspectable>& sender,
         const winrt::Collections::IVectorChangedEventArgs& e);
 
+    bool m_vectorViewInsteadOfVector{ false };
     tracker_ref<winrt::Collections::IVector<winrt::IInspectable>> m_vector{ this };
+    tracker_ref<winrt::Collections::IVectorView<winrt::IInspectable>> m_vectorView{ this };
 
     // To unhook event from data source
     tracker_ref<winrt::INotifyCollectionChanged> m_notifyCollectionChanged{ this };

--- a/dev/Repeater/InspectingDataSource.h
+++ b/dev/Repeater/InspectingDataSource.h
@@ -43,7 +43,6 @@ private:
         const winrt::Collections::IObservableVector<winrt::IInspectable>& sender,
         const winrt::Collections::IVectorChangedEventArgs& e);
 
-    bool m_vectorViewInsteadOfVector{ false };
     tracker_ref<winrt::Collections::IVector<winrt::IInspectable>> m_vector{ this };
     tracker_ref<winrt::Collections::IVectorView<winrt::IInspectable>> m_vectorView{ this };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The IVectorView (projected IReadOnlyList) interface weren't properly supported by ItemsSourceView.

Given that for some reason IVector does not derive from IVectorView despite being a superset of it API wise, we need to store a reference to the IVectorView manually, and branch if we need to invoke API's that deal with the data itself, e.g. `IndexOf` or ` GetAt`.

While adding support for IVectorView, we are also not listening to it's collection change, if the list supports INotifyCollectionChange.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

Fixes #151

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add new API tests.

## Additional Questions (All fixed)
It seems that in ItemsSourceView, we are not using `const` a lot. Was there a specific reason for this, or should we fix this, given that we are already in this class?

Another thing I noticed, is how we construct an InspectingSourceView. Instead of doing:

```c++
if(const auto isA = x.as<A>())
{}
else if(const auto isB = x.as<B>())
{}
else if(const auto isC =x.as<C>())
{}
```

we are doing:
```c++
if(const auto isA = x.as<A>())
{}
else
{
  if(const auto isB = x.as<B>())
  {}
  else 
  {
    if(const auto isC =x.as<C>())
    {}
    else
    {
      if(const auto isD =x.as<D>())
      {}
    }
  }
}
```

This nesting of ifs in else cases seems a bit weird given that we usually chain else ifs everywhere else. Is there a reason for this?