### PR TITLE
Fix ColorHelper Function Declarations

### DIFF
--- a/dev/ColorPicker/ColorHelpers.cpp
+++ b/dev/ColorPicker/ColorHelpers.cpp
@@ -8,14 +8,6 @@
 
 const int CheckerSize = 4;
 
-Hsv FindNextNamedColor(
-    const Hsv &originalHsv,
-    winrt::ColorPickerHsvChannel channel,
-    IncrementDirection direction,
-    bool shouldWrap,
-    double minBound,
-    double maxBound);
-
 Hsv IncrementColorChannel(
     const Hsv &originalHsv,
     winrt::ColorPickerHsvChannel channel,

--- a/dev/ColorPicker/ColorHelpers.h
+++ b/dev/ColorPicker/ColorHelpers.h
@@ -28,6 +28,14 @@ Hsv IncrementColorChannel(
     double minBound,
     double maxBound);
 
+Hsv FindNextNamedColor(
+    const Hsv& originalHsv,
+    winrt::ColorPickerHsvChannel channel,
+    IncrementDirection direction,
+    bool shouldWrap,
+    double minBound,
+    double maxBound);
+
 double IncrementAlphaChannel(
     double originalAlpha,
     IncrementDirection direction,

--- a/dev/ColorPicker/ColorHelpers.h
+++ b/dev/ColorPicker/ColorHelpers.h
@@ -28,6 +28,9 @@ Hsv IncrementColorChannel(
     double minBound,
     double maxBound);
 
+template <typename T>
+int sgn(T val);
+
 Hsv FindNextNamedColor(
     const Hsv& originalHsv,
     winrt::ColorPickerHsvChannel channel,


### PR DESCRIPTION
## Description

Moves FindNextNamedColor() function declaration to ColorHelper.h instead of the .cpp file.

## Motivation and Context

Fixes #3226

## How Has This Been Tested?

Compiles

## Screenshots (if appropriate):
N/A