### PR TITLE
Fix issue with ProgressRing not acting correctly when moving backwards

### DIFF
--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -305,8 +305,17 @@ void ProgressRing::UpdateLottieProgress()
         const double range = Maximum() - min;
         const double fromProgress = (m_oldValue - min) / range;
         const double toProgress = (value - min) / range;
+        if (fromProgress < toProgress)
+        {
+            const auto _ = player.PlayAsync(fromProgress, toProgress, false);
+        }
+        else
+        {
+            player.PlaybackRate(-1);
+            const auto _ = player.PlayAsync(fromProgress, toProgress, false);
+            player.PlaybackRate(1);
+        }
 
-        const auto _ = player.PlayAsync(fromProgress, toProgress, false);
         m_oldValue = value;
     }
 }

--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -311,9 +311,7 @@ void ProgressRing::UpdateLottieProgress()
         }
         else
         {
-            player.PlaybackRate(-1);
-            const auto _ = player.PlayAsync(fromProgress, toProgress, false);
-            player.PlaybackRate(1);
+            player.SetProgress(toProgress);
         }
 
         m_oldValue = value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When next value is below current value, we animate backwards instead of going to 100% and then to the value.
This is partially broken right now, when going backwards, the progressring jumps instead of animating.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3173 , Closes #3562
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![gif](https://user-images.githubusercontent.com/16122379/98355851-02ed9180-2023-11eb-9eee-e86806136685.gif)

The dark spot on the progress ring is a compression artifact, not visible when running the app.