### PR TITLE
NavigationView: Fix footer items scrollbar being visible without footer items to scroll

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -491,7 +491,8 @@
                                             <!-- FooterItems -->
                                             <local:ItemsRepeaterScrollHost Grid.Row="3">
                                                 <ScrollViewer x:Name="FooterItemsScrollViewer"
-                                                        contract7Present:VerticalAnchorRatio="1">
+                                                        contract7Present:VerticalAnchorRatio="1"
+                                                        VerticalScrollBarVisibility="Auto">
                                                     <local:ItemsRepeater
                                                         x:Name="FooterMenuItemsHost"
                                                         AutomationProperties.AccessibilityView = "Content"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a NavigationView issue where the scrollbar for the footer items would be visible even if there are no footer items to scroll.

## Motivation and Context
Fixes https://github.com/microsoft/microsoft-ui-xaml/issues/3771.

## How Has This Been Tested?
Tested manually.

| Before | After |
|---|---|
|![navview-footeritems-scrollviewer-pre-fix](https://user-images.githubusercontent.com/1398851/101263236-12581b80-3744-11eb-96cc-258781c9381f.gif)|![navview-footeritems-scrollviewer-post-fix](https://user-images.githubusercontent.com/1398851/101263241-213ece00-3744-11eb-8a26-170c8f0a85be.gif)|