### PR TITLE
Flyout review and changes

### DIFF
--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -23,7 +23,7 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="FlyoutContentPadding">24</Thickness>
+    <Thickness x:Key="FlyoutContentPadding">12</Thickness>
 
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -7,28 +7,23 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <contract7Present:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
-            <contract7NotPresent:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
-            <contract7Present:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
-            <contract7NotPresent:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
             <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
-            <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlPageBackgroundChromeMediumLowBrush" />
-            <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemControlTransientBorderBrush" />
-            <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
-            <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
+            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SystemColorWindowTextColorBrush" />
+            <Thickness x:Key="FlyoutBorderThemeThickness">2</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <contract7Present:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
-            <contract7NotPresent:StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
-            <contract7Present:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
-            <contract7NotPresent:StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
             <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
-            <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+
+    <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
 
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     
@@ -54,13 +49,12 @@
             <Setter.Value>
                 <ControlTemplate TargetType="FlyoutPresenter">
                     <Border
-                        Background="{TemplateBinding Background}"
-                        contract7Present:BackgroundSizing="OuterBorderEdge"
+                        Background="{TemplateBinding Background}"                        
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                        contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}"
-                        Padding="{ThemeResource FlyoutBorderThemePadding}">
+                        contract7Present:BackgroundSizing="OuterBorderEdge"
+                        Padding="{TemplateBinding Padding}">
                         <ScrollViewer x:Name="ScrollViewer"
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
@@ -71,7 +65,6 @@
                             <ContentPresenter Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 ContentTransitions="{TemplateBinding ContentTransitions}"
-                                Margin="{TemplateBinding Padding}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </ScrollViewer>

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -23,7 +23,7 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="FlyoutContentPadding">0</Thickness>
+    <Thickness x:Key="FlyoutContentPadding">24</Thickness>
 
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     
@@ -53,8 +53,7 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                        contract7Present:BackgroundSizing="OuterBorderEdge"
-                        Padding="{StaticResource FlyoutContentPadding}">
+                        contract7Present:BackgroundSizing="OuterBorderEdge">
                         <ScrollViewer x:Name="ScrollViewer"
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -23,7 +23,7 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="FlyoutBorderThemePadding">0</Thickness>
+    <Thickness x:Key="FlyoutContentPadding">0</Thickness>
 
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     
@@ -34,7 +34,7 @@
         <Setter Property="Background" Value="{ThemeResource FlyoutPresenterBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource FlyoutBorderThemeBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource FlyoutBorderThemeThickness}" />
-        <Setter Property="Padding" Value="{ThemeResource FlyoutContentThemePadding}" />
+        <Setter Property="Padding" Value="{ThemeResource FlyoutContentPadding}" />
         <Setter Property="MinWidth" Value="{ThemeResource FlyoutThemeMinWidth}" />
         <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource FlyoutThemeMinHeight}" />
@@ -54,7 +54,7 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         contract7Present:BackgroundSizing="OuterBorderEdge"
-                        Padding="{TemplateBinding Padding}">
+                        Padding="{StaticResource FlyoutContentPadding}">
                         <ScrollViewer x:Name="ScrollViewer"
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
@@ -65,6 +65,7 @@
                             <ContentPresenter Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 ContentTransitions="{TemplateBinding ContentTransitions}"
+                                Margin="{TemplateBinding Padding}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </ScrollViewer>


### PR DESCRIPTION
- Moving static resources from theme to static
- Removing extra resources
- Updating HC resources to correct brushes and stroke width (2 in HC)

Padding (of default 0) seemed to have been set twice, so actually moving it to template binding padding on outer border.

This is an empty container flyout - a lightweight control with no additional content.