### PR TITLE
Update ContentDialog ThemeResources - Fixing transition visual artifact

### DIFF
--- a/dev/ContentDialog/ContentDialog_themeresources.xaml
+++ b/dev/ContentDialog/ContentDialog_themeresources.xaml
@@ -280,7 +280,8 @@
                                         HorizontalAlignment="Stretch"
                                         VerticalAlignment="Bottom"
                                         XYFocusKeyboardNavigation="Enabled"
-                                        Padding="{StaticResource ContentDialogPadding}">
+                                        Padding="{StaticResource ContentDialogPadding}"
+                                        Background="{TemplateBinding Background}">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition x:Name="PrimaryColumn" Width="*" />
                                             <ColumnDefinition x:Name="FirstSpacer" Width="0" />


### PR DESCRIPTION
Adding the ``Background`` TemplateBinding to the CommandSpace Grid to prevent a visual artifact with the ThemeShadow

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have added the Background TemplateBinding to the Grid named **CommandSpace** which prevents the ThemeShadow's darkness from showing through the lower portion of the ContentDialog as it transitions in and out of view.


https://user-images.githubusercontent.com/7389110/106591976-d6c0ae80-6546-11eb-82b0-a433830cbbef.mp4

_The problem as demonstrated in a video_


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
![](https://user-images.githubusercontent.com/7389110/104667504-23defc80-56ce-11eb-9727-12d902a515e4.png)

As you can see from this set of stills taken as the ContentDialog transitions into view.  The lower area with the buttons darkens while the top overlay region does not.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
I ran the MUXControlsTestApp and saw the dialog animates without this visual artifact.

I am not used to making Pull Requests or contributing changes, so I would appreciate any reviews or testing from others more knowledgeable and able to foresee issues with this fix I have not noted.

## Screenshots

https://user-images.githubusercontent.com/7389110/106588563-d6beaf80-6542-11eb-9adf-1334c9d952bb.mp4

_This is the transition after the fix_