### PR TITLE
RadioButtons: Fix header not having correct color when disabled

### DIFF
--- a/dev/RadioButtons/APITests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/APITests/RadioButtonsTests.cs
@@ -9,6 +9,7 @@ using Common;
 using Windows.UI.Xaml.Markup;
 using System.Collections.Generic;
 using Windows.UI.Xaml.Media;
+using System.Linq;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -77,6 +78,46 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 testCondition = radioButton2.Foreground is SolidColorBrush brush2 && brush2.Color == Colors.Blue;
                 Verify.IsTrue(testCondition, "The foreground color of the RadioButton should have been [blue].");
+            });
+        }
+
+        [TestMethod]
+        public void VerifyIsEnabledChangeUpdatesVisualState()
+        {
+            RadioButtons radioButtons = null; ;
+            VisualStateGroup commonStatesGroup = null;
+            RunOnUIThread.Execute(() =>
+            {
+                radioButtons = new RadioButtons();
+
+                // Check 1: Set IsEnabled to true.
+                radioButtons.IsEnabled = true;
+
+                Content = radioButtons;
+                Content.UpdateLayout();
+
+                var radioButtonsLayoutRoot = (FrameworkElement)VisualTreeHelper.GetChild(radioButtons, 0);
+                commonStatesGroup = VisualStateManager.GetVisualStateGroups(radioButtonsLayoutRoot).First(vsg => vsg.Name.Equals("CommonStates"));
+
+                Verify.AreEqual("Normal", commonStatesGroup.CurrentState.Name);
+
+                // Check 2: Set IsEnabled to false.
+                radioButtons.IsEnabled = false;
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual("Disabled", commonStatesGroup.CurrentState.Name);
+
+                // Check 3: Set IsEnabled back to true.
+                radioButtons.IsEnabled = true;
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual("Normal", commonStatesGroup.CurrentState.Name);
             });
         }
     }

--- a/dev/RadioButtons/RadioButtons.cpp
+++ b/dev/RadioButtons/RadioButtons.cpp
@@ -49,6 +49,8 @@ void RadioButtons::OnApplyTemplate()
 {
     const winrt::IControlProtected controlProtected{ *this };
 
+    m_isEnabledChangedRevoker = IsEnabledChanged(winrt::auto_revoke, { this,  &RadioButtons::OnIsEnabledChanged });
+
     m_repeater.set([this, controlProtected]() {
         if (auto const repeater = GetTemplateChildT<winrt::ItemsRepeater>(s_repeaterName, controlProtected))
         {
@@ -64,6 +66,7 @@ void RadioButtons::OnApplyTemplate()
     }());
 
     UpdateItemsSource();
+    UpdateVisualStateForIsEnabledChange();
 }
 
 // When focus comes from outside the RadioButtons control we will put focus on the selected radio button.
@@ -489,6 +492,11 @@ void RadioButtons::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
     }
 }
 
+void RadioButtons::OnIsEnabledChanged(const winrt::IInspectable&, const winrt::DependencyPropertyChangedEventArgs&)
+{
+    UpdateVisualStateForIsEnabledChange();
+}
+
 winrt::UIElement RadioButtons::ContainerFromIndex(int index)
 {
     if (auto const repeater = m_repeater.get())
@@ -550,6 +558,11 @@ void RadioButtons::UpdateSelectedItem()
 void RadioButtons::UpdateItemTemplate()
 {
     m_radioButtonsElementFactory->UserElementFactory(ItemTemplate());
+}
+
+void RadioButtons::UpdateVisualStateForIsEnabledChange()
+{
+    winrt::VisualStateManager::GoToState(*this, IsEnabled() ? L"Normal" : L"Disabled", false);
 }
 
 // Test Hooks helpers, only function when m_testHooksEnabled == true

--- a/dev/RadioButtons/RadioButtons.h
+++ b/dev/RadioButtons/RadioButtons.h
@@ -58,6 +58,9 @@ private:
     void OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
     void OnAccessKeyInvoked(const winrt::UIElement&, const winrt::AccessKeyInvokedEventArgs& args);
 
+    void OnIsEnabledChanged(const winrt::IInspectable&, const winrt::DependencyPropertyChangedEventArgs&);
+    void UpdateVisualStateForIsEnabledChange();
+
     void UpdateItemsSource();
     winrt::IInspectable GetItemsSource();
 
@@ -88,6 +91,7 @@ private:
     com_ptr<RadioButtonsElementFactory> m_radioButtonsElementFactory{ nullptr };
 
     winrt::Control::Loaded_revoker m_repeaterLoadedRevoker{};
+    winrt::Control::IsEnabledChanged_revoker m_isEnabledChangedRevoker{};
     winrt::ItemsSourceView::CollectionChanged_revoker m_itemsSourceChanged{};
     winrt::ItemsRepeater::ElementPrepared_revoker m_repeaterElementPreparedRevoker{};
     winrt::ItemsRepeater::ElementClearing_revoker m_repeaterElementClearingRevoker{};

--- a/dev/RadioButtons/RadioButtons.xaml
+++ b/dev/RadioButtons/RadioButtons.xaml
@@ -28,7 +28,9 @@
                         </VisualStateManager.VisualStateGroups>
                         <ContentPresenter x:Name="HeaderContentPresenter"
                             Content="{TemplateBinding Header}"
-                            ContentTemplate="{TemplateBinding HeaderTemplate}"/>
+                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                            Foreground="{ThemeResource RadioButtonsHeaderForeground}"
+                            Margin="{ThemeResource RadioButtonsTopHeaderMargin}"/>
                         <local:ItemsRepeater x:Name="InnerRepeater">
                             <local:ItemsRepeater.Layout>
                                 <primitives:ColumnMajorUniformToLargestGridLayout

--- a/dev/RadioButtons/RadioButtons.xaml
+++ b/dev/RadioButtons/RadioButtons.xaml
@@ -16,7 +16,17 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:RadioButtons">
                     <StackPanel>
-                        <ContentPresenter
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource RadioButtonsHeaderForegroundDisabled}"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="HeaderContentPresenter"
                             Content="{TemplateBinding Header}"
                             ContentTemplate="{TemplateBinding HeaderTemplate}"/>
                         <local:ItemsRepeater x:Name="InnerRepeater">

