### PR TITLE
Switch to using ThemeResource for icon in InfoBar

### DIFF
--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -28,7 +28,7 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentRoot.Background" Value="{ThemeResource InfoBarErrorSeverityBackgroundBrush}"/>
                                         <Setter Target="StandardIcon.Glyph" Value="{StaticResource InfoBarErrorIconGlyph}"/>
-                                        <Setter Target="StandardIcon.Foreground" Value="{StaticResource InfoBarErrorSeverityIconForeground}"/>
+                                        <Setter Target="StandardIcon.Foreground" Value="{ThemeResource InfoBarErrorSeverityIconForeground}"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -36,7 +36,7 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentRoot.Background" Value="{ThemeResource InfoBarWarningSeverityBackgroundBrush}"/>
                                         <Setter Target="StandardIcon.Glyph" Value="{StaticResource InfoBarWarningIconGlyph}"/>
-                                        <Setter Target="StandardIcon.Foreground" Value="{StaticResource InfoBarWarningSeverityIconForeground}"/>
+                                        <Setter Target="StandardIcon.Foreground" Value="{ThemeResource InfoBarWarningSeverityIconForeground}"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -44,7 +44,7 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentRoot.Background" Value="{ThemeResource InfoBarSuccessSeverityBackgroundBrush}"/>
                                         <Setter Target="StandardIcon.Glyph" Value="{StaticResource InfoBarSuccessIconGlyph}"/>
-                                        <Setter Target="StandardIcon.Foreground" Value="{StaticResource InfoBarSuccessSeverityIconForeground}"/>
+                                        <Setter Target="StandardIcon.Foreground" Value="{ThemeResource InfoBarSuccessSeverityIconForeground}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -122,7 +122,7 @@
                                 Margin="{StaticResource InfoBarIconMargin}"
                                 FontSize="{StaticResource InfoBarIconFontSize}"
                                 Glyph="{StaticResource InfoBarInformationalIconGlyph}"
-                                Foreground="{StaticResource InfoBarInformationalSeverityIconForeground}"
+                                Foreground="{ThemeResource InfoBarInformationalSeverityIconForeground}"
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/InfoBar/InfoBar_themeresources.xaml
+++ b/dev/InfoBar/InfoBar_themeresources.xaml
@@ -5,7 +5,6 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
-
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
             <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="#FDE7E9"/>


### PR DESCRIPTION
Switching InfoBar icon foreground to use ThemeResource instead of StaticResource so that it updates with theme changes. Fixes #3581 
