### PR TITLE
Update the nuget readme with instructions of how to do app level overrides of Winui2 resources.

### DIFF
--- a/build/NuSpecs/readme.txt
+++ b/build/NuSpecs/readme.txt
@@ -8,7 +8,7 @@ Don't forget to set XamlControlsResources as your Application resources in App.x
         </Application.Resources>
     </Application>
 
-If you have other resources then we recommend you add those to the XamlControlsResources' MergedDictionaries.
+If you have other resources, then we recommend you add those to the XamlControlsResources' MergedDictionaries.
 This works with the platform's resource system to allow overrides of the XamlControlsResources resources.
 
 <Application

--- a/build/NuSpecs/readme.txt
+++ b/build/NuSpecs/readme.txt
@@ -14,18 +14,16 @@ This works with the platform's resource system to allow overrides of the XamlCon
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"/>
 
-    ...
-
-    <Application.Resources>
-        <ResourceDictionary>
-            <controls:XamlControlsResources />
+    <Application>
+        <Application.Resources>
+            <controls:XamlControlsResources>
                 <controls:XamlControlsResources.MergedDictionaries>
                     <!-- Other app resources here -->
                 </controls:XamlControlsResources.MergedDictionaries>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Application.Resources>
+            </controls:XamlControlsResources>
+        </Application.Resources>
+    </Application>
 
 See http://aka.ms/winui for more information.

--- a/build/NuSpecs/readme.txt
+++ b/build/NuSpecs/readme.txt
@@ -11,19 +11,17 @@ Don't forget to set XamlControlsResources as your Application resources in App.x
 If you have other resources then we recommend you add those to the XamlControlsResources' MergedDictionaries.
 This works with the platform's resource system to allow overrides of the XamlControlsResources resources.
 
-<ResourceDictionary
+<Application
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Microsoft.UI.Xaml.Controls"/>
-
-    <Application>
-        <Application.Resources>
-            <controls:XamlControlsResources>
-                <controls:XamlControlsResources.MergedDictionaries>
-                    <!-- Other app resources here -->
-                </controls:XamlControlsResources.MergedDictionaries>
-            </controls:XamlControlsResources>
-        </Application.Resources>
-    </Application>
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    <Application.Resources>
+        <controls:XamlControlsResources>
+            <controls:XamlControlsResources.MergedDictionaries>
+                <!-- Other app resources here -->
+            </controls:XamlControlsResources.MergedDictionaries>
+        </controls:XamlControlsResources>
+    </Application.Resources>
+</Application>
 
 See http://aka.ms/winui for more information.

--- a/build/NuSpecs/readme.txt
+++ b/build/NuSpecs/readme.txt
@@ -8,15 +8,23 @@ Don't forget to set XamlControlsResources as your Application resources in App.x
         </Application.Resources>
     </Application>
 
-or if you have other resources then add XamlControlsResources at the top as a merged dictionary:
+If you have other resources then we recommend you add those to the XamlControlsResources' MergedDictionaries.
+This works with the platform's resource system to allow overrides of the XamlControlsResources resources.
+
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+
+    ...
 
     <Application.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
+            <controls:XamlControlsResources />
+                <controls:XamlControlsResources.MergedDictionaries>
+                    <!-- Other app resources here -->
+                </controls:XamlControlsResources.MergedDictionaries>
             </ResourceDictionary.MergedDictionaries>
-            <!-- Other app resources here -->
         </ResourceDictionary>
     </Application.Resources>
 


### PR DESCRIPTION
The resource lookup system is extremely complicated.  In order to work with the system's features and bugs we are recommending that users put there app.xaml resources in the XamlControlsResources' MergedDictionaries.  This allows the system to app author overrides of resources defined in Theme Dictionaries.