### PR TITLE
Fixing incremental build after changing XAML files (take 2)

### DIFF
--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -596,6 +596,7 @@
       <Output ItemName="GeneratedXamlPagesFiles" TaskParameter="GeneratedXamlPagesFiles" />
     </CompileXaml>
     <ItemGroup>
+      <FileWrites Include="@(PageRequiringCustomCompilation -> '$(GeneratedFilesDir)Themes\%(Filename).xaml')" />
       <FileWrites Include="@(PageRequiringCustomCompilation -> '$(GeneratedFilesDir)Themes\%(Filename).xbf')" />
       <FileWrites Include="$(XamlSavedStateFilePath)" />
       <FileWrites Condition="'$(XamlRootsLog)' != ''" Include="$(XamlRootsLog)" />


### PR DESCRIPTION
There was [a previous change](https://github.com/microsoft/microsoft-ui-xaml/commit/3be53beee6e50e1bf445bb8b160e1e583916ff80) where we ensured that we didn't delete XBF files that needed to be copied when F5ing after changing a XAML file, but in some cases we also need to copy XAML files as well.  This adds those to the list of files that we don't want VS's IncrementalClean target to delete.

Fixes #3786