### PR TITLE
NumberBox: Updated the border and background of the spin button popup to match Fluent Design guidelines.

### DIFF
--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -137,9 +137,9 @@
                             HorizontalAlignment="Left">
 
                             <Grid x:Name="PopupContentRoot"
-                                Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
-                                BorderBrush="{ThemeResource ToolTipBorderBrush}"
-                                BorderThickness="{ThemeResource ToolTipBorderThemeThickness}"
+                                Background="{ThemeResource NumberBoxPopupBackground}"
+                                BorderBrush="{ThemeResource NumberBoxPopupBorderBrush}"
+                                BorderThickness="{ThemeResource NumberBoxPopupBorderThickness}"
                                 CornerRadius="{ThemeResource OverlayCornerRadius}">
 
                                 <Grid.RowDefinitions>
@@ -206,7 +206,7 @@
             <Setter Property="IsTabStop" Value="False"/>
             <Setter Property="Width" Value="40"/>
             <Setter Property="Height" Value="32"/>
-            <Setter Property="Background" Value="{ThemeResource TextControlBackground}"/>
+            <Setter Property="Background" Value="{ThemeResource NumberBoxPopupSpinButtonBackground}"/>
             <Setter Property="BorderThickness" Value="{ThemeResource NumberBoxPopupSpinButtonBorderThickness}"/>
             <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
         </Style.Setters>

--- a/dev/NumberBox/NumberBox_themeresources.xaml
+++ b/dev/NumberBox/NumberBox_themeresources.xaml
@@ -1,6 +1,7 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -8,18 +9,45 @@
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
             <contract7NotPresent:StaticResource x:Key="SystemControlDescriptionTextForegroundBrush" ResourceKey="SystemControlPageTextBaseMediumBrush" />
+            
+            <!-- The following NumberBoxPopup* theme resources resource must be defined at the app level in order to take effect. -->
+            <contract7Present:StaticResource x:Key="NumberBoxPopupBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+            <contract7NotPresent:StaticResource x:Key="NumberBoxPopupBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:StaticResource x:Key="NumberBoxPopupBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7NotPresent:StaticResource x:Key="NumberBoxPopupBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+            <Thickness x:Key="NumberBoxPopupBorderThickness">1</Thickness>
+
+            <StaticResource x:Key="NumberBoxPopupSpinButtonBackground" ResourceKey="SystemControlTransparentBrush" />
             <Thickness x:Key="NumberBoxPopupSpinButtonBorderThickness">0</Thickness>
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Dark">
             <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
             <contract7NotPresent:StaticResource x:Key="SystemControlDescriptionTextForegroundBrush" ResourceKey="SystemControlPageTextBaseMediumBrush" />
+
+            <!-- The following NumberBoxPopup* theme resources resource must be defined at the app level in order to take effect. -->
+            <contract7Present:StaticResource x:Key="NumberBoxPopupBackground" ResourceKey="SystemControlTransientBackgroundBrush" />
+            <contract7NotPresent:StaticResource x:Key="NumberBoxPopupBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:StaticResource x:Key="NumberBoxPopupBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7NotPresent:StaticResource x:Key="NumberBoxPopupBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+            <Thickness x:Key="NumberBoxPopupBorderThickness">1</Thickness>
+
+            <StaticResource x:Key="NumberBoxPopupSpinButtonBackground" ResourceKey="SystemControlTransparentBrush" />
             <Thickness x:Key="NumberBoxPopupSpinButtonBorderThickness">0</Thickness>
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
             <contract7NotPresent:StaticResource x:Key="SystemControlDescriptionTextForegroundBrush" ResourceKey="SystemControlPageTextBaseMediumBrush" />
+
+            <!-- The following NumberBoxPopup* theme resources resource must be defined at the app level in order to take effect. -->
+            <contract7Present:StaticResource x:Key="NumberBoxPopupBackground" ResourceKey="SystemControlBackgroundBaseHighBrush" />
+            <contract7NotPresent:StaticResource x:Key="NumberBoxPopupBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:StaticResource x:Key="NumberBoxPopupBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
+            <contract7NotPresent:StaticResource x:Key="NumberBoxPopupBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
+            <Thickness x:Key="NumberBoxPopupBorderThickness">1</Thickness>
+
+            <StaticResource x:Key="NumberBoxPopupSpinButtonBackground" ResourceKey="SystemControlTransparentBrush" />
             <Thickness x:Key="NumberBoxPopupSpinButtonBorderThickness">2</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>


