### PR TITLE
[Breadcrumb] Fix key handling for RS2 and prior versions

### DIFF
--- a/dev/Breadcrumb/Breadcrumb.cpp
+++ b/dev/Breadcrumb/Breadcrumb.cpp
@@ -45,6 +45,12 @@ void Breadcrumb::OnApplyTemplate()
     {
         thisAsIUIElement7.PreviewKeyDown({ this, &Breadcrumb::OnChildPreviewKeyDown });
     }
+    else if (auto const& thisAsUIElement = this->try_as<winrt::UIElement>())
+    {
+        m_breadcrumbKeyDownHandlerRevoker = AddRoutedEventHandler<RoutedEventType::KeyDown>(thisAsUIElement,
+            { this, &Breadcrumb::OnChildPreviewKeyDown },
+            true /*handledEventsToo*/);
+    }
 
     AccessKeyInvoked({ this, &Breadcrumb::OnAccessKeyInvoked });
     GettingFocus({ this, &Breadcrumb::OnGettingFocus });

--- a/dev/Breadcrumb/Breadcrumb.cpp
+++ b/dev/Breadcrumb/Breadcrumb.cpp
@@ -95,6 +95,8 @@ void Breadcrumb::OnBreadcrumbItemRepeaterLoaded(const winrt::IInspectable&, cons
     {
         OnBreadcrumbItemsSourceCollectionChanged(nullptr, nullptr);
     }
+
+    winrt::VisualStateManager::GoToState(*this, L"Rest", false);
 }
 
 void Breadcrumb::UpdateItemTemplate()

--- a/dev/Breadcrumb/Breadcrumb.h
+++ b/dev/Breadcrumb/Breadcrumb.h
@@ -68,6 +68,7 @@ private:
     winrt::ItemsRepeater::ElementIndexChanged_revoker m_itemRepeaterElementIndexChangedRevoker{};
     winrt::ItemsRepeater::ElementClearing_revoker m_itemRepeaterElementClearingRevoker{};
     winrt::ItemsSourceView::CollectionChanged_revoker m_itemsSourceChanged{};
+    RoutedEventHandler_revoker m_breadcrumbKeyDownHandlerRevoker{};
     
     tracker_ref<winrt::INotifyCollectionChanged> m_notifyCollectionChanged{ this };
     winrt::event_token m_itemsSourceAsCollectionChanged{};

--- a/dev/Breadcrumb/Breadcrumb.xaml
+++ b/dev/Breadcrumb/Breadcrumb.xaml
@@ -20,7 +20,7 @@
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualMargin" Value="-3" />
         <Setter Property="IsTabStop" Value="True"/>
-        <Setter Property="Padding" Value="{ThemeResource ButtonPadding}"/>
+        <Setter Property="Padding" Value="0,5,11,6"/>
 
         <Setter Property="Template">
             <Setter.Value>
@@ -31,78 +31,116 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             Padding="{TemplateBinding Padding}"
                             IsTabStop="False">
+
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="Foreground" Value="{ThemeResource BreadcrumbNormalForegroundColor}" />
+                                <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}" />
+                                <Setter Property="Background" Value="{ThemeResource BreadcrumbBackgroundBrush}" />
+                                <Setter Property="HorizontalAlignment" Value="Left" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                                <Setter Property="FontWeight" Value="SemiBold" />
+                                <Setter Property="FontSize" Value="{ThemeResource BreadcrumbItemThemeFontSize}" />
+                                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                                <Setter Property="FocusVisualMargin" Value="-3" />
+                                <Setter Property="Padding" Value="0,5,11,6" />
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                            <Grid Background="Transparent">
+
+                                                <VisualStateManager.VisualStateGroups>
+
+                                                    <VisualStateGroup x:Name="CommonStates">
+                                                        <VisualState x:Name="Normal">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbNormalForegroundColor}" />
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="CurrentNormal">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentNormalForegroundColor}" />
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="PointerOver">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbHoverForegroundColor}" />
+                                                                <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
+                                                                <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="CurrentPointerOver">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentHoverForegroundColor}" />
+                                                                <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
+                                                                <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Pressed">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbPressedForegroundColor}" />
+                                                                <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
+                                                                <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="CurrentPressed">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentPressedForegroundColor}" />
+                                                                <Setter Target="PART_ContentPresenter.Background" Value="Transparent"/>
+                                                                <Setter Target="PART_ContentPresenter.BorderBrush" Value="Transparent"/>
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Disabled">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbDisabledForegroundColor}" />
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="CurrentDisabled">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentDisabledForegroundColor}" />
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="Focus">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbFocusForegroundColor}" />
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+
+                                                        <VisualState x:Name="CurrentFocus">
+                                                            <VisualState.Setters>
+                                                                <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentFocusForegroundColor}" />
+                                                            </VisualState.Setters>
+                                                        </VisualState>
+                                                    </VisualStateGroup>
+                                                </VisualStateManager.VisualStateGroups>
+
+                                                <ContentPresenter x:Name="PART_ContentPresenter"
+                                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                                        Content="{TemplateBinding Content}"
+                                                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                        Padding="0,5,11,6"
+                                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                        AutomationProperties.AccessibilityView="Raw"/>
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Button.Style>
+
+
                         <VisualStateManager.VisualStateGroups>
