### PR TITLE
TreeView: Move SelectedItem DP to public

### DIFF
--- a/dev/TreeView/TreeView.idl
+++ b/dev/TreeView/TreeView.idl
@@ -135,8 +135,8 @@ unsealed runtimeclass TreeView : Windows.UI.Xaml.Controls.Control
     [WUXC_VERSION_PREVIEW]
     {
         event Windows.Foundation.TypedEventHandler<TreeView, TreeViewSelectionChangedEventArgs> SelectionChanged;
-        static Windows.UI.Xaml.DependencyProperty SelectedItemProperty{ get; };
     }
+    static Windows.UI.Xaml.DependencyProperty SelectedItemProperty{ get; };
 
     static Windows.UI.Xaml.DependencyProperty SelectionModeProperty{ get; };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moves the TreeView.SelectedItem DP to public.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #2458
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->