### PR TITLE
RatingControl: Fix visibility issues of unselected stars in new style

### DIFF
--- a/dev/RatingControl/RatingControl.xaml
+++ b/dev/RatingControl/RatingControl.xaml
@@ -53,9 +53,8 @@
                         <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="-20,-20,-20,-20">
                             <StackPanel x:Name="RatingBackgroundStackPanel" Orientation="Horizontal" Background="Transparent" Margin="20,20,0,20"/>
                             <TextBlock x:Name="Caption" Height="32" Margin="4,9,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption"
-                                IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
+                                Foreground="{ThemeResource RatingControlCaptionForeground}" VerticalAlignment="Center" IsHitTestVisible="False" 
+                                AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption" Text="{TemplateBinding Caption}"/>
                             <!-- 4 = 8 item spacing +4 of magic redline spacing -8 to compensate for scale of the last RatingItem -->
                             <!-- NB: The redlines say 8px, but it's really 12 px because:
                                 Designer note: The value between the last glyph and first text character is 12px.

--- a/dev/RatingControl/RatingControl.xaml
+++ b/dev/RatingControl/RatingControl.xaml
@@ -52,7 +52,10 @@
 
                         <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="-20,-20,-20,-20">
                             <StackPanel x:Name="RatingBackgroundStackPanel" Orientation="Horizontal" Background="Transparent" Margin="20,20,0,20"/>
-                            <TextBlock x:Name="Caption" Height="32" Margin="4,9,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}" VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption" IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
+                            <TextBlock x:Name="Caption" Height="32" Margin="4,9,20,0" TextLineBounds="TrimToBaseline" Style="{ThemeResource CaptionTextBlockStyle}"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" AutomationProperties.Name="RatingCaption"
+                                IsHitTestVisible="False" Text="{TemplateBinding Caption}"/>
                             <!-- 4 = 8 item spacing +4 of magic redline spacing -8 to compensate for scale of the last RatingItem -->
                             <!-- NB: The redlines say 8px, but it's really 12 px because:
                                 Designer note: The value between the last glyph and first text character is 12px.

--- a/dev/RatingControl/RatingControl_themeresources.xaml
+++ b/dev/RatingControl/RatingControl_themeresources.xaml
@@ -14,7 +14,7 @@
             <StaticResource x:Key="RatingControlPointerOverSelectedForeground" ResourceKey="AccentAAFillColorDefaultBrush"/>
             <StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="TextFillColorDisabledBrush"/>
             <!-- If this Foreground property is removed/renamed, please update ThemeResourcesTests::VerifyOverrides: -->
-            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
+            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="TextFillColorSecondaryBrush"/>
             <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;" UnsetGlyph="&#xE734;"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
@@ -25,7 +25,7 @@
             <StaticResource x:Key="RatingControlPointerOverUnselectedForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
             <StaticResource x:Key="RatingControlPointerOverSelectedForeground" ResourceKey="AccentAAFillColorDefaultBrush"/>
             <StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="TextFillColorDisabledBrush"/>
-            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
+            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="TextFillColorSecondaryBrush"/>
             <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;" UnsetGlyph="&#xE734;"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
@@ -36,7 +36,7 @@
             <StaticResource x:Key="RatingControlPointerOverUnselectedForeground" ResourceKey="SystemControlForegroundBaseMediumBrush"/>
             <StaticResource x:Key="RatingControlPointerOverSelectedForeground" ResourceKey="SystemControlHighlightAccentBrush"/>
             <StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="SystemColorGrayTextColor"/>
-            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="SystemControlForegroundBaseMediumBrush"/>
+            <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="TextFillColorSecondaryBrush"/>
             <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;" UnsetGlyph="&#xE734;"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>

--- a/dev/RatingControl/RatingControl_themeresources.xaml
+++ b/dev/RatingControl/RatingControl_themeresources.xaml
@@ -6,7 +6,7 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="RatingControlUnselectedForeground" ResourceKey="ControlFillColorTertiaryBrush"/>
+            <StaticResource x:Key="RatingControlUnselectedForeground" ResourceKey="TextFillColorSecondaryBrush"/>
             <StaticResource x:Key="RatingControlSelectedForeground" ResourceKey="AccentAAFillColorDefaultBrush"/>
             <StaticResource x:Key="RatingControlPlaceholderForeground" ResourceKey="TextFillColorPrimaryBrush"/>
             <StaticResource x:Key="RatingControlPointerOverPlaceholderForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
@@ -15,10 +15,10 @@
             <StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="TextFillColorDisabledBrush"/>
             <!-- If this Foreground property is removed/renamed, please update ThemeResourcesTests::VerifyOverrides: -->
             <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
-            <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;"/>
+            <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;" UnsetGlyph="&#xE734;"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="RatingControlUnselectedForeground" ResourceKey="ControlFillColorTertiaryBrush"/>
+            <StaticResource x:Key="RatingControlUnselectedForeground" ResourceKey="TextFillColorSecondaryBrush"/>
             <StaticResource x:Key="RatingControlSelectedForeground" ResourceKey="AccentAAFillColorDefaultBrush"/>
             <StaticResource x:Key="RatingControlPlaceholderForeground" ResourceKey="TextFillColorPrimaryBrush"/>
             <StaticResource x:Key="RatingControlPointerOverPlaceholderForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
@@ -26,7 +26,7 @@
             <StaticResource x:Key="RatingControlPointerOverSelectedForeground" ResourceKey="AccentAAFillColorDefaultBrush"/>
             <StaticResource x:Key="RatingControlDisabledSelectedForeground" ResourceKey="TextFillColorDisabledBrush"/>
             <StaticResource x:Key="RatingControlCaptionForeground" ResourceKey="ControlAltFillColorTertiaryBrush"/>
-            <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;"/>
+            <local:RatingItemFontInfo x:Key="MUX_RatingControlDefaultFontInfo" Glyph="&#xE735;" UnsetGlyph="&#xE734;"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="RatingControlUnselectedForeground" ResourceKey="SystemControlForegroundBaseLowBrush"/>

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -27,7 +27,7 @@ XamlControlsResources::XamlControlsResources()
 
 bool XamlControlsResources::UseLatestStyle()
 {
-    return Version() != winrt::StylesVersion::WinUI_2dot5;
+    return Version() == winrt::StylesVersion::WinUI_2dot5;
 }
 
 void XamlControlsResources::OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -27,7 +27,7 @@ XamlControlsResources::XamlControlsResources()
 
 bool XamlControlsResources::UseLatestStyle()
 {
-    return Version() == winrt::StylesVersion::WinUI_2dot5;
+    return Version() != winrt::StylesVersion::WinUI_2dot5;
 }
 
 void XamlControlsResources::OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Switches the unset glyph and updates the unset foreground color.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3925 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

![Image showing different RatingControls in light theme with unselected stars being visible](https://user-images.githubusercontent.com/16122379/104368059-e20e5480-551b-11eb-84c5-1c5712b9c549.png)

![Image showing different RatingControls in darktheme with unselected stars being visible](https://user-images.githubusercontent.com/16122379/104367985-cf941b00-551b-11eb-840a-2a424b448212.png)

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->