### PR TITLE
Fix crash in TabView when there are no items

### DIFF
--- a/dev/TabView/APITests/TabViewTests.cs
+++ b/dev/TabView/APITests/TabViewTests.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Provider;
+using System.Collections.ObjectModel;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -167,6 +168,25 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
+        [TestMethod]
+        public void VerifyTabViewWithoutTabsDoesNotCrash()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                TabView tabView = new TabView();
+                Content = tabView;
+
+                // Creating a TabView without tabs should not crash the app.
+                Content.UpdateLayout();
+
+                var tabItemsSource = new ObservableCollection<string>() { "Tab 1", "Tab 2" };
+                tabView.TabItemsSource = tabItemsSource;
+
+                // Clearing the ItemsSource should not crash the app.
+                Log.Comment("Clear the specified tab items source");
+                tabItemsSource.Clear();
+            });
+        }
         private static void VerifyTabWidthVisualStates(IList<object> items, bool isCompact)
         {
             foreach (var item in items)

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1009,7 +1009,7 @@ void TabView::UpdateSelectedIndex()
     {
         const auto selectedIndex = SelectedIndex();
         // Ensure that the selected index is within range of the items
-        if (selectedIndex < GetItemCount())
+        if (selectedIndex < static_cast<int>(listView.Items().Size()))
         {
             listView.SelectedIndex(selectedIndex);
         }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -583,7 +583,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
     {
         m_tabItemsChangedEventSource(*this, args);
 
-        int numItems = static_cast<int>(TabItems().Size());
+        const int numItems = static_cast<int>(TabItems().Size());
 
         if (args.CollectionChange() == winrt::CollectionChange::ItemRemoved)
         {
@@ -635,10 +635,14 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
         }
         else
         {
-            if (const auto newItem = TabItems().GetAt(args.Index()).try_as<TabViewItem>())
+            const auto index = static_cast<int>(args.Index());
+            if (index >= 0 && index < numItems)
             {
-                newItem->OnTabViewWidthModeChanged(TabWidthMode());
-                newItem->SetParentTabView(*this);
+                if (const auto newItem = TabItems().GetAt(index).try_as<TabViewItem>())
+                {
+                    newItem->OnTabViewWidthModeChanged(TabWidthMode());
+                    newItem->SetParentTabView(*this);
+                }
             }
             UpdateTabWidths();
         }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1007,7 +1007,12 @@ void TabView::UpdateSelectedIndex()
 {
     if (auto&& listView = m_listView.get())
     {
-        listView.SelectedIndex(SelectedIndex());
+        const auto selectedIndex = SelectedIndex();
+        // Ensure that the selected index is within range of the items
+        if (selectedIndex < GetItemCount())
+        {
+            listView.SelectedIndex(selectedIndex);
+        }
     }
 }
 

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -5,6 +5,7 @@
     xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
     xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
 
@@ -133,7 +134,11 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="primitives:TabViewListView">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            Background="{TemplateBinding Background}"
+                            BorderThickness="{TemplateBinding BorderThickness}"                           
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                            contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
                         <ScrollViewer x:Name="ScrollViewer"
                             Grid.Column="1"
                             AutomationProperties.AccessibilityView="Raw"
@@ -230,7 +235,7 @@
         <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
         <Setter Property="FontWeight" Value="Normal"/>
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}"/>
         <Setter Property="FocusVisualMargin" Value="-3"/>
         <Setter Property="Template">
@@ -244,7 +249,8 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
                         Content="{TemplateBinding Content}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                         ContentTransitions="{TemplateBinding ContentTransitions}"
                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                         Padding="{TemplateBinding Padding}"
@@ -290,7 +296,7 @@
     <Style x:Name="TabViewButtonStyle" TargetType="Button">
         <Setter Property="Background" Value="{ThemeResource TabViewButtonBackground}"/>
         <Setter Property="Foreground" Value="{ThemeResource TabViewButtonForeground}"/>
-        <Setter Property="CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}"/>
+        <contract7Present:Setter Property="CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}"/>
         <Setter Property="FontSize" Value="11"/>
         <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
         <Setter Property="VerticalAlignment" Value="Bottom"/>
@@ -305,7 +311,8 @@
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
                         ContentTransitions="{TemplateBinding ContentTransitions}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                         FontSize="{TemplateBinding FontSize}"
                         FontFamily="{TemplateBinding FontFamily}"
                         FontWeight="SemiLight"


### PR DESCRIPTION
Fixes for regression in TabView where we crashed when creating a TabView without any items and showing it as well as when clearing the Tabview of items.

The crash happens when we try to set selected index on ListView that is not in the Items collection range. Also added contract checks for CornerRadius which were causing the down-level OS failures.

Fixes #3104

Should also fix the down-level test failures @Felix-Dev  hit in [this PR](https://github.com/microsoft/microsoft-ui-xaml/pull/3118)

