### PR TITLE
Updating TabView to consume DropShadows

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -88,7 +88,10 @@ void TabView::OnApplyTemplate()
         m_tabStripPointerExitedRevoker = containerGrid.PointerExited(winrt::auto_revoke, { this,&TabView::OnTabStripPointerExited });
     }
 
-    m_shadowReceiver.set(GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected));
+    if (!SharedHelpers::Is21H1OrHigher())
+    {
+        m_shadowReceiver.set(GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected));
+    }
 
     m_listView.set([this, controlProtected]() {
         auto listView = GetTemplateChildT<winrt::ListView>(L"TabListView", controlProtected);
@@ -136,18 +139,21 @@ void TabView::OnApplyTemplate()
 
     if (SharedHelpers::IsThemeShadowAvailable())
     {
-        if (auto shadowCaster = GetTemplateChildT<winrt::Grid>(L"ShadowCaster", controlProtected))
+        if (!SharedHelpers::Is21H1OrHigher())
         {
-            winrt::ThemeShadow shadow;
-            shadow.Receivers().Append(GetShadowReceiver());
+            if (auto shadowCaster = GetTemplateChildT<winrt::Grid>(L"ShadowCaster", controlProtected))
+            {
+                winrt::ThemeShadow shadow;
+                shadow.Receivers().Append(GetShadowReceiver());
 
-            double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));
+                double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));
 
-            const auto currentTranslation = shadowCaster.Translation();
-            const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
-            shadowCaster.Translation(translation);
+                const auto currentTranslation = shadowCaster.Translation();
+                const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
+                shadowCaster.Translation(translation);
 
-            shadowCaster.Shadow(shadow);
+                shadowCaster.Shadow(shadow);
+            }
         }
     }
 
@@ -318,7 +324,10 @@ void TabView::UnhookEventsAndClearFields()
     m_addButtonColumn.set(nullptr);
     m_rightContentColumn.set(nullptr);
     m_tabContainerGrid.set(nullptr);
-    m_shadowReceiver.set(nullptr);
+    if (!SharedHelpers::Is21H1OrHigher())
+    {
+        m_shadowReceiver.set(nullptr);
+    }
     m_listView.set(nullptr);
     m_addButton.set(nullptr);
     m_itemsPresenter.set(nullptr);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -324,10 +324,7 @@ void TabView::UnhookEventsAndClearFields()
     m_addButtonColumn.set(nullptr);
     m_rightContentColumn.set(nullptr);
     m_tabContainerGrid.set(nullptr);
-    if (!SharedHelpers::Is21H1OrHigher())
-    {
-        m_shadowReceiver.set(nullptr);
-    }
+    m_shadowReceiver.set(nullptr);
     m_listView.set(nullptr);
     m_addButton.set(nullptr);
     m_itemsPresenter.set(nullptr);

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -44,9 +44,6 @@
                                 Content="{TemplateBinding TabStripHeader}"
                                 ContentTemplate="{TemplateBinding TabStripHeaderTemplate}"/>
 
-                            <Grid x:Name="ShadowReceiver"
-                                Grid.ColumnSpan="4"/>
-
                             <primitives:TabViewListView
                                 Grid.Column="1"
                                 x:Name="TabListView"
@@ -77,14 +74,6 @@
                                 ContentTemplate="{TemplateBinding TabStripFooterTemplate}"/>
 
                         </Grid>
-
-                        <!-- We don't want this to take space on the second row in case the user isn't using tab content. -->
-                        <Grid x:Name="ShadowCaster"
-                            Grid.Row="0"
-                            Height="10"
-                            Margin="0,0,0,-10"
-                            VerticalAlignment="Bottom"
-                            Background="Transparent"/>
 
                         <ContentPresenter x:Name="TabContentPresenter"
                             Grid.Row="1"

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -44,6 +44,9 @@
                                 Content="{TemplateBinding TabStripHeader}"
                                 ContentTemplate="{TemplateBinding TabStripHeaderTemplate}"/>
 
+                            <Grid x:Name="ShadowReceiver"
+                                Grid.ColumnSpan="4"/>
+
                             <primitives:TabViewListView
                                 Grid.Column="1"
                                 x:Name="TabListView"
@@ -74,6 +77,14 @@
                                 ContentTemplate="{TemplateBinding TabStripFooterTemplate}"/>
 
                         </Grid>
+
+                        <!-- We don't want this to take space on the second row in case the user isn't using tab content. -->
+                        <Grid x:Name="ShadowCaster"
+                            Grid.Row="0"
+                            Height="10"
+                            Margin="0,0,0,-10"
+                            VerticalAlignment="Bottom"
+                            Background="Transparent"/>
 
                         <ContentPresenter x:Name="TabContentPresenter"
                             Grid.Row="1"

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -66,7 +66,10 @@ void TabViewItem::OnApplyTemplate()
             if (internalTabView)
             {
                 winrt::ThemeShadow shadow;
-                shadow.Receivers().Append(internalTabView->GetShadowReceiver());
+                if (!SharedHelpers::Is21H1OrHigher())
+                {
+                    shadow.Receivers().Append(internalTabView->GetShadowReceiver());
+                }
                 m_shadow = shadow;
 
                 double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));


### PR DESCRIPTION
## Description
Since DropShadows don't require a caster or receiver, this PR checks for OS version 21H1 in codebehind before disabling the usage of the caster/receiver. The selected TabViewItem itself will have the DropShadow.

## Screenshots
![image](https://user-images.githubusercontent.com/57155886/109086532-96290080-76c0-11eb-9acf-55c4a2965fe9.png)

