### PR TITLE
Cache IsFullScreenMode and invalidate the value only when SizeChanged

### DIFF
--- a/dev/Lights/MaterialHelper.h
+++ b/dev/Lights/MaterialHelper.h
@@ -213,6 +213,7 @@ public:
     static void ResetFailedToAttachLightsCount();
 
 private:
+    bool IsFullScreenOrTabletModeImpl();
     void EnsureCompositionCapabilities();
     void EnsureSizeChangedHandler();
 
@@ -253,6 +254,8 @@ private:
     bool m_wasWindowHidden{};                           // True if we've received CoreWindow.VisiblityChanged w/ Visibility == false
     bool m_waitingForRenderingAfterBecomingVisible{};   // True if we got a VisibilityChanged(True) and are waiting for a CT.Rendering to complete the RS2 workaround for Bug 11159685
     bool m_energySaverStatusChangedRevokerValid{};
+    bool m_isFullScreenModeValid{};
+    bool m_isFullScreenMode{};
 
     event<std::function<void(com_ptr<MaterialHelperBase>, bool)>> m_policyChangedListeners;
     event<std::function<void(com_ptr<MaterialHelperBase>, bool)>> m_sizeChangedListeners;


### PR DESCRIPTION
I investigated #3536 and saw that AcrylicBrush's call to IsFullScreenMode was responsible for at least 2 seconds of delay (on my machine). AcrylicBrush was ending up calling this as a result of the AcrylicBrush instance being changed during the theme change and the new instance getting connected to the tree was causing MaterialHelper to re-query this value.

However because we create the MaterialHelper on the thread and keep it around forever we can just cache the value in the MaterialHelper instance and only reevaluate it when SizeChanged is raised (as, according to the documentation, SizeChanged is the trigger for both properties: IsFullScreenMode and UserInteractionMode).

This may not be the only issue but it seemed like an easy win to clean this up. I'll take a look later to see if there's more problems contributing to theme change delays.