### PR TITLE
MUXTestInfra now supporting MSIX as well as APPX.

### DIFF
--- a/test/testinfra/AppTestAutomationHelpers/nuspec/MUXAppTestHelpers.nuspec
+++ b/test/testinfra/AppTestAutomationHelpers/nuspec/MUXAppTestHelpers.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>MUXAppTestHelpers</id>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <title>MUXAppTestHelpers</title>
     <authors>MUXAppTestHelpers</authors>
     <owners>MUXAppTestHelpers</owners>

--- a/test/testinfra/MUXTestInfra/Infra/Application.cs
+++ b/test/testinfra/MUXTestInfra/Infra/Application.cs
@@ -519,14 +519,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 
             var exclude = new[] { "Microsoft.NET.CoreRuntime", "Microsoft.VCLibs" };
 
-            var files = Directory.GetFiles(_baseAppxDir, $"{_packageName}*.appx", SearchOption.AllDirectories).Where(f => !exclude.Any(Path.GetFileNameWithoutExtension(f).Contains));
+            var files = Directory.GetFiles(_baseAppxDir, $"{_packageName}*.appx", SearchOption.AllDirectories).ToList();
+            files.AddRange(Directory.GetFiles(_baseAppxDir, $"{_packageName}*.msix", SearchOption.AllDirectories));
 
-            if (files.Count() == 0)
+            var filteredFiles = files.Where(f => !exclude.Any(Path.GetFileNameWithoutExtension(f).Contains));
+
+            if (filteredFiles.Count() == 0)
             {
-                throw new Exception(string.Format("Failed to find '*.appx' in {0}'!", _baseAppxDir));
+                throw new Exception(string.Format("Failed to find '*.appx' or '*.msix' in {0}'!", _baseAppxDir));
             }
 
-            foreach (string file in files)
+            foreach (string file in filteredFiles)
             {
                 DateTime fileWriteTime = File.GetLastWriteTime(file);
 

--- a/test/testinfra/MUXTestInfra/MSTest/MUXTestInfra.MSTest.csproj
+++ b/test/testinfra/MUXTestInfra/MSTest/MUXTestInfra.MSTest.csproj
@@ -12,7 +12,7 @@
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <WindowsMetadataPath>$(UniversalCRTSdkDir)UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
   </PropertyGroup>
 
 

--- a/test/testinfra/MUXTestInfra/TAEF/MUXTestInfra.TAEF.csproj
+++ b/test/testinfra/MUXTestInfra/TAEF/MUXTestInfra.TAEF.csproj
@@ -31,7 +31,7 @@
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <WindowsMetadataPath>$(UniversalCRTSdkDir)UnionMetadata\$(TargetPlatformVersion)</WindowsMetadataPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
   </PropertyGroup>
 
 

--- a/test/testinfra/MUXTestInfra/TestAppInstallHelper.cs
+++ b/test/testinfra/MUXTestInfra/TestAppInstallHelper.cs
@@ -33,12 +33,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
         {
             if (!TestAppxInstalled.Contains(packageFamilyName))
             {
-                FileInfo appxFile = new FileInfo(Path.Combine(deploymentDir, appInstallerName + ".appx"));
-                if (!appxFile.Exists)
+                FileInfo FirstFileWithExtension(params string[] extensions)
                 {
-                    appxFile = new FileInfo(Path.Combine(deploymentDir, appInstallerName + ".appxbundle"));
+                    Log.Comment("Searching for Package file. Base dir: {0}", deploymentDir);
+                    FileInfo fileInfo = null;
+                    foreach (var ext in extensions)
+                    {
+                        fileInfo = new FileInfo(Path.Combine(deploymentDir, $"{appInstallerName}.{ext}"));
+                        if (fileInfo.Exists)
+                        {
+                            Log.Comment("File '{0}' found!", fileInfo.FullName);
+                            break;
+                        }
+                        else
+                        {
+                            Log.Comment("File '{0}' not found.", fileInfo.FullName);
+                        }
+                    }
+
+                    return fileInfo;
                 }
-                if (appxFile.Exists)
+
+                var packageFile = FirstFileWithExtension("appx", "appxbundle", "msix");
+
+                if (packageFile?.Exists == true)
                 {
                     PackageManager packageManager = new PackageManager();
                     DeploymentResult result = null;
@@ -88,7 +106,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                         }
                     }
 
-                    var packageUri = new Uri(Path.Combine(deploymentDir, appxFile.FullName));
+                    var packageUri = new Uri(Path.Combine(deploymentDir, packageFile.FullName));
 
                     Log.Comment("Installing Test Appx Package: {0}", packageUri.AbsolutePath);
 


### PR DESCRIPTION
## Description
Targeting newer SDKs change the output of packages from APPX to MSIX. MUXTestInfra was hardcoded to support only APPX. This PR updates it to support both.

## Motivation and Context
WCT required this change this we are now generating MSIXs and not APPXs. Our builds stopped passing due to this change, which was an unsupported scenario for MUXTestInfra.

## How Has This Been Tested?
Tested both TAEF and MSTest on both WCT and MUX, locally on my box.