-
-                            <VisualStateGroup x:Name="CommonVisualStates">
-                                <VisualState x:Name="Rest">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbRestForegroundColor}" />                                        
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="CurrentRest">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentRestForegroundColor}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="Hover">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbHoverForegroundColor}" />
-                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbHoverBackgroundBrush}"/>
-                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbHoverBorderBrush}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="CurrentHover">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentHoverForegroundColor}" />
-                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbHoverBackgroundBrush}"/>
-                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbHoverBorderBrush}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="Pressed">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbPressedForegroundColor}" />
-                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
-                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="CurrentPressed">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentPressedForegroundColor}" />
-                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
-                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbDisabledForegroundColor}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="CurrentDisabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentDisabledForegroundColor}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="Focus">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbFocusForegroundColor}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="CurrentFocus">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentFocusForegroundColor}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            
                             <VisualStateGroup x:Name="ItemTypeStates">
                                 <VisualState x:Name="Default">
                                     <VisualState.Setters>

--- a/dev/Breadcrumb/Breadcrumb.xaml
+++ b/dev/Breadcrumb/Breadcrumb.xaml
@@ -10,74 +10,95 @@
 
     <Style x:Key="BreadcrumbItemStyle" TargetType="local:BreadcrumbItem">
 
+        <Setter Property="Background" Value="{ThemeResource BreadcrumbBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="FontSize" Value="{ThemeResource BreadcrumbItemThemeFontSize}"/>
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualMargin" Value="-3" />
         <Setter Property="IsTabStop" Value="True"/>
+        <Setter Property="Padding" Value="{ThemeResource ButtonPadding}"/>
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BreadcrumbItem">
 
-                    <Button x:Name="PART_BreadcrumbItemButton">
+                    <Button x:Name="PART_BreadcrumbItemButton"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            Padding="{TemplateBinding Padding}"
+                            IsTabStop="False">
                         <VisualStateManager.VisualStateGroups>
 
-                            <VisualStateGroup x:Name="LargeTextNodeStates">
+                            <VisualStateGroup x:Name="CommonVisualStates">
                                 <VisualState x:Name="Rest">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbRestForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbRestForegroundColor}" />                                        
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="CurrentRest">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentRestForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentRestForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="Hover">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbHoverForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbHoverForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbHoverBackgroundBrush}"/>
+                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbHoverBorderBrush}"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="CurrentHover">
                                     <VisualState.Setters>
                                         <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentHoverForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbHoverBackgroundBrush}"/>
+                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbHoverBorderBrush}"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="Pressed">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbPressedForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbPressedForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
+                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="CurrentPressed">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentPressedForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentPressedForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Background" Value="{ThemeResource BreadcrumbBackgroundBrush}"/>
+                                        <Setter Target="PART_BreadcrumbItemButton.BorderBrush" Value="{ThemeResource BreadcrumbBorderBrush}"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="Disabled">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbDisabledForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbDisabledForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="CurrentDisabled">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentDisabledForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentDisabledForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="Focus">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbFocusForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbFocusForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
 
                                 <VisualState x:Name="CurrentFocus">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentFocusForegroundColor}" />
+                                        <Setter Target="PART_BreadcrumbItemButton.Foreground" Value="{ThemeResource BreadcrumbCurrentFocusForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -85,36 +106,37 @@
                             <VisualStateGroup x:Name="ItemTypeStates">
                                 <VisualState x:Name="Default">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="&#xE76C;"/>
+                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbChevronLeftToRight}"/>
                                     </VisualState.Setters>
                                 </VisualState>
+
+                                <VisualState x:Name="DefaultRTL">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbChevronRightToLeft}"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+
                                 <VisualState x:Name="LastItem">
                                     <VisualState.Setters>
                                         <Setter Target="PART_ChevronTextBlock.Visibility" Value="Collapsed"/>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.FontWeight" Value="Bold" />
+                                        <Setter Target="PART_SeparatorColumnDefinition.Width" Value="0px"/>
                                         <Setter Target="PART_ChevronColumnDefinition.Width" Value="0px" />
                                     </VisualState.Setters>
                                 </VisualState>
+                                
                                 <VisualState x:Name="Ellipsis">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="&#xE76C;"/>
+                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbChevronLeftToRight}"/>
                                         <Setter Target="PART_BreadcrumbEllipsisTextBlock.Visibility" Value="Visible"/>
                                         <Setter Target="PART_BreadcrumbItemContentPresenter.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>
                                 </VisualState>
-                            </VisualStateGroup>
 
