### PR TITLE
Move MUX Effects to private namespace

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -193,7 +193,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RevealBrush", "dev\Material
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Effects", "Effects", "{73E823BC-5485-4F26-9B09-8B83C133EE6B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.UI.Composition.Effects", "dev\Effects\Microsoft.UI.Composition.Effects.vcxitems", "{1522A856-17CE-4178-A6B3-0692F90D7C55}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.UI.Private.Composition.Effects", "dev\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems", "{1522A856-17CE-4178-A6B3-0692F90D7C55}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TreeView", "TreeView", "{0A38E3C5-3CFA-42EB-860C-395A861B6791}"
 EndProject
@@ -740,7 +740,7 @@ Global
 		dev\TwoPaneView\InteractionTests\TwoPaneView_InteractionTests.projitems*{1294409d-9bad-40cc-a74d-9ab29b343071}*SharedItemsImports = 13
 		dev\NumberBox\TestUI\NumberBox_TestUI.projitems*{13da8235-d04f-46d4-b5b4-f5ae774eeede}*SharedItemsImports = 13
 		dev\MenuBar\MenuBar_InteractionTests\MenuBar_InteractionTests.projitems*{1440a7b7-d3ca-4390-8c85-e1e9a7df8542}*SharedItemsImports = 13
-		dev\Effects\Microsoft.UI.Composition.Effects.vcxitems*{1522a856-17ce-4178-a6b3-0692f90d7c55}*SharedItemsImports = 9
+		dev\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems*{1522a856-17ce-4178-a6b3-0692f90d7c55}*SharedItemsImports = 9
 		dev\CommandBarFlyout\InteractionTests\CommandBarFlyout_InteractionTests.projitems*{16f32f80-a8b6-44e0-9d99-0e1c2c8e0579}*SharedItemsImports = 13
 		dev\TeachingTip\APITests\TeachingTip_APITests.projitems*{18f1db69-7457-461c-9d19-7f42bffc0803}*SharedItemsImports = 13
 		dev\IconSource\IconSource.vcxitems*{19ffff77-4814-4ad6-acd7-42c6a50ab0d8}*SharedItemsImports = 9
@@ -871,7 +871,7 @@ Global
 		dev\ContentDialog\ContentDialog.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\DatePicker\DatePicker.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\DropDownButton\DropDownButton.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\Effects\Microsoft.UI.Composition.Effects.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
+		dev\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Expander\Expander.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\FlipView\FlipView.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\IconSource\IconSource.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4

--- a/MUXControlsInnerLoop.sln
+++ b/MUXControlsInnerLoop.sln
@@ -118,7 +118,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RevealBrush", "dev\Material
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Effects", "Effects", "{73E823BC-5485-4F26-9B09-8B83C133EE6B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.UI.Composition.Effects", "dev\Effects\Microsoft.UI.Composition.Effects.vcxitems", "{1522A856-17CE-4178-A6B3-0692F90D7C55}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.UI.Private.Composition.Effects", "dev\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems", "{1522A856-17CE-4178-A6B3-0692F90D7C55}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TreeView", "TreeView", "{0A38E3C5-3CFA-42EB-860C-395A861B6791}"
 EndProject
@@ -552,7 +552,7 @@ Global
 		dev\TwoPaneView\InteractionTests\TwoPaneView_InteractionTests.projitems*{1294409d-9bad-40cc-a74d-9ab29b343071}*SharedItemsImports = 13
 		dev\NumberBox\TestUI\NumberBox_TestUI.projitems*{13da8235-d04f-46d4-b5b4-f5ae774eeede}*SharedItemsImports = 13
 		dev\MenuBar\MenuBar_InteractionTests\MenuBar_InteractionTests.projitems*{1440a7b7-d3ca-4390-8c85-e1e9a7df8542}*SharedItemsImports = 13
-		dev\Effects\Microsoft.UI.Composition.Effects.vcxitems*{1522a856-17ce-4178-a6b3-0692f90d7c55}*SharedItemsImports = 9
+		dev\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems*{1522a856-17ce-4178-a6b3-0692f90d7c55}*SharedItemsImports = 9
 		dev\CommandBarFlyout\InteractionTests\CommandBarFlyout_InteractionTests.projitems*{16f32f80-a8b6-44e0-9d99-0e1c2c8e0579}*SharedItemsImports = 13
 		dev\TeachingTip\APITests\TeachingTip_APITests.projitems*{18f1db69-7457-461c-9d19-7f42bffc0803}*SharedItemsImports = 13
 		dev\IconSource\IconSource.vcxitems*{19ffff77-4814-4ad6-acd7-42c6a50ab0d8}*SharedItemsImports = 9
@@ -667,7 +667,7 @@ Global
 		dev\CommonStyles\CommonStyles.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Common\Common.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\DropDownButton\DropDownButton.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\Effects\Microsoft.UI.Composition.Effects.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
+		dev\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\IconSource\IconSource.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Lights\Lights.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\Materials\Acrylic\AcrylicBrush.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4

--- a/dev/ColorPicker/SpectrumBrush.cpp
+++ b/dev/ColorPicker/SpectrumBrush.cpp
@@ -52,7 +52,7 @@ void SpectrumBrush::CreateSpectrumBrush()
 {
     winrt::Compositor compositor = winrt::Window::Current().Compositor();
 
-    m_brushEffect = winrt::make_self<Microsoft::UI::Composition::Effects::CrossFadeEffect>();
+    m_brushEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::CrossFadeEffect>();
     m_brushEffect->Source1(winrt::CompositionEffectSourceParameter{ L"MinSurface" });
     m_brushEffect->Source2(winrt::CompositionEffectSourceParameter{ L"MaxSurface" });
     m_brushEffect->Weight(static_cast<float>(MaxSurfaceOpacity()));

--- a/dev/ColorPicker/SpectrumBrush.h
+++ b/dev/ColorPicker/SpectrumBrush.h
@@ -10,7 +10,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 6101)  // Returning uninitialized memory '<value>'.  A successful path through the function does not set the named _Out_ parameter.
-#include <Microsoft.UI.Composition.Effects_impl.h>
+#include <Microsoft.UI.Private.Composition.Effects_impl.h>
 #pragma warning(pop)
 
 
@@ -36,6 +36,6 @@ private:
     winrt::CompositionSurfaceBrush m_minSurfaceBrush{ nullptr };
     winrt::CompositionSurfaceBrush m_maxSurfaceBrush{ nullptr };
 
-    com_ptr<Microsoft::UI::Composition::Effects::CrossFadeEffect> m_brushEffect{ nullptr };
+    com_ptr<Microsoft::UI::Private::Composition::Effects::CrossFadeEffect> m_brushEffect{ nullptr };
     winrt::CompositionEffectBrush m_brush{ nullptr };
 };

--- a/dev/Effects/Microsoft.UI.Private.Composition.Effects.vcxitems
+++ b/dev/Effects/Microsoft.UI.Private.Composition.Effects.vcxitems
@@ -15,10 +15,10 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="$(MSBuildThisFileDirectory)microsoft.ui.composition.effects_impl.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Microsoft.UI.Private.Composition.Effects_impl.h" />
   </ItemGroup>
   <ItemGroup>
-    <Midl Include="$(MSBuildThisFileDirectory)microsoft.ui.composition.effects.idl" Condition="$(BuildingWithBuildExe) != 'true'">
+    <Midl Include="$(MSBuildThisFileDirectory)Microsoft.UI.Private.Composition.Effects.idl" Condition="$(BuildingWithBuildExe) != 'true'">
       <AdditionalIncludeDirectories>$(MSBuildProjectDirectory)\..;$(MiniWindowsSDKIncludePath)</AdditionalIncludeDirectories>
       <AdditionalMetadataDirectories Condition="'$(MiniWindowsSDKWinMDPath)'!=''">$(MiniWindowsSDKWinMDPath)</AdditionalMetadataDirectories>
       <OutputDirectory>$(OutDir)</OutputDirectory>

--- a/dev/Effects/microsoft.ui.private.composition.effects.idl
+++ b/dev/Effects/microsoft.ui.private.composition.effects.idl
@@ -20,7 +20,7 @@
     [MUXCONTROLS_VERSION_ATTRIBUTE] \
 
 
-namespace Microsoft.UI.Composition.Effects
+namespace Microsoft.UI.Private.Composition.Effects
 {
     //----------------------------------------------------------------------------------------------
     // Common enums
@@ -237,11 +237,11 @@ namespace Microsoft.UI.Composition.Effects
     [uuid(31602441-15db-5b4a-98dd-ba4247548b40), exclusiveto(BorderEffect)]
     interface IBorderEffect : IInspectable
     {
-        [propget] HRESULT ExtendX([out, retval] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior* value);
-        [propput] HRESULT ExtendX([in] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior value);
+        [propget] HRESULT ExtendX([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasEdgeBehavior* value);
+        [propput] HRESULT ExtendX([in] Microsoft.UI.Private.Composition.Effects.CanvasEdgeBehavior value);
 
-        [propget] HRESULT ExtendY([out, retval] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior* value);
-        [propput] HRESULT ExtendY([in] Microsoft.UI.Composition.Effects.CanvasEdgeBehavior value);
+        [propget] HRESULT ExtendY([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasEdgeBehavior* value);
+        [propput] HRESULT ExtendY([in] Microsoft.UI.Private.Composition.Effects.CanvasEdgeBehavior value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -264,8 +264,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT ColorMatrix([out, retval] Matrix5x4* value);
         [propput] HRESULT ColorMatrix([in] Matrix5x4 value);
 
-        [propget] HRESULT AlphaMode([out, retval] Microsoft.UI.Composition.Effects.CanvasAlphaMode* value);
-        [propput] HRESULT AlphaMode([in] Microsoft.UI.Composition.Effects.CanvasAlphaMode value);
+        [propget] HRESULT AlphaMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasAlphaMode* value);
+        [propput] HRESULT AlphaMode([in] Microsoft.UI.Private.Composition.Effects.CanvasAlphaMode value);
 
         [propget] HRESULT ClampOutput([out, retval] boolean* value);
         [propput] HRESULT ClampOutput([in] boolean value);
@@ -307,8 +307,8 @@ namespace Microsoft.UI.Composition.Effects
     [uuid(58360908-1b6b-4302-8ecd-cc24b26f27b0), exclusiveto(CompositeStepEffect)]
     interface ICompositeStepEffect : IInspectable
     {
-        [propget] HRESULT Mode([out, retval] Microsoft.UI.Composition.Effects.CanvasComposite* value);
-        [propput] HRESULT Mode([in] Microsoft.UI.Composition.Effects.CanvasComposite value);
+        [propget] HRESULT Mode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasComposite* value);
+        [propput] HRESULT Mode([in] Microsoft.UI.Private.Composition.Effects.CanvasComposite value);
 
         [propget] HRESULT Destination([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Destination([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -397,8 +397,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT HeightMapKernelSize([out, retval] Windows.Foundation.Numerics.Vector2* value);
         [propput] HRESULT HeightMapKernelSize([in] Windows.Foundation.Numerics.Vector2 value);
 
-        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -439,8 +439,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT HeightMapKernelSize([out, retval] Windows.Foundation.Numerics.Vector2* value);
         [propput] HRESULT HeightMapKernelSize([in] Windows.Foundation.Numerics.Vector2 value);
 
-        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -745,8 +745,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT HeightMapKernelSize([out, retval] Windows.Foundation.Numerics.Vector2* value);
         [propput] HRESULT HeightMapKernelSize([in] Windows.Foundation.Numerics.Vector2 value);
 
-        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -784,8 +784,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT HeightMapKernelSize([out, retval] Windows.Foundation.Numerics.Vector2* value);
         [propput] HRESULT HeightMapKernelSize([in] Windows.Foundation.Numerics.Vector2 value);
 
-        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -874,8 +874,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT Intensity([out, retval] float* value);
         [propput] HRESULT Intensity([in] float value);
 
-        [propget] HRESULT AlphaMode([out, retval] Microsoft.UI.Composition.Effects.CanvasAlphaMode* value);
-        [propput] HRESULT AlphaMode([in] Microsoft.UI.Composition.Effects.CanvasAlphaMode value);
+        [propget] HRESULT AlphaMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasAlphaMode* value);
+        [propput] HRESULT AlphaMode([in] Microsoft.UI.Private.Composition.Effects.CanvasAlphaMode value);
         
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -919,8 +919,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT HeightMapKernelSize([out, retval] Windows.Foundation.Numerics.Vector2* value);
         [propput] HRESULT HeightMapKernelSize([in] Windows.Foundation.Numerics.Vector2 value);
 
-        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -967,8 +967,8 @@ namespace Microsoft.UI.Composition.Effects
         [propget] HRESULT HeightMapKernelSize([out, retval] Windows.Foundation.Numerics.Vector2* value);
         [propput] HRESULT HeightMapKernelSize([in] Windows.Foundation.Numerics.Vector2 value);
 
-        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT HeightMapInterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT HeightMapInterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT Source([out, retval] Windows.Graphics.Effects.IGraphicsEffectSource** source);
         [propput] HRESULT Source([in] Windows.Graphics.Effects.IGraphicsEffectSource* source);
@@ -1036,8 +1036,8 @@ namespace Microsoft.UI.Composition.Effects
     [uuid(4467d118-33e7-5b1a-87c2-0f1f0497353c), exclusiveto(Transform2DEffect)]
     interface ITransform2DEffect : IInspectable
     {
-        [propget] HRESULT InterpolationMode([out, retval] Microsoft.UI.Composition.Effects.CanvasImageInterpolation* value);
-        [propput] HRESULT InterpolationMode([in] Microsoft.UI.Composition.Effects.CanvasImageInterpolation value);
+        [propget] HRESULT InterpolationMode([out, retval] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation* value);
+        [propput] HRESULT InterpolationMode([in] Microsoft.UI.Private.Composition.Effects.CanvasImageInterpolation value);
 
         [propget] HRESULT BorderMode([out, retval] EffectBorderMode* value);
         [propput] HRESULT BorderMode([in] EffectBorderMode value);

--- a/dev/Effects/microsoft.ui.private.composition.effects_impl.h
+++ b/dev/Effects/microsoft.ui.private.composition.effects_impl.h
@@ -114,7 +114,7 @@ inline winrt::IPropertyValue& to_winrt(abi::IPropertyValue*& instance)
 }
 
 
-namespace Microsoft { namespace UI { namespace Composition { namespace Effects
+namespace Microsoft { namespace UI { namespace Private { namespace Composition { namespace Effects
 {
     // Base class for Win2D-like effect descriptions
     class EffectBase : 
@@ -279,7 +279,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class AlphaMaskEffect : 
-        public winrt::Microsoft::UI::Composition::Effects::implementation::AlphaMaskEffectT<AlphaMaskEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::AlphaMaskEffectT<AlphaMaskEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1AlphaMask);
@@ -289,7 +289,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class ArithmeticCompositeEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::ArithmeticCompositeEffectT<ArithmeticCompositeEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::ArithmeticCompositeEffectT<ArithmeticCompositeEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1ArithmeticComposite);
@@ -332,7 +332,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class BlendEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::BlendEffectT<BlendEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::BlendEffectT<BlendEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Blend);
@@ -360,7 +360,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class BorderEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::BorderEffectT<BorderEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::BorderEffectT<BorderEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Border);
@@ -391,7 +391,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class ColorMatrixEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::ColorMatrixEffectT<ColorMatrixEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::ColorMatrixEffectT<ColorMatrixEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1ColorMatrix);
@@ -435,7 +435,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class ColorSourceEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::ColorSourceEffectT<ColorSourceEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::ColorSourceEffectT<ColorSourceEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Flood);
@@ -465,7 +465,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     // We declare a simplified single-step composite effect between two sources.
 
     class CompositeStepEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::CompositeStepEffectT<CompositeStepEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::CompositeStepEffectT<CompositeStepEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Composite);
@@ -493,7 +493,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class ContrastEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::ContrastEffectT<ContrastEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::ContrastEffectT<ContrastEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Contrast);
@@ -524,7 +524,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class CrossFadeEffect : 
-        public winrt::Microsoft::UI::Composition::Effects::implementation::CrossFadeEffectT<CrossFadeEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::CrossFadeEffectT<CrossFadeEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1CrossFade);
@@ -552,7 +552,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class DistantDiffuseEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::DistantDiffuseEffectT<DistantDiffuseEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::DistantDiffuseEffectT<DistantDiffuseEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1DistantDiffuse);
@@ -600,7 +600,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class DistantSpecularEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::DistantSpecularEffectT<DistantSpecularEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::DistantSpecularEffectT<DistantSpecularEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1DistantSpecular);
@@ -651,7 +651,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class ExposureEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::ExposureEffectT<ExposureEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::ExposureEffectT<ExposureEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Exposure);
@@ -679,7 +679,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class GammaTransferEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::GammaTransferEffectT<GammaTransferEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::GammaTransferEffectT<GammaTransferEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1GammaTransfer);
@@ -754,7 +754,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
 
     //-----------------------------------------------------------------------------------------------------------------
     class GaussianBlurEffect : 
-        public winrt::Microsoft::UI::Composition::Effects::implementation::GaussianBlurEffectT<GaussianBlurEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::GaussianBlurEffectT<GaussianBlurEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1GaussianBlur);
@@ -788,7 +788,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class GrayscaleEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::GrayscaleEffectT<GrayscaleEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::GrayscaleEffectT<GrayscaleEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Grayscale);
@@ -798,7 +798,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class HueRotationEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::HueRotationEffectT<HueRotationEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::HueRotationEffectT<HueRotationEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1HueRotation);
@@ -827,7 +827,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class InvertEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::InvertEffectT<InvertEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::InvertEffectT<InvertEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Invert);
@@ -837,7 +837,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class LinearTransferEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::LinearTransferEffectT<LinearTransferEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::LinearTransferEffectT<LinearTransferEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1LinearTransfer);
@@ -901,7 +901,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class LuminanceToAlphaEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::LuminanceToAlphaEffectT<LuminanceToAlphaEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::LuminanceToAlphaEffectT<LuminanceToAlphaEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1LuminanceToAlpha);
@@ -911,7 +911,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class OpacityEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::OpacityEffectT<OpacityEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::OpacityEffectT<OpacityEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Opacity);
@@ -939,7 +939,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class PointDiffuseEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::PointDiffuseEffectT<PointDiffuseEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::PointDiffuseEffectT<PointDiffuseEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1PointDiffuse);
@@ -985,7 +985,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class PointSpecularEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::PointSpecularEffectT<PointSpecularEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::PointSpecularEffectT<PointSpecularEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1PointSpecular);
@@ -1034,7 +1034,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class PosterizeEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::PosterizeEffectT<PosterizeEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::PosterizeEffectT<PosterizeEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Posterize);
@@ -1068,7 +1068,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class PremultiplyEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::PremultiplyEffectT<PremultiplyEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::PremultiplyEffectT<PremultiplyEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Premultiply);
@@ -1078,7 +1078,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class SaturationEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::SaturationEffectT<SaturationEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::SaturationEffectT<SaturationEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Saturation);
@@ -1106,7 +1106,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class SepiaEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::SepiaEffectT<SepiaEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::SepiaEffectT<SepiaEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Sepia);
@@ -1147,7 +1147,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class SpotDiffuseEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::SpotDiffuseEffectT<SpotDiffuseEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::SpotDiffuseEffectT<SpotDiffuseEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1SpotDiffuse);
@@ -1204,7 +1204,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class SpotSpecularEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::SpotSpecularEffectT<SpotSpecularEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::SpotSpecularEffectT<SpotSpecularEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1SpotSpecular);
@@ -1264,7 +1264,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class TemperatureAndTintEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::TemperatureAndTintEffectT<TemperatureAndTintEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::TemperatureAndTintEffectT<TemperatureAndTintEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1TemperatureTint);
@@ -1295,7 +1295,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class TintEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::TintEffectT<TintEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::TintEffectT<TintEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1Tint);
@@ -1326,7 +1326,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class Transform2DEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::Transform2DEffectT<Transform2DEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::Transform2DEffectT<Transform2DEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D12DAffineTransform);
@@ -1364,7 +1364,7 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
     //-----------------------------------------------------------------------------------------------------------------
 
     class UnPremultiplyEffect :
