### PR TITLE
Move NavigationView footer menu items from preview to public

### DIFF
--- a/dev/NavigationView/NavigationView.idl
+++ b/dev/NavigationView/NavigationView.idl
@@ -175,11 +175,8 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
     [MUX_DEFAULT_VALUE("1008.0")]
     [MUX_PROPERTY_VALIDATION_CALLBACK("CoerceToGreaterThanZero")]
     Double ExpandedModeThresholdWidth { get; set; };
-    [WUXC_VERSION_PREVIEW]
-    {
-        Windows.Foundation.Collections.IVector<Object> FooterMenuItems{ get; };
-        Object FooterMenuItemsSource{ get; set; };
-    }
+    Windows.Foundation.Collections.IVector<Object> FooterMenuItems{ get; };
+    Object FooterMenuItemsSource{ get; set; };
     Windows.UI.Xaml.UIElement PaneFooter { get; set; };
     Object Header { get; set; };
     Windows.UI.Xaml.DataTemplate HeaderTemplate { get; set; };
@@ -216,11 +213,8 @@ unsealed runtimeclass NavigationView : Windows.UI.Xaml.Controls.ContentControl
     static Windows.UI.Xaml.DependencyProperty IsPaneOpenProperty { get; };
     static Windows.UI.Xaml.DependencyProperty CompactModeThresholdWidthProperty { get; };
     static Windows.UI.Xaml.DependencyProperty ExpandedModeThresholdWidthProperty { get; };
-    [WUXC_VERSION_PREVIEW]
-    {
-        static Windows.UI.Xaml.DependencyProperty FooterMenuItemsProperty{ get; };
-        static Windows.UI.Xaml.DependencyProperty FooterMenuItemsSourceProperty{ get; };
-    }
+    static Windows.UI.Xaml.DependencyProperty FooterMenuItemsProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty FooterMenuItemsSourceProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty PaneFooterProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HeaderProperty { get; };
     static Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; };


### PR DESCRIPTION
Moving NavigationView footer menu items API from preview to public now that the [API spec is complete](https://github.com/microsoft/microsoft-ui-xaml-specs/pull/79).