### PR TITLE
TeachingTip: Fix tip being included in tab order

### DIFF
--- a/dev/TeachingTip/APITests/TeachingTipTests.cs
+++ b/dev/TeachingTip/APITests/TeachingTipTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Controls;

--- a/dev/TeachingTip/InteractionTests/TeachingTipFocusTestPageElements.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipFocusTestPageElements.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Common;
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
+
+#if USING_TAEF
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+using WEX.Logging.Interop;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+#endif
+
+using Microsoft.Windows.Apps.Test.Automation;
+using Microsoft.Windows.Apps.Test.Foundation.Controls;
+using Microsoft.Windows.Apps.Test.Foundation.Waiters;
+using Microsoft.Windows.Apps.Test.Foundation;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
+{
+    class TeachingTipFocusTestPageElements
+    {
+        public Button GetOpenButton()
+        {
+            return GetElement(ref openButton, "OpenButton");
+        }
+        private Button openButton;
+
+        public Button GetCloseButton()
+        {
+            return GetElement(ref closeButton, "CloseButton");
+        }
+        private Button closeButton;
+
+        public CheckBox GetIsOpenCheckBox()
+        {
+            return GetElement(ref isOpenCheckBox, "IsOpenCheckBox");
+        }
+        private CheckBox isOpenCheckBox;
+
+        public CheckBox GetIsIdleCheckBox()
+        {
+            return GetElement(ref isIdleCheckBox, "IsIdleCheckBox");
+        }
+        private CheckBox isIdleCheckBox;
+
+        public CheckBox GetIsLightDismissEnabledCheckBox()
+        {
+            return GetElement(ref isLightDismissEnabledCheckBox, "IsLightDismissEnabledCheckBox");
+        }
+        private CheckBox isLightDismissEnabledCheckBox;
+
+        private T GetElement<T>(ref T element, string elementName) where T : UIObject
+        {
+            if (element == null)
+            {
+                Log.Comment("Find the " + elementName);
+                element = FindElement.ByNameOrId<T>(elementName);
+                Verify.IsNotNull(element);
+            }
+            return element;
+        }
+    }
+}

--- a/dev/TeachingTip/InteractionTests/TeachingTipTestPageElements.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTestPageElements.cs
@@ -1,4 +1,7 @@
-﻿using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 using System;
 using System.Numerics;

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -1,4 +1,7 @@
-﻿using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra;
 using Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Common;
 using System;
 using System.Numerics;
@@ -51,7 +54,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void CloseReasonIsAccurate()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -91,7 +94,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     Verify.IsTrue(message6.ToString().Contains("Programmatic"));
 
                     OpenTeachingTip();
-                    CloseTeachingTipByLightDismiss();
+                    CloseTeachingTipByLightDismiss(useEscKey: false);
                     var message7 = GetTeachingTipDebugMessage(7);
                     var message8 = GetTeachingTipDebugMessage(8);
                     Verify.IsTrue(message7.ToString().Contains("Closing"));
@@ -99,17 +102,26 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                     Verify.IsTrue(message8.ToString().Contains("Closed"));
                     Verify.IsTrue(message8.ToString().Contains("LightDismiss"));
 
+                    OpenTeachingTip();
+                    CloseTeachingTipByLightDismiss(useEscKey: true);
+                    var message9 = GetTeachingTipDebugMessage(9);
+                    var message10 = GetTeachingTipDebugMessage(10);
+                    Verify.IsTrue(message9.ToString().Contains("Closing"));
+                    Verify.IsTrue(message9.ToString().Contains("LightDismiss"));
+                    Verify.IsTrue(message10.ToString().Contains("Closed"));
+                    Verify.IsTrue(message10.ToString().Contains("LightDismiss"));
+
                     SetCloseButtonContent(CloseButtonContentOptions.ShortText);
                     OpenTeachingTip();
                     PressTipCloseButton();
-                    var message9 = GetTeachingTipDebugMessage(9);
-                    var message10 = GetTeachingTipDebugMessage(10);
                     var message11 = GetTeachingTipDebugMessage(11);
