### PR TITLE
Update progress ring API

### DIFF
--- a/dev/Generated/ProgressRing.properties.cpp
+++ b/dev/Generated/ProgressRing.properties.cpp
@@ -17,7 +17,10 @@ GlobalDependencyProperty ProgressRingProperties::s_DeterminateSourceProperty{ nu
 GlobalDependencyProperty ProgressRingProperties::s_IndeterminateSourceProperty{ nullptr };
 GlobalDependencyProperty ProgressRingProperties::s_IsActiveProperty{ nullptr };
 GlobalDependencyProperty ProgressRingProperties::s_IsIndeterminateProperty{ nullptr };
+GlobalDependencyProperty ProgressRingProperties::s_MaximumProperty{ nullptr };
+GlobalDependencyProperty ProgressRingProperties::s_MinimumProperty{ nullptr };
 GlobalDependencyProperty ProgressRingProperties::s_TemplateSettingsProperty{ nullptr };
+GlobalDependencyProperty ProgressRingProperties::s_ValueProperty{ nullptr };
 
 ProgressRingProperties::ProgressRingProperties()
 {
@@ -70,6 +73,28 @@ void ProgressRingProperties::EnsureProperties()
                 ValueHelper<bool>::BoxValueIfNecessary(true),
                 winrt::PropertyChangedCallback(&OnIsIndeterminatePropertyChanged));
     }
+    if (!s_MaximumProperty)
+    {
+        s_MaximumProperty =
+            InitializeDependencyProperty(
+                L"Maximum",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::ProgressRing>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxValueIfNecessary(100.0),
+                winrt::PropertyChangedCallback(&OnMaximumPropertyChanged));
+    }
+    if (!s_MinimumProperty)
+    {
+        s_MinimumProperty =
+            InitializeDependencyProperty(
+                L"Minimum",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::ProgressRing>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxValueIfNecessary(0.0),
+                winrt::PropertyChangedCallback(&OnMinimumPropertyChanged));
+    }
     if (!s_TemplateSettingsProperty)
     {
         s_TemplateSettingsProperty =
@@ -81,6 +106,17 @@ void ProgressRingProperties::EnsureProperties()
                 ValueHelper<winrt::ProgressRingTemplateSettings>::BoxedDefaultValue(),
                 nullptr);
     }
+    if (!s_ValueProperty)
+    {
+        s_ValueProperty =
+            InitializeDependencyProperty(
+                L"Value",
+                winrt::name_of<double>(),
+                winrt::name_of<winrt::ProgressRing>(),
+                false /* isAttached */,
+                ValueHelper<double>::BoxValueIfNecessary(0.0),
+                winrt::PropertyChangedCallback(&OnValuePropertyChanged));
+    }
 }
 
 void ProgressRingProperties::ClearProperties()
@@ -89,7 +125,10 @@ void ProgressRingProperties::ClearProperties()
     s_IndeterminateSourceProperty = nullptr;
     s_IsActiveProperty = nullptr;
     s_IsIndeterminateProperty = nullptr;
+    s_MaximumProperty = nullptr;
+    s_MinimumProperty = nullptr;
     s_TemplateSettingsProperty = nullptr;
+    s_ValueProperty = nullptr;
 }
 
 void ProgressRingProperties::OnDeterminateSourcePropertyChanged(
@@ -122,6 +161,30 @@ void ProgressRingProperties::OnIsIndeterminatePropertyChanged(
 {
     auto owner = sender.as<winrt::ProgressRing>();
     winrt::get_self<ProgressRing>(owner)->OnIsIndeterminatePropertyChanged(args);
+}
+
+void ProgressRingProperties::OnMaximumPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::ProgressRing>();
+    winrt::get_self<ProgressRing>(owner)->OnMaximumPropertyChanged(args);
+}
+
+void ProgressRingProperties::OnMinimumPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::ProgressRing>();
+    winrt::get_self<ProgressRing>(owner)->OnMinimumPropertyChanged(args);
+}
+
+void ProgressRingProperties::OnValuePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::ProgressRing>();
+    winrt::get_self<ProgressRing>(owner)->OnValuePropertyChanged(args);
 }
 
 void ProgressRingProperties::DeterminateSource(winrt::IAnimatedVisualSource const& value)
