### PR TITLE
Update issue refs

### DIFF
--- a/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
+++ b/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
@@ -88,8 +88,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
-        //BUGBUG: Bug 18287798: Failure 183760047- Failed: MUXControls.ApiTests.LightConfigurationTests.VerifyLightsOnSecondaryWindow
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void VerifyLightsOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())
@@ -107,9 +106,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
-        // Disabled due to: Bug 17808897: Test unreliable in master: MUXControls.ApiTests.LightConfigurationTests.VerifyLightsAfterResettingContentOnSecondaryWindow
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void VerifyLightsAfterResettingContentOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())
@@ -118,9 +116,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
-        // Disabled due to: Bug 17808897: Test unreliable in master: MUXControls.ApiTests.LightConfigurationTests.VerifyLightsAfterResettingContentOnSecondaryWindow
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")]  // Disabled as per tracking issue #3125
         public void VerifyLightsAttachedDuringLayoutOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())

--- a/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
+++ b/dev/Lights/ApiTests/Lights_ApiTests/LightConfigurationTests.cs
@@ -88,7 +88,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 18287798
         public void VerifyLightsOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 17808897
         public void VerifyLightsAfterResettingContentOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]  // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")]  // Disabled as per tracking issue #3125 and internal issue 17808897
         public void VerifyLightsAttachedDuringLayoutOnSecondaryWindow()
         {
             using (var config = new SecondaryWindowLightConfiguration())

--- a/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
+++ b/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
@@ -59,9 +59,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        // Disabled due to: Bug 17762113: MUXControls.InteractionTests.RevealBrushTests.RevealBrushAudit failing in MUXControls in master
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void RevealBrushAudit()
         {
             if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))

--- a/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
+++ b/dev/Materials/Reveal/InteractionTests/Reveal_InteractionTests/RevealBrushTests.cs
@@ -60,7 +60,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 17762113
         public void RevealBrushAudit()
         {
             if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -497,7 +497,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 18650478
         public void TitleBarTest()
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -497,8 +497,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
-        // Disabled due to: Bug 18650478: Test instability: NavigationViewTests.TitleBarTest
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void TitleBarTest()
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();
@@ -1102,7 +1101,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void ToolTipTest() // Verify tooltips appear, and that their contents change when headers change
         {
             var testScenarios = RegressionTestScenario.BuildLeftNavRegressionTestScenarios();
@@ -1231,7 +1230,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void ToolTipCustomContentTest() // Verify tooltips don't appear for custom NavViewItems (split off due to CatGates timeout)
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))

--- a/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
@@ -572,7 +572,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 19342138
         public void EnsurePaneCanBeHidden()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
@@ -589,7 +589,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 19342138
         public void EnsurePaneCanBeHiddenWithFixedWindowSize()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))

--- a/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
@@ -571,9 +571,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             }
         }
 
-        //Bug 19342138: Text of navigation menu items text is lost when shrinking the width of the UWP application
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void EnsurePaneCanBeHidden()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
@@ -589,9 +588,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
             }
         }
 
-        //Bug 19342138: Text of navigation menu items text is lost when shrinking the width of the UWP application
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void EnsurePaneCanBeHiddenWithFixedWindowSize()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 11754081
         public void DeconstructionHandlesCorrectlyTest()
         {
             using (var setup = new TestSetupHelper("ScrollViewerAdapter Tests")) // This literally clicks the button corresponding to the test page.

--- a/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
+++ b/dev/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/InteractionTests/ScrollViewerAdapterTests.cs
@@ -40,8 +40,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             TestCleanupHelper.Cleanup();
         }
 