-                            <VisualStateGroup x:Name="ItemTypeRTLStates">
-                                <VisualState x:Name="DefaultRTL">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="&#xE76B;"/>
-                                    </VisualState.Setters>
-                                </VisualState>
                                 <VisualState x:Name="EllipsisRTL">
                                     <VisualState.Setters>
                                         <Setter Target="PART_BreadcrumbEllipsisTextBlock.Visibility" Value="Visible"/>
                                         <Setter Target="PART_BreadcrumbItemContentPresenter.Visibility" Value="Collapsed"/>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="&#xE76B;"/>
+                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbChevronRightToLeft}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -127,32 +149,41 @@
 
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition x:Name="PART_ChevronColumnDefinition" Width="30px" />
+                                    <ColumnDefinition x:Name="PART_SeparatorColumnDefinition" Width="11px" />
+                                    <ColumnDefinition x:Name="PART_ChevronColumnDefinition" Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                
+
                                 <ContentPresenter x:Name="PART_BreadcrumbItemContentPresenter"
-                                                  Content="{TemplateBinding Content}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
                                                   Grid.Column="0"
-                                                  LineHeight="36"
-                                                  FontFamily="Segoe UI"
-                                                  FontStyle="Normal"
-                                                  FontWeight="SemiBold"/>
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  FontFamily="{TemplateBinding FontFamily}"
+                                                  FontSize="{TemplateBinding FontSize}"
+                                                  FontWeight="{TemplateBinding FontWeight}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  AutomationProperties.AccessibilityView="Raw"/>
 
                                 <TextBlock x:Name="PART_BreadcrumbEllipsisTextBlock"
-                                           FontFamily="Segoe MDL2 Assets"
+                                           FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                            Text="&#xE712;"
                                            Visibility="Collapsed"
                                            VerticalAlignment="Stretch"
+                                           IsTextScaleFactorEnabled="False"
+                                           FontSize="{TemplateBinding FontSize}"
+                                           AutomationProperties.AccessibilityView="Raw"
                                            Grid.Column="0"/>
 
                                 <TextBlock x:Name="PART_ChevronTextBlock"
-                                           FontFamily="Segoe MDL2 Assets"
+                                           FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                            Text="&#xE76C;"
                                            VerticalAlignment="Center"
                                            HorizontalAlignment="Center"
                                            IsTextScaleFactorEnabled="False"
-                                           Grid.Column="1"/>
+                                           FontSize="{TemplateBinding FontSize}"
+                                           AutomationProperties.AccessibilityView="Raw"
+                                           Grid.Column="2"/>
                             </Grid>
 
                         </Button.Content>
@@ -169,9 +200,8 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:Breadcrumb">
 
-                    <local:ItemsRepeater x:Name="PART_BreadcrumbItemsRepeater"
-                                         HorizontalAlignment="Left">
-                        
+                    <local:ItemsRepeater x:Name="PART_BreadcrumbItemsRepeater">
+
                         <local:ItemsRepeater.Layout>
                             <local:BreadcrumbLayout />
                         </local:ItemsRepeater.Layout>

--- a/dev/Breadcrumb/Breadcrumb.xaml
+++ b/dev/Breadcrumb/Breadcrumb.xaml
@@ -23,7 +23,61 @@
                             <VisualStateGroup x:Name="LargeTextNodeStates">
                                 <VisualState x:Name="Rest">
                                     <VisualState.Setters>
-                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BFC1}" />
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbRestForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CurrentRest">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentRestForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Hover">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbHoverForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CurrentHover">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentHoverForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Pressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbPressedForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CurrentPressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentPressedForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbDisabledForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CurrentDisabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentDisabledForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="Focus">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbFocusForegroundColor}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CurrentFocus">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BreadcrumbCurrentFocusForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -80,7 +134,10 @@
                                                   Content="{TemplateBinding Content}"
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"
                                                   Grid.Column="0"
-                                                  LineHeight="36"/>
+                                                  LineHeight="36"
+                                                  FontFamily="Segoe UI"
+                                                  FontStyle="Normal"
+                                                  FontWeight="SemiBold"/>
 
                                 <TextBlock x:Name="PART_BreadcrumbEllipsisTextBlock"
                                            FontFamily="Segoe MDL2 Assets"

--- a/dev/Breadcrumb/Breadcrumb.xaml
+++ b/dev/Breadcrumb/Breadcrumb.xaml
@@ -20,6 +20,14 @@
                     <Button x:Name="PART_BreadcrumbItemButton">
                         <VisualStateManager.VisualStateGroups>
 
+                            <VisualStateGroup x:Name="LargeTextNodeStates">
+                                <VisualState x:Name="Rest">
+                                    <VisualState.Setters>
+                                        <Setter Target="PART_BreadcrumbItemContentPresenter.Foreground" Value="{ThemeResource BFC1}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            
                             <VisualStateGroup x:Name="ItemTypeStates">
                                 <VisualState x:Name="Default">
                                     <VisualState.Setters>
