### PR TITLE
Remove explicit sizes of InfoBar

### DIFF
--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -172,7 +172,7 @@
                                             <Style.Setters>
                                                 <Setter Property="MinWidth" Value="{StaticResource InfoBarActionButtonMinWidth}"/>
                                                 <Setter Property="Padding" Value="{StaticResource InfoBarActionButtonPadding}"/>
-                                                <Setter Property="MinHeight" Value="24"/>
+                                                <Setter Property="MinHeight" Value="{StaticResource InfoBarActionButtonMinHeight}"/>
                                                 <contract7Present:Setter Property="CornerRadius" Value="{StaticResource InfoBarActionButtonCornerRadius}"/>
                                             </Style.Setters>
                                         </Style>
@@ -182,7 +182,7 @@
                                                 <Setter Property="FontSize" Value="{ThemeResource InfoBarHyperlinkButtonFontSize}"/>
                                                 <Setter Property="Foreground" Value="{ThemeResource InfoBarHyperlinkButtonForeground}"/>
                                                 <Setter Property="Padding" Value="{StaticResource InfoBarHyperlinkButtonPadding}"/>
-                                                <Setter Property="MinHeight" Value="24"/>
+                                                <Setter Property="MinHeight" Value="{ThemeResource InfoBarHyperlinkButtonMinHeight}"/>
                                             </Style.Setters>
                                         </Style>
                                     </ContentPresenter.Resources>

--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -171,7 +171,6 @@
                                         <Style TargetType="Button">
                                             <Style.Setters>
                                                 <Setter Property="MinWidth" Value="{StaticResource InfoBarActionButtonMinWidth}"/>
-                                                <Setter Property="Height" Value="{StaticResource InfoBarActionButtonHeight}"/>
                                                 <Setter Property="Padding" Value="{StaticResource InfoBarActionButtonPadding}"/>
                                                 <contract7Present:Setter Property="CornerRadius" Value="{StaticResource InfoBarActionButtonCornerRadius}"/>
                                             </Style.Setters>
@@ -181,7 +180,6 @@
                                             <Style.Setters>
                                                 <Setter Property="FontSize" Value="{ThemeResource InfoBarHyperlinkButtonFontSize}"/>
                                                 <Setter Property="Foreground" Value="{ThemeResource InfoBarHyperlinkButtonForeground}"/>
-                                                <Setter Property="Height" Value="{StaticResource InfoBarHyperlinkButtonHeight}"/>
                                                 <Setter Property="Padding" Value="{StaticResource InfoBarHyperlinkButtonPadding}"/>
                                             </Style.Setters>
                                         </Style>

--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -172,6 +172,7 @@
                                             <Style.Setters>
                                                 <Setter Property="MinWidth" Value="{StaticResource InfoBarActionButtonMinWidth}"/>
                                                 <Setter Property="Padding" Value="{StaticResource InfoBarActionButtonPadding}"/>
+                                                <Setter Property="MinHeight" Value="24"/>
                                                 <contract7Present:Setter Property="CornerRadius" Value="{StaticResource InfoBarActionButtonCornerRadius}"/>
                                             </Style.Setters>
                                         </Style>
@@ -181,6 +182,7 @@
                                                 <Setter Property="FontSize" Value="{ThemeResource InfoBarHyperlinkButtonFontSize}"/>
                                                 <Setter Property="Foreground" Value="{ThemeResource InfoBarHyperlinkButtonForeground}"/>
                                                 <Setter Property="Padding" Value="{StaticResource InfoBarHyperlinkButtonPadding}"/>
+                                                <Setter Property="MinHeight" Value="24"/>
                                             </Style.Setters>
                                         </Style>
                                     </ContentPresenter.Resources>

--- a/dev/InfoBar/InfoBar_themeresources.xaml
+++ b/dev/InfoBar/InfoBar_themeresources.xaml
@@ -99,10 +99,12 @@
     <Thickness x:Key="InfoBarActionVerticalLayoutMargin">0,12,0,0</Thickness>
 
     <x:Double x:Key="InfoBarActionButtonMinWidth">96</x:Double>
+    <x:Double x:Key="InfoBarActionButtonMinHeight">24</x:Double>
     <Thickness x:Key="InfoBarActionButtonPadding">8,0,8,1</Thickness>
     <CornerRadius x:Key="InfoBarActionButtonCornerRadius">2</CornerRadius>
 
     <x:Double x:Key="InfoBarHyperlinkButtonFontSize">14</x:Double>
+    <x:Double x:Key="InfoBarHyperlinkButtonMinHeight">24</x:Double>
     <Thickness x:Key="InfoBarHyperlinkButtonPadding">0,0,0,1</Thickness>
 
     <Symbol x:Key="InfoBarCloseButtonSymbol">Cancel</Symbol>

--- a/dev/InfoBar/InfoBar_themeresources.xaml
+++ b/dev/InfoBar/InfoBar_themeresources.xaml
@@ -99,12 +99,10 @@
     <Thickness x:Key="InfoBarActionVerticalLayoutMargin">0,12,0,0</Thickness>
 
     <x:Double x:Key="InfoBarActionButtonMinWidth">96</x:Double>
-    <x:Double x:Key="InfoBarActionButtonHeight">24</x:Double>
     <Thickness x:Key="InfoBarActionButtonPadding">8,0,8,1</Thickness>
     <CornerRadius x:Key="InfoBarActionButtonCornerRadius">2</CornerRadius>
 
     <x:Double x:Key="InfoBarHyperlinkButtonFontSize">14</x:Double>
-    <x:Double x:Key="InfoBarHyperlinkButtonHeight">24</x:Double>
     <Thickness x:Key="InfoBarHyperlinkButtonPadding">0,0,0,1</Thickness>
 
     <Symbol x:Key="InfoBarCloseButtonSymbol">Cancel</Symbol>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removing the explicit setting of action button and hyperlink height in InfoBar as that prevents large text from getting rendered properly.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3617
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

Images of InfoBar with text scaling set to 225%:

![Infobar with action button](https://user-images.githubusercontent.com/16122379/99698848-8ed6d300-2a91-11eb-9b56-b4a7f9ac9b24.png)

![Infobar with hyperlink](https://user-images.githubusercontent.com/16122379/99698905-9f874900-2a91-11eb-8eda-8fd95928a133.png)
