### PR TITLE
Add workaround so ItemsRepeater doesn't leak the result of DataTemplate::Load

### DIFF
--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -614,9 +614,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
     
         [TestMethod]
-        public void CreatesAndRecyclesSameNumberOfItems()
+        public void VerifyRepeaterDoesNotLeakItemContainers()
         {
-
             ObservableCollection<int> items = new ObservableCollection<int>();
             for(int i=0;i<10;i++)
             {

--- a/dev/Repeater/APITests/RepeaterTests.cs
+++ b/dev/Repeater/APITests/RepeaterTests.cs
@@ -30,9 +30,6 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Collections.Generic;
 using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks;
-using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common;
-using Windows.UI.Composition;
-using System.Threading.Tasks;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 {
@@ -645,8 +642,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
 
             IdleSynchronizer.Wait();
-            // Wait until the Tick to make sure all layout has completed.
-            RunOnUIThread.WaitForTick();
 
             RunOnUIThread.Execute(() =>
             {
@@ -659,8 +654,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
 
             IdleSynchronizer.Wait();
-            // Wait until the Tick to make sure all layout has completed.
-            RunOnUIThread.WaitForTick();
 
             GC.Collect();
             GC.WaitForPendingFinalizers();

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -621,7 +621,17 @@ void ItemsRepeater::OnItemTemplateChanged(const winrt::IElementFactory& oldValue
         if (auto dataTemplate = newValue.try_as<winrt::DataTemplate>())
         {
             m_itemTemplateWrapper = winrt::make<ItemTemplateWrapper>(dataTemplate);
-            if (!dataTemplate.LoadContent().as<winrt::FrameworkElement>()) {
+            if (auto content = dataTemplate.LoadContent().as<winrt::FrameworkElement>())
+            {
+                // Due to bug https://github.com/microsoft/microsoft-ui-xaml/issues/3057, we need to get the framework
+                // to take ownership of the extra implicit ref that was returned by LoadContent. The simplest way to do
+                // this is to add it to a Children collection and immediately remove it.
+                auto children = Children();
+                children.Append(content);
+                children.RemoveAtEnd();
+            }
+            else
+            {
                 // We have a DataTemplate which is empty, so we need to set it to true
                 m_isItemTemplateEmpty = true;
             }

--- a/dev/Repeater/TestUI/Repeater_TestUI.projitems
+++ b/dev/Repeater/TestUI/Repeater_TestUI.projitems
@@ -19,6 +19,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Samples\ItemTemplateSamples\DisposableUserControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Samples\LayoutSamples\VirtualLayoutPages\ActivityFeedSamplePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -111,6 +115,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Samples\ItemsSourceSamples\SortingAndFilteringPage.xaml.cs">
       <DependentUpon>SortingAndFilteringPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Samples\ItemTemplateSamples\DisposableUserControl.xaml.cs">
+      <DependentUpon>DisposableUserControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Samples\LayoutSamples\VirtualLayoutPages\ActivityFeedLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\LayoutSamples\VirtualLayoutPages\ActivityFeedSamplePage.xaml.cs">

--- a/dev/Repeater/TestUI/Samples/ItemTemplateSamples/DisposableUserControl.xaml
+++ b/dev/Repeater/TestUI/Samples/ItemTemplateSamples/DisposableUserControl.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl
+    x:Class="MUXControlsTestApp.Samples.DisposableUserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+        <TextBlock Text="{x:Bind Number}"/>
+    </Grid>
+</UserControl>

--- a/dev/Repeater/TestUI/Samples/ItemTemplateSamples/DisposableUserControl.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ItemTemplateSamples/DisposableUserControl.xaml.cs
@@ -21,15 +21,12 @@ namespace MUXControlsTestApp.Samples
     public sealed partial class DisposableUserControl : UserControl
     {
 
-        private int num;
-
         public int Number
         {
             get { return (int)GetValue(NumberProperty); }
-            set { SetValue(NumberProperty, value); num = value; }
+            set { SetValue(NumberProperty, value); }
         }
 
-        // Using a DependencyProperty as the backing store for Number.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty NumberProperty =
             DependencyProperty.Register("Number", typeof(int), typeof(DisposableUserControl), new PropertyMetadata(-1));
 
@@ -39,7 +36,6 @@ namespace MUXControlsTestApp.Samples
 
         public DisposableUserControl()
         {
-            num = -1;
             Interlocked.Increment(ref _counter);
             this.InitializeComponent();
         }
@@ -47,7 +43,6 @@ namespace MUXControlsTestApp.Samples
         ~DisposableUserControl()
         {
             Interlocked.Decrement(ref _counter);
-            int value = this.num;
         }
     }
 }

--- a/dev/Repeater/TestUI/Samples/ItemTemplateSamples/DisposableUserControl.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ItemTemplateSamples/DisposableUserControl.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace MUXControlsTestApp.Samples
+{
+    public sealed partial class DisposableUserControl : UserControl
+    {
+
+        private int num;
+
+        public int Number
+        {
+            get { return (int)GetValue(NumberProperty); }
+            set { SetValue(NumberProperty, value); num = value; }
+        }
+
+        // Using a DependencyProperty as the backing store for Number.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty NumberProperty =
+            DependencyProperty.Register("Number", typeof(int), typeof(DisposableUserControl), new PropertyMetadata(-1));
+
+
+        public static int OpenItems { get { return _counter; } }
+        private static int _counter = 0;
+
+        public DisposableUserControl()
+        {
+            num = -1;
+            Interlocked.Increment(ref _counter);
+            this.InitializeComponent();
+        }
+
+        ~DisposableUserControl()
+        {
+            Interlocked.Decrement(ref _counter);
+            int value = this.num;
+        }
+    }
+}

--- a/dev/Repeater/TestUI/Samples/ItemTemplateSamples/ItemTemplateDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/ItemTemplateSamples/ItemTemplateDemo.xaml
@@ -16,6 +16,7 @@
             <ColumnDefinition Width="auto" />
             <ColumnDefinition Width="auto" />
             <ColumnDefinition Width="auto" />
+            <ColumnDefinition Width="auto" />
         </Grid.ColumnDefinitions>
         <StackPanel>
             <TextBlock>DataTemplate Sample:</TextBlock>
@@ -80,7 +81,7 @@
             <TextBlock>ElementFactory Multiple Template Sample:</TextBlock>
             <controls:ItemsRepeaterScrollHost Height="400" Width="150">
                 <ScrollViewer>
-                    <controls:ItemsRepeater x:Name="repeater3" 
+                    <controls:ItemsRepeater x:Name="repeater4" 
                                             ItemsSource="{x:Bind Data}"
                                             Layout="{StaticResource stackLayout}">
                         <controls:ItemsRepeater.ItemTemplate>
@@ -94,6 +95,22 @@
                                     <TextBlock Text="{Binding}" Foreground="Green" />
                                 </DataTemplate>
                             </controls:RecyclingElementFactory>
+                        </controls:ItemsRepeater.ItemTemplate>
+                    </controls:ItemsRepeater>
+                </ScrollViewer>
+            </controls:ItemsRepeaterScrollHost>
+        </StackPanel>
+        <StackPanel Grid.Column="4">
+            <TextBlock>DataTemplate clear count checking:</TextBlock>
+            <controls:ItemsRepeaterScrollHost Height="400" Width="150">
+                <ScrollViewer>
+                    <controls:ItemsRepeater x:Name="repeater3" 
+                                            ItemsSource="{x:Bind Numbers}"
+                                            Layout="{StaticResource stackLayout}">
+                        <controls:ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="local:MyData" >
+                                <local:DisposableUserControl Number="{x:Bind number}"/>
+                            </DataTemplate>
                         </controls:ItemsRepeater.ItemTemplate>
                     </controls:ItemsRepeater>
                 </ScrollViewer>

--- a/dev/Repeater/TestUI/Samples/ItemTemplateSamples/ItemTemplateDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/ItemTemplateSamples/ItemTemplateDemo.xaml.cs
@@ -13,16 +13,34 @@ namespace MUXControlsTestApp.Samples
 {
     public sealed partial class ItemTemplateDemo : Page
     {
-        public List<int> Data { get; set; } 
+        public List<int> Data { get; set; }
+        public List<MyData> Numbers = new List<MyData>();
+
         public ItemTemplateDemo()
         {
             Data = Enumerable.Range(0, 1000).ToList();
+            
+            for(int i=0;i<10;i++)
+            {
+                Numbers.Add(new MyData(i));
+            }
+
             this.InitializeComponent();
         }
 
         private void OnSelectTemplateKey(RecyclingElementFactory sender, SelectTemplateEventArgs args)
         {
             args.TemplateKey = (((int)args.DataContext) % 2 == 0) ? "even" : "odd";
+        }
+    }
+
+    public class MyData
+    {
+        public int number;
+
+        public MyData(int number)
+        {
+            this.number = number;
         }
     }
 

--- a/test/MUXControlsTestApp/Utilities/RunOnUIThread.cs
+++ b/test/MUXControlsTestApp/Utilities/RunOnUIThread.cs
@@ -90,19 +90,26 @@ namespace MUXControlsTestApp.Utilities
             }
         }
 
-        public async Task WaitForTick()
+        public static void WaitForTick()
         {
-            var renderingEventFired = new TaskCompletionSource<object>();
+            var renderingEvent = new ManualResetEvent(false);
 
-            EventHandler<object> renderingCallback = (sender, arg) =>
+            EventHandler<object> renderingHandler = (object sender, object args) =>
             {
-                renderingEventFired.TrySetResult(null);
+                renderingEvent.Set();
             };
-            CompositionTarget.Rendering += renderingCallback;
 
-            await renderingEventFired.Task;
+            RunOnUIThread.Execute(() =>
+            {
+                Windows.UI.Xaml.Media.CompositionTarget.Rendering += renderingHandler;
+            });
 
-            CompositionTarget.Rendering -= renderingCallback;
+            renderingEvent.WaitOne();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Windows.UI.Xaml.Media.CompositionTarget.Rendering -= renderingHandler;
+            });
         }
 
     }

--- a/test/MUXControlsTestApp/Utilities/RunOnUIThread.cs
+++ b/test/MUXControlsTestApp/Utilities/RunOnUIThread.cs
@@ -101,14 +101,14 @@ namespace MUXControlsTestApp.Utilities
 
             RunOnUIThread.Execute(() =>
             {
-                Windows.UI.Xaml.Media.CompositionTarget.Rendering += renderingHandler;
+                CompositionTarget.Rendering += renderingHandler;
             });
 
             renderingEvent.WaitOne();
 
             RunOnUIThread.Execute(() =>
             {
-                Windows.UI.Xaml.Media.CompositionTarget.Rendering -= renderingHandler;
+                CompositionTarget.Rendering -= renderingHandler;
             });
         }
 


### PR DESCRIPTION
The thread of #1954 has lots more information, but the short story is that ItemsRepeater has a call to DataTemplate::LoadContent to decide if the template is empty. DataTemplate::LoadContent has a bug (#3057) where if you don't add the result to a UIElementCollection then the returned object will be leaked. The simplest workaround is to just add the result to the ItemsRepeater's own child collection and immediately remove it.

Thanks @chingucoding for the test code. I changed the scenario a little from what you had built because I wanted to verify that all the items get cleaned up.

Fixes #1954 