### PR TITLE
Change disabled tests to use [TestProperty("Ignore", "True")]

### DIFF
--- a/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
+++ b/dev/AutoSuggestBox/APITests/AutoSuggestBoxTests.cs
@@ -62,7 +62,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
         // Disabling flaky test
         // https://github.com/microsoft/microsoft-ui-xaml/issues/2363
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void VerifyVisualTree()
         {
             var autoSuggestBox = SetupAutoSuggestBox();

--- a/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
+++ b/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
@@ -87,7 +87,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         //BUGBUG: Bug 18287798: Failure 183760047- Failed: MUXControls.ApiTests.LightConfigurationTests.VerifyLightsOnSecondaryWindow
         public void VerifyLightsOnSecondaryWindow()
         {
@@ -107,7 +108,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         // Disabled due to: Bug 17808897: Test unreliable in master: MUXControls.ApiTests.LightConfigurationTests.VerifyLightsAfterResettingContentOnSecondaryWindow
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void VerifyLightsAfterResettingContentOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())
@@ -117,7 +119,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         // Disabled due to: Bug 17808897: Test unreliable in master: MUXControls.ApiTests.LightConfigurationTests.VerifyLightsAfterResettingContentOnSecondaryWindow
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void VerifyLightsAttachedDuringLayoutOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())

--- a/dev/Materials/Reveal/APITests/RevealTests.cs
+++ b/dev/Materials/Reveal/APITests/RevealTests.cs
@@ -24,7 +24,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
     [TestClass]
     public class RevealTests : ApiTestBase
     {
-        //[TestMethod] TODO: Re-enable once issue #644 is fixed.
+        [TestMethod] //TODO: Re-enable once issue #644 is fixed.
+        [TestProperty("Ignore", "True")]
         public void ValidateAppBarButtonRevealStyles()
         {
             AppBarButton buttonLabelsOnRight = null;

--- a/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
+++ b/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
@@ -60,7 +60,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         // Disabled due to: Bug 17762113: MUXControls.InteractionTests.RevealBrushTests.RevealBrushAudit failing in MUXControls in master
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void RevealBrushAudit()
         {
             if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))

--- a/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
+++ b/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
@@ -42,7 +42,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             TestCleanupHelper.Cleanup();
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: 
         // https://github.com/Microsoft/microsoft-ui-xaml/issues/115
         public void BasicMouseInteractionTest()
@@ -156,7 +157,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
         
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: MenuBarTests.KeyboardNavigationWithAccessKeysTest unreliable #135
         public void KeyboardNavigationWithAccessKeysTest()
         {

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -611,7 +611,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         // Disabled per GitHub Issue #211
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void VerifyCanNotAddWUXItems()
         {
             if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Controls.NavigationViewItem"))

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -496,7 +496,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             }
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: Bug 18650478: Test instability: NavigationViewTests.TitleBarTest
         public void TitleBarTest()
         {
@@ -1100,7 +1101,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             }
         }
 
-        // [TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void ToolTipTest() // Verify tooltips appear, and that their contents change when headers change
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();
@@ -1163,7 +1165,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             }
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: Multiple unreliable NavigationView tests #134
         public void KeyboardFocusToolTipTest() // Verify tooltips appear when Keyboard focused
         {
@@ -1227,7 +1230,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             }
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void ToolTipCustomContentTest() // Verify tooltips don't appear for custom NavViewItems (split off due to CatGates timeout)
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))

--- a/dev/NavigationView/NavigationView_InteractionTests/FocusBehaviorTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/FocusBehaviorTests.cs
@@ -101,6 +101,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                 Verify.IsNotNull(focusedElement);
             }
         }
+
         [TestMethod]
         public void EnsureLeftSettingsRetainsFocusAfterOrientationChanges()
         {

--- a/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
@@ -572,7 +572,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         //Bug 19342138: Text of navigation menu items text is lost when shrinking the width of the UWP application
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void EnsurePaneCanBeHidden()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
@@ -589,7 +590,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         //Bug 19342138: Text of navigation menu items text is lost when shrinking the width of the UWP application
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void EnsurePaneCanBeHiddenWithFixedWindowSize()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))

