### PR TITLE
Adding ability to run MUX-CI.yml with internal pipeline & Windows SDK

### DIFF
--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -7,7 +7,7 @@
     <SDKVersionRS4>10.0.17134.0</SDKVersionRS4>
     <SDKVersionRS5>10.0.17763.0</SDKVersionRS5>
     <SDKVersion19H1>10.0.18362.0</SDKVersion19H1>
-    <SDKVersionInsider>10.0.21296.0</SDKVersionInsider>
+    <SDKVersionInsider>10.0.21307.0</SDKVersionInsider>
   </PropertyGroup>
   <PropertyGroup>
     <!-- By default we use the publicly shipped SDK version which is 19H1 now -->

--- a/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
@@ -6,8 +6,6 @@ steps:
       appxPackageDir: $(appxPackageDir)
       buildOutputDir: $(buildOutputDir)
       publishDir: $(publishDir)
-      ${{ if ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/') }}:
-        useInsiderSDK: true
 
   - template: MUX-MakeFrameworkPackages-Steps.yml
     parameters:

--- a/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
@@ -6,6 +6,8 @@ steps:
       appxPackageDir: $(appxPackageDir)
       buildOutputDir: $(buildOutputDir)
       publishDir: $(publishDir)
+      ${{ if ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/') }}:
+        useInsiderSDK: true
 
   - template: MUX-MakeFrameworkPackages-Steps.yml
     parameters:

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -4,6 +4,7 @@ parameters:
   buildOutputDir: '$(Build.SourcesDirectory)\BuildOutput'
   appxPackageDir: '$(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages'
   artifactName: 'drop'
+  useInsiderSDK: false
 
 steps:
   - template: MUX-PopulateBuildDateAndRevision-Steps.yml
@@ -56,7 +57,7 @@ steps:
       vsVersion: 16.0
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/p:AppxPackageDir="${{ parameters.appxPackageDir }}" /p:AppxBundle=Never /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:MUXVersionBuild=$(builddate_yymm) /p:MUXVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode)'
+      msbuildArgs: '/p:UseInsiderSDK=${{ parameters.useInsiderSDK }} /p:AppxPackageDir="${{ parameters.appxPackageDir }}" /p:AppxBundle=Never /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:MUXVersionBuild=$(builddate_yymm) /p:MUXVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{ parameters.solutionPath }} binlog'

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -4,7 +4,6 @@ parameters:
   buildOutputDir: '$(Build.SourcesDirectory)\BuildOutput'
   appxPackageDir: '$(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages'
   artifactName: 'drop'
-  useInsiderSDK: false
 
 steps:
   - template: MUX-PopulateBuildDateAndRevision-Steps.yml
@@ -57,7 +56,7 @@ steps:
       vsVersion: 16.0
       platform: '$(buildPlatform)'
       configuration: '$(buildConfiguration)'
-      msbuildArgs: '/p:UseInsiderSDK=${{ parameters.useInsiderSDK }} /p:AppxPackageDir="${{ parameters.appxPackageDir }}" /p:AppxBundle=Never /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:MUXVersionBuild=$(builddate_yymm) /p:MUXVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode)'
+      msbuildArgs: '/p:UseInsiderSDK=$(UseInsiderSDK) /p:AppxPackageDir="${{ parameters.appxPackageDir }}" /p:AppxBundle=Never /p:AppxSymbolPackageEnabled=false /binaryLogger:$(Build.SourcesDirectory)/${{ parameters.solutionPath }}.$(buildPlatform).$(buildConfiguration).binlog /p:MUXVersionBuild=$(builddate_yymm) /p:MUXVersionRevision=$(builddate_dd)$(buildrevision) /p:VCToolsInstallDir="$(VCToolsInstallDir)\" /p:PGOBuildMode=$(PGOBuildMode)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{ parameters.solutionPath }} binlog'

--- a/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
@@ -10,27 +10,27 @@ steps:
     displayName: 'Install Windows SDK (${{ parameters.sdkVersion }})'
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    condition: eq(variables['UseInsiderSDK'], 'true')
     displayName: 'Install Insider Windows SDK Part 1'
     inputs:
       command: custom
       arguments: 'install InternalWindowsSDK-part1 -NonInteractive -Version 1.0.2 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    condition: eq(variables['UseInsiderSDK'], 'true')
     displayName: 'Install Insider Windows SDK Part 2'
     inputs:
       command: custom
       arguments: 'install InternalWindowsSDK-part2 -NonInteractive -Version 1.0.2 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
 
   - task: CmdLine@1
-    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    condition: eq(variables['UseInsiderSDK'], 'true')
     displayName: 'Merge Insider Windows SDK Parts'
     inputs:
       filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\MergeNupkgParts.cmd'
 
   - task: CmdLine@1
-    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    condition: eq(variables['UseInsiderSDK'], 'true')
     displayName: 'Set up Insider Windows SDK'
     inputs:
       filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\SetUpInternalWindowsSDK.cmd'

--- a/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
@@ -8,3 +8,30 @@ steps:
       filePath: build\Install-WindowsSdkISO.ps1
       arguments: ${{ parameters.sdkVersion }}
     displayName: 'Install Windows SDK (${{ parameters.sdkVersion }})'
+
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    displayName: 'Install Insider Windows SDK Part 1'
+    inputs:
+      command: custom
+      arguments: 'install InternalWindowsSDK-part1 -NonInteractive -Version 1.0.2 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
+
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    displayName: 'Install Insider Windows SDK Part 2'
+    inputs:
+      command: custom
+      arguments: 'install InternalWindowsSDK-part2 -NonInteractive -Version 1.0.2 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
+
+  - task: CmdLine@1
+    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    displayName: 'Merge Insider Windows SDK Parts'
+    inputs:
+      filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\MergeNupkgParts.cmd'
+
+  - task: CmdLine@1
+    condition: ne(variables['System.CollectionUri'],'https://dev.azure.com/ms/')
+    displayName: 'Set up Insider Windows SDK'
+    inputs:
+      filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\SetUpInternalWindowsSDK.cmd'
+

--- a/tools/InternalWindowsSDKNuget/MergeNupkgParts.cmd
+++ b/tools/InternalWindowsSDKNuget/MergeNupkgParts.cmd
@@ -1,0 +1,18 @@
+@ECHO OFF
+SETLOCAL
+set ERRORLEVEL=
+
+echo robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part1.1.0.2\windowssdk-21307.1000.210201-1505-part1 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
+call robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part1.1.0.2\windowssdk-21307.1000.210201-1505-part1 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
+
+echo robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part2.1.0.2\windowssdk-21307.1000.210201-1505-part2 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
+call robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part2.1.0.2\windowssdk-21307.1000.210201-1505-part2 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
+
+REM robocopy returns:
+REM - 0x0 for no files copied,
+REM - 0x1 for files copied, (https://support.microsoft.com/en-us/kb/954404)
+REM - 0×2 for Some Extra files or directories were detected. Some housekeeping may be needed.
+IF %ERRORLEVEL%==1 set ERRORLEVEL=0
+IF %ERRORLEVEL%==3 set ERRORLEVEL=0
+
+exit /B %ERRORLEVEL%

--- a/tools/InternalWindowsSDKNuget/NuSpecs/BuildNupkgs.cmd
+++ b/tools/InternalWindowsSDKNuget/NuSpecs/BuildNupkgs.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+echo %~dp0..\..\NugetWrapper.cmd pack InternalWindowsSDK-part1.nuspec -properties PROGRAMFILES="%ProgramFiles(x86)%"
+call %~dp0..\..\NugetWrapper.cmd pack InternalWindowsSDK-part1.nuspec -properties PROGRAMFILES="%ProgramFiles(x86)%"
+
+echo %~dp0..\..\NugetWrapper.cmd pack InternalWindowsSDK-part2.nuspec -properties PROGRAMFILES="%ProgramFiles(x86)%"
+call %~dp0..\..\NugetWrapper.cmd pack InternalWindowsSDK-part2.nuspec -properties PROGRAMFILES="%ProgramFiles(x86)%"

--- a/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part1.nuspec
+++ b/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part1.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>InternalWindowsSDK-part1</id>
+    <version>1.0.2</version>
+    <title>InternalWindowsSDK-part1</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Internal Windows SDK install files - part1.</description>
+    <releaseNotes>For Microsoft internal use only.</releaseNotes>
+    <copyright>Copyright 2021</copyright>
+  </metadata>
+  <files>
+    <file target="windowssdk-21307.1000.210201-1505-part1" src="..\windowssdk-21307.1000.210201-1505-part1\**\*.*"/>
+  </files>
+</package>

--- a/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part2.nuspec
+++ b/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part2.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>InternalWindowsSDK-part2</id>
+    <version>1.0.2</version>
+    <title>InternalWindowsSDK-part2</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Internal Windows SDK install files - part2.</description>
+    <releaseNotes>For Microsoft internal use only.</releaseNotes>
+    <copyright>Copyright 2021</copyright>
+  </metadata>
+  <files>
+    <file target="windowssdk-21307.1000.210201-1505-part2" src="..\windowssdk-21307.1000.210201-1505-part2\**\*.*"/>
+  </files>
+</package>

--- a/tools/InternalWindowsSDKNuget/NuSpecs/PublishNupkgs.cmd
+++ b/tools/InternalWindowsSDKNuget/NuSpecs/PublishNupkgs.cmd
@@ -1,0 +1,18 @@
+@ECHO OFF
+SETLOCAL
+set ERRORLEVEL=
+
+for %%A IN (%~dp0InternalWindowsSDK-part1.??.??.*.nupkg) do (
+    echo Candidate nuget package: %%A
+    echo %~dp0..\..\NugetWrapper.cmd push %%A -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -apikey VSTS
+    call %~dp0..\..\NugetWrapper.cmd push %%A -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -apikey VSTS
+)
+
+for %%A IN (%~dp0InternalWindowsSDK-part2.??.??.*.nupkg) do (
+    echo Candidate nuget package: %%A
+    echo %~dp0..\..\NugetWrapper.cmd push %%A -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -apikey VSTS
+    call %~dp0..\..\NugetWrapper.cmd push %%A -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -apikey VSTS
+)
+
+:END
+exit /B %ERRORLEVEL%

--- a/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
+++ b/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
@@ -1,0 +1,9 @@
+@ECHO OFF
+SETLOCAL
+set ERRORLEVEL=
+
+echo executing %~dp0..\..\packages\InternalWindowsSDK.1.0.2\winsdksetup.exe /quiet
+call %~dp0..\..\packages\InternalWindowsSDK.1.0.2\winsdksetup.exe /quiet
+
+:END
+exit /B %ERRORLEVEL%


### PR DESCRIPTION
Adding the ability to run the new WinUI2-MUX-CI pipeline with the insider SDK.

The /p:UseInsiderSDK=true parameter is sent to msbuild in that pipeline, causing insider SDK to be used.

Ran the WinUI2-MUX-CI pipeline with the  insider SDK.
