### PR TITLE
VisualTreeUtils: Improved API consistency, code cleanup

### DIFF
--- a/dev/CommonStyles/TestUI/CommonStylesPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/CommonStylesPage.xaml.cs
@@ -221,7 +221,7 @@ namespace MUXControlsTestApp
 
         private void ListViewItemDensityTest_Click(object sender, RoutedEventArgs e)
         {
-            var item = ListView1.FindElementOfTypeInSubtree<ListViewItem>();
+            var item = ListView1.FindVisualChildByType<ListViewItem>();
             SimpleVerify simpleVerify = new SimpleVerify();
             if (item != null)
             {

--- a/dev/CommonStyles/TestUI/CompactPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/CompactPage.xaml.cs
@@ -70,9 +70,9 @@ namespace MUXControlsTestApp
         private void RunTest_Click(object sender, RoutedEventArgs e)
         {           
             SimpleVerify simpleVerify = new SimpleVerify();
-            FrameworkElement item = ListView.FindElementOfTypeInSubtree<ListViewItem>();
+            FrameworkElement item = ListView.FindVisualChildByType<ListViewItem>();
             VerifyHeight(simpleVerify, item, 32, "ListViewItem");
-            item = TreeView.FindElementOfTypeInSubtree<TreeViewItem>();
+            item = TreeView.FindVisualChildByType<TreeViewItem>();
             VerifyHeight(simpleVerify, item, 24, "TreeViewItem");
 
             VerifyHeight(simpleVerify, NavItem1, 32, "NavigationViewItem");

--- a/dev/Repeater/TestUI/Samples/LayoutSamples/NestedLayoutSamples/ItemsViewWithDataPage.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/LayoutSamples/NestedLayoutSamples/ItemsViewWithDataPage.xaml.cs
@@ -239,7 +239,7 @@ namespace MUXControlsTestApp.Samples
 
                 if (i < indexPath.Length - 1)
                 {
-                    repeater = container.FindElementOfTypeInSubtree<ItemsRepeater>();
+                    repeater = container.FindVisualChildByType<ItemsRepeater>();
                 }
                 else
                 {

--- a/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabItemsSourcePage.xaml.cs
@@ -39,7 +39,7 @@ namespace MUXControlsTestApp
 
         private void TabViewTabItemsSourcePage_Loaded(object sender, RoutedEventArgs e)
         {
-            innerListView = TabViewItemsSourceSample.FindElementOfTypeInSubtree<ListView>();
+            innerListView = TabViewItemsSourceSample.FindVisualChildByType<ListView>();
 
             for (int tabIndex = 0; tabIndex < initialTabsCount; tabIndex++)
             {

--- a/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
+++ b/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
@@ -8,7 +8,7 @@ namespace MUXControlsTestApp.Utilities
 {
     public static class VisualTreeUtils
     {
-        public static T FindElementOfTypeInSubtree<T>(this DependencyObject element)
+        public static T FindVisualChildByType<T>(this DependencyObject element)
             where T : DependencyObject
         {
             if (element == null)
@@ -16,15 +16,15 @@ namespace MUXControlsTestApp.Utilities
                 return null;
             }
 
-            if (element is T)
+            if (element is T elementAsT)
             {
-                return (T)element;
+                return elementAsT;
             }
 
             int childrenCount = VisualTreeHelper.GetChildrenCount(element);
             for (int i = 0; i < childrenCount; i++)
             {
-                var result = FindElementOfTypeInSubtree<T>(VisualTreeHelper.GetChild(element, i));
+                var result = VisualTreeHelper.GetChild(element, i).FindVisualChildByType<T>();
                 if (result != null)
                 {
                     return result;
@@ -34,27 +34,25 @@ namespace MUXControlsTestApp.Utilities
             return null;
         }
 
-        public static DependencyObject FindVisualChildByName(FrameworkElement parent, string name)
+        public static FrameworkElement FindVisualChildByName(this DependencyObject element, string name)
         {
-            if (parent.Name == name)
+            if (element == null || string.IsNullOrWhiteSpace(name))
             {
-                return parent;
+                return null;
             }
 
-            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+            if (element is FrameworkElement elementAsFE && elementAsFE.Name == name)
+            {
+                return elementAsFE;
+            }
 
+            int childrenCount = VisualTreeHelper.GetChildrenCount(element);
             for (int i = 0; i < childrenCount; i++)
             {
-                FrameworkElement childAsFE = VisualTreeHelper.GetChild(parent, i) as FrameworkElement;
-
-                if (childAsFE != null)
+                var result = VisualTreeHelper.GetChild(element, i).FindVisualChildByName(name);
+                if (result != null)
                 {
-                    DependencyObject result = FindVisualChildByName(childAsFE, name);
-
-                    if (result != null)
-                    {
-                        return result;
-                    }
+                    return result;
                 }
             }
 


### PR DESCRIPTION
## Description
[As discussed](https://github.com/microsoft/microsoft-ui-xaml/pull/3082#pullrequestreview-463810609) in PR https://github.com/microsoft/microsoft-ui-xaml/pull/3082 this PR aims to improve the API surface of the WinUI internal`VisualTreeUtils` class. Namely the following:

* Naming consistency: `FindElementOfTypeInSubtree()` has been renamed to `FindVisualChildByType()`
* Parameter consistency: `FindVisualChildByName()` now takes a `DependencyObject` as argument just like `FindVisualChildByType()` (including matching parameter name)
* Method call consistency: `FindVisualChildByName()` is now an extension method just like `FindVisualChildByType()`
* Internal code cleanup: Pattern matching, more compact code,...

Originally, I had planned to make this PR only after PR https://github.com/microsoft/microsoft-ui-xaml/pull/3082 had been merged into master but unfortunately, that PR might take some more time due to as of yet unresolved test failures. I don't want to have this work item waiting until then.

#### Important
Once this PR has been merged into master, any open PR adding new `FindElementOfTypeInSubtree()` calls needs to merge with master first. As far as I can tell though, no currently open PR *not* authored by me (I made a note for my PRs - if required) adds new calls to `FindElementOfTypeInSubtree()` right now.