### PR TITLE
PipsPager: Fix border being visible on controls in new style

### DIFF
--- a/dev/PipsPager/PipsPager_themeresources.xaml
+++ b/dev/PipsPager/PipsPager_themeresources.xaml
@@ -63,6 +63,8 @@
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Width" Value="{StaticResource PipsPagerNavigationButtonWidth}"/>
         <Setter Property="Height" Value="{StaticResource PipsPagerNavigationButtonHeight}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -127,6 +129,8 @@
         <Setter Property="Height" Value="{StaticResource PipsPagerButtonHeight}"/>
         <Setter Property="Content" Value="{StaticResource PipsPagerDefaultGlyph}"/>
         <Setter Property="FontSize" Value="{StaticResource PipsPagerDefaultGlyphFontSize}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button" >

--- a/dev/PipsPager/PipsPager_themeresources_v2.5.xaml
+++ b/dev/PipsPager/PipsPager_themeresources_v2.5.xaml
@@ -63,6 +63,8 @@
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Width" Value="{StaticResource PipsPagerNavigationButtonWidth}"/>
         <Setter Property="Height" Value="{StaticResource PipsPagerNavigationButtonHeight}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -127,6 +129,8 @@
         <Setter Property="Height" Value="{StaticResource PipsPagerButtonHeight}"/>
         <Setter Property="Content" Value="{StaticResource PipsPagerDefaultGlyph}"/>
         <Setter Property="FontSize" Value="{StaticResource PipsPagerDefaultGlyphFontSize}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransparentBrush}"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button" >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set bordethickness to 0 and borderbrush to SystemControlTransparentBrush. Since those styles will eventually replace the 2.5, I also added them to the 2.5 files as suggested by @mdtauk.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3922 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
![Image showing new style PipsPager with correct border rendering of buttons, meaning no borders](https://user-images.githubusercontent.com/16122379/104329728-888f3100-54ed-11eb-8b9c-4d41fc92aa21.png)

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->