@@ -176,6 +239,32 @@ bool ProgressRingProperties::IsIndeterminate()
     return ValueHelper<bool>::CastOrUnbox(static_cast<ProgressRing*>(this)->GetValue(s_IsIndeterminateProperty));
 }
 
+void ProgressRingProperties::Maximum(double value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<ProgressRing*>(this)->SetValue(s_MaximumProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    }
+}
+
+double ProgressRingProperties::Maximum()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<ProgressRing*>(this)->GetValue(s_MaximumProperty));
+}
+
+void ProgressRingProperties::Minimum(double value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<ProgressRing*>(this)->SetValue(s_MinimumProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    }
+}
+
+double ProgressRingProperties::Minimum()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<ProgressRing*>(this)->GetValue(s_MinimumProperty));
+}
+
 void ProgressRingProperties::TemplateSettings(winrt::ProgressRingTemplateSettings const& value)
 {
     [[gsl::suppress(con)]]
@@ -187,4 +276,17 @@ void ProgressRingProperties::TemplateSettings(winrt::ProgressRingTemplateSetting
 winrt::ProgressRingTemplateSettings ProgressRingProperties::TemplateSettings()
 {
     return ValueHelper<winrt::ProgressRingTemplateSettings>::CastOrUnbox(static_cast<ProgressRing*>(this)->GetValue(s_TemplateSettingsProperty));
+}
+
+void ProgressRingProperties::Value(double value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<ProgressRing*>(this)->SetValue(s_ValueProperty, ValueHelper<double>::BoxValueIfNecessary(value));
+    }
+}
+
+double ProgressRingProperties::Value()
+{
+    return ValueHelper<double>::CastOrUnbox(static_cast<ProgressRing*>(this)->GetValue(s_ValueProperty));
 }

--- a/dev/Generated/ProgressRing.properties.h
+++ b/dev/Generated/ProgressRing.properties.h
@@ -21,20 +21,35 @@ public:
     void IsIndeterminate(bool value);
     bool IsIndeterminate();
 
+    void Maximum(double value);
+    double Maximum();
+
+    void Minimum(double value);
+    double Minimum();
+
     void TemplateSettings(winrt::ProgressRingTemplateSettings const& value);
     winrt::ProgressRingTemplateSettings TemplateSettings();
+
+    void Value(double value);
+    double Value();
 
     static winrt::DependencyProperty DeterminateSourceProperty() { return s_DeterminateSourceProperty; }
     static winrt::DependencyProperty IndeterminateSourceProperty() { return s_IndeterminateSourceProperty; }
     static winrt::DependencyProperty IsActiveProperty() { return s_IsActiveProperty; }
     static winrt::DependencyProperty IsIndeterminateProperty() { return s_IsIndeterminateProperty; }
+    static winrt::DependencyProperty MaximumProperty() { return s_MaximumProperty; }
+    static winrt::DependencyProperty MinimumProperty() { return s_MinimumProperty; }
     static winrt::DependencyProperty TemplateSettingsProperty() { return s_TemplateSettingsProperty; }
+    static winrt::DependencyProperty ValueProperty() { return s_ValueProperty; }
 
     static GlobalDependencyProperty s_DeterminateSourceProperty;
     static GlobalDependencyProperty s_IndeterminateSourceProperty;
     static GlobalDependencyProperty s_IsActiveProperty;
     static GlobalDependencyProperty s_IsIndeterminateProperty;
+    static GlobalDependencyProperty s_MaximumProperty;
+    static GlobalDependencyProperty s_MinimumProperty;
     static GlobalDependencyProperty s_TemplateSettingsProperty;
+    static GlobalDependencyProperty s_ValueProperty;
 
     static void EnsureProperties();
     static void ClearProperties();
@@ -52,6 +67,18 @@ public:
         winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnIsIndeterminatePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnMaximumPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnMinimumPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnValuePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/ProgressRing/InteractionTests/ProgressRingTests.cs
+++ b/dev/ProgressRing/InteractionTests/ProgressRingTests.cs
@@ -21,6 +21,9 @@ using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
 using Microsoft.Windows.Apps.Test.Foundation.Patterns;
 using Microsoft.Windows.Apps.Test.Foundation.Waiters;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Controls.Primitives;
+using ToggleButton = Microsoft.Windows.Apps.Test.Foundation.Controls.ToggleButton;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {
@@ -199,6 +202,100 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Log.Comment("IsActive set to false updates ProgressRing to Inactive state");
                 Verify.AreEqual("Inactive", visualStateText.DocumentText);
+            }
+        }
+
+        [TestMethod]
+        public void ChangeValueTest()
+        {
+            using (var setup = new TestSetupHelper("ProgressRing Tests"))
+            {
+                Log.Comment("Changing Value of ProgressRing");
+
+                CheckBox indeterminateCheckBox = FindElement.ByName<CheckBox>("ShowIsIndeterminateCheckBox");
+                indeterminateCheckBox.Uncheck();
+
+                RangeValueSpinner progressRing = FindElement.ByName<RangeValueSpinner>("TestProgressRing");
+                Verify.AreEqual(0, progressRing.Value);
+
+                double oldValue = progressRing.Value;
+
+                // NOTE: Interaction tests can only access what accessibility tools see. In this case, we can find the button because we
+                // set AutomationProperties.Name on the button in ProgressRingPage.xaml
+                Button changeValueButton = FindElement.ByName<Button>("ChangeValueButton");
+                changeValueButton.InvokeAndWait();
+
+                double newValue = progressRing.Value;
+                double diff = Math.Abs(oldValue - newValue);
+
+                Log.Comment("ProgressRing value changed");
+                Verify.IsGreaterThan(diff, 0.0);
+            }
+        }
+
+        [TestMethod]
+        public void UpdateMinMaxTest()
+        {
+            using (var setup = new TestSetupHelper("ProgressRing Tests"))
+            {
+                Log.Comment("Updating Minimum and Maximum value of ProgressBar");
+
+                CheckBox indeterminateCheckBox = FindElement.ByName<CheckBox>("ShowIsIndeterminateCheckBox");
+                indeterminateCheckBox.Uncheck();
+
+                RangeValueSpinner progressRing = FindElement.ByName<RangeValueSpinner>("TestProgressRing");
+
+                double oldMinimumInputText = progressRing.Minimum;
+                double oldMaximumInputText = progressRing.Maximum;
+
+                Edit minimumInput = FindElement.ByName<Edit>("MinimumInput");
+                Edit maximumInput = FindElement.ByName<Edit>("MaximumInput");
+
+                minimumInput.SetValue("10");
+                maximumInput.SetValue("15");
+
+                Button updateMinMaxButton = FindElement.ByName<Button>("UpdateMinMaxButton");
+                updateMinMaxButton.InvokeAndWait();
+
+                double newMinimumInputText = progressRing.Minimum;
+                double newMaximumInputText = progressRing.Maximum;
+
+                Verify.AreNotSame(oldMinimumInputText, newMinimumInputText, "Minimum updated");
+                Verify.AreNotSame(oldMaximumInputText, newMaximumInputText, "Maximum updated");
+
+                // Below edge cases are handled by Rangebase
+
+                Log.Comment("Updating Minimum and Maximum when Maximum < Minimum");
+
+                maximumInput.SetValue("5");
+                updateMinMaxButton.InvokeAndWait();
+
+                Verify.AreEqual(progressRing.Minimum, progressRing.Maximum, "Maximum updates to equal Minimum");
+
+                Log.Comment("Updating Minimum and Maximum when Minimum > Value");
+
+                minimumInput.SetValue("15");
+                updateMinMaxButton.InvokeAndWait();
+
+                Verify.AreEqual(progressRing.Value, progressRing.Minimum, "Value updates to equal Minimum");
+                Verify.AreEqual(progressRing.Maximum, progressRing.Minimum, "Maximum also updates to equal Minimum");
+
+                Log.Comment("Updating Minimum and Maximum to be a decimal number");
+
+                minimumInput.SetValue("0.1");
+                maximumInput.SetValue("1.1");
+
+                updateMinMaxButton.InvokeAndWait();
+
+                double oldValue = progressRing.Value;
+
+                Button changeValueButton = FindElement.ByName<Button>("ChangeValueButton");
+                changeValueButton.InvokeAndWait();
+
+                double newValue = progressRing.Value;
+                double diff = Math.Abs(oldValue - newValue);
+
+                Verify.IsGreaterThan(diff, Convert.ToDouble(0), "Value of ProgressBar increments properly within range with decimal Minimum and Maximum");
             }
         }
     }