### PR DESCRIPTION
## Description
This PR updates the border and background brushes of the NumberBox spin button popup (showhen when the NumberBox is set to a [SpinButtonPlacementMode](https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.numberbox.spinbuttonplacementmode?view=winui-2.4#Microsoft_UI_Xaml_Controls_NumberBox_SpinButtonPlacementMode) of [Compact]. As the popup is a *transient* UI, per the [acrylic guidelines](https://docs.microsoft.com/en-us/windows/uwp/design/style/acrylic#when-to-use-acrylic) it should sport in-app acrylic as its default background.

As an additional benefit, the popup can now easily be distinguished from the default page background in dark theme.

The updated brushes have been taken [from the MenuFlyout default style](https://github.com/microsoft/microsoft-ui-xaml/blob/master/dev/MenuFlyout/MenuFlyout_themeresources.xaml#L57) as [requested](https://github.com/microsoft/microsoft-ui-xaml/issues/2843#issuecomment-670704815) by the team. Below you find a table showing the updated design:

| Theme | Current | Updated - 1809+ (contract 7 present) | Updated - 1803 and less (contract 7 not present) |
|-----|------|-----|----|
| Light | ![image](https://user-images.githubusercontent.com/1398851/86671330-d46c9500-bff5-11ea-922d-ea7236917c6e.png)|![image](https://user-images.githubusercontent.com/1398851/86671188-b2731280-bff5-11ea-8011-9d075c7de1cd.png) |![image](https://user-images.githubusercontent.com/1398851/86672194-b3587400-bff6-11ea-92e1-52097925275e.png)|
| Dark|![image](https://user-images.githubusercontent.com/1398851/86671410-e77f6500-bff5-11ea-91a7-716db787fbf3.png)| ![image](https://user-images.githubusercontent.com/1398851/86671075-94a5ad80-bff5-11ea-8b88-b0a36d95c25c.png)|![image](https://user-images.githubusercontent.com/1398851/86671951-72f8f600-bff6-11ea-86be-7d728f8c5a0e.png)|

The in-app acrylic effect is noticeable as you can see [here](https://github.com/microsoft/microsoft-ui-xaml/issues/2843#issuecomment-674026836) and below:

![image](https://user-images.githubusercontent.com/1398851/86825038-362d0d80-c08f-11ea-8285-dc1eff7aa7c2.png)

| Light Theme | Dark Theme |
|----|-----|
|![image](https://user-images.githubusercontent.com/1398851/86825276-77252200-c08f-11ea-9f6e-eee1a26e63af.png)|![image](https://user-images.githubusercontent.com/1398851/86825080-42b16600-c08f-11ea-8105-a889d42dda68.png)|

In High-contrast mode, the look remains essentially unchanged from today:

| Theme | Current | Updated|
|-----|------|-----|
| Light | ![image](https://user-images.githubusercontent.com/1398851/90298847-0514d980-de94-11ea-8784-e5507be608eb.png)| ![image](https://user-images.githubusercontent.com/1398851/90298870-19f16d00-de94-11ea-918e-5b0d93f6152f.png)|
| Dark | ![image](https://user-images.githubusercontent.com/1398851/90299297-d5ff6780-de95-11ea-8d91-5d6193e23599.png)| ![image](https://user-images.githubusercontent.com/1398851/90298822-e9a9ce80-de93-11ea-83e4-51e2fb7b1d32.png)|

### Implementation Notes
In order to implement these changes, I introduced a couple new theme resources:
* NumberBoxPopupBackground
* NumberBoxPopupBorderBrush
* NumberBoxPopupBorderThickness
* NumberBoxPopupSpinButtonBackground

These resources where required because prior to this PR, the Popup's background, border brush & thickness were driven by the following theme resources:
* SystemControlBackgroundAltHighBrush (Background)
* ToolTipBorderBrush (BorderBrush)
* ToolTipBorderThemeThickness (BorderThickness)

The new `NumberBoxPopupSpinButtonBackground` has been introduced to set the background of Popup's spin buttons to *transparent* so that we will get the full acrylic effect. Previously, the background of a spin button was set by the `TextControlBackground` theme resource to a background not fully transparent.

Updating these resources was not an option as they would have affected controls other than the NumberBox as well, so I made the decision here to introduce a couple of NumberBox specific theme resources - which is something which should be done anyway (see tracking issue #2844). 

## Motivation and Context
Fixes #2843.  

## How Has This Been Tested?
Tested visually (see screenshots above).

## Additional Notes
@chigy @kikisaints FYI.
