### PR TITLE
Change handlers to revokers

### DIFF
--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -85,6 +85,24 @@ void MenuBarItem::AttachEventHandlers()
         m_pointerOverRevoker = RegisterPropertyChanged(button, winrt::ButtonBase::IsPointerOverProperty(), { this, &MenuBarItem::OnVisualPropertyChanged });
     }
 
+    m_onMenuBarItemPointerPressedRevoker = AddRoutedEventHandler<RoutedEventType::PointerPressed>(
+        *this,
+        [this](auto const& sender, auto const& args)
+        {
+            OnMenuBarItemPointerPressed(sender, args);
+        },
+        true /*handledEventsToo*/
+    );
+
+    m_onMenuBarItemKeyDownRevoker = AddRoutedEventHandler<RoutedEventType::KeyDown>(
+        *this,
+        [this](auto const& sender, auto const& args)
+        {
+            OnMenuBarItemKeyDown(sender, args);
+        },
+        true /*handledEventsToo*/
+     );
+
     if (auto flyout = m_flyout.get())
     {
         m_flyoutClosedRevoker = flyout.Closed(winrt::auto_revoke, { this, &MenuBarItem::OnFlyoutClosed });
@@ -92,12 +110,6 @@ void MenuBarItem::AttachEventHandlers()
     }
 
     m_pointerEnteredRevoker = PointerEntered(winrt::auto_revoke, { this, &MenuBarItem::OnMenuBarItemPointerEntered });
-
-    m_onMenuBarItemPointerPressedHandler = winrt::box_value<winrt::PointerEventHandler>({ this, &MenuBarItem::OnMenuBarItemPointerPressed });
-    AddHandler(winrt::UIElement::PointerPressedEvent(), m_onMenuBarItemPointerPressedHandler, true);
-
-    m_onMenuBarItemKeyDownHandler = winrt::box_value<winrt::KeyEventHandler>({ this, &MenuBarItem::OnMenuBarItemKeyDown });
-    AddHandler(winrt::UIElement::KeyDownEvent(), m_onMenuBarItemKeyDownHandler, true);
 
     m_accessKeyInvokedRevoker = AccessKeyInvoked(winrt::auto_revoke, { this, &MenuBarItem::OnMenuBarItemAccessKeyInvoked });
 }
@@ -110,17 +122,8 @@ void MenuBarItem::DetachEventHandlers(bool useSafeGet)
     m_flyoutClosedRevoker.revoke();
     m_flyoutOpeningRevoker.revoke();
 
-    if (m_onMenuBarItemPointerPressedHandler)
-    {
-        RemoveHandler(winrt::UIElement::PointerPressedEvent(), m_onMenuBarItemPointerPressedHandler);
-        m_onMenuBarItemPointerPressedHandler = nullptr;
-    }
-
-    if (m_onMenuBarItemKeyDownHandler)
-    {
-        RemoveHandler(winrt::UIElement::KeyDownEvent(), m_onMenuBarItemKeyDownHandler);
-        m_onMenuBarItemKeyDownHandler = nullptr;
-    }
+    m_onMenuBarItemPointerPressedRevoker.revoke();
+    m_onMenuBarItemKeyDownRevoker.revoke();
 }
 
 // Event Handlers

--- a/dev/MenuBar/MenuBarItem.h
+++ b/dev/MenuBar/MenuBarItem.h
@@ -69,8 +69,8 @@ private:
     winrt::UIElement::PointerEntered_revoker m_pointerEnteredRevoker{};
     winrt::UIElement::AccessKeyInvoked_revoker m_accessKeyInvokedRevoker{};
 
-    winrt::IInspectable m_onMenuBarItemPointerPressedHandler{ nullptr };
-    winrt::IInspectable m_onMenuBarItemKeyDownHandler{ nullptr };
+    RoutedEventHandler_revoker m_onMenuBarItemPointerPressedRevoker{};
+    RoutedEventHandler_revoker m_onMenuBarItemKeyDownRevoker{};
 
     PropertyChanged_revoker m_pressedRevoker{};
     PropertyChanged_revoker m_pointerOverRevoker{};


### PR DESCRIPTION
## Description
Replaces the manual AddHandler/RemoveHandler in MenuBarItem calls with the helper methods from RoutedEventHelpers.h.

## Motivation and Context
Reflecting the change made for WinUi 3 in WinUi 2. It fixes #3148 in WinUi 3.

## How Has This Been Tested?
It has been manually tested.