### PR TITLE
NavigationView: Fix app crash in Top mode when clearing the item collection while a selected item exists

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -251,9 +251,10 @@ void NavigationView::OnSelectionModelSelectionChanged(const winrt::SelectionMode
 
     if (IsTopNavigationView())
     {
-        auto const inMainMenu = selectedIndex.GetAt(0) == c_mainMenuBlockIndex;
         // If selectedIndex does not exist, means item is being deselected through API
-        auto const isInOverflow = (selectedIndex && selectedIndex.GetSize() > 0) ? inMainMenu && !m_topDataProvider.IsItemInPrimaryList(selectedIndex.GetAt(1)) : false;
+        auto const isInOverflow = (selectedIndex && selectedIndex.GetSize() > 1)
+            ? selectedIndex.GetAt(0) == c_mainMenuBlockIndex && !m_topDataProvider.IsItemInPrimaryList(selectedIndex.GetAt(1))
+            : false;
         if (isInOverflow)
         {
             // We only want to close the overflow flyout and move the item on selection if it is a leaf node

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -872,5 +872,47 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.IsTrue(testCondition, "ToolTip text should have been \"More\".");
             });
         }
+
+        [TestMethod]
+        public void VerifyClearingItemsCollectionDoesNotCrashWhenItemSelectedOnTopNav()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var navView = new NavigationView();
+                navView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
+
+                var navViewItem1 = new NavigationViewItem() { Content = "MenuItem 1", };
+                var navViewItem2 = new NavigationViewItem() { Content = "MenuItem 2" };
+
+                Log.Comment("Set up the MenuItems collection");
+                navView.MenuItems.Add(navViewItem1);
+                navView.MenuItems.Add(navViewItem2);
+
+                Content = navView;
+                Content.UpdateLayout();
+
+                Log.Comment("Set MenuItem 1 as selected");
+                navView.SelectedItem = navViewItem1;
+                Verify.AreEqual(navViewItem1, navView.SelectedItem, "MenuItem 1 should have been selected");
+
+                // Clearing the MenuItems collection should not crash the app
+                Log.Comment("Clear the MenuItems collection");
+                navView.MenuItems.Clear();
+
+                Log.Comment("Set up the MenuItemsSource collection");
+                var itemsSource = new ObservableCollection<NavigationViewItem>() { navViewItem1, navViewItem2 };
+                navView.MenuItemsSource = itemsSource;
+
+                Content.UpdateLayout();
+
+                Log.Comment("Set MenuItem 1 as selected");
+                navView.SelectedItem = navViewItem1;
+                Verify.AreEqual(navViewItem1, navView.SelectedItem, "MenuItem 1 should have been selected");
+
+                // Clearing the MenuItemsSource collection should not crash the app
+                Log.Comment("Clear the MenuItemsSource collection");
+                itemsSource.Clear();
+            });
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes a regression introduced with PR https://github.com/microsoft/microsoft-ui-xaml/pull/1997 which manifested itself in an app crash. The crash occured when the NavigationView is 
* in Top pane display mode
* one of its menu items is selected and
* the item collection used to populate the NavigationView (either MenuItems or MenuItemsSource) is cleared

## Motivation and Context
Fixes https://github.com/microsoft/microsoft-ui-xaml/issues/3200

## How Has This Been Tested?
Tested manually and added API test.