### PR TITLE
Adding resources for Hyperlink foreground colors

### DIFF
--- a/dev/CommonStyles/CommonStyles.vcxitems
+++ b/dev/CommonStyles/CommonStyles.vcxitems
@@ -26,6 +26,11 @@
       <Type>ThemeResources</Type>
       <Priority>1</Priority>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Hyperlink_themeresources.xaml">
+      <UseVisualStyle>Latest</UseVisualStyle>
+      <Version>RS1</Version>
+      <Type>ThemeResources</Type>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)HyperlinkButton_themeresources.xaml">
       <UseVisualStyle>Latest</UseVisualStyle>
       <Version>RS1</Version>

--- a/dev/CommonStyles/Hyperlink_themeresources.xaml
+++ b/dev/CommonStyles/Hyperlink_themeresources.xaml
@@ -4,27 +4,19 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <Color x:Key="HyperlinkForegroundColor">#FF99EBFF</Color>
-            <Color x:Key="HyperlinkForegroundPointerOverColor">#FF99EBFF</Color>
-            <Color x:Key="HyperlinkForegroundPressedColor">#FF4CC2FF</Color>
-
-            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource HyperlinkForegroundColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource HyperlinkForegroundPointerOverColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource HyperlinkForegroundPressedColor}"/>
+            <StaticResource x:Key="HyperlinkForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+            <StaticResource x:Key="HyperlinkForegroundPointerOver" ResourceKey="AccentTextFillColorSecondaryBrush" />
+            <StaticResource x:Key="HyperlinkForegroundPressed" ResourceKey="AccentTextFillColorTertiaryBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource SystemColorWindowTextColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource SystemColorWindowTextColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource SystemColorHotlightColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource SystemColorHotlightColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource SystemColorHotlightColor}"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <Color x:Key="HyperlinkForegroundColor">#FF003E92</Color>
-            <Color x:Key="HyperlinkForegroundPointerOverColor">#FF001A68</Color>
-            <Color x:Key="HyperlinkForegroundPressedColor">#FF0067C0</Color>
-
-            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource HyperlinkForegroundColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource HyperlinkForegroundPointerOverColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource HyperlinkForegroundPressedColor}"/>
+            <StaticResource x:Key="HyperlinkForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />
+            <StaticResource x:Key="HyperlinkForegroundPointerOver" ResourceKey="AccentTextFillColorSecondaryBrush" />
+            <StaticResource x:Key="HyperlinkForegroundPressed" ResourceKey="AccentTextFillColorTertiaryBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/dev/CommonStyles/Hyperlink_themeresources.xaml
+++ b/dev/CommonStyles/Hyperlink_themeresources.xaml
@@ -1,0 +1,30 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <Color x:Key="HyperlinkForegroundColor">#FF99EBFF</Color>
+            <Color x:Key="HyperlinkForegroundPointerOverColor">#FF99EBFF</Color>
+            <Color x:Key="HyperlinkForegroundPressedColor">#FF4CC2FF</Color>
+
+            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource HyperlinkForegroundColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource HyperlinkForegroundPointerOverColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource HyperlinkForegroundPressedColor}"/>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource SystemColorWindowTextColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource SystemColorWindowTextColor}"/>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+            <Color x:Key="HyperlinkForegroundColor">#FF003E92</Color>
+            <Color x:Key="HyperlinkForegroundPointerOverColor">#FF001A68</Color>
+            <Color x:Key="HyperlinkForegroundPressedColor">#FF0067C0</Color>
+
+            <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource HyperlinkForegroundColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource HyperlinkForegroundPointerOverColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource HyperlinkForegroundPressedColor}"/>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/dev/CommonStyles/Hyperlink_themeresources.xaml
+++ b/dev/CommonStyles/Hyperlink_themeresources.xaml
@@ -10,8 +10,8 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource SystemColorHotlightColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource SystemColorHotlightColor}"/>
-            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource SystemColorHotlightColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}"/>
+            <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource SystemColorHighlightColor}"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="HyperlinkForeground" ResourceKey="AccentTextFillColorPrimaryBrush" />

--- a/dev/CommonStyles/TestUI/CommonStylesPage.xaml
+++ b/dev/CommonStyles/TestUI/CommonStylesPage.xaml
@@ -142,6 +142,11 @@
                             </CommandBar.SecondaryCommands>
                         </CommandBar>
                         <RichEditBox x:Name="RichEditBox" Grid.Row="6" Header="RichEditBox" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                        <TextBlock Grid.Row="7">
+                            <Run>Pre-hyperlink</Run>
+                            <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>
+                            <Run>Post-hyperlink</Run>
+                        </TextBlock>
                     </Grid>
                 </StackPanel>
                 <StackPanel Style="{ThemeResource CompactPanelStyle}">
@@ -216,6 +221,11 @@
                             </CommandBar.SecondaryCommands>
                         </CommandBar>
                         <RichEditBox Grid.Row="6" Header="RichEditBox" VerticalAlignment="Top" />
+                        <TextBlock Grid.Row="7">
+                            <Run>Pre-hyperlink</Run>
+                            <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>
+                            <Run>Post-hyperlink</Run>
+                        </TextBlock>
                     </Grid>
                 </StackPanel>
                 <StackPanel Style="{ThemeResource CompactPanelStyle}">


### PR DESCRIPTION
Providing theme resources for Hyperlink's HyperlinkForeground/HyperlinkForegroundPointerOver/HyperlinkForegroundPressed brushes.

Done for internal task 31139635.
Tested on newer 21H1 Windows build using the updated CommonStyles test page of the MUXControlTestApp.
