### PR TITLE
Remove screenshots field from failed test runs report in AzDO

### DIFF
--- a/build/Helix/UpdateUnreliableTests.ps1
+++ b/build/Helix/UpdateUnreliableTests.ps1
@@ -82,20 +82,12 @@ foreach ($testRun in $testRuns.value)
                 
                 if ($rerun.outcome -ne "Passed")
                 {
-                    $screenshots = "$($rerunResults.blobPrefix)/$($rerun.screenshots -join @"
-$($rerunResults.blobSuffix)
-$($rerunResults.blobPrefix)
-"@)$($rerunResults.blobSuffix)"
-
                     # We subtract 1 from the error index because we added 1 so we could use 0
                     # as a default value not injected into the JSON in order to keep its size down.
                     # We did this because there's a maximum size enforced for the errorMessage parameter
                     # in the Azure DevOps REST API.
                     $fullErrorMessage = @"
 Log: $($rerunResults.blobPrefix)/$($rerun.log)$($rerunResults.blobSuffix)
-
-Screenshots:
-$screenshots
 
 Error log:
 $($rerunResults.errors[$rerun.errorIndex - 1])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes the screenshots section on the Azure DevOps failed test report.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1427
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->