### PR TITLE
Switched AppTestAutomationHelpers nuspec to Release mode.

### DIFF
--- a/test/testinfra/AppTestAutomationHelpers/nuspec/MUXAppTestHelpers.nuspec
+++ b/test/testinfra/AppTestAutomationHelpers/nuspec/MUXAppTestHelpers.nuspec
@@ -11,19 +11,19 @@
   </metadata>
   <files>
     
-    <file target="lib\uap10.0" src="..\..\..\..\BuildOutput\Debug\x86\AppTestAutomationHelpers\AppTestAutomationHelpers.winmd"/>
+    <file target="lib\uap10.0" src="..\..\..\..\BuildOutput\Release\x86\AppTestAutomationHelpers\AppTestAutomationHelpers.winmd"/>
 
-    <file target="runtimes\win10-x86\native" src="..\..\..\..\BuildOutput\Debug\x86\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
-    <file target="runtimes\win10-x86\native" src="..\..\..\..\BuildOutput\Debug\x86\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
+    <file target="runtimes\win10-x86\native" src="..\..\..\..\BuildOutput\Release\x86\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
+    <file target="runtimes\win10-x86\native" src="..\..\..\..\BuildOutput\Release\x86\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
 
-    <file target="runtimes\win10-x64\native" src="..\..\..\..\BuildOutput\Debug\x64\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
-    <file target="runtimes\win10-x64\native" src="..\..\..\..\BuildOutput\Debug\x64\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
+    <file target="runtimes\win10-x64\native" src="..\..\..\..\BuildOutput\Release\x64\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
+    <file target="runtimes\win10-x64\native" src="..\..\..\..\BuildOutput\Release\x64\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
 
-    <file target="runtimes\win10-arm\native" src="..\..\..\..\BuildOutput\Debug\ARM\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
-    <file target="runtimes\win10-arm\native" src="..\..\..\..\BuildOutput\Debug\ARM\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
+    <file target="runtimes\win10-arm\native" src="..\..\..\..\BuildOutput\Release\ARM\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
+    <file target="runtimes\win10-arm\native" src="..\..\..\..\BuildOutput\Release\ARM\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
 
-    <file target="runtimes\win10-arm64\native" src="..\..\..\..\BuildOutput\Debug\ARM64\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
-    <file target="runtimes\win10-arm64\native" src="..\..\..\..\BuildOutput\Debug\ARM64\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
+    <file target="runtimes\win10-arm64\native" src="..\..\..\..\BuildOutput\Release\ARM64\AppTestAutomationHelpers\AppTestAutomationHelpers.dll"/>
+    <file target="runtimes\win10-arm64\native" src="..\..\..\..\BuildOutput\Release\ARM64\AppTestAutomationHelpers\AppTestAutomationHelpers.pri"/>
     
   </files>
 </package>

--- a/test/testinfra/AppTestAutomationHelpers/nuspec/MUXAppTestHelpers.nuspec
+++ b/test/testinfra/AppTestAutomationHelpers/nuspec/MUXAppTestHelpers.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>MUXAppTestHelpers</id>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <title>MUXAppTestHelpers</title>
     <authors>MUXAppTestHelpers</authors>
     <owners>MUXAppTestHelpers</owners>

--- a/test/testinfra/MUXTestInfra/MSTest/MUXTestInfra.MSTest.csproj
+++ b/test/testinfra/MUXTestInfra/MSTest/MUXTestInfra.MSTest.csproj
@@ -12,7 +12,7 @@
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <WindowsMetadataPath>$(UniversalCRTSdkDir)UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
   </PropertyGroup>
 
 

--- a/test/testinfra/MUXTestInfra/TAEF/MUXTestInfra.TAEF.csproj
+++ b/test/testinfra/MUXTestInfra/TAEF/MUXTestInfra.TAEF.csproj
@@ -31,7 +31,7 @@
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <WindowsMetadataPath>$(UniversalCRTSdkDir)UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
   </PropertyGroup>
 
 


### PR DESCRIPTION
AppTestAutomationHelpers crashes on release builds, since the nuget is being generated with the debug assemblies, so it fails to create its objects due to missing dependencies (likely some debug specific one that is not bundled on release builds)

## Description

<!--- Describe your changes in detail -->
Switched AppTestAutomationHelpers nuspec to use the Release mode dlls.

## Motivation and Context
Bugfix

## How Has This Been Tested?
With the WCT muxtestinfra branch, that was crashing on release builds. Its not anymore with locally built assemblies in release mode.