-                    Verify.IsTrue(message9.ToString().Contains("Close Button Clicked"));
-                    Verify.IsTrue(message10.ToString().Contains("Closing"));
-                    Verify.IsTrue(message10.ToString().Contains("CloseButton"));
-                    Verify.IsTrue(message11.ToString().Contains("Closed"));
-                    Verify.IsTrue(message11.ToString().Contains("CloseButton"));
+                    var message12 = GetTeachingTipDebugMessage(12);
+                    var message13 = GetTeachingTipDebugMessage(13);
+                    Verify.IsTrue(message11.ToString().Contains("Close Button Clicked"));
+                    Verify.IsTrue(message12.ToString().Contains("Closing"));
+                    Verify.IsTrue(message12.ToString().Contains("CloseButton"));
+                    Verify.IsTrue(message13.ToString().Contains("Closed"));
+                    Verify.IsTrue(message13.ToString().Contains("CloseButton"));
 
                     ClearTeachingTipDebugMessages();
                 }
@@ -119,7 +131,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void TargetUnloadingClosesTeachingTip()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 elements.GetSetTargetButton().InvokeAndWait();
@@ -140,7 +152,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void PreviousTargetUnloadingLeavesTeachingTipOpen()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 elements.GetSetTargetButton().InvokeAndWait();
@@ -163,7 +175,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void TeachingTipRemovalClosesPopup()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 ScrollTargetIntoView();
@@ -186,7 +198,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void TipCanFollowTarget()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -249,7 +261,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 return;
             }
 
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -308,7 +320,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125
         public void AutoPlacement()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -334,7 +346,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void SpecifiedPlacement()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
 
@@ -507,7 +519,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void SpecifiedPlacementRTL()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
 
@@ -685,7 +697,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void NoIconDoesNotCrash()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
 
@@ -710,7 +722,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void CanSwitchShouldConstrainToRootBounds()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
 
@@ -744,7 +756,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void TipsWhichDoNotFitDoNotOpen()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
 
@@ -785,7 +797,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 return;
             }
 
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -822,7 +834,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("Ignore", "True")]
         public void SettingTitleOrSubtitleToEmptyStringCollapsesTextBox()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach (TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -894,7 +906,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void AutomationNameIsForwardedToPopup()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 foreach(TipLocationOptions location in Enum.GetValues(typeof(TipLocationOptions)))
@@ -916,7 +928,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void F6PutsFocusOnCloseButton()
         {
-            using (var setup = new TestSetupHelper("TeachingTip Tests"))
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTip Test" }))
             {
                 elements = new TeachingTipTestPageElements();
                 ScrollTargetIntoView();
@@ -929,6 +941,72 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 OpenTeachingTip();
                 UseF6ToReturnToTestPageToCloseTip();
                 SetCloseButtonContent(CloseButtonContentOptions.NoText);
+            }
+        }
+
+        [TestMethod]
+        public void VerifyTeachingTipNotIncludedInTabOrder()
+        {
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTipFocus Test" }))
+            {
+                var elements = new TeachingTipFocusTestPageElements();
+                var openTeachingTipButton = elements.GetOpenButton();
+
+                Log.Comment("Verify open button has keyboard focus.");
+                Verify.IsTrue(openTeachingTipButton.HasKeyboardFocus);
+
+                Log.Comment("Verify that a closed teaching tip does not appear in tab order.");
+                KeyboardHelper.PressKey(Key.Tab);
+                Wait.ForIdle();
+                Verify.IsTrue(openTeachingTipButton.HasKeyboardFocus);
+
+                Log.Comment("Verify that an opened teaching tip does not appear in tab order.");
+                OpenTeachingTip();
+                Verify.IsTrue(openTeachingTipButton.HasKeyboardFocus);
+                KeyboardHelper.PressKey(Key.Tab);
+                Wait.ForIdle();
+                Verify.IsTrue(openTeachingTipButton.HasKeyboardFocus);
+
+                Log.Comment("Switch to light-dismissable teaching tip.");
+                CloseTeachingTipProgrammatically();
+                EnableLightDismiss();
+
+                Log.Comment("Verify that a closed light-dismissable teaching tip does not appear in tab order.");
+
+                Verify.IsTrue(openTeachingTipButton.HasKeyboardFocus);
+                KeyboardHelper.PressKey(Key.Tab);
+                Wait.ForIdle();
+                Verify.IsTrue(openTeachingTipButton.HasKeyboardFocus);
+
+                void OpenTeachingTip()
+                {
+                    if (elements.GetIsOpenCheckBox().ToggleState != ToggleState.On)
+                    {
+                        openTeachingTipButton.InvokeAndWait();
+                        WaitForChecked(elements.GetIsOpenCheckBox());
+                        WaitForChecked(elements.GetIsIdleCheckBox());
+                    }
+                }
+
+                void CloseTeachingTipProgrammatically()
+                {
+                    if (elements.GetIsOpenCheckBox().ToggleState != ToggleState.Off)
+                    {
+                        elements.GetCloseButton().InvokeAndWait();
+                        WaitForUnchecked(elements.GetIsOpenCheckBox());
+                        WaitForChecked(elements.GetIsIdleCheckBox());
+                    }
+                }
+
+                void EnableLightDismiss()
+                {
+                    var isLightDismissEnabledCheckBox = elements.GetIsLightDismissEnabledCheckBox();
+                    if (isLightDismissEnabledCheckBox.ToggleState != ToggleState.On)
+                    {
+                        isLightDismissEnabledCheckBox.Check();
+                        WaitForChecked(isLightDismissEnabledCheckBox);
+                    }
+                }
             }
         }
 
@@ -978,11 +1056,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        private void CloseTeachingTipByLightDismiss()
+        private void CloseTeachingTipByLightDismiss(bool useEscKey)
         {
             if (elements.GetIsOpenCheckBox().ToggleState != ToggleState.Off)
             {
-                InputHelper.LeftClick(elements.GetActionButtonContentComboBox());
+                if (useEscKey)
+                {
+                    KeyboardHelper.PressKey(Key.Escape);
+                }
+                else
+                {
+                    InputHelper.LeftClick(elements.GetActionButtonContentComboBox());
+                }
+
                 WaitForTipClosed();
             }
         }

--- a/dev/TeachingTip/InteractionTests/TeachingTip_InteractionTests.projitems
+++ b/dev/TeachingTip/InteractionTests/TeachingTip_InteractionTests.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>TeachingTip_InteractionTests</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)TeachingTipFocusTestPageElements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TeachingTipTestPageElements.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TeachingTipTests.cs" />
   </ItemGroup>

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1,3 +1,6 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
 #include "pch.h"
 #include "common.h"
 #include "TeachingTip.h"

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "pch.h"
 #include "common.h"

