### PR TITLE
NavigationView: Throw exception when a WUX NavigationViewItem is added to it as a menu item

### DIFF
--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -58,6 +58,14 @@ winrt::UIElement NavigationViewItemsFactory::GetElementCore(winrt::ElementFactor
         return newItem;
     }
 
+    // Acidentally adding a OS XAML NavigationViewItem to WinUI's NavigationView can cause unnecessary confusion for developers
+    // due to unexpected rendering, potentially without an easy way to understand what went wrong here. To help out developers,
+    // we are explicitly checking for this scenario here and throw a helpful error message so that they can quickly fix their app.
+    if (newContent.try_as<winrt::Windows::UI::Xaml::Controls::NavigationViewItemBase>())
+    {
+        throw winrt::hresult_invalid_argument(L"A NavigationView instance contains a Windows.UI.Xaml.Controls.NavigationViewItem. This control requires that its NavigationViewItems be of type Microsoft.UI.Xaml.Controls.NavigationViewItem.");
+    }
+
     // Get or create a wrapping container for the data
     auto const nvi = [this]() {
         if (navigationViewItemPool.size() > 0)

--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -58,7 +58,7 @@ winrt::UIElement NavigationViewItemsFactory::GetElementCore(winrt::ElementFactor
         return newItem;
     }
 
-    // Acidentally adding a OS XAML NavigationViewItem to WinUI's NavigationView can cause unnecessary confusion for developers
+    // Accidentally adding a OS XAML NavigationViewItem to WinUI's NavigationView can cause unnecessary confusion for developers
     // due to unexpected rendering, potentially without an easy way to understand what went wrong here. To help out developers,
     // we are explicitly checking for this scenario here and throw a helpful error message so that they can quickly fix their app.
     if (newContent.try_as<winrt::Windows::UI::Xaml::Controls::NavigationViewItemBase>())


### PR DESCRIPTION
## Description
With PR https://github.com/microsoft/microsoft-ui-xaml/pull/69, logic was added to throw an exception with a helpful error message when a developer accidentally adds a WUX NavigationViewItem to a MUX NavigationView. Unfortunately, with the move to `ItemsRepeater` in PR https://github.com/microsoft/microsoft-ui-xaml/pull/1683, this logic did not survive and thus starting with WinUI 2.4, WinUI no longer guards against adding WUX NavigationViewItems.

This PR adds back this logic when a developer adds a WUX NavigationViewItem to a NavigationView (via the APIs `MenuItems`\\`MenuItemsSource` or `FooterMenuItems`\\`FooterMenuItemsSource`). The exception looks like this in a WinUI C# app:
![image](https://user-images.githubusercontent.com/1398851/91999881-2e12e680-ed3d-11ea-8477-923eb8ba57eb.png)

## Motivation and Context
Prevents developer confusion when they accidentally add a WUX NavigationViewItem to a NavigationView and see "weird" rendering behavior as a result. The image below shows the rendering difference between a MUX NavigationViewItem and a WUX NavigationViewItem when added to a MUX NavigationView:
![image](https://user-images.githubusercontent.com/1398851/92000026-5864a400-ed3d-11ea-9230-51b5f21680aa.png)

## How Has This Been Tested?
Tested manually. Unfortunately, while an API test for this scenario [exists](https://github.com/microsoft/microsoft-ui-xaml/blob/master/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs#L615), it appears we cannot use a simple API test here because adding a WUX NavigationViewItem to the UI will lead to *multiple* calls of the `NavigationViewItemsFactory::GetElementCore` method during the UI update phase. Each of these calls will throw our added exception and I was unable to catch *all* of them and have the API test succeed. I tried adding an additional `Application.Current.UnhandledException` handler in the API test to catch all thrown exceptions in addition to the one we catch in https://github.com/microsoft/microsoft-ui-xaml/blob/986d48adaccaabd569dab76137543b1102b24b6c/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs#L639
but the VS test explorer still showed the test as failing because they apparently still managed to slip through my added unhandled exception handling (and I set `UnhandledExceptionEventArgs.Handled` to true).

Any other ideas here? If we cannot get this API test to work, we should add the reason why it is disabled as a comment (or alternatively just remove it, though keeping it will act as a documentation for this test case).