### PR TITLE
Unblock Breadcrumb test failure on RS2 or lower versions of Windows

### DIFF
--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -122,8 +122,12 @@ void BreadcrumbItem::OnFlyoutElementPreparedEvent(winrt::ItemsRepeater sender, w
     element.AddHandler(winrt::UIElement::PointerPressedEvent(),
         winrt::box_value<winrt::PointerEventHandler>({this, &BreadcrumbItem::OnFlyoutElementClickEvent}),
         true);
-    
-    element.PreviewKeyDown({ this, &BreadcrumbItem::OnFlyoutElementKeyDownEvent });    
+
+    // TODO: Investigate an RS2 or lower way to invoke via keyboard
+    if (SharedHelpers::IsRS3OrHigher())
+    {
+        element.PreviewKeyDown({ this, &BreadcrumbItem::OnFlyoutElementKeyDownEvent });
+    }
 }
 
 void BreadcrumbItem::OnFlyoutElementKeyDownEvent(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args)

--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -44,7 +44,6 @@ void BreadcrumbItem::OnApplyTemplate()
 
     winrt::IControlProtected controlProtected{ *this };
 
-    // TODO: Implement
     m_breadcrumbItemButton.set(GetTemplateChildT<winrt::Button>(L"PART_BreadcrumbItemButton", controlProtected));
 
     RegisterPropertyChangedCallback(winrt::FrameworkElement::FlowDirectionProperty(), { this, &BreadcrumbItem::OnFlowDirectionChanged });
@@ -123,7 +122,7 @@ void BreadcrumbItem::OnFlyoutElementPreparedEvent(winrt::ItemsRepeater sender, w
         winrt::box_value<winrt::PointerEventHandler>({this, &BreadcrumbItem::OnFlyoutElementClickEvent}),
         true);
 
-    // TODO: Investigate an RS2 or lower way to invoke via keyboard
+    // TODO: Investigate an RS2 or lower way to invoke via keyboard. Github issue #3997
     if (SharedHelpers::IsRS3OrHigher())
     {
         element.PreviewKeyDown({ this, &BreadcrumbItem::OnFlyoutElementKeyDownEvent });


### PR DESCRIPTION
The Breadcrumb control is creating a test failure due to the use of the `PreviewKeyDown` property, to remove the test failure, a check for RS2 or higher versions, while also creating an issue to investigate a lasting fix: #3997

## Description
A wrapping check for RS3+ systems was added to the control to unblock the tests. A bug was filed to investigate a long lasting solution to this issue
