### PR TITLE
Adding back previous name for content padding for Flyout

### DIFF
--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -23,8 +23,6 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="FlyoutContentThemePadding">12</Thickness>
-
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     
     <Style x:Key="DefaultFlyoutPresenterStyle" TargetType="FlyoutPresenter">

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -24,6 +24,7 @@
     </ResourceDictionary.ThemeDictionaries>
 
     <Thickness x:Key="FlyoutContentPadding">12</Thickness>
+    <Thickness x:Key="FlyoutContentThemePadding">0</Thickness>
 
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -23,8 +23,7 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="FlyoutContentPadding">12</Thickness>
-    <Thickness x:Key="FlyoutContentThemePadding">0</Thickness>
+    <Thickness x:Key="FlyoutContentThemePadding">12</Thickness>
 
     <Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}" />
     
@@ -35,7 +34,7 @@
         <Setter Property="Background" Value="{ThemeResource FlyoutPresenterBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource FlyoutBorderThemeBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource FlyoutBorderThemeThickness}" />
-        <Setter Property="Padding" Value="{ThemeResource FlyoutContentPadding}" />
+        <Setter Property="Padding" Value="{ThemeResource FlyoutContentThemePadding}" />
         <Setter Property="MinWidth" Value="{ThemeResource FlyoutThemeMinWidth}" />
         <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource FlyoutThemeMinHeight}" />

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -32,7 +32,7 @@
         <Setter Property="Background" Value="{ThemeResource FlyoutPresenterBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource FlyoutBorderThemeBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource FlyoutBorderThemeThickness}" />
-        <Setter Property="Padding" Value="{StaticResource FlyoutContentThemePadding}" />
+        <Setter Property="Padding" Value="{ThemeResource FlyoutContentThemePadding}" />
         <Setter Property="MinWidth" Value="{ThemeResource FlyoutThemeMinWidth}" />
         <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource FlyoutThemeMinHeight}" />

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -34,7 +34,7 @@
         <Setter Property="Background" Value="{ThemeResource FlyoutPresenterBackground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource FlyoutBorderThemeBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource FlyoutBorderThemeThickness}" />
-        <Setter Property="Padding" Value="{ThemeResource FlyoutContentThemePadding}" />
+        <Setter Property="Padding" Value="{StaticResource FlyoutContentThemePadding}" />
         <Setter Property="MinWidth" Value="{ThemeResource FlyoutThemeMinWidth}" />
         <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
         <Setter Property="MinHeight" Value="{ThemeResource FlyoutThemeMinHeight}" />

--- a/dev/CommonStyles/TestUI/CommonStylesPage.xaml
+++ b/dev/CommonStyles/TestUI/CommonStylesPage.xaml
@@ -225,6 +225,17 @@
                     <!-- Checking that the DefaultRadioButtonStyle can be accessed as resource -->
                     <RadioButton Style="{StaticResource DefaultRadioButtonStyle}" Content="I am a RadioButton with DefaultRadioButtonStyle set" />
 
+                    <Button Content="Test flyout">
+                        <Button.Flyout>
+                            <Flyout>
+                                <StackPanel>
+                                    <TextBlock Style="{ThemeResource BaseTextBlockStyle}" Text="All items will be removed. Do you want to continue?" Margin="0,0,0,12" />
+                                    <Button Content="Yes, empty my cart" />
+                                </StackPanel>
+                            </Flyout>
+                        </Button.Flyout>
+                    </Button>
+
                 </StackPanel>
                 <StackPanel Style="{ThemeResource CompactPanelStyle}">
                     <TextBlock  Text="Miscellaneous testing area" Style="{ThemeResource StandardGroupHeader}"/>


### PR DESCRIPTION
Flyout is used in a lot of other controls and code. Using new padding value but adding back the name even though it's not really a theming property to avoid possible breaks.