### PR TITLE
Pipeline fixes take 3

### DIFF
--- a/build/Helix/ProcessHelixFiles.ps1
+++ b/build/Helix/ProcessHelixFiles.ps1
@@ -51,13 +51,20 @@ function Log-Error
 function Append-HelixAccessTokenToUrl
 {
     Param ([string]$url, [string]$token)
-    if($url.Contains("?"))
+    if($token)
     {
-        $url = "$($url)&access_token=$($token)"
+        if($url.Contains("?"))
+        {
+            $url = "$($url)&access_token=$($token)"
+        }
+        else
+        {
+            $url = "$($url)?access_token=$($token)"
+        }
     }
     else
     {
-        $url = "$($url)?access_token=$($token)"
+        Write-Host "The Helix Access Token was empty, returning the URL as is."
     }
     return $url
 }
@@ -132,7 +139,17 @@ foreach ($testRun in $testRuns.value)
                     }
                     catch
                     {
-                        Log-Error "Failed to download $($file.Name): $($_.Exception.Message)"
+                        Log-Error "Failed to download $($verificationFile.Name) to $destination : $($_.Exception.Message) -- URL: $($verificationFile.Link)"
+                        Write-Host "Trying backup download"
+                        try
+                        {
+                            $backupDestination = "$visualTreeVerificationFolder\$($verificationFile.Name)"
+                            $webClient.DownloadFile($fileurl, $backupDestination)
+                        }
+                        catch
+                        {
+                            Log-Error "Backup also failed to download $($verificationFile.Name) to $backupDestination : $($_.Exception.Message) -- URL: $($verificationFile.Link)"
+                        }
                     }
                 }
 

--- a/build/Helix/ProcessHelixFiles.ps1
+++ b/build/Helix/ProcessHelixFiles.ps1
@@ -62,10 +62,6 @@ function Append-HelixAccessTokenToUrl
             $url = "$($url)?access_token=$($token)"
         }
     }
-    else
-    {
-        Write-Host "The Helix Access Token was empty, returning the URL as is."
-    }
     return $url
 }
 
@@ -140,16 +136,6 @@ foreach ($testRun in $testRuns.value)
                     catch
                     {
                         Log-Error "Failed to download $($verificationFile.Name) to $destination : $($_.Exception.Message) -- URL: $($verificationFile.Link)"
-                        Write-Host "Trying backup download"
-                        try
-                        {
-                            $backupDestination = "$visualTreeVerificationFolder\$($verificationFile.Name)"
-                            $webClient.DownloadFile($fileurl, $backupDestination)
-                        }
-                        catch
-                        {
-                            Log-Error "Backup also failed to download $($verificationFile.Name) to $backupDestination : $($_.Exception.Message) -- URL: $($verificationFile.Link)"
-                        }
                     }
                 }
 

--- a/build/Helix/ProcessHelixFiles.ps1
+++ b/build/Helix/ProcessHelixFiles.ps1
@@ -126,8 +126,7 @@ foreach ($testRun in $testRuns.value)
                 }
                 foreach($verificationFile in $visualTreeVerificationFiles)
                 {
-                    $directory = $(get-location).Path
-                    $destination = "$directory\$visualTreeVerificationFolder\$($verificationFile.Name)"
+                    $destination = "$visualTreeVerificationFolder\$($verificationFile.Name)"
                     $fileurl = Append-HelixAccessTokenToUrl $verificationFile.Link  $HelixAccessToken
                     try
                     {


### PR DESCRIPTION
The previous pipeline stability fix had an error in the construction of the VisualVerificationUpdates folder which results it it not being possible to update visual verification files. This fixes that error. Even without this change the pipeline should be stable but this should be the last piece of the puzzle.