--- a/dev/NavigationView/NavigationView_InteractionTests/SelectionTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/SelectionTests.cs
@@ -39,7 +39,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             TestEnvironment.Initialize(testContext);
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: Multiple unreliable NavigationView tests #134
         public void SuppressSelectionItemInvokeTest()
         {

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
@@ -40,7 +40,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             TestCleanupHelper.Cleanup();
         }
 
-        // [TestMethod] Disabled pending investigation of 11754081
+        [TestMethod] //Disabled pending investigation of 11754081
+        [TestProperty("Ignore", "True")]
         public void DeconstructionHandlesCorrectlyTest()
         {
             using (var setup = new TestSetupHelper("ScrollViewerAdapter Tests")) // This literally clicks the button corresponding to the test page.

--- a/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
+++ b/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
@@ -55,7 +55,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             "Expanded"
         };
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         //Disabled due to Bug 19603059: RadioMenuFlyoutItemTests is occasionally failing in the lab
         public void BasicTest()
         {

--- a/dev/RatingControl/InteractionTests/RatingControlTests.cs
+++ b/dev/RatingControl/InteractionTests/RatingControlTests.cs
@@ -266,8 +266,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        //RatingControlTests.GamepadTest unreliable test #155
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")] //RatingControlTests.GamepadTest unreliable test #155
         public void GamepadTest()
         {
             using (var setup = new TestSetupHelper("RatingControl Tests")) // This literally clicks the button corresponding to the test page.
@@ -662,7 +662,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         // These two tests that try and test live mid-input visual changes are unreliable.
-        // [TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void EnsureScaleMaintainedOnTap()
         {
             using (var setup = new TestSetupHelper("RatingControl Tests")) // This literally clicks the button corresponding to the test page.
@@ -691,7 +692,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // [TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void VerifyRatingItemFallback()
         {
             // This test is actually performed in the test app itself, so go look at RatingControlPage.xaml.cs for the meat of it.

--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -441,7 +441,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void ReplaceMultipleItems()
         {
             // TODO: Lower prioirty scenario. Tracked by work item: 9738020

--- a/dev/Repeater/APITests/ViewManagerTests.cs
+++ b/dev/Repeater/APITests/ViewManagerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common;
@@ -85,7 +85,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        // [TestMethod] Issue #1018
+        [TestMethod] //Issue #1018
+        [TestProperty("Ignore", "True")]
         public void CanPinFocusedElements()
         {
             // Setup a grouped repeater scenario with two groups each containing two items.
@@ -186,7 +187,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        // [TestMethod] Issue 1018
+        [TestMethod] //Issue 1018
+        [TestProperty("Ignore", "True")]
         public void CanReuseElementsDuringUniqueIdReset()
         {
             var data = new WinRTCollection(Enumerable.Range(0, 2).Select(i => string.Format("Item #{0}", i)));
@@ -658,7 +660,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        // [TestMethod] Issue 1018
+        [TestMethod]// Issue 1018
+        [TestProperty("Ignore", "True")]
         public void ValidateFocusMoveOnElementCleared()
         {
             ItemsRepeater repeater = null;
@@ -702,7 +705,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 });
         }
 
-        // [TestMethod] Issue 1018
+        [TestMethod] //Issue 1018
+        [TestProperty("Ignore", "True")]
         public void ValidateFocusMoveOnElementClearedWithUniqueIds()
         {
             ItemsRepeater repeater = null;

--- a/dev/Repeater/APITests/ViewportTests.cs
+++ b/dev/Repeater/APITests/ViewportTests.cs
@@ -97,7 +97,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        // [TestMethod] Temporarily disabled for bug 18866003
+        [TestMethod]// Temporarily disabled for bug 18866003
+        [TestProperty("Ignore", "True")]
         public void ValidateItemsRepeaterScrollHostScenario()
         {
             var realizationRects = new List<Rect>();
@@ -840,7 +841,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        // [TestMethod] Temporarily disabled for bug 18866003
+        [TestMethod]// Temporarily disabled for bug 18866003
+        [TestProperty("Ignore", "True")]
         public void ValidateLoadUnload()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone2))
@@ -990,7 +992,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
         // Test is flaky - disabling it while debugging the issue.
         // Bug 17581054: RepeaterTests.ViewportTests.CanBringIntoViewElements is failing on RS4 
-        // [TestMethod]
+        [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void CanBringIntoViewElements()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))

--- a/dev/ScrollPresenter/InteractionTests/ScrollPresenterTestsWithInputHelper.cs
+++ b/dev/ScrollPresenter/InteractionTests/ScrollPresenterTestsWithInputHelper.cs
@@ -365,8 +365,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        //[TestMethod]
-        //[TestProperty("Description", "Pinch a Rectangle in a ScrollPresenter.")]
+        [TestMethod]
+        [TestProperty("Description", "Pinch a Rectangle in a ScrollPresenter.")]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: ScrollPresenterTestsWithInputHelper Pinch/Stretch tests fail on RS5 in Helix #132
         public void PinchRectangle()
         {
@@ -484,8 +485,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             while (additionalAttempts > 0);
         }
 
-        //[TestMethod]
-        //[TestProperty("Description", "Stretch an Image in a ScrollPresenter.")]
+        [TestMethod]
+        [TestProperty("Description", "Stretch an Image in a ScrollPresenter.")]
+        [TestProperty("Ignore", "True")]
         // Disable due to: ScrollPresenterTestsWithInputHelper Pinch/Stretch tests fail on RS5 in Helix #132
         public void StretchImage()
         {
@@ -582,8 +584,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             while (additionalAttempts > 0);
         }
 
-        //[TestMethod]
-        //[TestProperty("Description", "Pinch a Rectangle in a ScrollPresenter with the mouse wheel.")]
+        [TestMethod]
+        [TestProperty("Description", "Pinch a Rectangle in a ScrollPresenter with the mouse wheel.")]
+        [TestProperty("Ignore", "True")]
         // Disabled due to: ScrollPresenterTestsWithInputHelper Pinch/Stretch tests fail on RS5 in Helix #132
         public void PinchRectangleWithMouseWheel()
         {
@@ -675,8 +678,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         //Test failures with keyboard/gamepad/mousewheel input #269
-        //[TestMethod]
-        //[TestProperty("Description", "Stretch an Image in a ScrollPresenter with the mouse wheel.")]
+        [TestMethod]
+        [TestProperty("Description", "Stretch an Image in a ScrollPresenter with the mouse wheel.")]
+        [TestProperty("Ignore", "True")]
         public void StretchImageWithMouseWheel()
         {
             Log.Comment("Selecting ScrollPresenter tests");

--- a/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
+++ b/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
@@ -411,7 +411,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        //[TestMethod] replace with Dmitry's more reliable method
+        [TestMethod]// replace with Dmitry's more reliable method
+        [TestProperty("Ignore", "True")]
         public void SwipeDoesntJumpWhenItReverts()
         {
             using (var setup = new TestSetupHelper("SwipeControl Tests"))

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -304,7 +304,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // [TestMethod] // Not currently passing, tracked by issue #643
+        [TestMethod] // Not currently passing, tracked by issue #643
+        [TestProperty("Ignore", "True")]
         public void AutoPlacement()
         {
             using (var setup = new TestSetupHelper("TeachingTip Tests"))
@@ -638,7 +639,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        //[TestMethod] Disabled with issue #1769
+        [TestMethod] //Disabled with issue #1769
+        [TestProperty("Ignore", "True")]
         public void SettingTitleOrSubtitleToEmptyStringCollapsesTextBox()
         {
             using (var setup = new TestSetupHelper("TeachingTip Tests"))

--- a/dev/TreeView/APITests/TreeViewTests.cs
+++ b/dev/TreeView/APITests/TreeViewTests.cs
@@ -235,7 +235,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
-        //[TestMethod] Disabled with issue number #1775
+        [TestMethod]// Disabled with issue number #1775
+        [TestProperty("Ignore", "True")]
         public void TreeViewInheritanceTest()
         {
             RunOnUIThread.Execute(() =>

--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
@@ -1707,8 +1707,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         //Test failures with keyboard/gamepad/mousewheel input #269
-        //[TestMethod]
-        //[TestProperty("TestSuite", "B")]
+        [TestMethod]
+        [TestProperty("TestSuite", "B")]
+        [TestProperty("Ignore", "True")]
         public void TreeViewMultiSelectGamepadTest_ContentMode()
         {
             TreeViewMultiSelectGamepadTest(isContentMode:true);


### PR DESCRIPTION
Change disabled tests to use [TestProperty("Ignore", "True")] instead of commenting out the value so that they are still detectable.