### PR TITLE
Add Version and StylesVersion back

### DIFF
--- a/dev/Generated/XamlControlsResources.properties.cpp
+++ b/dev/Generated/XamlControlsResources.properties.cpp
@@ -15,6 +15,7 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 
 GlobalDependencyProperty XamlControlsResourcesProperties::s_ControlsResourcesVersionProperty{ nullptr };
 GlobalDependencyProperty XamlControlsResourcesProperties::s_UseCompactResourcesProperty{ nullptr };
+GlobalDependencyProperty XamlControlsResourcesProperties::s_VersionProperty{ nullptr };
 
 XamlControlsResourcesProperties::XamlControlsResourcesProperties()
 {
@@ -45,12 +46,24 @@ void XamlControlsResourcesProperties::EnsureProperties()
                 ValueHelper<bool>::BoxValueIfNecessary(false),
                 winrt::PropertyChangedCallback(&OnUseCompactResourcesPropertyChanged));
     }
+    if (!s_VersionProperty)
+    {
+        s_VersionProperty =
+            InitializeDependencyProperty(
+                L"Version",
+                winrt::name_of<winrt::StylesVersion>(),
+                winrt::name_of<winrt::XamlControlsResources>(),
+                false /* isAttached */,
+                ValueHelper<winrt::StylesVersion>::BoxValueIfNecessary(winrt::StylesVersion::WinUI_2dot5),
+                winrt::PropertyChangedCallback(&OnVersionPropertyChanged));
+    }
 }
 
 void XamlControlsResourcesProperties::ClearProperties()
 {
     s_ControlsResourcesVersionProperty = nullptr;
     s_UseCompactResourcesProperty = nullptr;
+    s_VersionProperty = nullptr;
 }
 
 void XamlControlsResourcesProperties::OnControlsResourcesVersionPropertyChanged(
@@ -62,6 +75,14 @@ void XamlControlsResourcesProperties::OnControlsResourcesVersionPropertyChanged(
 }
 
 void XamlControlsResourcesProperties::OnUseCompactResourcesPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::XamlControlsResources>();
+    winrt::get_self<XamlControlsResources>(owner)->OnPropertyChanged(args);
+}
+
+void XamlControlsResourcesProperties::OnVersionPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
@@ -93,4 +114,17 @@ void XamlControlsResourcesProperties::UseCompactResources(bool value)
 bool XamlControlsResourcesProperties::UseCompactResources()
 {
     return ValueHelper<bool>::CastOrUnbox(static_cast<XamlControlsResources*>(this)->GetValue(s_UseCompactResourcesProperty));
+}
+
+void XamlControlsResourcesProperties::Version(winrt::StylesVersion const& value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<XamlControlsResources*>(this)->SetValue(s_VersionProperty, ValueHelper<winrt::StylesVersion>::BoxValueIfNecessary(value));
+    }
+}
+
+winrt::StylesVersion XamlControlsResourcesProperties::Version()
+{
+    return ValueHelper<winrt::StylesVersion>::CastOrUnbox(static_cast<XamlControlsResources*>(this)->GetValue(s_VersionProperty));
 }

--- a/dev/Generated/XamlControlsResources.properties.h
+++ b/dev/Generated/XamlControlsResources.properties.h
@@ -15,11 +15,16 @@ public:
     void UseCompactResources(bool value);
     bool UseCompactResources();
 
+    void Version(winrt::StylesVersion const& value);
+    winrt::StylesVersion Version();
+
     static winrt::DependencyProperty ControlsResourcesVersionProperty() { return s_ControlsResourcesVersionProperty; }
     static winrt::DependencyProperty UseCompactResourcesProperty() { return s_UseCompactResourcesProperty; }
+    static winrt::DependencyProperty VersionProperty() { return s_VersionProperty; }
 
     static GlobalDependencyProperty s_ControlsResourcesVersionProperty;
     static GlobalDependencyProperty s_UseCompactResourcesProperty;
+    static GlobalDependencyProperty s_VersionProperty;
 
     static void EnsureProperties();
     static void ClearProperties();
@@ -29,6 +34,10 @@ public:
         winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnUseCompactResourcesPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnVersionPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -41,6 +41,13 @@ void XamlControlsResources::OnPropertyChanged(const winrt::DependencyPropertyCha
         // Source link depends on ControlsResourcesVersion and UseCompactResources flag, we need to update it when either property changed
         UpdateSource();
     }
+
+    // To be deleted
+    // Version is going to be replaced with ControlsResourcesVersion
+    else if (property == s_VersionProperty)
+    {
+        ControlsResourcesVersion(Version() == winrt::StylesVersion::Latest ? winrt::ControlsResourcesVersion::Version2 : winrt::ControlsResourcesVersion::Version1);
+    }
 }
 
 void XamlControlsResources::UpdateSource()

--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -144,6 +144,15 @@ namespace MU_XC_NAMESPACE
         Version2 = 2,
     };
 
+    // To be removed
+    [MUX_PREVIEW]
+    [webhosthidden]
+    enum StylesVersion
+    {
+        Latest = 0,
+        WinUI_2dot5 = 1,
+    };
+
     [MUX_PUBLIC]
     [webhosthidden]
     [default_interface]
@@ -168,6 +177,15 @@ namespace MU_XC_NAMESPACE
             ControlsResourcesVersion ControlsResourcesVersion{ get; set; };
 
             static Windows.UI.Xaml.DependencyProperty ControlsResourcesVersionProperty{ get; };
+        }
+
+        // To be removed
+        [MUX_PREVIEW]
+        {
+            [MUX_DEFAULT_VALUE("winrt::StylesVersion::WinUI_2dot5")]
+            StylesVersion Version{ get; set; };
+
+            static Windows.UI.Xaml.DependencyProperty VersionProperty{ get; };
         }
     }
 }


### PR DESCRIPTION
Version was replaced with ControlsResourcesVersion in public API.
Add Version and StylesVersion back to reduce the customer impact.
but it will be finally removed from MUX in a very near future.