### PR TITLE
ScrollBar: Update delay before collapsing

### DIFF
--- a/dev/ScrollBar/ScrollBar_themeresources.xaml
+++ b/dev/ScrollBar/ScrollBar_themeresources.xaml
@@ -199,7 +199,7 @@
 
     <x:Double x:Key="ScrollBarButtonArrowIconFontSize">8</x:Double>
     <x:String x:Key="ScrollBarExpandBeginTime">00:00:00.40</x:String>
-    <x:String x:Key="ScrollBarContractBeginTime">00:00:02.00</x:String>
+    <x:String x:Key="ScrollBarContractBeginTime">00:00:00.50</x:String>
     <CornerRadius x:Key="ScrollBarCornerRadius">3</CornerRadius>
 
     <primitives:CornerRadiusFilterConverter x:Key="TopLeftCornerRadiusDoubleValueConverter8x" Filter="TopLeftValue" Scale="8"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the delay time that the ScrollBar will wait before going to Collapsed state from Expanded state.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
The old delay was equal to 2s what is currently considered to be a bit too slow.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
New Delay:
![new_delay](https://user-images.githubusercontent.com/21356912/107298120-9cb14a00-6a29-11eb-8dcf-b2a58b7ee113.gif) 
Old delay:
![old_delay](https://user-images.githubusercontent.com/21356912/107298338-07628580-6a2a-11eb-9f7c-5cf85074bf7e.gif)