### PR TITLE
Fix issue with collection change inside item invoked crashing NavigationView

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -867,7 +867,13 @@ void NavigationView::RaiseItemInvokedForNavigationViewItem(const winrt::Navigati
     {
         auto inspectingDataSource = static_cast<InspectingDataSource*>(winrt::get_self<ItemsSourceView>(itemsSourceView));
         auto itemIndex = parentIR.GetElementIndex(nvi);
-        nextItem = inspectingDataSource->GetAt(itemIndex);
+
+        // Check that index is NOT -1, meaning it is actually realized
+        if (itemIndex != -1)
+        {
+            // Something went wrong, item might not be realized yet.
+            nextItem = inspectingDataSource->GetAt(itemIndex);
+        }
     }
 
     // Determine the recommeded transition direction.

--- a/dev/NavigationView/TestUI/Common/NavigationViewPageDataContext.xaml
+++ b/dev/NavigationView/TestUI/Common/NavigationViewPageDataContext.xaml
@@ -31,9 +31,9 @@
         </muxcontrols:NavigationView>
 
         <muxcontrols:NavigationView
-            Width="400" PaneDisplayMode="Left"
-		    MenuItemsSource="{x:Bind Pages, Mode=OneWay}"
-		    ItemInvoked="NavigationView_ItemInvoked">
+                Width="400" PaneDisplayMode="Left"
+                MenuItemsSource="{x:Bind Pages, Mode=OneWay}"
+                ItemInvoked="NavigationView_ItemInvoked">
             <muxcontrols:NavigationView.MenuItemTemplate>
                 <DataTemplate>
                     <muxcontrols:NavigationViewItem Content="{Binding Name}" AutomationProperties.Name="{Binding Name}"/>

--- a/dev/NavigationView/TestUI/Common/NavigationViewPageDataContext.xaml
+++ b/dev/NavigationView/TestUI/Common/NavigationViewPageDataContext.xaml
@@ -9,7 +9,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid>
+    <StackPanel Orientation="Horizontal">
+       
         <muxcontrols:NavigationView
             x:Name="NavView"
             AutomationProperties.Name="NavView"
@@ -28,6 +29,19 @@
                 </StackPanel>
             </StackPanel>
         </muxcontrols:NavigationView>
-    </Grid>
+
+        <muxcontrols:NavigationView
+            Width="400" PaneDisplayMode="Left"
+		    MenuItemsSource="{x:Bind Pages, Mode=OneWay}"
+		    ItemInvoked="NavigationView_ItemInvoked">
+            <muxcontrols:NavigationView.MenuItemTemplate>
+                <DataTemplate>
+                    <muxcontrols:NavigationViewItem Content="{Binding Name}" AutomationProperties.Name="{Binding Name}"/>
+                </DataTemplate>
+            </muxcontrols:NavigationView.MenuItemTemplate>
+
+            <TextBlock Text="{Binding SelectedPage.Name}" />
+        </muxcontrols:NavigationView>
+    </StackPanel>
 
 </local:TestPage>

--- a/dev/NavigationView/TestUI/Common/NavigationViewPageDataContext.xaml.cs
+++ b/dev/NavigationView/TestUI/Common/NavigationViewPageDataContext.xaml.cs
@@ -13,11 +13,34 @@ using Windows.ApplicationModel.Core;
 using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
 using NavigationViewSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs;
 using NavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 
 namespace MUXControlsTestApp
 {
-    public sealed partial class NavigationViewPageDataContext : TestPage
+    public sealed partial class NavigationViewPageDataContext : TestPage, INotifyPropertyChanged
     {
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private NavViewPageData[] _pages;
+
+        public NavViewPageData[] Pages
+        {
+            get => _pages;
+            set
+            {
+                _pages = value;
+                NotifyPropertyChanged(nameof(Pages));
+            }
+        }
+
         public NavigationViewPageDataContext()
         {
             this.InitializeComponent();
@@ -32,6 +55,32 @@ namespace MUXControlsTestApp
             }
 
             NavView.SelectedItem = NavView.MenuItems[0];
+
+            Pages = new[]
+            {
+                new NavViewPageData("FirstInvokeChangeItem"),
+                new NavViewPageData("SecondInvokeChangeItem"),
+                new NavViewPageData("ThirdInvokeChangeItem"),
+                new NavViewPageData("FourthInvokeChangeItem"),
+                new NavViewPageData("FifthInvokeChangeItem"),
+                new NavViewPageData("SixthInvokeChangeItem"),
+                new NavViewPageData("SeventhInvokeChangeItem"),
+            };
+        }
+
+        private void NavigationView_ItemInvoked(NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
+        {
+            if (_pages != null && _pages.Length == 0)
+            {
+                return;
+            }
+
+            var page = Pages[0];
+            var newPages = new List<NavViewPageData>();
+            newPages.Add(new NavViewPageData($"Clicked {page.Name}"));
+            newPages.AddRange(Pages);
+
+            Pages = newPages.ToArray();
         }
 
         private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
@@ -44,6 +93,16 @@ namespace MUXControlsTestApp
         {
             var visualstates = Utilities.VisualStateHelper.GetCurrentVisualStateName(NavView);
             NavViewActiveVisualStatesResult.Text = string.Join(",", visualstates);
+        }
+    }
+
+    public class NavViewPageData
+    {
+        public string Name { get; set; }
+
+        public NavViewPageData(string name)
+        {
+            Name = name;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When changing the MenuItemsSource of a NavigationView inside the ItemInvoked handler, new items might not be realized resulting in invalid indices. NavView however assumed that at that state all items are realized which is a problem if the MenuItemsSource changed while processing the ItemInvoked event.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2818
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Add new interaction test.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->