### PR TITLE
Adding More Slider Examples to TestUI Page

### DIFF
--- a/dev/Slider/TestUI/SliderPage.xaml
+++ b/dev/Slider/TestUI/SliderPage.xaml
@@ -9,6 +9,7 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -49,5 +50,6 @@
             </StackPanel>
         </ScrollViewer>
     </Grid>
+
 
 </local:TestPage>

--- a/dev/Slider/TestUI/SliderPage.xaml
+++ b/dev/Slider/TestUI/SliderPage.xaml
@@ -9,7 +9,6 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -50,6 +49,5 @@
             </StackPanel>
         </ScrollViewer>
     </Grid>
-
 
 </local:TestPage>

--- a/dev/Slider/TestUI/SliderPage.xaml
+++ b/dev/Slider/TestUI/SliderPage.xaml
@@ -48,6 +48,6 @@
                 </StackPanel>
             </StackPanel>
         </ScrollViewer>
-    </Grid>
+    </Grid> 
 
 </local:TestPage>

--- a/dev/Slider/TestUI/SliderPage.xaml
+++ b/dev/Slider/TestUI/SliderPage.xaml
@@ -9,11 +9,45 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <StackPanel Margin="12">
-        <TextBlock Text="Sample Slider" Style="{ThemeResource StandardGroupHeader}"/>
-        <Slider/>
-        <Slider Header="Slider with header"/>
-        <Slider Header="Slider with preset values" Value="25" Minimum="0" Maximum="50"/>
-    </StackPanel>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="1.25*"/>
+        </Grid.ColumnDefinitions>
+
+        <ScrollViewer  Grid.Column="0">
+            <StackPanel Orientation="Vertical" Margin="12" Grid.Column="0">
+                <TextBlock Text="Sample Horizontal Sliders" Style="{ThemeResource StandardGroupHeader}"/>
+                <StackPanel Orientation="Vertical">
+                    <Slider Margin="12,12,12,32" />
+                    <Slider Header="Slider with header" Margin="12" />
+                    <Slider Header="Slider with preset values" Value="25" Minimum="0" Maximum="50" Margin="12" />
+                    <Slider Header="Slider with TickPlacement Inline" Margin="12" TickPlacement="Inline" TickFrequency="12"/>
+                    <Slider Header="Slider with TickPlacement Outside" Margin="12" TickPlacement="Outside" TickFrequency="12"/>
+                    <Slider Header="Slider with TickPlacement TopLeft" Margin="12" TickPlacement="TopLeft" TickFrequency="12"/>
+                    <Slider Header="Slider with TickPlacement BottomRight" Margin="12" TickPlacement="BottomRight" TickFrequency="12"/>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer  Grid.Column="1">
+            <StackPanel Orientation="Vertical" Margin="12">
+                <TextBlock Text="Sample Vertical Sliders" Style="{ThemeResource StandardGroupHeader}"/>
+                <StackPanel Orientation="Horizontal" Height="240">
+                    <Slider Orientation="Vertical" Margin="12,12,64,12"/>
+                    <Slider Header="Slider with header" Orientation="Vertical" Margin="12" />
+                    <Slider Header="Slider with preset values" Value="25" Minimum="0" Maximum="50" Orientation="Vertical" Margin="12" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="240" Margin="0,12,0,0">
+                    <Slider Header="Slider with TickPlacement Inline" Orientation="Vertical" Margin="12" TickPlacement="Inline" TickFrequency="12"/>
+                    <Slider Header="Slider with TickPlacement Outside" Orientation="Vertical" Margin="12" TickPlacement="Outside" TickFrequency="12"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Height="240" Margin="0,12,0,0">
+                    <Slider Header="Slider with TickPlacement TopLeft" Orientation="Vertical" Margin="12" TickPlacement="TopLeft" TickFrequency="12"/>
+                    <Slider Header="Slider with TickPlacement BottomRight" Orientation="Vertical" Margin="12" TickPlacement="BottomRight" TickFrequency="12"/>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 
 </local:TestPage>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Additional sliders for test UI
<!--- Describe your changes in detail -->
I am Adding extra Slider control examples to the TestUI/SliderPage.xaml to include examples of TickPlacement properties - as well as adding vertically orientated examples.

- I used a ``Grid`` with columns to separate the Horizontal and Vertical examples
- I wrapped each ``StackPanel`` in a ``ScrollViewer`` as the vertical examples would extend beyond the visible region with the lab conditions bounding toggled.
- I added ``Margin`` values to the controls and panels to make it easier to identify each example.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Following a suggestion I made in Pull Request #3768 by @karenbtlai I was asked to make a Pull Request adding more Slider examples to the TestUI SliderPage

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I built the solution and ran the MUXTestApp, checking the Page displayed correctly.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![Light Theme Slider Page](https://user-images.githubusercontent.com/7389110/106062692-0c9d0780-60ef-11eb-9da1-9bfe1c8cbb34.png)

![Dark Theme toggled Slider Page](https://user-images.githubusercontent.com/7389110/106062728-1b83ba00-60ef-11eb-93d6-1afb418d04e9.png)

_This is a replacement for Pull Request #3821 as I messed up the branching by mistake_