### PR TITLE
Mark expander automation peer public

### DIFF
--- a/dev/Expander/ExpanderAutomationPeer.idl
+++ b/dev/Expander/ExpanderAutomationPeer.idl
@@ -1,7 +1,7 @@
 ﻿namespace MU_XAP_NAMESPACE
 {
 
-[MUX_PREVIEW]
+[MUX_PUBLIC]
 [webhosthidden]
 unsealed runtimeclass ExpanderAutomationPeer : Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,
 Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider


### PR DESCRIPTION
moving expander automation peer to public (was missed out when expander was moved)