### PR TITLE
RuntimeProfiler: catch the exception in case application instance is null

### DIFF
--- a/dev/Telemetry/RuntimeProfiler.cpp
+++ b/dev/Telemetry/RuntimeProfiler.cpp
@@ -262,11 +262,19 @@ namespace RuntimeProfiler {
         
         //  Since MUX doesn't piggyback the WUX Extension suspend handler,
         //  we sign up for suspension notifications.
-        winrt::Application::Current().Suspending(([](auto &, auto &)
-            {
-                FireEvent(true);
-            }
-        ));
+        try
+        {
+            winrt::Application::Current().Suspending(([](auto&, auto&)
+                {
+                    FireEvent(true);
+                }
+            ));
+        }
+        catch (winrt::hresult_error e)
+        {
+            // We might not have an Application instance object in XamlPresenter scenarios
+            // because we don't need it.
+        }
 
         return ((nullptr != g_pTimer)?TRUE:FALSE);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running xaml in a desktop process in XamlPresenter mode, we might not have an Application instance object. 
Trying to get it in the telemetry will throw an exception and crash the app.
This code change will catch the exception and simply 'eat' it if it's thrown.