--- a/dev/RadioButtons/RadioButtons_themeresources.xaml
+++ b/dev/RadioButtons/RadioButtons_themeresources.xaml
@@ -5,16 +5,21 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="RadioButtonsHeaderForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="RadioButtonsHeaderForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Dark">
+            <StaticResource x:Key="RadioButtonsHeaderForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="RadioButtonsHeaderForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
+            <StaticResource x:Key="RadioButtonsHeaderForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="RadioButtonsHeaderForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
     <x:Double x:Key="RadioButtonsColumnSpacing">7</x:Double>
     <x:Double x:Key="RadioButtonsRowSpacing">3</x:Double>
+
+    <Thickness x:Key="RadioButtonsTopHeaderMargin">0,0,0,4</Thickness>
 </ResourceDictionary>

--- a/dev/RadioButtons/RadioButtons_themeresources.xaml
+++ b/dev/RadioButtons/RadioButtons_themeresources.xaml
@@ -3,6 +3,17 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="RadioButtonsHeaderForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Dark">
+            <StaticResource x:Key="RadioButtonsHeaderForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+            <StaticResource x:Key="RadioButtonsHeaderForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
 
     <x:Double x:Key="RadioButtonsColumnSpacing">7</x:Double>
     <x:Double x:Key="RadioButtonsRowSpacing">3</x:Double>


### PR DESCRIPTION
This PR fixes the RadioButtons' header not having the correct foreground color when the control is disabled. It now matches the foreground color seen for controls like the TextBox, ComboBox,....

This PR introduces the following new theme resources for the header foreground:
* RadioButtonsHeaderForeground
* RadioButtonsHeaderForegroundDisabled

These theme resources match the theme resources available for the TextBox header or the ComboBox header, for example.

In addition to the two theme resources above, I have also introduced the following new resources:
* RadioButtonsTopHeaderMargin

Both the TextBox (`TextBoxTopHeaderMargin`) and the ComboBox (`ComboBoxTopHeaderMargin`) expose such a resource, thus the RadioButtons control should likely have one as well. I'm not exactly sold on the "Top" term here as the resource names to style the header foreground don't use that additional term and they appear totally fine to me... but for naming consistency, I went along here.

## Motivation and Context
Fixes https://github.com/microsoft/microsoft-ui-xaml/issues/3350

## How Has This Been Tested?
Tested visually and added API test.

## Screenshots:
| Light | Dark |
|--|--|
| ![image](https://user-images.githubusercontent.com/1398851/94861516-f2506700-0437-11eb-9833-cb21ceaf40a6.png)|![image](https://user-images.githubusercontent.com/1398851/94861568-085e2780-0438-11eb-9188-f2d2db509874.png)|

## Open Questions
The ComboBox' Header also exposes a `ComboBoxHeaderThemeFontWeight` theme resource so customers can individually style the font weight of the header. I think exposing such a resource for the RadioButtons control would make sense as well, since setting the FontWeight API on the RadioButtons control affects *both* the header and the content of its radio buttons:

```xml
<muxc:RadioButtonsHeader="RadioButtonsHeader"
                   FontWeight="Bold">
    <x:String>Option 1</x:String>
    <x:String>Option 2</x:String>
</muxc:RadioButtons>
```
![image](https://user-images.githubusercontent.com/1398851/94867760-20d33f80-0442-11eb-954e-d0e9f386d276.png)

As written above, the ComboBox names that resource `ComboBoxHeaderThemeFontWeight` so if I were to stay consistent with the naming here, then it would be `RadioButtonsHeaderThemeFontWeight`. Again, not really sure why the "Theme" term is needed here...

The TextBox [does not expose](https://github.com/microsoft/microsoft-ui-xaml/blob/master/dev/CommonStyles/TextBox_themeresources.xaml#L287) such a resource today but instead hard-codes the font weight of the header in the template: https://github.com/microsoft/microsoft-ui-xaml/blob/f4c811b92ae90ac74635c0523aa4c94b3c1d48eb/dev/CommonStyles/TextBox_themeresources.xaml#L287

Since the TextBox.FontWeight API already affects the TextBox's text, to allow individual customization of the header font weight, we should also introduce a theme resource here for the TextBox. Perhaps named `TextControlHeaderThemeFontWeight` (or `TextBoxHeaderThemeFontWeight`). Both the `TextControl` and the `TextBox` prefixes are used for for the TextBox's header resources. 

Adding such a TextBox resource could also be done as part of this.