### PR TITLE
Move build to windevbuildagents

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -5,7 +5,7 @@ variables:
 jobs:
 - job: Build
   pool:
-    vmImage: 'windows-2019'
+    name: 'windevbuildagents'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -21,7 +21,7 @@ jobs:
       ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
     )
   pool:
-    vmImage: 'windows-2019'
+    name: 'windevbuildagents'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -16,7 +16,7 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'')
   pool:
-    vmImage: 'windows-2019'
+    name: 'windevbuildagents'
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -11,7 +11,7 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'') 
   pool:
-    vmImage: 'windows-2019'
+    name: 'windevbuildagents'
   timeoutInMinutes: 120
   variables:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages


### PR DESCRIPTION
This build pool should be more powerful than the 'windows-2019' pool and so PR and CI builds should be quicker.

Here is a link to a green run of the CI build with this change:
https://dev.azure.com/ms/microsoft-ui-xaml/_build/results?buildId=118925&view=results