@@ -71,7 +79,8 @@
                                 <ContentPresenter x:Name="PART_BreadcrumbItemContentPresenter"
                                                   Content="{TemplateBinding Content}"
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  Grid.Column="0"/>
+                                                  Grid.Column="0"
+                                                  LineHeight="36"/>
 
                                 <TextBlock x:Name="PART_BreadcrumbEllipsisTextBlock"
                                            FontFamily="Segoe MDL2 Assets"
@@ -105,6 +114,7 @@
 
                     <local:ItemsRepeater x:Name="PART_BreadcrumbItemsRepeater"
                                          HorizontalAlignment="Left">
+                        
                         <local:ItemsRepeater.Layout>
                             <local:BreadcrumbLayout />
                         </local:ItemsRepeater.Layout>

--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -56,6 +56,7 @@ void BreadcrumbItem::OnApplyTemplate()
     if (const auto& breadcrumbItemButton = m_breadcrumbItemButton.get())
     {
         m_breadcrumbItemButtonLoadedRevoker = breadcrumbItemButton.Loaded(winrt::auto_revoke, { this, &BreadcrumbItem::OnLoadedEvent });
+        m_pointerOverButtonRevoker = RegisterPropertyChanged(breadcrumbItemButton, winrt::ButtonBase::IsPointerOverProperty(), { this, &BreadcrumbItem::OnVisualPropertyChanged });
     }
 }
 
@@ -86,6 +87,8 @@ void BreadcrumbItem::OnLoadedEvent(const winrt::IInspectable&, const winrt::Rout
     {
         ResetVisualProperties();
     }
+
+    UpdateCommonVisualState();
 }
 
 void BreadcrumbItem::SetParentBreadcrumb(const winrt::Breadcrumb& parent)
@@ -215,12 +218,15 @@ void BreadcrumbItem::CloseFlyout()
     }
 }
 
+void BreadcrumbItem::OnVisualPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&)
+{
+    UpdateCommonVisualState();
+}
+
 void BreadcrumbItem::UpdateVisualState()
 {
     const bool isLeftToRight = (FlowDirection() == winrt::FlowDirection::LeftToRight);
     hstring visualStateName;
-
-    // winrt::VisualStateManager::GoToState(*this, L"Rest", false);
 
     if (m_isEllipsisNode)
     {
@@ -250,6 +256,35 @@ void BreadcrumbItem::UpdateVisualState()
     }
 
     winrt::VisualStateManager::GoToState(*this, visualStateName, false);
+}
+
+void BreadcrumbItem::UpdateCommonVisualState()
+{
+    if (const auto& breadcrumbItemButton = m_breadcrumbItemButton.get())
+    {
+        if (m_isLastNode)
+        {
+            if (breadcrumbItemButton.IsPointerOver())
+            {
+                winrt::VisualStateManager::GoToState(*this, L"CurrentHover", false);
+            }
+            else
+            {
+                winrt::VisualStateManager::GoToState(*this, L"CurrentRest", false);
+            }
+        }
+        else
+        {
+            if (breadcrumbItemButton.IsPointerOver())
+            {
+                winrt::VisualStateManager::GoToState(*this, L"Hover", false);
+            }
+            else
+            {
+                winrt::VisualStateManager::GoToState(*this, L"Rest", false);
+            }
+        }
+    }
 }
 
 void BreadcrumbItem::OnEllipsisItemClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args)

--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -183,7 +183,14 @@ void BreadcrumbItem::OnChildPreviewKeyDown(const winrt::IInspectable& sender, co
 {
     if (args.Key() == winrt::VirtualKey::Enter)
     {
-        OnBreadcrumbItemClick(nullptr, nullptr);
+        if (m_isEllipsisNode)
+        {
+            OnEllipsisItemClick(nullptr, nullptr);
+        }
+        else
+        {
+            OnBreadcrumbItemClick(nullptr, nullptr);
+        }
         args.Handled(true);
     }
 }
@@ -306,7 +313,7 @@ void BreadcrumbItem::UpdateCommonVisualState()
     }
 }
 
-void BreadcrumbItem::OnEllipsisItemClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args)
+void BreadcrumbItem::OnEllipsisItemClick(const winrt::IInspectable&, const winrt::RoutedEventArgs&)
 {
     if (const auto& breadcrumb = m_parentBreadcrumb.get())
     {

--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -295,14 +295,14 @@ void BreadcrumbItem::UpdateCommonVisualState()
         }
         else if (breadcrumbItemButton.IsPointerOver())
         {
-            commonVisualStateName = commonVisualStateName + L"Hover";
+            commonVisualStateName = commonVisualStateName + L"PointerOver";
         }
         else
         {
-            commonVisualStateName = commonVisualStateName + L"Rest";
+            commonVisualStateName = commonVisualStateName + L"Normal";
         }
 
-        winrt::VisualStateManager::GoToState(*this, commonVisualStateName, false);
+        winrt::VisualStateManager::GoToState(breadcrumbItemButton, commonVisualStateName, false);
     }
 }
 

