### PR TITLE
IconSource: Fix issue with Foreground property not being forwarded

### DIFF
--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -511,6 +511,10 @@ winrt::IconElement SharedHelpers::MakeIconElementFrom(winrt::IconSource const& i
 
         fontIcon.Glyph(fontIconSource.Glyph());
         fontIcon.FontSize(fontIconSource.FontSize());
+        if (const auto newForeground = fontIconSource.Foreground())
+        {
+            fontIcon.Foreground(newForeground);
+        }
 
         if (fontIconSource.FontFamily())
         {
@@ -528,7 +532,10 @@ winrt::IconElement SharedHelpers::MakeIconElementFrom(winrt::IconSource const& i
     {
         winrt::SymbolIcon symbolIcon;
         symbolIcon.Symbol(symbolIconSource.Symbol());
-
+        if (const auto newForeground = symbolIconSource.Foreground())
+        {
+            symbolIcon.Foreground(newForeground);
+        }
         return symbolIcon;
     }
     else if (auto bitmapIconSource = iconSource.try_as<winrt::BitmapIconSource>())
@@ -544,7 +551,10 @@ winrt::IconElement SharedHelpers::MakeIconElementFrom(winrt::IconSource const& i
         {
             bitmapIcon.ShowAsMonochrome(bitmapIconSource.ShowAsMonochrome());
         }
-
+        if (const auto newForeground = bitmapIconSource.Foreground())
+        {
+            bitmapIcon.Foreground(newForeground);
+        }
         return bitmapIcon;
     }
     else if (auto pathIconSource = iconSource.try_as<winrt::PathIconSource>())
@@ -555,7 +565,10 @@ winrt::IconElement SharedHelpers::MakeIconElementFrom(winrt::IconSource const& i
         {
             pathIcon.Data(pathIconSource.Data());
         }
-
+        if (const auto newForeground = pathIconSource.Foreground())
+        {
+            pathIcon.Foreground(newForeground);
+        }
         return pathIcon;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The sharedhelper used for converting did not forward the foreground property appropriately making it impossible to customize that property.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #3264 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually by setting foreground on the icon sources on the TeachingTip page. The API in question is internal only with the bug only coming up when used inside other controls. There doesn't seem to be an easy how to test this without walking the visual tree.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->