--- a/dev/ProgressRing/ProgressRing.h
+++ b/dev/ProgressRing/ProgressRing.h
@@ -34,18 +34,27 @@ public:
     void OnBackgroundPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
     void OnBackgroundColorPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
 
+    void OnValuePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnMinimumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+
 private:
     void SetAnimatedVisualPlayerSource();
     void SetLottieForegroundColor(const winrt::IAnimatedVisualSource);
     void SetLottieBackgroundColor(const winrt::IAnimatedVisualSource);
-    void OnRangeBasePropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
     void OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&);
     void UpdateStates();
     void ApplyTemplateSettings();
     void UpdateLottieProgress();
 
+    void CoerceMinimum();
+    void CoerceMaximum();
+    void CoerceValue();
+    bool IsInBounds(double value);
+
     tracker_ref<winrt::Grid> m_layoutRoot{ this };
     tracker_ref<winrt::AnimatedVisualPlayer> m_player{ this };
 
     double m_oldValue{ 0 };
+    bool m_rangeBasePropertyUpdating{ false };
 };

--- a/dev/ProgressRing/ProgressRing.idl
+++ b/dev/ProgressRing/ProgressRing.idl
@@ -14,7 +14,7 @@ runtimeclass ProgressRingTemplateSettings : Windows.UI.Xaml.DependencyObject
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
-unsealed runtimeclass ProgressRing : Windows.UI.Xaml.Controls.Primitives.RangeBase
+unsealed runtimeclass ProgressRing : Windows.UI.Xaml.Controls.Control
 {
     ProgressRing();
 
@@ -39,6 +39,23 @@ unsealed runtimeclass ProgressRing : Windows.UI.Xaml.Controls.Primitives.RangeBa
     static Windows.UI.Xaml.DependencyProperty IsIndeterminateProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty DeterminateSourceProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty IndeterminateSourceProperty{ get; };
+
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    [MUX_DEFAULT_VALUE("0.0")]
+    Double Value;
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    [MUX_DEFAULT_VALUE("0.0")]
+    Double Minimum;
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    [MUX_DEFAULT_VALUE("100.0")]
+    Double Maximum;
+
+    static Windows.UI.Xaml.DependencyProperty ValueProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty MinimumProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty MaximumProperty{ get; };
 }
 
 }
