### PR TITLE
Fix Expander's tab order

### DIFF
--- a/dev/Expander/Expander.xaml
+++ b/dev/Expander/Expander.xaml
@@ -125,6 +125,25 @@
                             <RowDefinition x:Name="Row0" Height="Auto" />
                             <RowDefinition x:Name="Row1" Height="*" />
                         </Grid.RowDefinitions>
+                        <ToggleButton
+                            x:Name="ExpanderHeader"
+                            AutomationProperties.AutomationId="ExpanderToggleButton"
+                            Background="{TemplateBinding Background}"
+                            contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            MinHeight="{TemplateBinding MinHeight}"
+                            MinWidth="{TemplateBinding MinWidth}"
+                            MaxWidth="{TemplateBinding MaxWidth}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                            IsEnabled="{TemplateBinding IsEnabled}"
+                            Padding="{TemplateBinding Padding}"
+                            Style="{StaticResource ExpanderHeaderDownStyle}"
+                            Content="{TemplateBinding Header}"
+                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                            ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                            HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                            IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
                         <!-- The clip is a composition clip applied in code -->
                         <Border x:Name="ExpanderContentClip" Grid.Row="1">
                             <Border
@@ -150,26 +169,6 @@
                                 </Border.RenderTransform>
                             </Border>
                         </Border>
-
-                        <ToggleButton
-                            x:Name="ExpanderHeader"
-                            AutomationProperties.AutomationId="ExpanderToggleButton"
-                            Background="{TemplateBinding Background}"
-                            contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            MinHeight="{TemplateBinding MinHeight}"
-                            MinWidth="{TemplateBinding MinWidth}"
-                            MaxWidth="{TemplateBinding MaxWidth}"
-                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                            IsEnabled="{TemplateBinding IsEnabled}"
-                            Padding="{TemplateBinding Padding}"
-                            Style="{StaticResource ExpanderHeaderDownStyle}"
-                            Content="{TemplateBinding Header}"
-                            ContentTemplate="{TemplateBinding HeaderTemplate}"
-                            ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                            HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                            IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/dev/Expander/TestUI/ExpanderPage.xaml
+++ b/dev/Expander/TestUI/ExpanderPage.xaml
@@ -26,7 +26,7 @@
                         <TextBlock Text="This is the second line of text." Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </StackPanel>
                 </controls:Expander.Header>
-                <TextBlock AutomationProperties.AutomationId="ExpandedExpanderContent">Content</TextBlock>
+                <Button AutomationProperties.AutomationId="ExpandedExpanderContent">Content</Button>
             </controls:Expander>
 
             <controls:Expander AutomationProperties.AutomationId="CollapsedExpander" AutomationProperties.Name="Expander2" IsExpanded="False" Margin="12">


### PR DESCRIPTION
Expander's tab order was incorrect, it had the content receiving focus before the header. This was in an attempt to get the header to render above the content during its opening animation, but this is no longer needed as we are doing the animation with a clipped viewport.