### PR TITLE
Fix the build breaks in the CI loop

### DIFF
--- a/dev/NumberBox/NumberBoxParser.cpp
+++ b/dev/NumberBox/NumberBoxParser.cpp
@@ -113,7 +113,7 @@ std::vector<MathToken> NumberBoxParser::ConvertInfixToPostfix(const std::vector<
     std::vector<MathToken> postfixTokens;
     std::stack<MathToken> operatorStack;
 
-    for (auto const token : infixTokens)
+    for (auto const& token : infixTokens)
     {
         if (token.Type == MathTokenType::Numeric)
         {
@@ -123,7 +123,7 @@ std::vector<MathToken> NumberBoxParser::ConvertInfixToPostfix(const std::vector<
         {
             while (!operatorStack.empty())
             {
-                const auto top = operatorStack.top();
+                const auto& top = operatorStack.top();
                 if (top.Type != MathTokenType::Parenthesis && (GetPrecedenceValue(top.Char) >= GetPrecedenceValue(token.Char)))
                 {
                     postfixTokens.push_back(operatorStack.top());
@@ -183,7 +183,7 @@ winrt::IReference<double> NumberBoxParser::ComputePostfixExpression(const std::v
 {
     std::stack<double> stack;
 
-    for (auto const token : tokens)
+    for (auto const& token : tokens)
     {
         if (token.Type == MathTokenType::Operator)
         {

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -438,7 +438,7 @@ void ViewportManagerWithPlatformFeatures::UpdateViewport(winrt::Rect const& view
         previousVisibleWindow.X, previousVisibleWindow.Y, previousVisibleWindow.Width, previousVisibleWindow.Height,
         viewport.X, viewport.Y, viewport.Width, viewport.Height);
 
-    const auto currentVisibleWindow = viewport;
+    const auto& currentVisibleWindow = viewport;
 
     if (-currentVisibleWindow.X <= ItemsRepeater::ClearedElementsArrangePosition.X &&
         -currentVisibleWindow.Y <= ItemsRepeater::ClearedElementsArrangePosition.Y)

--- a/dev/ScrollPresenter/ScrollPresenter.cpp
+++ b/dev/ScrollPresenter/ScrollPresenter.cpp
@@ -3904,21 +3904,23 @@ winrt::IVector<winrt::ZoomSnapPointBase> ScrollPresenter::GetConsolidatedZoomSna
     return snapPoints;
 }
 
-SnapPointWrapper<winrt::ScrollSnapPointBase>* ScrollPresenter::GetScrollSnapPointWrapper(ScrollPresenterDimension dimension, winrt::ScrollSnapPointBase const& scrollSnapPoint)
+std::shared_ptr<SnapPointWrapper<winrt::ScrollSnapPointBase>> ScrollPresenter::GetScrollSnapPointWrapper(ScrollPresenterDimension dimension, winrt::ScrollSnapPointBase const& scrollSnapPoint)
 {
-    std::set<std::shared_ptr<SnapPointWrapper<winrt::ScrollSnapPointBase>>, SnapPointWrapperComparator<winrt::ScrollSnapPointBase>> snapPointsSet;
-
-    switch (dimension)
+    const auto& snapPointsSet = [&]()
     {
-    case ScrollPresenterDimension::VerticalScroll:
-        snapPointsSet = m_sortedConsolidatedVerticalSnapPoints;
-        break;
-    case ScrollPresenterDimension::HorizontalScroll:
-        snapPointsSet = m_sortedConsolidatedHorizontalSnapPoints;
-        break;
-    default:
-        MUX_ASSERT(false);
-    }
+        switch (dimension)
+        {
+        case ScrollPresenterDimension::VerticalScroll:
+            return m_sortedConsolidatedVerticalSnapPoints;
+            break;
+        case ScrollPresenterDimension::HorizontalScroll:
+            return m_sortedConsolidatedHorizontalSnapPoints;
+            break;
+        default:
+            MUX_ASSERT(false);
+            return m_sortedConsolidatedVerticalSnapPoints;
+        }
+    }();
 
     for (std::shared_ptr<SnapPointWrapper<winrt::ScrollSnapPointBase>> snapPointWrapper : snapPointsSet)
     {
@@ -3926,14 +3928,14 @@ SnapPointWrapper<winrt::ScrollSnapPointBase>* ScrollPresenter::GetScrollSnapPoin
 
         if (winrtScrollSnapPoint == scrollSnapPoint)
         {
-            return snapPointWrapper.get();
+            return snapPointWrapper;
         }
     }
 
     return nullptr;
 }
 
-SnapPointWrapper<winrt::ZoomSnapPointBase>* ScrollPresenter::GetZoomSnapPointWrapper(winrt::ZoomSnapPointBase const& zoomSnapPoint)
+std::shared_ptr<SnapPointWrapper<winrt::ZoomSnapPointBase>> ScrollPresenter::GetZoomSnapPointWrapper(winrt::ZoomSnapPointBase const& zoomSnapPoint)
 {
     for (std::shared_ptr<SnapPointWrapper<winrt::ZoomSnapPointBase>> snapPointWrapper : m_sortedConsolidatedZoomSnapPoints)
     {
@@ -3941,7 +3943,7 @@ SnapPointWrapper<winrt::ZoomSnapPointBase>* ScrollPresenter::GetZoomSnapPointWra
 
         if (winrtZoomSnapPoint == zoomSnapPoint)
         {
-            return snapPointWrapper.get();
+            return snapPointWrapper;
         }
     }
 

--- a/dev/ScrollPresenter/ScrollPresenter.h
+++ b/dev/ScrollPresenter/ScrollPresenter.h
@@ -233,18 +233,18 @@ public:
     winrt::IVector<winrt::ScrollSnapPointBase> GetConsolidatedScrollSnapPoints(ScrollPresenterDimension dimension);
     winrt::IVector<winrt::ZoomSnapPointBase> GetConsolidatedZoomSnapPoints();
 
-    SnapPointWrapper<winrt::ScrollSnapPointBase>* GetHorizontalSnapPointWrapper(winrt::ScrollSnapPointBase const& scrollSnapPoint)
+    std::shared_ptr<SnapPointWrapper<winrt::ScrollSnapPointBase>> GetHorizontalSnapPointWrapper(winrt::ScrollSnapPointBase const& scrollSnapPoint)
     {
         return GetScrollSnapPointWrapper(ScrollPresenterDimension::HorizontalScroll, scrollSnapPoint);
     }
 
-    SnapPointWrapper<winrt::ScrollSnapPointBase>* GetVerticalSnapPointWrapper(winrt::ScrollSnapPointBase const& scrollSnapPoint)
+    std::shared_ptr<SnapPointWrapper<winrt::ScrollSnapPointBase>> GetVerticalSnapPointWrapper(winrt::ScrollSnapPointBase const& scrollSnapPoint)
     {
         return GetScrollSnapPointWrapper(ScrollPresenterDimension::VerticalScroll, scrollSnapPoint);
     }
 
-    SnapPointWrapper<winrt::ScrollSnapPointBase>* GetScrollSnapPointWrapper(ScrollPresenterDimension dimension, winrt::ScrollSnapPointBase const& scrollSnapPoint);
-    SnapPointWrapper<winrt::ZoomSnapPointBase>* GetZoomSnapPointWrapper(winrt::ZoomSnapPointBase const& zoomSnapPoint);
+    std::shared_ptr<SnapPointWrapper<winrt::ScrollSnapPointBase>> GetScrollSnapPointWrapper(ScrollPresenterDimension dimension, winrt::ScrollSnapPointBase const& scrollSnapPoint);
+    std::shared_ptr<SnapPointWrapper<winrt::ZoomSnapPointBase>> GetZoomSnapPointWrapper(winrt::ZoomSnapPointBase const& zoomSnapPoint);
 
     // Invoked when a dependency property of this ScrollPresenter has changed.
     void OnPropertyChanged(

--- a/dev/ScrollPresenter/ScrollPresenterTestHooks.cpp
+++ b/dev/ScrollPresenter/ScrollPresenterTestHooks.cpp
@@ -414,7 +414,7 @@ winrt::float2 ScrollPresenterTestHooks::GetHorizontalSnapPointActualApplicableZo
 {
     if (scrollSnapPoint)
     {
-        const SnapPointWrapper<winrt::ScrollSnapPointBase>* snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetHorizontalSnapPointWrapper(scrollSnapPoint);
+        const auto snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetHorizontalSnapPointWrapper(scrollSnapPoint);
         auto zone = snapPointWrapper->ActualApplicableZone();
 
         return winrt::float2{ static_cast<float>(std::get<0>(zone)), static_cast<float>(std::get<1>(zone)) };
@@ -431,7 +431,7 @@ winrt::float2 ScrollPresenterTestHooks::GetVerticalSnapPointActualApplicableZone
 {
     if (scrollSnapPoint)
     {
-        const SnapPointWrapper<winrt::ScrollSnapPointBase>* snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetVerticalSnapPointWrapper(scrollSnapPoint);
+        const auto snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetVerticalSnapPointWrapper(scrollSnapPoint);
         auto zone = snapPointWrapper->ActualApplicableZone();
 
         return winrt::float2{ static_cast<float>(std::get<0>(zone)), static_cast<float>(std::get<1>(zone)) };
@@ -448,7 +448,7 @@ winrt::float2 ScrollPresenterTestHooks::GetZoomSnapPointActualApplicableZone(
 {
     if (zoomSnapPoint)
     {
-        const SnapPointWrapper<winrt::ZoomSnapPointBase>* snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetZoomSnapPointWrapper(zoomSnapPoint);
+        const auto snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetZoomSnapPointWrapper(zoomSnapPoint);
         auto zone = snapPointWrapper->ActualApplicableZone();
 
         return winrt::float2{ static_cast<float>(std::get<0>(zone)), static_cast<float>(std::get<1>(zone)) };
@@ -465,7 +465,7 @@ int ScrollPresenterTestHooks::GetHorizontalSnapPointCombinationCount(
 {
     if (scrollSnapPoint)
     {
-        const SnapPointWrapper<winrt::ScrollSnapPointBase>* snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetHorizontalSnapPointWrapper(scrollSnapPoint);
+        const auto snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetHorizontalSnapPointWrapper(scrollSnapPoint);
 
         return snapPointWrapper->CombinationCount();
     }
@@ -481,7 +481,7 @@ int ScrollPresenterTestHooks::GetVerticalSnapPointCombinationCount(
 {
     if (scrollSnapPoint)
     {
-        const SnapPointWrapper<winrt::ScrollSnapPointBase>* snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetVerticalSnapPointWrapper(scrollSnapPoint);
+        const auto snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetVerticalSnapPointWrapper(scrollSnapPoint);
 
         return snapPointWrapper->CombinationCount();
     }
@@ -497,7 +497,7 @@ int ScrollPresenterTestHooks::GetZoomSnapPointCombinationCount(
 {
     if (zoomSnapPoint)
     {
-        const SnapPointWrapper<winrt::ZoomSnapPointBase>* snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetZoomSnapPointWrapper(zoomSnapPoint);
+        const auto snapPointWrapper = winrt::get_self<ScrollPresenter>(scrollPresenter)->GetZoomSnapPointWrapper(zoomSnapPoint);
 
         return snapPointWrapper->CombinationCount();
     }


### PR DESCRIPTION
The build machines we use for the CI loop upgraded the version of VS installed on them and that introduced a few new static analysis warnings that this change addresses.