-        public winrt::Microsoft::UI::Composition::Effects::implementation::UnPremultiplyEffectT<UnPremultiplyEffect, EffectBase>
+        public winrt::Microsoft::UI::Private::Composition::Effects::implementation::UnPremultiplyEffectT<UnPremultiplyEffect, EffectBase>
     {
     public:
         DECLARE_D2D_GUID(CLSID_D2D1UnPremultiply);
@@ -1383,5 +1383,5 @@ namespace Microsoft { namespace UI { namespace Composition { namespace Effects
 #    pragma pop_macro("DECLARE_NAMED_PROPERTY_MAPPING")
 #endif
 
-}}}}
+}}}}}
 #pragma warning(pop)

--- a/dev/Lights/RevealBorderLight.cpp
+++ b/dev/Lights/RevealBorderLight.cpp
@@ -10,7 +10,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 6101)  // Returning uninitialized memory '<value>'.  A successful path through the function does not set the named _Out_ parameter.
-#include "Microsoft.UI.Composition.Effects_impl.h"
+#include "Microsoft.UI.Private.Composition.Effects_impl.h"
 #pragma warning(pop)
 
 #include "RevealBorderLight.properties.cpp"

--- a/dev/Lights/RevealHoverLight.cpp
+++ b/dev/Lights/RevealHoverLight.cpp
@@ -9,7 +9,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 6101)  // Returning uninitialized memory '<value>'.  A successful path through the function does not set the named _Out_ parameter.
-#include "Microsoft.UI.Composition.Effects_impl.h"
+#include "Microsoft.UI.Private.Composition.Effects_impl.h"
 #pragma warning(pop)
 
 #include "RevealHoverLight.properties.cpp"