--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -1,4 +1,5 @@
-﻿<ResourceDictionary
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
@@ -15,6 +16,7 @@
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
         <Setter Property="ActionButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>
         <Setter Property="CloseButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>
+        <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:TeachingTip">

--- a/dev/TeachingTip/TeachingTipAutomationPeer.cpp
+++ b/dev/TeachingTip/TeachingTipAutomationPeer.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "common.h"
 #include "ResourceAccessor.h"
 #include "TeachingTipAutomationPeer.h"

--- a/dev/TeachingTip/TeachingTipAutomationPeer.h
+++ b/dev/TeachingTip/TeachingTipAutomationPeer.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #include "TeachingTip.h"
 #include "TeachingTipAutomationPeer.g.h"
 

--- a/dev/TeachingTip/TeachingTipClosedEventArgs.cpp
+++ b/dev/TeachingTip/TeachingTipClosedEventArgs.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "common.h"
 #include "TeachingTipClosedEventArgs.h"
 

--- a/dev/TeachingTip/TeachingTipClosedEventArgs.h
+++ b/dev/TeachingTip/TeachingTipClosedEventArgs.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "TeachingTipClosedEventArgs.g.h"
 

--- a/dev/TeachingTip/TeachingTipClosingEventArgs.cpp
+++ b/dev/TeachingTip/TeachingTipClosingEventArgs.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "common.h"
 #include "TeachingTipClosingEventArgs.h"
 

--- a/dev/TeachingTip/TeachingTipClosingEventArgs.h
+++ b/dev/TeachingTip/TeachingTipClosingEventArgs.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 #pragma once
 
 #include "TeachingTipClosingEventArgs.g.h"

--- a/dev/TeachingTip/TeachingTipTestHooks.cpp
+++ b/dev/TeachingTip/TeachingTipTestHooks.cpp
@@ -1,4 +1,7 @@
-﻿#include "pch.h"
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
 #include "common.h"
 #include "TeachingTipTestHooks.h"
 