-        [TestMethod] //Disabled pending investigation of 11754081
-        [TestProperty("Ignore", "True")]
+        [TestMethod]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void DeconstructionHandlesCorrectlyTest()
         {
             using (var setup = new TestSetupHelper("ScrollViewerAdapter Tests")) // This literally clicks the button corresponding to the test page.

--- a/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
+++ b/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
@@ -56,8 +56,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         };
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
-        //Disabled due to Bug 19603059: RadioMenuFlyoutItemTests is occasionally failing in the lab
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void BasicTest()
         {
             using (var setup = new TestSetupHelper("RadioMenuFlyoutItem Tests"))

--- a/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
+++ b/dev/RadioMenuFlyoutItem/InteractionTests/RadioMenuFlyoutItemTests.cs
@@ -56,7 +56,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         };
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 19603059
         public void BasicTest()
         {
             using (var setup = new TestSetupHelper("RadioMenuFlyoutItem Tests"))

--- a/dev/RatingControl/InteractionTests/RatingControlTests.cs
+++ b/dev/RatingControl/InteractionTests/RatingControlTests.cs
@@ -663,7 +663,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         // These two tests that try and test live mid-input visual changes are unreliable.
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void EnsureScaleMaintainedOnTap()
         {
             using (var setup = new TestSetupHelper("RatingControl Tests")) // This literally clicks the button corresponding to the test page.
@@ -693,7 +693,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void VerifyRatingItemFallback()
         {
             // This test is actually performed in the test app itself, so go look at RatingControlPage.xaml.cs for the meat of it.

--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -442,7 +442,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void ReplaceMultipleItems()
         {
             // TODO: Lower prioirty scenario. Tracked by work item: 9738020

--- a/dev/Repeater/APITests/ViewportTests.cs
+++ b/dev/Repeater/APITests/ViewportTests.cs
@@ -98,7 +98,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 18866003
         public void ValidateItemsRepeaterScrollHostScenario()
         {
             var realizationRects = new List<Rect>();
@@ -842,7 +842,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 18866003
         public void ValidateLoadUnload()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone2))
@@ -992,7 +992,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
         // Test is flaky - disabling it while debugging the issue.
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 17581054
         public void CanBringIntoViewElements()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))

--- a/dev/Repeater/APITests/ViewportTests.cs
+++ b/dev/Repeater/APITests/ViewportTests.cs
@@ -97,8 +97,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        [TestMethod]// Temporarily disabled for bug 18866003
-        [TestProperty("Ignore", "True")]
+        [TestMethod]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void ValidateItemsRepeaterScrollHostScenario()
         {
             var realizationRects = new List<Rect>();
@@ -841,8 +841,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
-        [TestMethod]// Temporarily disabled for bug 18866003
-        [TestProperty("Ignore", "True")]
+        [TestMethod]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void ValidateLoadUnload()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone2))
@@ -991,9 +991,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
         }
 
         // Test is flaky - disabling it while debugging the issue.
-        // Bug 17581054: RepeaterTests.ViewportTests.CanBringIntoViewElements is failing on RS4 
         [TestMethod]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void CanBringIntoViewElements()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))

--- a/dev/ScrollPresenter/InteractionTests/ScrollPresenterTestsWithInputHelper.cs
+++ b/dev/ScrollPresenter/InteractionTests/ScrollPresenterTestsWithInputHelper.cs
@@ -677,7 +677,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        //Test failures with keyboard/gamepad/mousewheel input #269
+        //Test failures with keyboard/gamepad/mousewheel input #1329
         [TestMethod]
         [TestProperty("Description", "Stretch an Image in a ScrollPresenter with the mouse wheel.")]
         [TestProperty("Ignore", "True")]

--- a/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
+++ b/dev/SwipeControl/SwipeControl_InteractionTests/SwipeControlTests.cs
@@ -412,7 +412,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]// replace with Dmitry's more reliable method
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")]  // Disabled as per tracking issue #3125
         public void SwipeDoesntJumpWhenItReverts()
         {
             using (var setup = new TestSetupHelper("SwipeControl Tests"))

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -304,8 +304,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        [TestMethod] // Not currently passing, tracked by issue #643
-        [TestProperty("Ignore", "True")]
+        [TestMethod] 
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void AutoPlacement()
         {
             using (var setup = new TestSetupHelper("TeachingTip Tests"))

--- a/dev/TreeView/InteractionTests/TreeViewTests.cs
+++ b/dev/TreeView/InteractionTests/TreeViewTests.cs
@@ -1706,10 +1706,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             TreeViewMultiSelectGamepadTest();
         }
 
-        //Test failures with keyboard/gamepad/mousewheel input #269
         [TestMethod]
         [TestProperty("TestSuite", "B")]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void TreeViewMultiSelectGamepadTest_ContentMode()
         {
             TreeViewMultiSelectGamepadTest(isContentMode:true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates the disabled tests to point to the new issues tracking them.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
All disabled tests are now tracked on github.
## Questions
The following tests seem like they should be reenabled:

* VerifyVisualTreeExampleWithCustomerFilter -> See this proposed change which was implemented that probably fixed the reliability: https://github.com/microsoft/microsoft-ui-xaml/pull/642/files/4dbcac88010ade143f75475afbad3863f76589aa#r280285062
* EnsurePaneCanBeHidden -> I am not sure what the behavior described by the comment actually is nor have I seen it
* EnsurePaneCanBeHiddenWithFixedWindowSize -> Same as EnsurePaneCanBeHidden

The SwipeDoesntJumpWhenItReverts test talks about a more reliable method, is there any info on this?

The ReplaceMultipleItems tests is just a "throw NotImplementedExecption", should we remove that test, and create an issue to create that test at some point in the future, or should we leave it as is?