### PR TITLE
TabView: Fix all tabs squeezed into viewport when last tab is closed

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -782,7 +782,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Wait.ForIdle();
 
                 Log.Comment("Verify correct TabView width");
-                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - 500) < pixelTolerance);
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - 283) < pixelTolerance);
             }
 
             void CloseTabAndVerifyWidth(string tabName, int expectedValue, string expectedScrollbuttonStates)

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -804,6 +804,44 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void VerifyHeaderSizeWhenClosingLastTab()
+        {
+            using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
+            {
+                var increaseScrollButton = FindElement.ByName<Button>("IncreaseScrollButton");
+                increaseScrollButton.Click();
+                Wait.ForIdle();
+                var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
+                readTabViewWidthButton.Click();
+                Wait.ForIdle();
+
+                var initialWidth = GetTabViewHeaderWidth();
+                Verify.AreEqual(100, initialWidth);
+
+                var lastTab = FindElement.ByName("Tab 5");
+                FindCloseButton(lastTab).Click();
+                Wait.ForIdle();
+
+                var widthAfterClose = GetTabViewHeaderWidth();
+                Verify.AreEqual(100, widthAfterClose);
+                Verify.AreEqual("False;True;", FindElement.ByName("ScrollButtonStatus").GetText());
+
+                var newLastTab = FindElement.ByName("Tab 4");
+                FindCloseButton(newLastTab).Click();
+                Wait.ForIdle();
+
+                var widthAfterSecondClose = GetTabViewHeaderWidth();
+                Verify.AreEqual(100, widthAfterSecondClose);
+
+                double GetTabViewHeaderWidth()
+                {
+                    var tabViewHeaderWidth = new TextBlock(FindElement.ByName("TabViewHeaderWidth"));
+                    return double.Parse(tabViewHeaderWidth.GetText());
+                }
+            }
+        }
+
         public void PressButtonAndVerifyText(String buttonName, String textBlockName, String expectedText)
         {
             Button button = FindElement.ByName<Button>(buttonName);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -887,7 +887,8 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths,bool fillAllAvailableSpace
                         }
 
                         // Use current size to update items to fill the currently occupied space
-                        tabWidth = availableTabViewSpace / (double)(TabItems().Size());
+                        auto const tabWidthUnclamped = availableTabViewSpace / (double)(TabItems().Size());
+                        tabWidth = std::clamp(tabWidthUnclamped, minTabWidth, maxTabWidth);
                     }
 
 

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml
@@ -23,7 +23,7 @@
                     <muxc:TabViewItem Header="Tab 0" AutomationProperties.Name="Tab 0"/>
                     <muxc:TabViewItem Header="Tab 1" AutomationProperties.Name="Tab 1"/>
                     <muxc:TabViewItem Header="Tab 2" AutomationProperties.Name="Tab 2"/>
-                    <muxc:TabViewItem Header="Tab 3" AutomationProperties.Name="Tab 3"/>
+                    <muxc:TabViewItem Header="Tab 3" x:Name="Tab3" AutomationProperties.Name="Tab 3"/>
                     <muxc:TabViewItem Header="Tab 4" AutomationProperties.Name="Tab 4"/>
                     <muxc:TabViewItem Header="Tab 5" AutomationProperties.Name="Tab 5"/>
                 </muxc:TabView>
@@ -33,11 +33,16 @@
                 <TextBlock x:Name="TabViewWidth" AutomationProperties.Name="TabViewWidth"/>
                 <TextBlock Text="Scroll buttons status"/>
                 <TextBlock x:Name="ScrollButtonStatus" AutomationProperties.Name="ScrollButtonStatus" />
+                <TextBlock Text="Header Width"/>
+                <TextBlock x:Name="TabViewHeaderWidth" AutomationProperties.Name="TabViewHeaderWidth"/>
             </StackPanel>
             <StackPanel>
                 <Button AutomationProperties.Name="GetActualWidthButton"
                         Click="GetActualWidthsButton_Click"
                         Content="Get actual TabView width"/>
+                <Button AutomationProperties.Name="IncreaseScrollButton"
+                        Click="IncreaseScrollButton_Click"
+                        Content="Increase scroll" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
@@ -50,6 +50,7 @@ namespace MUXControlsTestApp
             Tabs.TabItems.Remove(e.Tab);
 
             TabViewWidth.Text = Tabs.ActualWidth.ToString();
+            TabViewHeaderWidth.Text = Tab3.Width.ToString();
 
             var scrollButtonStateValue = "";
 
@@ -66,6 +67,15 @@ namespace MUXControlsTestApp
         {
             // This is the smallest width that fits our content without any scrolling.
             TabViewWidth.Text = Tabs.ActualWidth.ToString();
+
+            // Header width
+            TabViewHeaderWidth.Text = Tab3.Width.ToString();
+        }
+
+        public void IncreaseScrollButton_Click(object sender, RoutedEventArgs e)
+        {
+            var sv = VisualTreeUtils.FindVisualChildByName(Tabs, "ScrollViewer") as ScrollViewer;
+            sv.ChangeView(10000, null, null, disableAnimation: true);
         }
 
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a large number of tabs are present (ie enough to scroll), closing the last tab will cause all of the tabs to squeeze into the visible viewport (see screencap below), before resetting to correct widths when pointer is removed from the tab header bar. 

This is happening because the code path that's called when closing the last tab (`fillAllAvailableSpace = true`) isn't applying min (and max) tab widths as expected. This PR fixes the bug by clamping the applied tabWidth within those values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually in the MUXControlsTestApp

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
#### Behaviour before the fix:

![TabView_Last_Item_Before](https://user-images.githubusercontent.com/8270914/104744311-b907e280-571a-11eb-9105-03d2abd10feb.gif)

#### Behaviour after the fix:
![TabView_Last_Item_After](https://user-images.githubusercontent.com/8270914/104744421-db99fb80-571a-11eb-8fb8-1a477289a46c.gif)