@@ -48,7 +65,7 @@ namespace MU_XAP_NAMESPACE
 
 [WUXC_VERSION_MUXONLY]
 [webhosthidden]
-unsealed runtimeclass ProgressRingAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
+unsealed runtimeclass ProgressRingAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer, Windows.UI.Xaml.Automation.Provider.IRangeValueProvider
 {
     ProgressRingAutomationPeer(MU_XC_NAMESPACE.ProgressRing owner);
 }

--- a/dev/ProgressRing/ProgressRingAutomationPeer.cpp
+++ b/dev/ProgressRing/ProgressRingAutomationPeer.cpp
@@ -15,6 +15,16 @@ ProgressRingAutomationPeer::ProgressRingAutomationPeer(winrt::ProgressRing const
 {
 }
 
+winrt::IInspectable ProgressRingAutomationPeer::GetPatternCore(winrt::PatternInterface const& patternInterface)
+{
+    if (patternInterface == winrt::PatternInterface::RangeValue)
+    {
+        return *this;
+    }
+
+    return __super::GetPatternCore(patternInterface);
+}
+
 winrt::hstring ProgressRingAutomationPeer::GetClassNameCore()
 {
     return winrt::hstring_name_of<winrt::ProgressRing>();
@@ -29,7 +39,14 @@ winrt::hstring ProgressRingAutomationPeer::GetNameCore()
     {
         if (progressRing.IsActive())
         {
-            return winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingIndeterminateStatus) + name };
+            if (progressRing.IsIndeterminate())
+            {
+                return winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingIndeterminateStatus) + name };
+            }
+            else
+            {
+                return name;
+            }
         }
     }
     return name;
