### PR TITLE
TreeView: Fix visual flicker when directly clicking the expand/collapse chevron

### DIFF
--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -152,28 +152,30 @@
                             </Grid>
 
                             <Grid x:Name="ExpandCollapseChevron"
-                                    Grid.Column="1"
-                                    Padding="12,0,12,0"
-                                    Width="Auto"
-                                    Opacity="{TemplateBinding GlyphOpacity}"
-                                    Background="Transparent">
+                                Grid.Column="1"
+                                Padding="12,0,12,0"
+                                Width="Auto"
+                                Opacity="{TemplateBinding GlyphOpacity}"
+                                Background="Transparent">
                                 <TextBlock Foreground="{TemplateBinding GlyphBrush}"
-                                            Width="12" Height="12"
-                                            Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.CollapsedGlyphVisibility}" 
-                                            FontSize="{TemplateBinding GlyphSize}" Text="{TemplateBinding CollapsedGlyph}"
-                                            FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                            VerticalAlignment="Center"
-                                            AutomationProperties.AccessibilityView="Raw"
-                                            IsTextScaleFactorEnabled="False" />
+                                    Width="12" Height="12"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.CollapsedGlyphVisibility}"
+                                    FontSize="{TemplateBinding GlyphSize}" Text="{TemplateBinding CollapsedGlyph}"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    IsTextScaleFactorEnabled="False"
+                                    IsHitTestVisible="False"/>
                                 <TextBlock Foreground="{TemplateBinding GlyphBrush}"
-                                            Width="12" Height="12"
-                                            Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.ExpandedGlyphVisibility}" 
-                                            FontSize="{TemplateBinding GlyphSize}"
-                                            Text="{TemplateBinding ExpandedGlyph}"
-                                            FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                            VerticalAlignment="Center"
-                                            AutomationProperties.AccessibilityView="Raw"
-                                            IsTextScaleFactorEnabled="False"/>
+                                    Width="12" Height="12"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.ExpandedGlyphVisibility}" 
+                                    FontSize="{TemplateBinding GlyphSize}"
+                                    Text="{TemplateBinding ExpandedGlyph}"
+                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    IsTextScaleFactorEnabled="False"
+                                    IsHitTestVisible="False"/>
                             </Grid>
 
                             <ContentPresenter x:Name="ContentPresenter"


### PR DESCRIPTION
## Description
When a `TreeViewItem`'s expand/collapse chevron is directly clicked, the background of the TreeViewItem visually flickers. See this gif below:
![treeview-chevron-flickering](https://user-images.githubusercontent.com/1398851/92507530-6b78e780-f207-11ea-88cd-07dac028e486.gif)

This PR fixes the visual flickering:
![treeview-chevron-flickering-fix](https://user-images.githubusercontent.com/1398851/92507775-c7dc0700-f207-11ea-8455-d27bd1363b7d.gif)

## How Has This Been Tested?
Tested visually.