### PR TITLE
Stretch content horizontally in ListViewItem

### DIFF
--- a/dev/CommonStyles/ListViewItem_themeresources.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources.xaml
@@ -179,7 +179,7 @@
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
         <Setter Property="Padding" Value="12,0,12,0" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />
@@ -237,7 +237,7 @@
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
         <Setter Property="Padding" Value="12,0,12,0" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />

--- a/dev/CommonStyles/ListViewItem_themeresources_v2.5.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources_v2.5.xaml
@@ -161,7 +161,7 @@
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
         <Setter Property="Padding" Value="12,0,12,0" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />
@@ -219,7 +219,7 @@
         <Setter Property="TabNavigation" Value="Local" />
         <Setter Property="IsHoldingEnabled" Value="True" />
         <Setter Property="Padding" Value="12,0,12,0" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />


### PR DESCRIPTION
## Description

Content in ListViewItem is not horizontally stretched by default. Instead, the content is left aligned. This makes content appear as shown in the top image instead of the expected bottom image below (taken from #1402) 

![](https://user-images.githubusercontent.com/1250894/66121156-ca3be700-e5dc-11e9-8f88-f11fb200f2bf.png)

This PR changes the horizontal alignment to `Stretch` from `Left`. Risks of this change should be quite low since it's only changing the container style (ListViewItem itself) https://github.com/microsoft/microsoft-ui-xaml/issues/1402#issuecomment-737396498

The original behavior (`Left` alignment) is different from older XAML technologies such as WPF and is counterintuitive for application developers. It prevents doing something such as what is below unless the ItemContainerStyle is overridden:

![](https://camo.githubusercontent.com/7f112273217ab97af495f9eba20e9ac8b752c1d6583dd077814736b29d212e26/68747470733a2f2f646f63732e6d6963726f736f66742e636f6d2f656e2d75732f77696e646f77732f7577702f64657369676e2f636f6e74726f6c732d616e642d7061747465726e732f696d616765732f636f6d6d616e64696e672f7374616e646172647569636f6d6d616e6473616d706c656f7074696d697a65642e676966)

```xaml
<ListView>
  <ListView.ItemContainerStyle>
    <Style TargetType="ListViewItem">
        <Setter Property="HorizontalContentAlignment"
                Value="Stretch" />
    </Style>
  </ListView.ItemContainerStyle>
</ListView>
```

The reasons for switching may have been due to the prevalence of horizontal scrolling in ListViews when UWP/Metro styling first came around. 

## Motivation and Context

Closes #1402
Closes #3682

## How Has This Been Tested?

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->