@@ -43,4 +60,47 @@ winrt::AutomationControlType ProgressRingAutomationPeer::GetAutomationControlTyp
 winrt::hstring ProgressRingAutomationPeer::GetLocalizedControlTypeCore()
 {
     return ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingName);
+}
+
+// IRangeValueProvider
+double ProgressRingAutomationPeer::Minimum()
+{
+    return GetImpl()->Minimum();
+}
+
+double ProgressRingAutomationPeer::Maximum()
+{
+    return GetImpl()->Maximum();
+}
+
+double ProgressRingAutomationPeer::Value()
+{
+    return GetImpl()->Value();
+}
+
+double ProgressRingAutomationPeer::SmallChange()
+{
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+double ProgressRingAutomationPeer::LargeChange()
+{
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+void ProgressRingAutomationPeer::SetValue(double value)
+{
+    GetImpl()->Value(value);
+}
+
+com_ptr<ProgressRing> ProgressRingAutomationPeer::GetImpl()
+{
+    com_ptr<ProgressRing> impl = nullptr;
+
+    if (auto numberBox = Owner().try_as<winrt::ProgressRing>())
+    {
+        impl = winrt::get_self<ProgressRing>(numberBox)->get_strong();
+    }
+
+    return impl;
 }

--- a/dev/ProgressRing/ProgressRingAutomationPeer.h
+++ b/dev/ProgressRing/ProgressRingAutomationPeer.h
@@ -13,9 +13,22 @@ class ProgressRingAutomationPeer :
 public:
     ProgressRingAutomationPeer(winrt::ProgressRing const& owner);
 
+    winrt::IInspectable GetPatternCore(winrt::PatternInterface const& patternInterface);
     winrt::hstring GetClassNameCore();
     winrt::hstring GetNameCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
     winrt::hstring GetLocalizedControlTypeCore();
+
+    // IRangeValueProvider
+    bool IsReadOnly() { return true; }
+    double Minimum();
+    double Maximum();
+    double Value();
+    double SmallChange();
+    double LargeChange();
+    void SetValue(double value);
+
+private:
+    com_ptr<ProgressRing> GetImpl();
 };
 

--- a/dev/ProgressRing/TestUI/ProgressRingPage.xaml
+++ b/dev/ProgressRing/TestUI/ProgressRingPage.xaml
@@ -19,6 +19,8 @@
         <StackPanel Orientation="Vertical">
             <controls:ProgressRing
                 x:Name="TestProgressRing"
+                AutomationProperties.Name="TestProgressRing"
+                IsTabStop="True"
                 IsActive="{x:Bind ShowIsActiveCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
                 IsIndeterminate="{x:Bind ShowIsIndeterminateCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
             />

--- a/dev/ProgressRing/TestUI/ProgressRingPage.xaml
+++ b/dev/ProgressRing/TestUI/ProgressRingPage.xaml
@@ -20,7 +20,6 @@
             <controls:ProgressRing
                 x:Name="TestProgressRing"
                 AutomationProperties.Name="TestProgressRing"
-                IsTabStop="True"
                 IsActive="{x:Bind ShowIsActiveCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
                 IsIndeterminate="{x:Bind ShowIsIndeterminateCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
             />


### PR DESCRIPTION
We made changes to progress ring which were not ABI stable, namely changing the base type to RangeBase. This change reverts the base change type while adding the Value, min, and max properties we needed from it.  We also expand the automation peer to implement the IRangeValueProvider.