### PR TITLE
Set correct date for next community call

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
           <h4>Get connected with us on <a href="https://twitter.com/WindowsUI">Twitter</a> and <a href="https://discord.gg/PF8FCHZ">Discord</a>, and file issues or feature requests on our <a href="https://github.com/microsoft/microsoft-ui-xaml">Github repository</a>.</h4>
           <br/><br/>
           <h4>Our next community call is on:</h4>
-          <h4><span style="font-weight: 600; margin-top: 5px;"> August 19<span style="vertical-align: text-top;"> | </span> </span><i class="icon-calendar m-auto text-icon"></i><span id="add-to-cal"><a href="./WinUICommunityCall.ics"> Add to calendar</a></span></h4> 
+          <h4><span style="font-weight: 600; margin-top: 5px;"> October 21<span style="vertical-align: text-top;"> | </span> </span><i class="icon-calendar m-auto text-icon"></i><span id="add-to-cal"><a href="./WinUICommunityCall.ics"> Add to calendar</a></span></h4> 
           <br/><br/>
         </div>
         <div class="col-sm-9 col-md-6 embed-responsive embed-responsive-16by9" id="video-wrapper">


### PR DESCRIPTION
X-Ref https://github.com/microsoft/microsoft-ui-xaml/issues/3418

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the date for the next community call

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Showing the old date:
- reduces expose/awareness of upcoming call
- makes it look like regular calls have stopped
- makes the site look out-of-date (or no longer maintained) by not being updated to show current information

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
It's just text change.
Manually verified.
No automated testing necessary

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->