--- a/dev/TeachingTip/TeachingTipTestHooks.h
+++ b/dev/TeachingTip/TeachingTipTestHooks.h
@@ -1,4 +1,7 @@
-﻿#pragma once
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
 
 #include "TeachingTip.h"
 

--- a/dev/TeachingTip/TeachingTip_rs1_themeresources.xaml
+++ b/dev/TeachingTip/TeachingTip_rs1_themeresources.xaml
@@ -1,4 +1,5 @@
-﻿<ResourceDictionary
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">

--- a/dev/TeachingTip/TeachingTip_rs2_themeresources.xaml
+++ b/dev/TeachingTip/TeachingTip_rs2_themeresources.xaml
@@ -1,4 +1,5 @@
-﻿<ResourceDictionary
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">

--- a/dev/TeachingTip/TestUI/TeachingTipCaseBundle.xaml
+++ b/dev/TeachingTip/TestUI/TeachingTipCaseBundle.xaml
@@ -1,0 +1,29 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="MUXControlsTestApp.TeachingTipCaseBundle"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <VariableSizedWrapGrid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+            Orientation="Horizontal">
+        <VariableSizedWrapGrid.Resources>
+            <Style TargetType="StackPanel">
+                <Setter Property="Margin" Value="4"/>
+                <Setter Property="MaxWidth" Value="400" />
+                <Setter Property="MinWidth" Value="200" />
+            </Style>
+        </VariableSizedWrapGrid.Resources>
+
+        <StackPanel>
+            <TextBlock Text="Common Tests"/>
+            <Button x:Name="TeachingTipPageButton" AutomationProperties.Name="TeachingTip Test" Margin="2" HorizontalAlignment="Stretch">TeachingTip Test</Button>
+            <TextBlock Text="Special Tests" />
+            <Button x:Name="TeachingTipFocusPageButton" AutomationProperties.Name="TeachingTipFocus Test" Margin="2" HorizontalAlignment="Stretch">TeachingTip Focus Test</Button>
+        </StackPanel>
+    </VariableSizedWrapGrid>
+</local:TestPage>

--- a/dev/TeachingTip/TestUI/TeachingTipCaseBundle.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipCaseBundle.xaml.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace MUXControlsTestApp
+{
+    [TopLevelTestPage(Name = "TeachingTip", Icon = "TeachingTip.png")]
+    public sealed partial class TeachingTipCaseBundle : TestPage
+    {
+        public TeachingTipCaseBundle()
+        {
+            InitializeComponent();
+
+            TeachingTipPageButton.Click += delegate { Frame.NavigateWithoutAnimation(typeof(TeachingTipPage), 0); };
+            TeachingTipFocusPageButton.Click += delegate { Frame.NavigateWithoutAnimation(typeof(TeachingTipFocusPage), 0); };
+        }
+    }
+}

--- a/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml
+++ b/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml
@@ -1,0 +1,32 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="MUXControlsTestApp.TeachingTipFocusPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    AutomationProperties.Name="TeachingTipFocusPage"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid Margin="10">
+        <muxc:TeachingTip x:Name="TestTeachingTip" Title="Title" IsLightDismissEnabled="{x:Bind (x:Boolean)IsLightDismissEnabledCheckBox.IsChecked, Mode=OneWay}" />
+
+        <StackPanel>
+            <TextBlock Text="TeachingTip special focus test page" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,15"/>
+            <StackPanel Orientation="Horizontal">
+                <Button x:Name="OpenButton" AutomationProperties.Name="OpenButton" Content="Open tip" Click="OpenTeachingTipButton_Click"/>
+                <Button x:Name="CloseButton" AutomationProperties.Name="CloseButton" Content="Close tip" Margin="10,0,0,0" IsTabStop="False" Click="CloseTeachingTipButton_Click"/>
+            </StackPanel>
+
+            <TextBlock Text="TeachingTip status:" Margin="0,10,0,0"/>
+            <CheckBox x:Name="IsOpenCheckBox" AutomationProperties.Name="IsOpenCheckBox" Content="IsOpen" IsChecked="False" IsEnabled="False"/>
+            <CheckBox x:Name="IsIdleCheckBox" AutomationProperties.Name="IsIdleCheckBox" Content="IsIdle" IsChecked="True" IsEnabled="False"/>
+
+            <TextBlock Text="TeachingTip configuration:" Margin="0,10,0,0"/>
+            <CheckBox x:Name="IsLightDismissEnabledCheckBox" AutomationProperties.Name="IsLightDismissEnabledCheckBox" Content="IsLightDismissEnabled" IsChecked="False" IsTabStop="False"/>
+        </StackPanel>
+    </Grid>
+</local:TestPage>

