### PR TITLE
 Update [Code style and conventions] doc to link to the pretty-printed version of the C++ guidelines

### DIFF
--- a/docs/code_style_and_conventions.md
+++ b/docs/code_style_and_conventions.md
@@ -1,6 +1,6 @@
 # Code style and conventions
 
-* C++: [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md)
+* C++: [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html)
 * C#: Follow the .NET Core team's [C# coding style](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md)
 
 For all languages respect the [.editorconfig](https://editorconfig.org/) file 


### PR DESCRIPTION
I just saw @jevansaks [suggesting](https://github.com/microsoft/ProjectReunion/pull/145#discussion_r474179319) over at Project Reunion to link to the pretty-printed version of the C++ guidelines and I felt that WinUI should link to it as well (as it looks to me to be the best reading version available of the C++ guidelines).