### PR TITLE
Ensure we update the ClosedCompact visual state for NavigationViewItemPresenter when it applies its template.

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -202,11 +202,6 @@ void NavigationViewItem::UpdateIsClosedCompact()
             && (splitView.DisplayMode() == winrt::SplitViewDisplayMode::CompactOverlay || splitView.DisplayMode() == winrt::SplitViewDisplayMode::CompactInline);
 
         UpdateVisualState(true /*useTransitions*/);
-
-        if (const auto presenter = GetPresenter())
-        {
-            presenter->UpdateClosedCompactVisualState(IsTopLevelItem(), m_isClosedCompact);
-        }
     }
 }
 
@@ -303,6 +298,14 @@ void NavigationViewItem::UpdateVisualStateForIconAndContent(bool showIcon, bool 
     {
         auto stateName = showIcon ? (showContent ? L"IconOnLeft" : L"IconOnly") : L"ContentOnly";
         winrt::VisualStateManager::GoToState(presenter, stateName, false /*useTransitions*/);
+    }
+}
+
+void NavigationViewItem::UpdateVisualStateForClosedCompact()
+{
+    if (const auto presenter = GetPresenter())
+    {
+        presenter->UpdateClosedCompactVisualState(IsTopLevelItem(), m_isClosedCompact);
     }
 }
 
@@ -469,6 +472,8 @@ void NavigationViewItem::UpdateVisualState(bool useTransitions)
             // Backward Compatibility with RS4-, new implementation prefer IconOnLeft/IconOnly/ContentOnly
             winrt::VisualStateManager::GoToState(presenter, shouldShowIcon ? L"IconVisible" : L"IconCollapsed", useTransitions);
         }
+
+        UpdateVisualStateForClosedCompact();
     } 
    
     UpdateVisualStateForToolTip();

--- a/dev/NavigationView/NavigationViewItem.h
+++ b/dev/NavigationView/NavigationViewItem.h
@@ -92,6 +92,7 @@ private:
     void UpdateVisualStateForToolTip();
     void UpdateVisualStateForPointer();
     void UpdateVisualStateForChevron();
+    void UpdateVisualStateForClosedCompact();
 
     void UpdateVisualState(bool useTransitions);
     bool ShouldShowIcon();

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -29,6 +29,8 @@ using NavigationViewBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationVie
 using System.Collections.ObjectModel;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Composition;
+using Windows.UI.Xaml.Markup;
+using System.Collections.Generic;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -662,6 +664,68 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual(menuItem2, navView.SelectedItem);
             });
         }
+
+        [TestMethod]
+        public void VerifyClosedCompactVisualState()
+        {
+            NavigationView navView = null;
+            RunOnUIThread.Execute(() =>
+            {
+                navView = new NavigationView();
+                Content = navView;
+
+                var template = (DataTemplate)XamlReader.Load(@"
+                    <DataTemplate
+                        xmlns ='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                        xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                        <controls:NavigationViewItem
+                            Content='Item'>
+                            <controls:NavigationViewItem.Icon>
+                                <SymbolIcon Symbol='Home' />
+                            </controls:NavigationViewItem.Icon>
+                         </controls:NavigationViewItem>
+                      </DataTemplate>");
+                navView.MenuItemTemplate = template;
+                navView.IsPaneOpen = false;
+                navView.IsSettingsVisible = false;
+
+                RoutedEventHandler loaded = null;
+                loaded = (object sender, RoutedEventArgs args) =>
+                {
+                    navView.Loaded -= loaded;
+
+                    var items = new List<object>() { new object() }; ;
+                    navView.MenuItemsSource = items;
+                };
+                navView.Loaded += loaded;
+
+                Content.UpdateLayout();
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                var footerRepeater = VisualTreeUtils.FindVisualChildByName(navView, "MenuItemsHost") as FrameworkElement;
+                var menuItem = VisualTreeHelper.GetChild(footerRepeater, 0) as FrameworkElement;
+                var menuItemLayoutRoot = VisualTreeHelper.GetChild(menuItem, 0) as FrameworkElement;
+                var navItemPresenter = VisualTreeHelper.GetChild(menuItemLayoutRoot, 0) as FrameworkElement;
+                var navItemPresenterLayoutRoot = VisualTreeHelper.GetChild(navItemPresenter, 0) as FrameworkElement;
+                var statesGroups = VisualStateManager.GetVisualStateGroups(navItemPresenterLayoutRoot);
+
+                string navItemPresenter1CurrentState = null;
+                foreach (var visualStateGroup in statesGroups)
+                {
+                    if (visualStateGroup.Name == "PaneAndTopLevelItemStates")
+                    {
+                        navItemPresenter1CurrentState = visualStateGroup.CurrentState.Name;
+                    }
+                }
+
+                Verify.AreEqual("ClosedCompactAndTopLevelItem", navItemPresenter1CurrentState);
+            });
+        }
+
 
         [TestMethod]
         public void VerifyNavigationItemUIAType()


### PR DESCRIPTION
When NavigationViewItemPresenter applies its template, it calls NavigationViewItem.UpdateVisualStateNoTransition() to make sure all the visual states are correct. However the visual state for ClosedCompact is not included. This PR updates the UpdateVisualState method to include updating this state.

## Motivation and Context
This change makes sure that in Left Nav the NavigationViewItemPresenter is in the correct visual state on launch and enables the YourPhone app to correctly show/hide badges. 

## How Has This Been Tested?
Manually tested by explicitly putting the control in this visual state.