--- a/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Microsoft.UI.Private.Controls;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+
+namespace MUXControlsTestApp
+{
+    public sealed partial class TeachingTipFocusPage : TestPage
+    {
+        public TeachingTipFocusPage()
+        {
+            this.InitializeComponent();
+            TeachingTipTestHooks.IdleStatusChanged += TeachingTipTestHooks_IdleStatusChanged;
+            TeachingTipTestHooks.OpenedStatusChanged += TeachingTipTestHooks_OpenedStatusChanged;
+
+            this.Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            ChangeTestFrameVisibility(Visibility.Collapsed);
+        }
+
+        private void ChangeTestFrameVisibility(Visibility visibility)
+        {
+            var testFrame = Window.Current.Content as TestFrame;
+            testFrame.ChangeBarVisibility(visibility);
+        }
+
+        private void OpenTeachingTipButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.TestTeachingTip.IsOpen = true;
+        }
+
+        private void CloseTeachingTipButton_Click(object sender, RoutedEventArgs e)
+        {
+            this.TestTeachingTip.IsOpen = false;
+        }
+
+        private void TeachingTipTestHooks_OpenedStatusChanged(TeachingTip sender, object args)
+        {
+            if (this.TestTeachingTip.IsOpen)
+            {
+                this.IsOpenCheckBox.IsChecked = true;
+            }
+            else
+            {
+                this.IsOpenCheckBox.IsChecked = false;
+            }
+        }
+
+        private void TeachingTipTestHooks_IdleStatusChanged(TeachingTip sender, object args)
+        {
+            if (TeachingTipTestHooks.GetIsIdle(this.TestTeachingTip))
+            {
+                this.IsIdleCheckBox.IsChecked = true;
+            }
+            else
+            {
+                this.IsIdleCheckBox.IsChecked = false;
+            }
+        }
+    }
+}

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml
@@ -1,4 +1,5 @@
-﻿<local:TestPage
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
     x:Class="MUXControlsTestApp.TeachingTipPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
@@ -35,7 +32,6 @@ namespace MUXControlsTestApp
         Resources = 1
     }
 
-    [TopLevelTestPage(Name = "TeachingTip", Icon = "TeachingTip.png")]
     public sealed partial class TeachingTipPage : TestPage, INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;

--- a/dev/TeachingTip/TestUI/TeachingTip_TestUI.projitems
+++ b/dev/TeachingTip/TestUI/TeachingTip_TestUI.projitems
@@ -9,12 +9,26 @@
     <Import_RootNamespace>TeachingTip_TestUI</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Page Include="$(MSBuildThisFileDirectory)TeachingTipCaseBundle.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)TeachingTipFocusPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)TeachingTipPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)TeachingTipCaseBundle.xaml.cs">
+      <DependentUpon>TeachingTipCaseBundle.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)TeachingTipFocusPage.xaml.cs">
+      <DependentUpon>TeachingTipFocusPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)TeachingTipPage.xaml.cs">
       <DependentUpon>TeachingTipPage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the issue where teaching tips (opened or not) where included in the tab order. Customers can still set focus inside the tip by pressing F6 and circle through the interactive tip elements by pressing Tab.

This PR also adds a bunch of missing license file header comments to multiple teaching tip files.

## Motivation and Context
Fixes https://github.com/microsoft/microsoft-ui-xaml/issues/3473

## How Has This Been Tested?
Tested manually and added interaction test. To simplify testing, I added a new test page for the teaching tip control (see "Screenshots"). 

While I was at it, I modified the existing `CloseReasonIsAccurate()` interaction test to also cover the scenario where users can press the Esc key to close a *light-dismissable* tip. Until now, we only tested whether a (mouse) click on the UI surface closed such a tip.

## Screenshots:
![image](https://user-images.githubusercontent.com/1398851/100255830-537e4d80-2f44-11eb-9971-247bc0c3555e.png)
(The added test page.)
