### PR TITLE
Don't call UpdateViewport if viewport management is disabled

### DIFF
--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -420,15 +420,18 @@ void ViewportManagerWithPlatformFeatures::EnsureScroller()
             parent = CachedVisualTreeHelpers::GetParent(parent);
         }
 
-        if (!m_scroller)
+        if (!m_managingViewportDisabled)
         {
-            // We usually update the viewport in the post arrange handler. But, since we don't have
-            // a scroller, let's do it now.
-            UpdateViewport(winrt::Rect{});
-        }
-        else if (!m_managingViewportDisabled)
-        {
-            m_effectiveViewportChangedRevoker = m_owner->EffectiveViewportChanged(winrt::auto_revoke, { this, &ViewportManagerWithPlatformFeatures::OnEffectiveViewportChanged });
+            if (!m_scroller)
+            {
+                // We usually update the viewport in the post arrange handler. 
+                // But, since we don't have a scroller, let's do it now.s
+                UpdateViewport(winrt::Rect{});
+            }
+            else
+            {
+                m_effectiveViewportChangedRevoker = m_owner->EffectiveViewportChanged(winrt::auto_revoke, { this, &ViewportManagerWithPlatformFeatures::OnEffectiveViewportChanged });
+            }
         }
 
         m_ensuredScroller = true;

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.cpp
@@ -425,7 +425,7 @@ void ViewportManagerWithPlatformFeatures::EnsureScroller()
             if (!m_scroller)
             {
                 // We usually update the viewport in the post arrange handler. 
-                // But, since we don't have a scroller, let's do it now.s
+                // But, since we don't have a scroller, let's do it now.
                 UpdateViewport(winrt::Rect{});
             }
             else


### PR DESCRIPTION
In certain cases, it is possible to end up calling UpdateViewport when the viewport management is disabled. Viewport management is disabled for non virtualizing layouts. This update is to avoid doing that call.

I don't think see an easy way to test this yet. 