--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -220,6 +220,8 @@ void BreadcrumbItem::UpdateVisualState()
     const bool isLeftToRight = (FlowDirection() == winrt::FlowDirection::LeftToRight);
     hstring visualStateName;
 
+    // winrt::VisualStateManager::GoToState(*this, L"Rest", false);
+
     if (m_isEllipsisNode)
     {
         if (isLeftToRight)

--- a/dev/Breadcrumb/BreadcrumbItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbItem.cpp
@@ -137,13 +137,23 @@ void BreadcrumbItem::OnFlyoutElementPreparedEvent(winrt::ItemsRepeater sender, w
     const auto& element = args.Element();
 
     element.AddHandler(winrt::UIElement::PointerPressedEvent(),
-        winrt::box_value<winrt::PointerEventHandler>({this, &BreadcrumbItem::OnFlyoutElementClickEvent}),
+        winrt::box_value<winrt::PointerEventHandler>({ this, &BreadcrumbItem::OnFlyoutElementClickEvent }),
         true);
 
     // TODO: Investigate an RS2 or lower way to invoke via keyboard. Github issue #3997
     if (SharedHelpers::IsRS3OrHigher())
     {
         element.PreviewKeyDown({ this, &BreadcrumbItem::OnFlyoutElementKeyDownEvent });
+    }
+    else
+    {
+        // Prior to RS3, UIElement.PreviewKeyDown is not available.
+        AddRoutedEventHandler<RoutedEventType::KeyDown>(element.try_as<winrt::UIElement>(), 
+            [this](auto const& sender, auto const& args)
+            {
+                OnFlyoutElementKeyDownEvent(sender, nullptr);
+            },
+            true /*handledEventsToo*/);
     }
 }
 
@@ -176,7 +186,7 @@ void BreadcrumbItem::OnFlyoutElementClickEvent(const winrt::IInspectable& sender
 
 void BreadcrumbItem::OnFlowDirectionChanged(winrt::DependencyObject const&, winrt::DependencyProperty const&)
 {
-    UpdateVisualState();
+    UpdateItemTypeVisualState();
 }
 
 void BreadcrumbItem::OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args)
@@ -245,7 +255,7 @@ void BreadcrumbItem::OnVisualPropertyChanged(const winrt::DependencyObject&, con
     UpdateCommonVisualState();
 }
 
-void BreadcrumbItem::UpdateVisualState()
+void BreadcrumbItem::UpdateItemTypeVisualState()
 {
     const bool isLeftToRight = (FlowDirection() == winrt::FlowDirection::LeftToRight);
     hstring visualStateName;
@@ -337,7 +347,7 @@ void BreadcrumbItem::SetPropertiesForLastNode()
     m_isEllipsisNode = false;
     m_isLastNode = true;
 
-    UpdateVisualState();
+    UpdateItemTypeVisualState();
 }
 
 void BreadcrumbItem::ResetVisualProperties()
@@ -352,7 +362,7 @@ void BreadcrumbItem::ResetVisualProperties()
     m_ellipsisFlyout.set(nullptr);
     m_ellipsisItemsRepeater.set(nullptr);
 
-    UpdateVisualState();
+    UpdateItemTypeVisualState();
 }
 
 void BreadcrumbItem::InstantiateFlyout()
@@ -392,5 +402,5 @@ void BreadcrumbItem::SetPropertiesForEllipsisNode()
 
     InstantiateFlyout();
 
-    UpdateVisualState();
+    UpdateItemTypeVisualState();
 }

--- a/dev/Breadcrumb/BreadcrumbItem.h
+++ b/dev/Breadcrumb/BreadcrumbItem.h
@@ -35,12 +35,14 @@ private:
     void OnFlyoutElementClickEvent(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnFlowDirectionChanged(winrt::DependencyObject const&, winrt::DependencyProperty const&);
     void OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
+    void OnVisualPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
 
     void InstantiateFlyout();
     void OpenFlyout();
     void CloseFlyout();
 
     void UpdateVisualState();
+    void UpdateCommonVisualState();
 
     winrt::IInspectable CloneEllipsisItemSource(const winrt::Collections::IVector<winrt::IInspectable>& ellipsisItemsSource);
 
@@ -61,4 +63,5 @@ private:
     winrt::Button::Loaded_revoker m_breadcrumbItemButtonLoadedRevoker{};
     winrt::Button::Click_revoker m_breadcrumbItemButtonClickRevoker{};
     winrt::ItemsRepeater::ElementPrepared_revoker m_ellipsisRepeaterElementPreparedRevoker{};
+    PropertyChanged_revoker m_pointerOverButtonRevoker{};
 };

--- a/dev/Breadcrumb/BreadcrumbItem.h
+++ b/dev/Breadcrumb/BreadcrumbItem.h
@@ -42,7 +42,7 @@ private:
     void OpenFlyout();
     void CloseFlyout();
 
-    void UpdateVisualState();
+    void UpdateItemTypeVisualState();
     void UpdateCommonVisualState();
 
     winrt::IInspectable CloneEllipsisItemSource(const winrt::Collections::IVector<winrt::IInspectable>& ellipsisItemsSource);
