### PR TITLE
Fix NumberBox's APITests project location in the innerloop solution.

### DIFF
--- a/MUXControlsInnerLoop.sln
+++ b/MUXControlsInnerLoop.sln
@@ -568,7 +568,6 @@ Global
 		dev\CommonStyles\TestUI\CommonStyles_TestUI.projitems*{a7f6d6c4-a5a9-43eb-930c-b766417a5e5c}*SharedItemsImports = 13
 		dev\Materials\Acrylic\TestUI\AcrylicBrush_TestUI.projitems*{a800e818-7212-4fd7-ae3a-1dcab539db87}*SharedItemsImports = 13
 		dev\Collections\Collections.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\ComboBox\ComboBox.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\CommonStyles\CommonStyles.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Common\Common.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\DropDownButton\DropDownButton.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
@@ -577,9 +576,6 @@ Global
 		dev\Lights\Lights.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Materials\Acrylic\AcrylicBrush.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Materials\Reveal\RevealBrush.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\NumberBox\NumberBox.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\RadioButtons\RadioButtons.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\Repeater\Repeater.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\ResourceHelper\ResourceHelper.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\SplitButton\SplitButton.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Telemetry\Telemetry.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
@@ -991,6 +987,7 @@ Global
 		{1A5321F3-B837-4EB6-9547-37CC70088EA9} = {C5EFA126-F329-4F8B-8DC9-E4182F4976D0}
 		{E95C2CA1-FF23-47CC-A896-CC5175B37890} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
 		{9D23C997-1F46-444A-8C07-4A4BFF7E4E63} = {E95C2CA1-FF23-47CC-A896-CC5175B37890}
+		{80AF98CA-BC1D-4011-8460-5671799EC419} = {E95C2CA1-FF23-47CC-A896-CC5175B37890}
 		{13DA8235-D04F-46D4-B5B4-F5AE774EEEDE} = {E95C2CA1-FF23-47CC-A896-CC5175B37890}
 		{773F7592-E7B3-42FC-A14A-E815AFD6A0CB} = {E95C2CA1-FF23-47CC-A896-CC5175B37890}
 		{64447EFA-19B4-4BF2-9D63-618635C483EC} = {5A911304-2863-4A73-8023-26EFCB4E01DA}
@@ -1005,7 +1002,6 @@ Global
 		{3566798E-9E24-44EF-B89D-2A62AE8F697A} = {0EC260CC-03C7-4790-B16A-43428EBCF5AD}
 		{675121BF-CABC-48E7-9C9D-4571BC507406} = {0EC260CC-03C7-4790-B16A-43428EBCF5AD}
 		{675373CE-6ACD-4C4B-A009-09A3C9B218E6} = {0EC260CC-03C7-4790-B16A-43428EBCF5AD}
-		{E6E42A4B-01D2-4CF4-9D24-98E9FF71669B} = {0EC260CC-03C7-4790-B16A-43428EBCF5AD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D93836AB-52D3-4DE2-AE25-23F26F55ECED}


### PR DESCRIPTION
I guess third time's the charm...after PRs https://github.com/microsoft/microsoft-ui-xaml/pull/2981 and https://github.com/microsoft/microsoft-ui-xaml/pull/2224 the NumberBox's APITests project was still not correctly placed in the inner loop solution:

![image](https://user-images.githubusercontent.com/1398851/90331374-076e5500-dfb4-11ea-9be8-08d3d4db8fab.png)

Expected position:

![image](https://user-images.githubusercontent.com/1398851/90331398-35ec3000-dfb4-11ea-871b-2eb58320083d.png)

This PR should finally get the job properly done. Here's the position of the APITests project following this PR:

![image](https://user-images.githubusercontent.com/1398851/90331422-6764fb80-dfb4-11ea-81cf-cc2a2e7ec22d.png)