### PR TITLE
Revert some changes to ListBox resources to have selected state be visible

### DIFF
--- a/dev/CommonStyles/ListBox_themeresources.xaml
+++ b/dev/CommonStyles/ListBox_themeresources.xaml
@@ -13,9 +13,9 @@
             <StaticResource x:Key="ListBoxItemForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="ListBoxItemBackgroundPointerOver" ResourceKey="GhostFillColorSecondaryBrush" />
             <StaticResource x:Key="ListBoxItemBackgroundPressed" ResourceKey="GhostFillColorTertiaryBrush" />
-            <StaticResource x:Key="ListBoxItemBackgroundSelected" ResourceKey="GhostFillColorSecondaryBrush" />
-            <StaticResource x:Key="ListBoxItemBackgroundSelectedPointerOver" ResourceKey="GhostFillColorTertiaryBrush" />
-            <StaticResource x:Key="ListBoxItemBackgroundSelectedPressed" ResourceKey="GhostFillColorSecondaryBrush" />
+            <StaticResource x:Key="ListBoxItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush"/>
+            <StaticResource x:Key="ListBoxItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
+            <StaticResource x:Key="ListBoxItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
             <SolidColorBrush x:Key="ListBoxBackgroundThemeBrush" Color="#CCFFFFFF" />
             <SolidColorBrush x:Key="ListBoxBorderThemeBrush" Color="Transparent" />
             <SolidColorBrush x:Key="ListBoxDisabledForegroundThemeBrush" Color="#66FFFFFF" />
@@ -26,7 +26,7 @@
             <SolidColorBrush x:Key="ListBoxItemPointerOverForegroundThemeBrush" Color="#FF000000" />
             <SolidColorBrush x:Key="ListBoxItemPressedBackgroundThemeBrush" Color="#FFD3D3D3" />
             <SolidColorBrush x:Key="ListBoxItemPressedForegroundThemeBrush" Color="#FF000000" />
-            <SolidColorBrush x:Key="ListBoxItemSelectedBackgroundThemeBrush" Color="#FF4617B4" />
+            <StaticResource x:Key="ListBoxItemSelectedBackgroundThemeBrush" ResourceKey="SystemControlHighlightListAccentLowBrush" />
             <SolidColorBrush x:Key="ListBoxItemSelectedDisabledBackgroundThemeBrush" Color="#66FFFFFF" />
             <SolidColorBrush x:Key="ListBoxItemSelectedDisabledForegroundThemeBrush" Color="#99000000" />
             <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="White" />
@@ -69,9 +69,9 @@
             <StaticResource x:Key="ListBoxItemForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="ListBoxItemBackgroundPointerOver" ResourceKey="GhostFillColorSecondaryBrush" />
             <StaticResource x:Key="ListBoxItemBackgroundPressed" ResourceKey="GhostFillColorTertiaryBrush" />
-            <StaticResource x:Key="ListBoxItemBackgroundSelected" ResourceKey="GhostFillColorSecondaryBrush" />
-            <StaticResource x:Key="ListBoxItemBackgroundSelectedPointerOver" ResourceKey="GhostFillColorTertiaryBrush" />
-             <StaticResource x:Key="ListBoxItemBackgroundSelectedPressed" ResourceKey="GhostFillColorSecondaryBrush" />
+            <StaticResource x:Key="ListBoxItemBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush"/>
+            <StaticResource x:Key="ListBoxItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentMediumBrush" />
+            <StaticResource x:Key="ListBoxItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentHighBrush" />
             <SolidColorBrush x:Key="ListBoxBackgroundThemeBrush" Color="#CCFFFFFF" />
             <SolidColorBrush x:Key="ListBoxBorderThemeBrush" Color="#45000000" />
             <SolidColorBrush x:Key="ListBoxDisabledForegroundThemeBrush" Color="#66000000" />
@@ -82,7 +82,7 @@
             <SolidColorBrush x:Key="ListBoxItemPointerOverForegroundThemeBrush" Color="#FF000000" />
             <SolidColorBrush x:Key="ListBoxItemPressedBackgroundThemeBrush" Color="#FFD3D3D3" />
             <SolidColorBrush x:Key="ListBoxItemPressedForegroundThemeBrush" Color="#FF000000" />
-            <SolidColorBrush x:Key="ListBoxItemSelectedBackgroundThemeBrush" Color="#FF4617B4" />
+            <StaticResource x:Key="ListBoxItemSelectedBackgroundThemeBrush" ResourceKey="SystemControlHighlightListAccentLowBrush" />
             <SolidColorBrush x:Key="ListBoxItemSelectedDisabledBackgroundThemeBrush" Color="#8C000000" />
             <SolidColorBrush x:Key="ListBoxItemSelectedDisabledForegroundThemeBrush" Color="#99FFFFFF" />
             <SolidColorBrush x:Key="ListBoxItemSelectedForegroundThemeBrush" Color="White" />
@@ -279,5 +279,3 @@
     </Style>
 
 </ResourceDictionary>
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert some resource changes to make the selected item of the ListBox visible.

Few notes:
- Added cert and pfx file as otherwise test app won't compile anymore due to expired certificates
- This is not a hard reset of changes but rather an update of few brushes to get the desired behavior back while also keeping current XAML design

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3808
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually:
![Gif showing listbox selection hover states](https://user-images.githubusercontent.com/16122379/103711521-eedcf680-4fb7-11eb-9686-20d4d85b9b5c.gif)

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->