@@ -68,6 +68,7 @@ private:
     PropertyChanged_revoker m_pressedButtonRevoker{};
     PropertyChanged_revoker m_pointerOverButtonRevoker{};
 
+    // Revokers for events that change visual state changes
     winrt::UIElement::PointerEntered_revoker m_breadcrumbItemPointerEnteredRevoker{};
     winrt::UIElement::PointerExited_revoker m_breadcrumbItemPointerExitedRevoker{};
     winrt::UIElement::PointerPressed_revoker m_breadcrumbItemPointerPressedRevoker{};
@@ -75,5 +76,6 @@ private:
     winrt::UIElement::PointerCanceled_revoker m_breadcrumbItemPointerCanceledRevoker{};
     winrt::UIElement::PointerCaptureLost_revoker m_breadcrumbItemPointerCaptureLostRevoker{};
 
-    
+    // Revokers for the ellipsis item flyout elements
+    RoutedEventHandler_revoker m_ellipsisItemKeyDownRevoker{};
 };

--- a/dev/Breadcrumb/BreadcrumbItem.h
+++ b/dev/Breadcrumb/BreadcrumbItem.h
@@ -63,7 +63,10 @@ private:
 
     winrt::Button::Loaded_revoker m_breadcrumbItemButtonLoadedRevoker{};
     winrt::Button::Click_revoker m_breadcrumbItemButtonClickRevoker{};
+    RoutedEventHandler_revoker m_breadcrumbItemKeyDownHandlerRevoker{};
+
     winrt::ItemsRepeater::ElementPrepared_revoker m_ellipsisRepeaterElementPreparedRevoker{};
+    winrt::ItemsRepeater::ElementClearing_revoker m_ellipsisRepeaterElementClearingRevoker{};
 
     PropertyChanged_revoker m_pressedButtonRevoker{};
     PropertyChanged_revoker m_pointerOverButtonRevoker{};
@@ -77,5 +80,5 @@ private:
     winrt::UIElement::PointerCaptureLost_revoker m_breadcrumbItemPointerCaptureLostRevoker{};
 
     // Revokers for the ellipsis item flyout elements
-    RoutedEventHandler_revoker m_ellipsisItemKeyDownRevoker{};
+    std::vector<RoutedEventHandler_revoker> m_ellipsisItemKeyDownRevokers;
 };

--- a/dev/Breadcrumb/BreadcrumbItem.h
+++ b/dev/Breadcrumb/BreadcrumbItem.h
@@ -36,6 +36,7 @@ private:
     void OnFlowDirectionChanged(winrt::DependencyObject const&, winrt::DependencyProperty const&);
     void OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
     void OnVisualPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
+    void OnPointerEvent(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
 
     void InstantiateFlyout();
     void OpenFlyout();
@@ -63,5 +64,16 @@ private:
     winrt::Button::Loaded_revoker m_breadcrumbItemButtonLoadedRevoker{};
     winrt::Button::Click_revoker m_breadcrumbItemButtonClickRevoker{};
     winrt::ItemsRepeater::ElementPrepared_revoker m_ellipsisRepeaterElementPreparedRevoker{};
+
+    PropertyChanged_revoker m_pressedButtonRevoker{};
     PropertyChanged_revoker m_pointerOverButtonRevoker{};
+
+    winrt::UIElement::PointerEntered_revoker m_breadcrumbItemPointerEnteredRevoker{};
+    winrt::UIElement::PointerExited_revoker m_breadcrumbItemPointerExitedRevoker{};
+    winrt::UIElement::PointerPressed_revoker m_breadcrumbItemPointerPressedRevoker{};
+    winrt::UIElement::PointerReleased_revoker m_breadcrumbItemPointerReleasedRevoker{};
+    winrt::UIElement::PointerCanceled_revoker m_breadcrumbItemPointerCanceledRevoker{};
+    winrt::UIElement::PointerCaptureLost_revoker m_breadcrumbItemPointerCaptureLostRevoker{};
+
+    
 };

