### PR TITLE
ItemsRepeater: Fix bug where inserting at front would result in unrendered items

### DIFF
--- a/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
+++ b/dev/Repeater/APITests/FlowLayoutCollectionChangeTests.cs
@@ -164,7 +164,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 repeater.UpdateLayout();
 
                 realized = VerifyRealizedRange(repeater, dataSource);
-                Verify.IsLessThanOrEqual(3, realized);
+                Verify.IsLessThanOrEqual(2, realized);
             });
         }
 

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -422,7 +422,7 @@ void ElementManager::OnItemsAdded(int index, int count)
     // to insert items.
     const int lastRealizedDataIndex = m_firstRealizedDataIndex + GetRealizedElementCount() - 1;
     const int newStartingIndex = index;
-    if (newStartingIndex > m_firstRealizedDataIndex &&
+    if (newStartingIndex >= m_firstRealizedDataIndex &&
         newStartingIndex <= lastRealizedDataIndex)
     {
         // Inserted within the realized range

--- a/dev/Repeater/InteractionTests/RepeaterTests.cs
+++ b/dev/Repeater/InteractionTests/RepeaterTests.cs
@@ -40,5 +40,26 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             TestCleanupHelper.Cleanup();
         }
+
+        [TestMethod]
+        public void InsertAtStartBehavior()
+        {
+            using (var setup = new TestSetupHelper(new[] { "ItemsRepeater Tests" }))
+            {
+                FindElement.ByName("Basic Demo").Click();
+                var addItemButton = FindElement.ByName("InsertAtStartButton");
+                var itemCountLabel = FindElement.ByName("InsertAtStartChildCountLabel");
+
+                for (int i = 0; i < 10; i++)
+                {
+                    // For performance reasons, invoking the button also reevaluates the children count.
+                    // Technically there are i+1 children, but the button is one item behind.
+                    // Since i starts at 0, everything lines up correctly in here and we don't have to invoke two buttons.
+                    addItemButton.Click();
+                    Wait.ForIdle();
+                    Verify.AreEqual(i.ToString(), itemCountLabel.GetText());
+                }
+            }
+        }
     }
 }

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml
@@ -45,22 +45,25 @@
                 </controls:ItemsRepeater>
             </ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
-
-        <controls:ItemsRepeater Grid.Row="2" MinHeight="300"
-                x:Name="insertStartTestRepeater"
-                ItemsSource="{x:Bind simpleStringsList}">
-            <controls:ItemsRepeater.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding}" VerticalAlignment="Center"/>
-                    </Grid>
-                </DataTemplate>
-            </controls:ItemsRepeater.ItemTemplate>
-        </controls:ItemsRepeater>
         
+        <controls:ItemsRepeaterScrollHost Grid.Row="2">
+            <ScrollViewer>
+                <controls:ItemsRepeater Grid.Row="2" MinHeight="100"
+                    x:Name="insertStartTestRepeater"
+                    ItemsSource="{x:Bind simpleStringsList}">
+                    <controls:ItemsRepeater.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="{Binding}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </DataTemplate>
+                    </controls:ItemsRepeater.ItemTemplate>
+                </controls:ItemsRepeater>
+            </ScrollViewer>
+        </controls:ItemsRepeaterScrollHost>
         <!-- No ItemsRepeaterScrollHost for RS5+. ScrollViewer can do the anchoring itself-->
         <!--controls:ScrollViewer x:Name="scrollViewer" Height="500">
             <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0" />

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml
@@ -27,10 +27,13 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <StackPanel>
             <Button x:Name="goBackButton">Back</Button>
+            <Button Click="OnAddRecipeButton_Click" AutomationProperties.Name="InsertAtStartButton">Insert item at start</Button>
+            <TextBlock x:Name="InsertAtStartChildCountLabel" AutomationProperties.Name="InsertAtStartChildCountLabel" Text="0"/>
         </StackPanel>
 
         <controls:ItemsRepeaterScrollHost x:Name="tracker" Grid.Row="1">
@@ -43,6 +46,21 @@
             </ScrollViewer>
         </controls:ItemsRepeaterScrollHost>
 
+        <controls:ItemsRepeater Grid.Row="2" MinHeight="300"
+                x:Name="insertStartTestRepeater"
+                ItemsSource="{x:Bind simpleStringsList}">
+            <controls:ItemsRepeater.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{Binding}" VerticalAlignment="Center"/>
+                    </Grid>
+                </DataTemplate>
+            </controls:ItemsRepeater.ItemTemplate>
+        </controls:ItemsRepeater>
+        
         <!-- No ItemsRepeaterScrollHost for RS5+. ScrollViewer can do the anchoring itself-->
         <!--controls:ScrollViewer x:Name="scrollViewer" Height="500">
             <controls:ItemsRepeater x:Name="repeater" VerticalCacheLength="0" />

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Microsoft.UI.Xaml.Controls;
+using System.Collections.ObjectModel;
 using System.Linq;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using SelectTemplateEventArgs = Microsoft.UI.Xaml.Controls.SelectTemplateEventArgs;
 
@@ -11,14 +14,22 @@ namespace MUXControlsTestApp.Samples
 {
     public sealed partial class BasicDemo : Page
     {
+        public ObservableCollection<string> simpleStringsList = new ObservableCollection<string>();
+
         public BasicDemo()
         {
             this.InitializeComponent();
             goBackButton.Click += delegate { Frame.GoBack(); };
-            repeater.ItemTemplate = elementFactory;            
+            repeater.ItemTemplate = elementFactory;
             var stack = repeater.Layout as StackLayout;
             int numItems = (stack != null && stack.DisableVirtualization) ? 10 : 10000;
             repeater.ItemsSource = Enumerable.Range(0, numItems).Select(x => x.ToString());
+        }
+
+        private void OnAddRecipeButton_Click(object sender, RoutedEventArgs e)
+        {
+            InsertAtStartChildCountLabel.Text = VisualTreeHelper.GetChildrenCount(insertStartTestRepeater).ToString();
+            simpleStringsList.Insert(0,"Item" + simpleStringsList.Count );
         }
 
         private void OnSelectTemplateKey(RecyclingElementFactory sender, SelectTemplateEventArgs args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When inserting at index 0, the comparison whether we are in the realization range or not fails since `0>0 == false`. I've updated the check to also allow inserting at the start of the realization rect and make it possible to have that item rendered if there is enough space.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #3381 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added interaction test, unfortunately, this behavior did not repro in an API test (reliably).
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->