### PR TITLE
Adding HyperlinkUnderlineVisible resource for Hyperlink(Button)

### DIFF
--- a/dev/CommonStyles/Hyperlink_themeresources.xaml
+++ b/dev/CommonStyles/Hyperlink_themeresources.xaml
@@ -19,4 +19,6 @@
             <StaticResource x:Key="HyperlinkForegroundPressed" ResourceKey="AccentTextFillColorTertiaryBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+    
+    <x:Boolean x:Key="HyperlinkUnderlineVisible">False</x:Boolean>
 </ResourceDictionary>

--- a/dev/CommonStyles/ListViewItem_themeresources_21h1.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources_21h1.xaml
@@ -4,7 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <x:Boolean x:Key="ListViewBaseItemRoundedChromeEnabled">True</x:Boolean>
             <x:Boolean x:Key='ListViewItemSelectionIndicatorVisualEnabled'>True</x:Boolean>
             <x:Double x:Key="ListViewItemContentOffsetX">-40.5</x:Double>
             <x:Double x:Key="ListViewItemDisabledThemeOpacity">0.3</x:Double>
@@ -83,7 +82,6 @@
             <StaticResource x:Key="ListViewItemSelectionIndicatorDisabledBrush" ResourceKey="AccentAAFillColorDisabledBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <x:Boolean x:Key="ListViewBaseItemRoundedChromeEnabled">True</x:Boolean>
             <x:Boolean x:Key='ListViewItemSelectionIndicatorVisualEnabled'>True</x:Boolean>
             <x:Double x:Key="ListViewItemContentOffsetX">-40.5</x:Double>
             <x:Double x:Key="ListViewItemDisabledThemeOpacity">0.3</x:Double>
@@ -162,7 +160,6 @@
             <SolidColorBrush x:Key="ListViewItemSelectionIndicatorDisabledBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <x:Boolean x:Key="ListViewBaseItemRoundedChromeEnabled">True</x:Boolean>
             <x:Boolean x:Key='ListViewItemSelectionIndicatorVisualEnabled'>True</x:Boolean>
             <x:Double x:Key="ListViewItemContentOffsetX">-40.5</x:Double>
             <x:Double x:Key="ListViewItemDisabledThemeOpacity">0.3</x:Double>
@@ -240,6 +237,8 @@
             <StaticResource x:Key="ListViewItemSelectionIndicatorDisabledBrush" ResourceKey="AccentAAFillColorDisabledBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+
+    <x:Boolean x:Key="ListViewBaseItemRoundedChromeEnabled">True</x:Boolean>
 
     <Style TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}" />
 

--- a/dev/CommonStyles/TestUI/CommonStylesPage.xaml
+++ b/dev/CommonStyles/TestUI/CommonStylesPage.xaml
@@ -142,11 +142,14 @@
                             </CommandBar.SecondaryCommands>
                         </CommandBar>
                         <RichEditBox x:Name="RichEditBox" Grid.Row="6" Header="RichEditBox" HorizontalAlignment="Right" VerticalAlignment="Top"/>
-                        <TextBlock Grid.Row="7">
-                            <Run>Pre-hyperlink</Run>
-                            <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>
-                            <Run>Post-hyperlink</Run>
-                        </TextBlock>
+                        <StackPanel Orientation="Horizontal" Grid.Row="7">
+                            <TextBlock Margin="2,0,2,0">
+                                <Run>Pre-hyperlink</Run>
+                                <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>
+                                <Run>Post-hyperlink</Run>
+                            </TextBlock>
+                            <HyperlinkButton Margin="2,0,2,0" Content="Microsoft.com HyperlinkButton" NavigateUri="http://www.microsoft.com"/>
+                        </StackPanel>
                     </Grid>
                 </StackPanel>
                 <StackPanel Style="{ThemeResource CompactPanelStyle}">
@@ -221,11 +224,14 @@
                             </CommandBar.SecondaryCommands>
                         </CommandBar>
                         <RichEditBox Grid.Row="6" Header="RichEditBox" VerticalAlignment="Top" />
-                        <TextBlock Grid.Row="7">
-                            <Run>Pre-hyperlink</Run>
-                            <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>
-                            <Run>Post-hyperlink</Run>
-                        </TextBlock>
+                        <StackPanel Orientation="Horizontal" Grid.Row="7">
+                            <TextBlock Margin="2,0,2,0">
+                                <Run>Pre-hyperlink</Run>
+                                <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>
+                                <Run>Post-hyperlink</Run>
+                            </TextBlock>
+                            <HyperlinkButton Margin="2,0,2,0" Content="Microsoft.com HyperlinkButton" NavigateUri="http://www.microsoft.com"/>
+                        </StackPanel>
                     </Grid>
                 </StackPanel>
                 <StackPanel Style="{ThemeResource CompactPanelStyle}">


### PR DESCRIPTION
Adding the HyperlinkUnderlineVisible resource for the Hyperlink and HyperlinkButton components.

This is part of internal task 30997431.
The new resource is similar to ListViewBaseItem's ListViewBaseItemRoundedChromeEnabled which I moved out of the theme-specific sections as a single declaration is enough.

Tested the behavior in conjunction with the task 30997431 changes in 21H1 OS.