--- a/dev/Breadcrumb/BreadcrumbLayout.cpp
+++ b/dev/Breadcrumb/BreadcrumbLayout.cpp
@@ -77,10 +77,10 @@ winrt::Size BreadcrumbLayout::MeasureOverride(winrt::NonVirtualizingLayoutContex
 void BreadcrumbLayout::ArrangeItem(const winrt::UIElement& breadcrumbItem, float& accumulatedWidths, float& maxElementHeight)
 {
     const winrt::Size elementSize = breadcrumbItem.DesiredSize();
-    const winrt::Rect arrangeRect(accumulatedWidths, 0, elementSize.Width, elementSize.Height);
+    const winrt::Rect arrangeRect(accumulatedWidths, 0, elementSize.Width, maxElementHeight);
     breadcrumbItem.Arrange(arrangeRect);
 
-    maxElementHeight = std::max(maxElementHeight, elementSize.Height);
+    // maxElementHeight = std::max(maxElementHeight, elementSize.Height);
     accumulatedWidths += elementSize.Width;
 }
 
@@ -121,6 +121,23 @@ int BreadcrumbLayout::GetFirstBreadcrumbItemToArrange(winrt::NonVirtualizingLayo
     return 0;
 }
 
+float BreadcrumbLayout::GetBreadcrumbItemsHeight(winrt::NonVirtualizingLayoutContext const& context, int firstItemToRender)
+{
+    float maxElementHeight{};
+
+    if (m_ellipsisIsRendered)
+    {
+        maxElementHeight = m_ellipsisButton.get().DesiredSize().Height;
+    }
+
+    for (uint32_t i = firstItemToRender; i < GetItemCount(context); ++i)
+    {
+        maxElementHeight = std::max(maxElementHeight, GetElementAt(context, i).DesiredSize().Height);
+    }
+
+    return maxElementHeight;
+}
+
 // Arranging is performed in a single step, as many elements are tried to be drawn going from the last element
 // towards the first one, if there's not enough space, then the ellipsis button is drawn
 winrt::Size BreadcrumbLayout::ArrangeOverride(winrt::NonVirtualizingLayoutContext const& context, winrt::Size const& finalSize)
@@ -139,7 +156,7 @@ winrt::Size BreadcrumbLayout::ArrangeOverride(winrt::NonVirtualizingLayoutContex
     }
 
     float accumulatedWidths{};
-    float maxElementHeight{};
+    float maxElementHeight = GetBreadcrumbItemsHeight(context, firstElementToRender);
 
     // If there is at least one element, we may render the ellipsis item
     if (itemCount > 0)

--- a/dev/Breadcrumb/BreadcrumbLayout.h
+++ b/dev/Breadcrumb/BreadcrumbLayout.h
@@ -34,6 +34,7 @@ private:
     void HideItem(const winrt::UIElement& breadcrumbItem);
     void HideItem(const winrt::NonVirtualizingLayoutContext& context, int index);
     int GetFirstBreadcrumbItemToArrange(winrt::NonVirtualizingLayoutContext const& context);
+    float GetBreadcrumbItemsHeight(winrt::NonVirtualizingLayoutContext const& context, int firstItemToRender);
 
     uint32_t GetItemCount(winrt::NonVirtualizingLayoutContext const& context);
     winrt::UIElement GetElementAt(winrt::NonVirtualizingLayoutContext const& context, uint32_t index);

--- a/dev/Breadcrumb/Breadcrumb_themeresources.xaml
+++ b/dev/Breadcrumb/Breadcrumb_themeresources.xaml
@@ -10,61 +10,57 @@
     <ResourceDictionary.ThemeDictionaries>
 
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbNormalForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
             <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
 
-            <StaticResource x:Key="BreadcrumbCurrentRestForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentNormalForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
             <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
 
-            <SolidColorBrush x:Key="BreadcrumbBackgroundBrush" Color="Transparent" Opacity="0.0"/>
-            <SolidColorBrush x:Key="BreadcrumbBorderBrush" Color="Transparent" Opacity="0.0"/>
-            <SolidColorBrush x:Key="BreadcrumbHoverBackgroundBrush" Color="Transparent" Opacity="0.0"/>
-            <SolidColorBrush x:Key="BreadcrumbHoverBorderBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbBackgroundBrush" Color="Transparent"/>
+            <SolidColorBrush x:Key="BreadcrumbBorderBrush" Color="Transparent"/>
 
             <StaticResource x:Key="BreadcrumbItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbNormalForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
             <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
 
-            <StaticResource x:Key="BreadcrumbCurrentRestForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentNormalForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
             <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
 
-            <SolidColorBrush x:Key="BreadcrumbBackgroundBrush" Color="Transparent" Opacity="0.0"/>
-            <SolidColorBrush x:Key="BreadcrumbBorderBrush" Color="Transparent" Opacity="0.0"/>
-            <SolidColorBrush x:Key="BreadcrumbHoverBackgroundBrush" Color="Transparent" Opacity="0.0"/>
-            <SolidColorBrush x:Key="BreadcrumbHoverBorderBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbBackgroundBrush" Color="Transparent"/>
+            <SolidColorBrush x:Key="BreadcrumbBorderBrush" Color="Transparent"/>
 
             <StaticResource x:Key="BreadcrumbItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbNormalForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
-            <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
-            <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
 
-            <StaticResource x:Key="BreadcrumbCurrentRestForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
-            <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
-            <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
-            <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentNormalForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
 
-            <StaticResource x:Key="BreadcrumbBackgroundBrush" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbBackgroundBrush" ResourceKey="SystemControlBackgroundBaseLowBrush" />
             <StaticResource x:Key="BreadcrumbBorderBrush" ResourceKey="SystemControlBackgroundBaseLowBrush" />
 
             <StaticResource x:Key="BreadcrumbItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />

--- a/dev/Breadcrumb/Breadcrumb_themeresources.xaml
+++ b/dev/Breadcrumb/Breadcrumb_themeresources.xaml
@@ -8,6 +8,31 @@
 
         <ResourceDictionary x:Key="Default">
             <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="ControlFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
+
+            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+
+            <StaticResource x:Key="BreadcrumbCurrentRestForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+
+            
+            <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="HighContrast">
+            <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="BFC1" ResourceKey="ControlFillColorTertiaryBrush" />
             <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
         </ResourceDictionary>

--- a/dev/Breadcrumb/Breadcrumb_themeresources.xaml
+++ b/dev/Breadcrumb/Breadcrumb_themeresources.xaml
@@ -1,7 +1,17 @@
-<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
+    <ResourceDictionary.ThemeDictionaries>
+
+        <ResourceDictionary x:Key="Default">
+            <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BFC1" ResourceKey="ControlFillColorTertiaryBrush" />
+            <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
+        </ResourceDictionary>
+        
+    </ResourceDictionary.ThemeDictionaries>
+    
 </ResourceDictionary>

--- a/dev/Breadcrumb/Breadcrumb_themeresources.xaml
+++ b/dev/Breadcrumb/Breadcrumb_themeresources.xaml
@@ -4,17 +4,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
+    <x:String x:Key="BreadcrumbChevronLeftToRight">&#xE76C;</x:String>
+    <x:String x:Key="BreadcrumbChevronRightToLeft">&#xE76B;</x:String>
+
     <ResourceDictionary.ThemeDictionaries>
 
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="ControlFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
-        </ResourceDictionary>
-
-        <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
-
             <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
@@ -27,14 +22,52 @@
             <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
 
-            
-            <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
+            <SolidColorBrush x:Key="BreadcrumbBackgroundBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbBorderBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbHoverBackgroundBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbHoverBorderBrush" Color="Transparent" Opacity="0.0"/>
+
+            <StaticResource x:Key="BreadcrumbItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
+        </ResourceDictionary>
+
+        <ResourceDictionary x:Key="Light">
+            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+
+            <StaticResource x:Key="BreadcrumbCurrentRestForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="TextFillColorSecondaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="TextFillColorPrimaryBrush" />
+
+            <SolidColorBrush x:Key="BreadcrumbBackgroundBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbBorderBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbHoverBackgroundBrush" Color="Transparent" Opacity="0.0"/>
+            <SolidColorBrush x:Key="BreadcrumbHoverBorderBrush" Color="Transparent" Opacity="0.0"/>
+
+            <StaticResource x:Key="BreadcrumbItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="SplitButtonForeground" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="BFC1" ResourceKey="ControlFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbRestForegroundColor2" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="BreadcrumbRestForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbHoverForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbPressedForegroundColor" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbDisabledForegroundColor" ResourceKey="SystemControlBackgroundBaseLowBrush" />
+            <StaticResource x:Key="BreadcrumbFocusForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+
+            <StaticResource x:Key="BreadcrumbCurrentRestForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentHoverForegroundColor" ResourceKey="SystemControlHighlightBaseHighBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentPressedForegroundColor" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentDisabledForegroundColor" ResourceKey="SystemControlBackgroundBaseLowBrush" />
+            <StaticResource x:Key="BreadcrumbCurrentFocusForegroundColor" ResourceKey="SystemControlForegroundBaseHighBrush" />
+
+            <StaticResource x:Key="BreadcrumbBackgroundBrush" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbBorderBrush" ResourceKey="SystemControlBackgroundBaseLowBrush" />
+
+            <StaticResource x:Key="BreadcrumbItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>
         
     </ResourceDictionary.ThemeDictionaries>

--- a/dev/Breadcrumb/TestUI/BreadcrumbPage.xaml
+++ b/dev/Breadcrumb/TestUI/BreadcrumbPage.xaml
@@ -43,7 +43,7 @@
                                       VerticalAlignment="Stretch"
                                       Grid.Column="1">
                     <controls:TwoPaneView.Pane1>
-                        <Grid x:Name="Pane1Content" AutomationProperties.Name="Pane1Content" Background="{ThemeResource SystemChromeDisabledHighColor}">
+                        <Grid x:Name="Pane1Content" AutomationProperties.Name="Pane1Content">
 
                             <Border x:Name="Content1Border" AutomationProperties.Name="Content1Border" BorderThickness="5" Padding="7">
                                 <Grid>


### PR DESCRIPTION
Adds keyboard navigation functionality for machines with RS2 or below

## Description
Adds AddRoutedEventHandler calls as an alternative for OnPreviewKeyDown for RS2 and previous versions of windows.

## Motivation and Context
Fixes #3997 

## How Has This Been Tested?
This change was tested in a RS2 virtual machine

## Screenshots (if appropriate):
![BreadCrumbKeyboardRs2](https://user-images.githubusercontent.com/35784165/107069496-e6363680-6796-11eb-8b06-2801b6d03473.gif)