### PR TITLE
TabView: Add scrolling into view on selection

### DIFF
--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -97,6 +97,7 @@ void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sen
     if (IsSelected())
     {
         SetValue(winrt::Canvas::ZIndexProperty(),box_value(20));
+        StartBringIntoView();
     }
     else
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added calling `StartBringIntoView` whenever the Selected property of a TabViewItem changes to `true`. Changing the selection on the TabView itsself will also notify the TabViewItem so this covers both cases.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3945 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![Gif showing how changing selection on TabView scrolls the newly selected item into view.](https://user-images.githubusercontent.com/16122379/104812639-f1cfb680-5803-11eb-9589-b6c54db260e4.gif)