--- a/dev/Lights/XamlAmbientLight.cpp
+++ b/dev/Lights/XamlAmbientLight.cpp
@@ -8,7 +8,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 6101)  // Returning uninitialized memory '<value>'.  A successful path through the function does not set the named _Out_ parameter.
-#include "Microsoft.UI.Composition.Effects_impl.h"
+#include "Microsoft.UI.Private.Composition.Effects_impl.h"
 #pragma warning(pop)
 
 const winrt::Color XamlAmbientLight::sc_defaultColor{ 255, 255, 255, 255 };

--- a/dev/Materials/Acrylic/AcrylicBrush.cpp
+++ b/dev/Materials/Acrylic/AcrylicBrush.cpp
@@ -629,27 +629,27 @@ winrt::CompositionEffectBrush AcrylicBrush::CreateAcrylicBrushWorker(
 
 winrt::IGraphicsEffect AcrylicBrush::CombineNoiseWithTintEffect_Legacy(
     const winrt::IGraphicsEffectSource& blurredSource,
-    const winrt::Microsoft::UI::Composition::Effects::ColorSourceEffect& tintColorEffect)
+    const winrt::Microsoft::UI::Private::Composition::Effects::ColorSourceEffect& tintColorEffect)
 {
     // Apply saturation
-    auto saturationEffect = winrt::make_self<Microsoft::UI::Composition::Effects::SaturationEffect>();
+    auto saturationEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::SaturationEffect>();
     saturationEffect->Name(L"Saturation");
     saturationEffect->Saturation(sc_saturation);
     saturationEffect->Source(blurredSource);
 
     // Apply exclusion:
     // Exclusion Color
-    auto exclusionColorEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+    auto exclusionColorEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
     exclusionColorEffect->Name(L"ExclusionColor");
     exclusionColorEffect->Color(sc_exclusionColor);
     // Exclusion blend
-    auto blendEffectInner = winrt::make_self<Microsoft::UI::Composition::Effects::BlendEffect>();
+    auto blendEffectInner = winrt::make_self<Microsoft::UI::Private::Composition::Effects::BlendEffect>();
     blendEffectInner->Mode(winrt::BlendEffectMode::Exclusion);
     blendEffectInner->Foreground(*exclusionColorEffect);
     blendEffectInner->Background(*saturationEffect);
 
     // Apply tint
-    auto compositeEffect = winrt::make_self<Microsoft::UI::Composition::Effects::CompositeStepEffect>();
+    auto compositeEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::CompositeStepEffect>();
     compositeEffect->Mode(winrt::CanvasComposite::SourceOver);
     compositeEffect->Destination(*blendEffectInner);
     compositeEffect->Source(tintColorEffect);

--- a/dev/Materials/Acrylic/AcrylicBrush.cpp
+++ b/dev/Materials/Acrylic/AcrylicBrush.cpp
@@ -659,7 +659,7 @@ winrt::IGraphicsEffect AcrylicBrush::CombineNoiseWithTintEffect_Legacy(
 
 winrt::IGraphicsEffect AcrylicBrush::CombineNoiseWithTintEffect_Luminosity(
     const winrt::IGraphicsEffectSource& blurredSource,
-    const winrt::Microsoft::UI::Composition::Effects::ColorSourceEffect& tintColorEffect,
+    const winrt::Microsoft::UI::Private::Composition::Effects::ColorSourceEffect& tintColorEffect,
     const winrt::Color initialLuminosityColor,
     std::vector<winrt::hstring>& animatedProperties
 )
@@ -669,12 +669,12 @@ winrt::IGraphicsEffect AcrylicBrush::CombineNoiseWithTintEffect_Luminosity(
     // Apply luminosity:
 
     // Luminosity Color
-    auto luminosityColorEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+    auto luminosityColorEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
     luminosityColorEffect->Name(L"LuminosityColor");
     luminosityColorEffect->Color(initialLuminosityColor);
 
     // Luminosity blend
-    auto luminosityBlendEffect = winrt::make_self<Microsoft::UI::Composition::Effects::BlendEffect>();
+    auto luminosityBlendEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::BlendEffect>();
     // NOTE: There is currently a bug where the names of BlendEffectMode::Luminosity and BlendEffectMode::Color are flipped.
     // This should be changed to Luminosity when/if the bug is fixed.
     luminosityBlendEffect->Mode(winrt::BlendEffectMode::Color);
@@ -684,7 +684,7 @@ winrt::IGraphicsEffect AcrylicBrush::CombineNoiseWithTintEffect_Luminosity(
     // Apply tint:
 
     // Color blend
-    auto colorBlendEffect = winrt::make_self<Microsoft::UI::Composition::Effects::BlendEffect>();
+    auto colorBlendEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::BlendEffect>();
     // NOTE: There is currently a bug where the names of BlendEffectMode::Luminosity and BlendEffectMode::Color are flipped.
     // This should be changed to Color when/if the bug is fixed.
     colorBlendEffect->Mode(winrt::BlendEffectMode::Luminosity);
@@ -811,7 +811,7 @@ winrt::CompositionEffectFactory AcrylicBrush::CreateAcrylicBrushCompositionEffec
     winrt::IGraphicsEffect tintOutput;
 
     // Tint Color - either used directly or in a Color blend over a blurred backdrop
-    auto tintColorEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+    auto tintColorEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
     tintColorEffect->Name(L"TintColor");
     tintColorEffect->Color(initialTintColor);
 
@@ -837,7 +837,7 @@ winrt::CompositionEffectFactory AcrylicBrush::CreateAcrylicBrushCompositionEffec
         else
         {
             // ...or we apply the blur ourselves
-            auto gaussianBlurEffect = winrt::make_self<Microsoft::UI::Composition::Effects::GaussianBlurEffect>();
+            auto gaussianBlurEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::GaussianBlurEffect>();
             gaussianBlurEffect->Name(L"Blur");
             gaussianBlurEffect->BorderMode(winrt::EffectBorderMode::Hard);
             gaussianBlurEffect->BlurAmount(sc_blurRadius);
@@ -852,19 +852,19 @@ winrt::CompositionEffectFactory AcrylicBrush::CreateAcrylicBrushCompositionEffec
 
     // Create noise with alpha and wrap:
     // Noise image BorderEffect (infinitely tiles noise image)
-    auto noiseBorderEffect = winrt::make_self<Microsoft::UI::Composition::Effects::BorderEffect>();
+    auto noiseBorderEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::BorderEffect>();
     noiseBorderEffect->ExtendX(winrt::CanvasEdgeBehavior::Wrap);
     noiseBorderEffect->ExtendY(winrt::CanvasEdgeBehavior::Wrap);
     winrt::CompositionEffectSourceParameter noiseEffectSourceParameter{ L"Noise" };
     noiseBorderEffect->Source(noiseEffectSourceParameter);
     // OpacityEffect applied to wrapped noise
-    auto noiseOpacityEffect = winrt::make_self<Microsoft::UI::Composition::Effects::OpacityEffect>();
+    auto noiseOpacityEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::OpacityEffect>();
     noiseOpacityEffect->Name(L"NoiseOpacity");
     noiseOpacityEffect->Opacity(sc_noiseOpacity);
     noiseOpacityEffect->Source(*noiseBorderEffect);
 
     // Blend noise on top of tint
-    auto blendEffectOuter = winrt::make_self<Microsoft::UI::Composition::Effects::CompositeStepEffect>();
+    auto blendEffectOuter = winrt::make_self<Microsoft::UI::Private::Composition::Effects::CompositeStepEffect>();
     blendEffectOuter->Mode(winrt::CanvasComposite::SourceOver);
     blendEffectOuter->Destination(tintOutput);
     blendEffectOuter->Source(*noiseOpacityEffect);
@@ -872,12 +872,12 @@ winrt::CompositionEffectFactory AcrylicBrush::CreateAcrylicBrushCompositionEffec
     if (useCrossFadeEffect)
     {
         // Fallback color
-        auto fallbackColorEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+        auto fallbackColorEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
         fallbackColorEffect->Name(L"FallbackColor");
         fallbackColorEffect->Color(initialFallbackColor);
 
         // CrossFade with the fallback color. Weight = 0 means full fallback, 1 means full acrylic.
-        auto fadeInOutEffect = winrt::make_self<Microsoft::UI::Composition::Effects::CrossFadeEffect>();
+        auto fadeInOutEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::CrossFadeEffect>();
         fadeInOutEffect->Name(L"FadeInOut");
         fadeInOutEffect->Source1(*fallbackColorEffect);
         fadeInOutEffect->Source2(*blendEffectOuter);

--- a/dev/Materials/Acrylic/AcrylicBrush.h
+++ b/dev/Materials/Acrylic/AcrylicBrush.h
@@ -85,7 +85,7 @@ private:
 
     static winrt::IGraphicsEffect CombineNoiseWithTintEffect_Legacy(
         const winrt::IGraphicsEffectSource& blurredSource,
-        const winrt::Microsoft::UI::Composition::Effects::ColorSourceEffect& tintColorEffect);
+        const winrt::Microsoft::UI::Private::Composition::Effects::ColorSourceEffect& tintColorEffect);
 
     static winrt::IGraphicsEffect CombineNoiseWithTintEffect_Luminosity(
         const winrt::IGraphicsEffectSource& blurredSource,

--- a/dev/Materials/Acrylic/AcrylicBrush.h
+++ b/dev/Materials/Acrylic/AcrylicBrush.h
@@ -13,7 +13,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 6101)  // Returning uninitialized memory '<value>'.  A successful path through the function does not set the named _Out_ parameter.
-#include "Microsoft.UI.Composition.Effects_impl.h"
+#include "Microsoft.UI.Private.Composition.Effects_impl.h"
 #pragma warning(pop)
 
 winrt::Color GetLuminosityColor(winrt::Color tintColor, winrt::IReference<double> luminosityOpacity);
@@ -89,7 +89,7 @@ private:
 
     static winrt::IGraphicsEffect CombineNoiseWithTintEffect_Luminosity(
         const winrt::IGraphicsEffectSource& blurredSource,
-        const winrt::Microsoft::UI::Composition::Effects::ColorSourceEffect& tintColorEffect,
+        const winrt::Microsoft::UI::Private::Composition::Effects::ColorSourceEffect& tintColorEffect,
         const winrt::Color initialLuminosityColor,
         std::vector<winrt::hstring>& animatedProperties);
 

--- a/dev/Materials/Reveal/RevealBrush.cpp
+++ b/dev/Materials/Reveal/RevealBrush.cpp
@@ -7,7 +7,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 6101)  // Returning uninitialized memory '<value>'.  A successful path through the function does not set the named _Out_ parameter.
-#include "Microsoft.UI.Composition.Effects_impl.h"
+#include "Microsoft.UI.Private.Composition.Effects_impl.h"
 #pragma warning(pop)
 
 #include "XamlAmbientLight.h"
@@ -509,14 +509,14 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealHove
     winrt::Color initBaseColor{ 0, 0, 0, 0 };
 
     // (9) Noise image BorderEffect (infinitely tiles noise image)
-    auto noiseBorderEffect = winrt::make_self<Microsoft::UI::Composition::Effects::BorderEffect>();
+    auto noiseBorderEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::BorderEffect>();
     noiseBorderEffect->ExtendX(winrt::CanvasEdgeBehavior::Wrap);
     noiseBorderEffect->ExtendY(winrt::CanvasEdgeBehavior::Wrap);
     winrt::CompositionEffectSourceParameter noiseEffectSourceParameter{ L"Noise" };
     noiseBorderEffect->Source(noiseEffectSourceParameter);
 
     // (8) ColorMatrixEffect applied to (9) to introduce alpha, to be used to mask the SceneLightingEffect
-    auto noiseOpacityEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorMatrixEffect>();
+    auto noiseOpacityEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorMatrixEffect>();
     noiseOpacityEffect->ColorMatrix(sc_colorToAlphaMatrix);
     noiseOpacityEffect->AlphaMode(winrt::CanvasAlphaMode::Straight);
     noiseOpacityEffect->Source(*noiseBorderEffect);
@@ -525,40 +525,40 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealHove
     // Note: Unlike the Win2D-based effects, SceneLightingEffect is a public Windows platform type, we can instatiate it directly via winrt.
     // No ambient coefficient. This SLE gets noise applied to it, and we don't want the ambient contribution to be affected by noise. The
     // ambient contribution will be added by a separate ColorSourceEffect.
-    winrt::SceneLightingEffect sceneLightingEffect;
+    winrt::Microsoft::UI::Composition::Effects::SceneLightingEffect sceneLightingEffect;
     sceneLightingEffect.AmbientAmount(0);
     sceneLightingEffect.DiffuseAmount(sc_diffuseAmount);
     sceneLightingEffect.SpecularAmount(sc_specularAmount);
     sceneLightingEffect.SpecularShine(sc_specularShine);
 
     // (6) Alpha mask of (7) with (8)
-    auto blendEffectOuter = winrt::make_self<Microsoft::UI::Composition::Effects::AlphaMaskEffect>();
+    auto blendEffectOuter = winrt::make_self<Microsoft::UI::Private::Composition::Effects::AlphaMaskEffect>();
     blendEffectOuter->Source(sceneLightingEffect);
     blendEffectOuter->Mask(*noiseOpacityEffect);
 
     // (5) ColorSourceEffect
-    auto colorSourceEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+    auto colorSourceEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
     colorSourceEffect->Color(sc_ambientContributionColor);
 
     // (4) Composite of (5) with (6)
-    auto compositeEffect = winrt::make_self<Microsoft::UI::Composition::Effects::CompositeStepEffect>();
+    auto compositeEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::CompositeStepEffect>();
     compositeEffect->Mode(winrt::CanvasComposite::Add);
     compositeEffect->Destination(*colorSourceEffect);
     compositeEffect->Source(*blendEffectOuter);
 
     // (3) ColorMatrixEffect applied to (4)
-    auto colorMatrixEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorMatrixEffect>();
+    auto colorMatrixEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorMatrixEffect>();
     colorMatrixEffect->ColorMatrix(sc_luminanceToAlphaMatrix);
     colorMatrixEffect->AlphaMode(winrt::CanvasAlphaMode::Straight);
     colorMatrixEffect->Source(*compositeEffect);
 
     // (2) Base Color Effect
-    auto baseColorEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+    auto baseColorEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
     baseColorEffect->Name(L"BaseColorEffect");
     baseColorEffect->Color(initBaseColor);
 
     // (1) Composite of (3) [source] with (2) [destination]
-    auto arithmeticCompositeEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ArithmeticCompositeEffect>();
+    auto arithmeticCompositeEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ArithmeticCompositeEffect>();
     arithmeticCompositeEffect->Source1Amount(2.0f);
     arithmeticCompositeEffect->Source2Amount(2.0f);
     arithmeticCompositeEffect->MultiplyAmount(-2.0f);
@@ -573,14 +573,14 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealBord
 {
     // (1) SceneLightingEffect
     // Note: Unlike the Win2D-based effects, SceneLightingEffect is a public Windows platform type, we can instatiate it directly via winrt.
-    winrt::SceneLightingEffect sceneLightingEffect;
+    winrt::Microsoft::UI::Composition::Effects::SceneLightingEffect sceneLightingEffect;
     sceneLightingEffect.AmbientAmount(0.0f);
     sceneLightingEffect.DiffuseAmount(sc_diffuseAmountBorder);
     sceneLightingEffect.SpecularAmount(sc_specularAmountBorder);
     sceneLightingEffect.SpecularShine(sc_specularShineBorder);
 
     // (2) ColorMatrixEffect applied to 1
-    auto colorMatrixEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorMatrixEffect>();
+    auto colorMatrixEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorMatrixEffect>();
     colorMatrixEffect->ColorMatrix(isInverted ? sc_revealInvertedBorderColorMatrix : sc_revealBorderColorMatrix);
     colorMatrixEffect->AlphaMode(winrt::CanvasAlphaMode::Straight);
     colorMatrixEffect->Source(sceneLightingEffect);
@@ -588,7 +588,7 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealBord
     if (hasBaseColor)
     {
         // (3) Base Color Effect
-        auto  baseColorEffect = winrt::make_self<Microsoft::UI::Composition::Effects::ColorSourceEffect>();
+        auto  baseColorEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::ColorSourceEffect>();
         baseColorEffect->Name(L"BaseColorEffect");
         // Set base color to 0 because we want to build one EffectFactory and cache it regardless of the different colors that
         // the app may choose. So make the factory have it as 0,0,0,0 and then we'll make it an animatable property and set it
@@ -596,7 +596,7 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealBord
         baseColorEffect->Color({ 0,0,0,0 });
 
         // (4) Do a source over blend of (2) the color matrix with (3) the base color.
-        auto compositeEffect = winrt::make_self<Microsoft::UI::Composition::Effects::CompositeStepEffect>();
+        auto compositeEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::CompositeStepEffect>();
         compositeEffect->Mode(winrt::CanvasComposite::SourceOver);
         compositeEffect->Source(*colorMatrixEffect);
         compositeEffect->Destination(*baseColorEffect);

--- a/dev/Materials/Reveal/RevealBrush.cpp
+++ b/dev/Materials/Reveal/RevealBrush.cpp
@@ -525,7 +525,7 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealHove
     // Note: Unlike the Win2D-based effects, SceneLightingEffect is a public Windows platform type, we can instatiate it directly via winrt.
     // No ambient coefficient. This SLE gets noise applied to it, and we don't want the ambient contribution to be affected by noise. The
     // ambient contribution will be added by a separate ColorSourceEffect.
-    winrt::Microsoft::UI::Composition::Effects::SceneLightingEffect sceneLightingEffect;
+    winrt::Windows::UI::Composition::Effects::SceneLightingEffect sceneLightingEffect;
     sceneLightingEffect.AmbientAmount(0);
     sceneLightingEffect.DiffuseAmount(sc_diffuseAmount);
     sceneLightingEffect.SpecularAmount(sc_specularAmount);
@@ -573,7 +573,7 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealBord
 {
     // (1) SceneLightingEffect
     // Note: Unlike the Win2D-based effects, SceneLightingEffect is a public Windows platform type, we can instatiate it directly via winrt.
-    winrt::Microsoft::UI::Composition::Effects::SceneLightingEffect sceneLightingEffect;
+    winrt::Windows::UI::Composition::Effects::SceneLightingEffect sceneLightingEffect;
     sceneLightingEffect.AmbientAmount(0.0f);
     sceneLightingEffect.DiffuseAmount(sc_diffuseAmountBorder);
     sceneLightingEffect.SpecularAmount(sc_specularAmountBorder);

--- a/dev/dll/CppWinRTFilterTypes.tt
+++ b/dev/dll/CppWinRTFilterTypes.tt
@@ -23,5 +23,5 @@
   
        WriteLine("-filter " + MakeWindowsTypeFullName(type));
     }
-    WriteLine("-filter Microsoft.UI.Composition.Effects");
+    WriteLine("-filter Microsoft.UI.Private.Composition.Effects");
 #>

--- a/dev/dll/Microsoft.UI.Xaml.vcxproj
+++ b/dev/dll/Microsoft.UI.Xaml.vcxproj
@@ -102,7 +102,7 @@
     <Import Project="..\ColorPicker\ColorPicker.vcxitems" Label="Shared" Condition="$(FeatureColorPickerEnabled) == 'true' Or $(FeatureColorPickerEnabled) == 'productOnly'" />
     <Import Project="..\Collections\Collections.vcxitems" Label="Shared" Condition="$(FeatureCollectionsEnabled) == 'true' Or $(FeatureCollectionsEnabled) == 'productOnly'" />
     <Import Project="..\CommandBarFlyout\CommandBarFlyout.vcxitems" Label="Shared" Condition="$(FeatureCommandBarFlyoutEnabled) == 'true' Or $(FeatureCommandBarFlyoutEnabled) == 'productOnly'" />
-    <Import Project="..\Effects\Microsoft.UI.Composition.Effects.vcxitems" Label="Shared" Condition="$(FeatureEffectsEnabled) == 'true' Or $(FeatureEffectsEnabled) == 'productOnly'" />
+    <Import Project="..\Effects\Microsoft.UI.Private.Composition.Effects.vcxitems" Label="Shared" Condition="$(FeatureEffectsEnabled) == 'true' Or $(FeatureEffectsEnabled) == 'productOnly'" />
     <Import Project="..\PersonPicture\PersonPicture.vcxitems" Label="Shared" Condition="$(FeaturePersonPictureEnabled) == 'true' Or $(FeaturePersonPictureEnabled) == 'productOnly'" />
     <Import Project="..\ResourceHelper\ResourceHelper.vcxitems" Label="Shared" Condition="$(FeatureResourceHelperEnabled) == 'true' Or $(FeatureResourceHelperEnabled) == 'productOnly'" />
     <Import Project="..\PullToRefresh\RefreshContainer\RefreshContainer.vcxitems" Label="Shared" Condition="$(FeaturePullToRefreshEnabled) == 'true' Or $(FeaturePullToRefreshEnabled) == 'productOnly'" />
@@ -249,6 +249,7 @@
         $(GeneratedFilesDir)\Media;
         $(GeneratedFilesDir)\XamlTypeInfo;
         $(GeneratedFilesDir)\Microsoft\UI\Composition\Effects;
+        $(GeneratedFilesDir)\Microsoft\UI\Private\Composition\Effects;
         $(GeneratedFilesDir)\Microsoft\UI\Private\Controls;
         $(GeneratedFilesDir)\Microsoft\UI\Private\Media;
         %(AdditionalIncludeDirectories);

--- a/dev/inc/CppWinRTIncludes.h
+++ b/dev/inc/CppWinRTIncludes.h
@@ -72,8 +72,8 @@
 #include <winrt\Microsoft.UI.Xaml.Automation.Peers.h>
 #endif
 
-#if __has_include("winrt\Microsoft.UI.Composition.Effects.h")
-#include <winrt\Microsoft.UI.Composition.Effects.h>
+#if __has_include("winrt\Microsoft.UI.Private.Composition.Effects.h")
+#include <winrt\Microsoft.UI.Private.Composition.Effects.h>
 #endif
 
 namespace winrt

--- a/dev/inc/CppWinRTIncludes.h
+++ b/dev/inc/CppWinRTIncludes.h
@@ -182,7 +182,7 @@ namespace winrt
     }
 
 #ifdef EFFECTS_INCLUDED
-    using namespace ::winrt::Microsoft::UI::Composition::Effects;
+    using namespace ::winrt::Microsoft::UI::Private::Composition::Effects;
 #endif
 
     // using namespace ::winrt::Windows::UI::Xaml::Controls;

--- a/idl/Effects.idl
+++ b/idl/Effects.idl
@@ -1,1 +1,1 @@
-#include "..\dev\effects\microsoft.ui.composition.effects.idl"
+#include "..\dev\effects\Microsoft.UI.Private.Composition.Effects.idl"

--- a/tools/CheckCompatibility.ps1
+++ b/tools/CheckCompatibility.ps1
@@ -81,7 +81,7 @@ foreach ($error in $apiInformationErrors)
 [System.Collections.Generic.List[Compatibility.Error]]$versionUsages = @()
 [System.Collections.Generic.List[Compatibility.Error]]$missingWebhosthiddenAttributes = @()
 
-$files = Get-ChildItem $PSScriptRoot\..\dev -Include "*.idl" -Exclude "Microsoft.UI.Xaml.idl","Microsoft.UI.Composition.Effects.idl" -Recurse
+$files = Get-ChildItem $PSScriptRoot\..\dev -Include "*.idl" -Exclude "Microsoft.UI.Xaml.idl","Microsoft.UI.Private.Composition.Effects.idl" -Recurse
 
 Write-Verbose ""
 Write-Verbose "Checking IDL files..."


### PR DESCRIPTION
This is a backport of a fix for WinUI3. It has no specific impact for WinUI2, but porting it now will make future merges of WinUI2 into WinUI3 easier.

MUX has a set of Effects that it uses for its own internal implementation purposes. It is not intended for them to be used by other consumers.

These effects are in the Microsoft.UI.Composition.Effects namespace. In WinUI2, these types did not get included in the nuget package, since that only includes the Microsoft.UI.Xaml namespace. So these types were correctly filtered out.

However, WinUI3 publishes everything under Microsoft.UI, so we were unintentionally publishing these internal types. The fix is to move these types to a Microsoft.UI.Private namespace so that they get filtered out.