### PR TITLE
Fix issue with ScrollBar in HC not being visible

### DIFF
--- a/dev/ScrollBar/ScrollBar_themeresources.xaml
+++ b/dev/ScrollBar/ScrollBar_themeresources.xaml
@@ -100,8 +100,8 @@
             <StaticResource x:Key="ScrollBarTrackStroke" ResourceKey="SystemControlForegroundTransparentBrush" />
             <StaticResource x:Key="ScrollBarTrackStrokePointerOver" ResourceKey="SystemControlForegroundTransparentBrush" />
             <StaticResource x:Key="ScrollBarTrackStrokeDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
-            <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="{StaticResource ScrollBarThumbBackgroundColor}" />
-            <SolidColorBrush x:Key="ScrollBarPanningThumbBackground" Color="{StaticResource ScrollBarPanningThumbBackgroundColor}" />
+            <StaticResource x:Key="ScrollBarThumbBackground" ResourceKey="SystemControlForegroundChromeDisabledLowBrush" />
+            <StaticResource x:Key="ScrollBarPanningThumbBackground" ResourceKey="SystemControlForegroundChromeDisabledLowBrush" />
             <StaticResource x:Key="ScrollBarPanningThumbBackgroundDisabled" ResourceKey="SystemControlDisabledChromeHighBrush" />
             <x:Double x:Key="ScrollBarTrackBorderThemeThickness">1</x:Double>
             <Thickness x:Key="ScrollBarPanningBorderThemeThickness">1</Thickness>
@@ -527,8 +527,8 @@
                                 </VisualState>
                                 <VisualState x:Name="NoIndicator">
                                     <VisualState.Setters>
-                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
-                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackground}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackground}"/>
                                     </VisualState.Setters>
                                     <Storyboard>
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="ScaleX" To="{ThemeResource SmallScrollThumbScale}" />
@@ -625,8 +625,8 @@
                                         <Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
                                         <Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
                                         <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
-                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
-                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarThumbBackground}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarThumbBackground}"/>
                                     </VisualState.Setters>
 
                                     <Storyboard>
@@ -662,8 +662,8 @@
                                         <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
                                         <contract7Present:Setter Target="HorizontalThumb.CornerRadius" Value="0" />
                                         <contract7Present:Setter Target="VerticalThumb.CornerRadius" Value="0" />
-                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
-                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarThumbBackground}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarThumbBackground}"/>
                                     </VisualState.Setters>
                                     <!-- The storyboard below cannot be moved to a transition since transitions
                                              will not be run by the framework when animations are disabled in the system -->
@@ -686,8 +686,8 @@
                                 </VisualState>
                                 <VisualState x:Name="CollapsedWithoutAnimation">
                                     <VisualState.Setters>
-                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
-                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackground}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackground}"/>
                                     </VisualState.Setters>
                                     <!-- The storyboard below cannot be moved to a transition since transitions
                                              will not be run by the framework when animations are disabled in the system -->

--- a/dev/ScrollBar/ScrollBar_themeresources.xaml
+++ b/dev/ScrollBar/ScrollBar_themeresources.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All Rights Reserved. -->
+<!-- Copyright (c) Microsoft Corporation. All Rights Reserved. -->
 <ResourceDictionary
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
@@ -526,9 +526,11 @@
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="NoIndicator">
+                                    <VisualState.Setters>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                    </VisualState.Setters>
                                     <Storyboard>
-                                        <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
-                                        <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="ScaleX" To="{ThemeResource SmallScrollThumbScale}" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="TranslateX" To="{ThemeResource SmallScrollThumbOffset}" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="HorizontalThumbTransform" Storyboard.TargetProperty="ScaleY" To="{ThemeResource SmallScrollThumbScale}" />
@@ -586,8 +588,6 @@
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="Expanded" To="Collapsed">
                                         <Storyboard>
-                                            <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
-                                            <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
                                             <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="ScaleX" To="{ThemeResource SmallScrollThumbScale}" />
                                             <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="TranslateX" To="{ThemeResource SmallScrollThumbOffset}" />
                                             <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalThumbTransform" Storyboard.TargetProperty="ScaleY" To="{ThemeResource SmallScrollThumbScale}" />
@@ -611,7 +611,12 @@
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
-                                <VisualState x:Name="Collapsed" />
+                                <VisualState x:Name="Collapsed">
+                                    <VisualState.Setters>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                    </VisualState.Setters>
+                                </VisualState>
                                 <VisualState x:Name="Expanded">
                                     <VisualState.Setters>
                                         <Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
@@ -620,11 +625,11 @@
                                         <Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
                                         <Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
                                         <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
                                     </VisualState.Setters>
 
                                     <Storyboard>
-                                        <ColorAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarThumbBackgroundColor}" />
-                                        <ColorAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarThumbBackgroundColor}" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="ScaleX" To="1.0" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="TranslateX" To="0" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalThumbTransform" Storyboard.TargetProperty="ScaleY" To="1.0" />
@@ -657,12 +662,12 @@
                                         <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
                                         <contract7Present:Setter Target="HorizontalThumb.CornerRadius" Value="0" />
                                         <contract7Present:Setter Target="VerticalThumb.CornerRadius" Value="0" />
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarThumbBackgroundColor}"/>
                                     </VisualState.Setters>
                                     <!-- The storyboard below cannot be moved to a transition since transitions
                                              will not be run by the framework when animations are disabled in the system -->
                                     <Storyboard>
-                                        <ColorAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarThumbBackgroundColor}" />
-                                        <ColorAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarThumbBackgroundColor}" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="ScaleX" To="1.0" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="TranslateX" To="0" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalThumbTransform" Storyboard.TargetProperty="ScaleY" To="1.0" />
@@ -680,11 +685,13 @@
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="CollapsedWithoutAnimation">
+                                    <VisualState.Setters>
+                                        <Setter Target="HorizontalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                        <Setter Target="VerticalThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}"/>
+                                    </VisualState.Setters>
                                     <!-- The storyboard below cannot be moved to a transition since transitions
                                              will not be run by the framework when animations are disabled in the system -->
                                     <Storyboard>
-                                        <ColorAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
-                                        <ColorAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="ScaleX" To="{ThemeResource SmallScrollThumbScale}" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="VerticalThumbTransform" Storyboard.TargetProperty="TranslateX" To="{ThemeResource SmallScrollThumbOffset}" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalThumbTransform" Storyboard.TargetProperty="ScaleY" To="{ThemeResource SmallScrollThumbScale}" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue was that the theme resources did not update when switching theme, resulting in invisible scrollthumbs when switching themes. By switching to brushes instead of colors for those areas and moving towards setters instead of 0 second color transitions, this issue is now fixed.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2727
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->