### PR TITLE
[Breadcrumb] Add and modify style for ellipsis item flyout

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -25,7 +25,8 @@
             <Setter.Value>
                 <ControlTemplate TargetType="local:BreadcrumbBarItem">
                     <Grid x:Name="PART_LayoutRoot"
-                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}" >
+                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                          contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="ItemTypeStates">
@@ -232,15 +233,16 @@
                                 </Style>
                             </Button.Style>
 
-                            <Button.Content>
-                                <Grid AutomationProperties.Name="BreadcrumbBarItemGrid" AutomationProperties.AccessibilityView="Raw">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition x:Name="PART_SeparatorColumnDefinition" Width="0px" />
-                                        <ColumnDefinition x:Name="PART_ChevronColumnDefinition" Width="Auto" />
-                                    </Grid.ColumnDefinitions>
+                            <!-- This is the Button Content -->
+                            <Grid AutomationProperties.Name="BreadcrumbBarItemGrid"
+                                  AutomationProperties.AccessibilityView="Raw">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition x:Name="PART_SeparatorColumnDefinition" Width="0px" />
+                                    <ColumnDefinition x:Name="PART_ChevronColumnDefinition" Width="Auto" />
+                                </Grid.ColumnDefinitions>
 
-                                    <ContentPresenter x:Name="PART_ItemContentPresenter"
+                                <ContentPresenter x:Name="PART_ItemContentPresenter"
                                         AutomationProperties.Name="BreadcrumbBarItemContentPresenter"
                                         Grid.Column="0"
                                         Content="{TemplateBinding Content}"
@@ -254,7 +256,7 @@
                                         LineHeight="20"
                                         AutomationProperties.AccessibilityView="Raw"/>
 
-                                    <TextBlock x:Name="PART_EllipsisTextBlock"
+                                <TextBlock x:Name="PART_EllipsisTextBlock"
                                         AutomationProperties.Name="BreadcrumbBarEllipsisTextBlock"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                         Text="&#xE712;"
@@ -265,7 +267,7 @@
                                         AutomationProperties.AccessibilityView="Raw"
                                         Grid.Column="0"/>
 
-                                    <TextBlock x:Name="PART_ChevronTextBlock"
+                                <TextBlock x:Name="PART_ChevronTextBlock"
                                         AutomationProperties.Name="ChevronTextBlock"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                         Foreground="{ThemeResource BreadcrumbBarNormalForegroundBrush}"
@@ -277,8 +279,7 @@
                                         AutomationProperties.AccessibilityView="Raw"
                                         Padding="2,2,2,2"
                                         Grid.Column="2"/>
-                                </Grid>
-                            </Button.Content>
+                            </Grid>
 
                             <Button.Flyout>
                                 <Flyout>
@@ -302,23 +303,25 @@
                                                 <Setter.Value>
                                                     <ControlTemplate TargetType="FlyoutPresenter">
                                                         <Grid Background="{TemplateBinding Background}"
-                                                  contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                  contract7Present:BackgroundSizing="InnerBorderEdge">
+                                                              contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                              contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
+                                                              contract7Present:BackgroundSizing="InnerBorderEdge">
                                                             <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
-                                                              Margin="{TemplateBinding Padding}"
-                                                              HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                              VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                              IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                                              IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                                              ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                                                              Content="{TemplateBinding Content}"
-                                                              AutomationProperties.AccessibilityView="Raw" />
+                                                                          Margin="{TemplateBinding Padding}"
+                                                                          HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                                                          HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                                          VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                                                          VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                                          IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                                                          IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                                                          ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+                                                                          Content="{TemplateBinding Content}"
+                                                                          AutomationProperties.AccessibilityView="Raw" />
                                                             <Border x:Name="FlyoutPresenterBorder"
-                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
+                                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                                    contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"/>
                                                         </Grid>
                                                     </ControlTemplate>
                                                 </Setter.Value>
@@ -337,7 +340,7 @@
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             ContentTransitions="{TemplateBinding ContentTransitions}"
                             HorizontalAlignment="Stretch"
-                            HorizontalContentAlignment="Stretch"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </Grid>
                 </ControlTemplate>

--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -34,7 +34,6 @@
                                 <Setter Property="BorderThickness" Value="{ThemeResource MenuFlyoutPresenterBorderThemeThickness}" />
                                 <Setter Property="Padding" Value="{StaticResource MenuFlyoutPresenterThemePadding}" />
                                 <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-                                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
                                 <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
                                 <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
                                 <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
@@ -60,8 +59,7 @@
                                                               IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
                                                               ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                                                               Content="{TemplateBinding Content}"
-                                                              AutomationProperties.AccessibilityView="Raw">
-                                                </ScrollViewer>
+                                                              AutomationProperties.AccessibilityView="Raw" />
                                                 <Border x:Name="FlyoutPresenterBorder"
                                                         BorderBrush="{TemplateBinding BorderBrush}"
                                                         BorderThickness="{TemplateBinding BorderThickness}"

--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -27,51 +27,6 @@
                     <Grid x:Name="PART_LayoutRoot"
                           contract7Present:CornerRadius="{TemplateBinding CornerRadius}" >
 
-                        <Grid.Resources>
-                            <Style TargetType="FlyoutPresenter" x:Key="DefaultBreadcrumbBarItemFlyoutPresenterStyle">
-                                <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
-                                <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
-                                <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
-                                <Setter Property="Padding" Value="{StaticResource BreadcrumbBarEllipsisFlyoutPresenterThemePadding}" />
-                                <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-                                <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
-                                <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-                                <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
-                                <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
-                                <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-                                <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
-                                <Setter Property="MinHeight" Value="{StaticResource BreadcrumbBarEllipsisFlyoutThemeMinHeight}" />
-                                <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
-
-                                <Setter Property="Template">
-                                    <Setter.Value>
-                                        <ControlTemplate TargetType="FlyoutPresenter">
-                                            <Grid Background="{TemplateBinding Background}"
-                                                  contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                  contract7Present:BackgroundSizing="InnerBorderEdge">
-                                                <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
-                                                              Margin="{TemplateBinding Padding}"
-                                                              HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                              VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                              IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                                              IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                                              ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                                                              Content="{TemplateBinding Content}"
-                                                              AutomationProperties.AccessibilityView="Raw" />
-                                                <Border x:Name="FlyoutPresenterBorder"
-                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
-                                            </Grid>
-                                        </ControlTemplate>
-                                    </Setter.Value>
-                                </Setter>
-
-                            </Style>
-                        </Grid.Resources>
-
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="ItemTypeStates">
                                 <VisualState x:Name="Inline"/>
@@ -324,6 +279,56 @@
                                         Grid.Column="2"/>
                                 </Grid>
                             </Button.Content>
+
+                            <Button.Flyout>
+                                <Flyout>
+                                    <Flyout.FlyoutPresenterStyle>
+                                        <Style TargetType="FlyoutPresenter">
+                                            <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
+                                            <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
+                                            <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
+                                            <Setter Property="Padding" Value="{StaticResource BreadcrumbBarEllipsisFlyoutPresenterThemePadding}" />
+                                            <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
+                                            <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
+                                            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+                                            <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+                                            <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+                                            <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+                                            <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
+                                            <Setter Property="MinHeight" Value="{StaticResource BreadcrumbBarEllipsisFlyoutThemeMinHeight}" />
+                                            <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="FlyoutPresenter">
+                                                        <Grid Background="{TemplateBinding Background}"
+                                                  contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                  contract7Present:BackgroundSizing="InnerBorderEdge">
+                                                            <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
+                                                              Margin="{TemplateBinding Padding}"
+                                                              HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                              VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                              IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                                              IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                                              ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+                                                              Content="{TemplateBinding Content}"
+                                                              AutomationProperties.AccessibilityView="Raw" />
+                                                            <Border x:Name="FlyoutPresenterBorder"
+                                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
+                                                        </Grid>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+
+                                        </Style>
+                                    </Flyout.FlyoutPresenterStyle>
+                                </Flyout>
+                            </Button.Flyout>
+                            
                         </Button>
                         <ContentPresenter x:Name="PART_EllipsisDropDownItemContentPresenter"
                             x:DeferLoadStrategy="Lazy"

--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -29,10 +29,10 @@
 
                         <Grid.Resources>
                             <Style TargetType="FlyoutPresenter" x:Key="DefaultBreadcrumbBarItemFlyoutPresenterStyle">
-                                <Setter Property="Background" Value="{ThemeResource MenuFlyoutPresenterBackground}" />
-                                <Setter Property="BorderBrush" Value="{ThemeResource MenuFlyoutPresenterBorderBrush}" />
-                                <Setter Property="BorderThickness" Value="{ThemeResource MenuFlyoutPresenterBorderThemeThickness}" />
-                                <Setter Property="Padding" Value="{StaticResource MenuFlyoutPresenterThemePadding}" />
+                                <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
+                                <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
+                                <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
+                                <Setter Property="Padding" Value="{StaticResource BreadcrumbBarEllipsisFlyoutPresenterThemePadding}" />
                                 <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
                                 <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
                                 <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
@@ -40,7 +40,7 @@
                                 <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
                                 <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
                                 <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
-                                <Setter Property="MinHeight" Value="{StaticResource MenuFlyoutThemeMinHeight}" />
+                                <Setter Property="MinHeight" Value="{StaticResource BreadcrumbBarEllipsisFlyoutThemeMinHeight}" />
                                 <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
 
                                 <Setter Property="Template">
@@ -79,8 +79,8 @@
                                     <VisualState.Setters>
                                         <Setter Target="PART_ItemButton.Visibility" Value="Collapsed"/>
                                         <Setter Target="PART_EllipsisDropDownItemContentPresenter.Visibility" Value="Visible"/>
-                                        <Setter Target="PART_LayoutRoot.Padding" Value="11,9,11,10"/>
-                                        <Setter Target="PART_LayoutRoot.Margin" Value="4,2,4,2"/>
+                                        <Setter Target="PART_LayoutRoot.Padding" Value="{StaticResource BreadcrumbBarEllipsisDropDownItemPadding}"/>
+                                        <Setter Target="PART_LayoutRoot.Margin" Value="{StaticResource BreadcrumbBarEllipsisDropDownItemMargin}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -2,13 +2,15 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.UI.Xaml.Controls">
+    xmlns:local="using:Microsoft.UI.Xaml.Controls"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <Style x:Key="DefaultBreadcrumbBarItemStyle" TargetType="local:BreadcrumbBarItem">
         <Setter Property="Foreground" Value="{ThemeResource BreadcrumbBarForegroundBrush}" />
         <Setter Property="Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -18,10 +20,60 @@
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="FocusVisualMargin" Value="-3" />
         <Setter Property="IsTabStop" Value="True"/>
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BreadcrumbBarItem">
-                    <Grid x:Name="PART_LayoutRoot" CornerRadius="{TemplateBinding CornerRadius}" >
+                    <Grid x:Name="PART_LayoutRoot"
+                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}" >
+
+                        <Grid.Resources>
+                            <Style TargetType="FlyoutPresenter" x:Key="DefaultBreadcrumbBarItemFlyoutPresenterStyle">
+                                <Setter Property="Background" Value="{ThemeResource MenuFlyoutPresenterBackground}" />
+                                <Setter Property="BorderBrush" Value="{ThemeResource MenuFlyoutPresenterBorderBrush}" />
+                                <Setter Property="BorderThickness" Value="{ThemeResource MenuFlyoutPresenterBorderThemeThickness}" />
+                                <Setter Property="Padding" Value="{StaticResource MenuFlyoutPresenterThemePadding}" />
+                                <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
+                                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+                                <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
+                                <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+                                <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+                                <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+                                <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+                                <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
+                                <Setter Property="MinHeight" Value="{StaticResource MenuFlyoutThemeMinHeight}" />
+                                <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="FlyoutPresenter">
+                                            <Grid Background="{TemplateBinding Background}"
+                                                  contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                  contract7Present:BackgroundSizing="InnerBorderEdge">
+                                                <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
+                                                              Margin="{TemplateBinding Padding}"
+                                                              HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                              VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                              IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                                              IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                                              ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+                                                              Content="{TemplateBinding Content}"
+                                                              AutomationProperties.AccessibilityView="Raw">
+                                                </ScrollViewer>
+                                                <Border x:Name="FlyoutPresenterBorder"
+                                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+
+                            </Style>
+                        </Grid.Resources>
+
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="ItemTypeStates">
                                 <VisualState x:Name="Inline"/>
@@ -29,6 +81,8 @@
                                     <VisualState.Setters>
                                         <Setter Target="PART_ItemButton.Visibility" Value="Collapsed"/>
                                         <Setter Target="PART_EllipsisDropDownItemContentPresenter.Visibility" Value="Visible"/>
+                                        <Setter Target="PART_LayoutRoot.Padding" Value="11,9,11,10"/>
+                                        <Setter Target="PART_LayoutRoot.Margin" Value="4,2,4,2"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -276,11 +330,11 @@
                         <ContentPresenter x:Name="PART_EllipsisDropDownItemContentPresenter"
                             x:DeferLoadStrategy="Lazy"
                             Visibility="Collapsed"
-                            Margin="{ThemeResource BreadcrumbBarEllipsisDropDownItemMargin}"
                             Content="{TemplateBinding Content}"
                             ContentTemplate="{TemplateBinding ContentTemplate}"
                             ContentTransitions="{TemplateBinding ContentTransitions}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </Grid>
                 </ControlTemplate>

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -106,7 +106,6 @@ void BreadcrumbBarItem::OnApplyTemplate()
         winrt::IControlProtected controlProtected{ *this };
 
         m_button.set(GetTemplateChildT<winrt::Button>(s_itemButtonPartName, controlProtected));
-        m_grid.set(GetTemplateChildT<winrt::Grid>(s_itemGridPartName, controlProtected));
 
         if (const auto& button = m_button.get())
         {
@@ -345,35 +344,6 @@ void BreadcrumbBarItem::OpenFlyout()
     }
 }
 
-winrt::Style BreadcrumbBarItem::RetrieveFlyoutStyle()
-{
-    if (const auto& grid = m_grid.get())
-    {
-        const auto& resources = grid.Resources();
-
-        /*
-        if (resources.HasKey(box_value(L"DefaultBreadcrumbBarItemFlyoutPresenterStyle")))
-        {
-            const auto& value = resources.Lookup(box_value(L"DefaultBreadcrumbBarItemFlyoutPresenterStyle"));
-            return value.try_as<winrt::Style>();
-        }
-        */
-
-        for (const auto& themeDictionaryEntry : resources)
-        {
-            winrt::hstring entryKey = winrt::unbox_value_or<winrt::hstring>(themeDictionaryEntry.Key(), L"");
-            if (const auto& entryValue = themeDictionaryEntry.Value().try_as<winrt::Style>())
-            {
-                const auto& targetType = entryValue.TargetType();
-                const auto& name = targetType.Name;
-                return entryValue;
-            }
-        }
-    }
-
-    return winrt::Style();
-}
-
 void BreadcrumbBarItem::CloseFlyout()
 {
     MUX_ASSERT(!m_isEllipsisDropDownItem);
@@ -582,16 +552,14 @@ void BreadcrumbBarItem::InstantiateFlyout()
         m_ellipsisItemsRepeater.set(ellipsisItemsRepeater);
 
         // Create the Flyout and add the ItemsRepeater as content
-        const auto& ellipsisFlyout = winrt::Flyout();
-        winrt::AutomationProperties::SetName(ellipsisFlyout, s_ellipsisFlyoutAutomationName);
-        ellipsisFlyout.Content(ellipsisItemsRepeater);
-        ellipsisFlyout.Placement(winrt::FlyoutPlacementMode::Bottom);
-        ellipsisFlyout.FlyoutPresenterStyle(RetrieveFlyoutStyle());
+        if (const auto& ellipsisFlyout = button.Flyout().try_as<winrt::Flyout>())
+        {
+            winrt::AutomationProperties::SetName(ellipsisFlyout, s_ellipsisFlyoutAutomationName);
+            ellipsisFlyout.Content(ellipsisItemsRepeater);
+            ellipsisFlyout.Placement(winrt::FlyoutPlacementMode::Bottom);
 
-        m_ellipsisFlyout.set(ellipsisFlyout);
-
-        // Set the Flyout to the ellipsis button
-        button.Flyout(ellipsisFlyout);
+            m_ellipsisFlyout.set(ellipsisFlyout);
+        }
     }
 }
 

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -106,6 +106,7 @@ void BreadcrumbBarItem::OnApplyTemplate()
         winrt::IControlProtected controlProtected{ *this };
 
         m_button.set(GetTemplateChildT<winrt::Button>(s_itemButtonPartName, controlProtected));
+        m_grid.set(GetTemplateChildT<winrt::Grid>(s_itemGridPartName, controlProtected));
 
         if (const auto& button = m_button.get())
         {
@@ -344,6 +345,35 @@ void BreadcrumbBarItem::OpenFlyout()
     }
 }
 
+winrt::Style BreadcrumbBarItem::RetrieveFlyoutStyle()
+{
+    if (const auto& grid = m_grid.get())
+    {
+        const auto& resources = grid.Resources();
+
+        /*
+        if (resources.HasKey(box_value(L"DefaultBreadcrumbBarItemFlyoutPresenterStyle")))
+        {
+            const auto& value = resources.Lookup(box_value(L"DefaultBreadcrumbBarItemFlyoutPresenterStyle"));
+            return value.try_as<winrt::Style>();
+        }
+        */
+
+        for (const auto& themeDictionaryEntry : resources)
+        {
+            winrt::hstring entryKey = winrt::unbox_value_or<winrt::hstring>(themeDictionaryEntry.Key(), L"");
+            if (const auto& entryValue = themeDictionaryEntry.Value().try_as<winrt::Style>())
+            {
+                const auto& targetType = entryValue.TargetType();
+                const auto& name = targetType.Name;
+                return entryValue;
+            }
+        }
+    }
+
+    return winrt::Style();
+}
+
 void BreadcrumbBarItem::CloseFlyout()
 {
     MUX_ASSERT(!m_isEllipsisDropDownItem);
@@ -556,6 +586,7 @@ void BreadcrumbBarItem::InstantiateFlyout()
         winrt::AutomationProperties::SetName(ellipsisFlyout, s_ellipsisFlyoutAutomationName);
         ellipsisFlyout.Content(ellipsisItemsRepeater);
         ellipsisFlyout.Placement(winrt::FlyoutPlacementMode::Bottom);
+        ellipsisFlyout.FlyoutPresenterStyle(RetrieveFlyoutStyle());
 
         m_ellipsisFlyout.set(ellipsisFlyout);
 

--- a/dev/Breadcrumb/BreadcrumbBarItem.h
+++ b/dev/Breadcrumb/BreadcrumbBarItem.h
@@ -81,7 +81,6 @@ private:
     void UpdateButtonCommonVisualState(bool useTransitions);
     void UpdateFlyoutIndex(const winrt::UIElement& element, const uint32_t index);
     winrt::IInspectable CloneEllipsisItemSource(const winrt::Collections::IVector<winrt::IInspectable>& ellipsisItemsSource);
-    winrt::Style RetrieveFlyoutStyle();
 
     // Common item fields
 
@@ -96,7 +95,6 @@ private:
 
     // BreadcrumbBarItem visual representation
     tracker_ref<winrt::Button> m_button{ this };
-    tracker_ref<winrt::Grid> m_grid{ this };
     // Parent BreadcrumbBarItem to ask for hidden elements
     tracker_ref<winrt::BreadcrumbBar> m_parentBreadcrumb{ this };
 

--- a/dev/Breadcrumb/BreadcrumbBarItem.h
+++ b/dev/Breadcrumb/BreadcrumbBarItem.h
@@ -81,6 +81,7 @@ private:
     void UpdateButtonCommonVisualState(bool useTransitions);
     void UpdateFlyoutIndex(const winrt::UIElement& element, const uint32_t index);
     winrt::IInspectable CloneEllipsisItemSource(const winrt::Collections::IVector<winrt::IInspectable>& ellipsisItemsSource);
+    winrt::Style RetrieveFlyoutStyle();
 
     // Common item fields
 
@@ -95,6 +96,7 @@ private:
 
     // BreadcrumbBarItem visual representation
     tracker_ref<winrt::Button> m_button{ this };
+    tracker_ref<winrt::Grid> m_grid{ this };
     // Parent BreadcrumbBarItem to ask for hidden elements
     tracker_ref<winrt::BreadcrumbBar> m_parentBreadcrumb{ this };
 
@@ -155,6 +157,7 @@ private:
 
     // Template Parts
     static constexpr std::wstring_view s_ellipsisItemsRepeaterPartName{ L"PART_EllipsisItemsRepeater"sv };
+    static constexpr std::wstring_view s_itemGridPartName{ L"PART_LayoutRoot"sv };
     static constexpr std::wstring_view s_itemButtonPartName{ L"PART_ItemButton"sv };
 
     // Automation Names

--- a/dev/Breadcrumb/BreadcrumbBarItem.h
+++ b/dev/Breadcrumb/BreadcrumbBarItem.h
@@ -155,7 +155,6 @@ private:
 
     // Template Parts
     static constexpr std::wstring_view s_ellipsisItemsRepeaterPartName{ L"PART_EllipsisItemsRepeater"sv };
-    static constexpr std::wstring_view s_itemGridPartName{ L"PART_LayoutRoot"sv };
     static constexpr std::wstring_view s_itemButtonPartName{ L"PART_ItemButton"sv };
 
     // Automation Names

--- a/dev/Breadcrumb/BreadcrumbBar_themeresources.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar_themeresources.xaml
@@ -6,8 +6,11 @@
     <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE76C;</x:String>
     <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE76B;</x:String>
 
-    <Thickness x:Key="BreadcrumbBarEllipsisDropDownItemMargin">11,11,11,12</Thickness>
-    
+    <x:Double x:Key="BreadcrumbBarEllipsisFlyoutThemeMinHeight">40</x:Double>
+    <Thickness x:Key="BreadcrumbBarEllipsisDropDownItemMargin">5,3,5,3</Thickness>
+    <Thickness x:Key="BreadcrumbBarEllipsisDropDownItemPadding">11,7,11,9</Thickness>
+    <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterThemePadding">0,2,0,2</Thickness>
+
     <ResourceDictionary.ThemeDictionaries>
 
         <ResourceDictionary x:Key="Default">
@@ -34,6 +37,10 @@
             <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
             <SolidColorBrush x:Key="BreadcrumbBarBackgroundBrush" Color="Transparent"/>
             <SolidColorBrush x:Key="BreadcrumbBarBorderBrush" Color="Transparent"/>
+
+            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+            <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">1</Thickness>
 
             <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>
@@ -64,6 +71,10 @@
             <SolidColorBrush x:Key="BreadcrumbBarBackgroundBrush" Color="Transparent"/>
             <SolidColorBrush x:Key="BreadcrumbBarBorderBrush" Color="Transparent"/>
 
+            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorDefaultBrush" />
+            <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">1</Thickness>
+
             <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>
 
@@ -91,6 +102,10 @@
             <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="SystemColorWindowTextColorBrush" />
             <StaticResource x:Key="BreadcrumbBarBackgroundBrush" ResourceKey="SystemColorButtonFaceColor" />
             <StaticResource x:Key="BreadcrumbBarBorderBrush" ResourceKey="SystemColorButtonFaceColor" />
+
+            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />
+            <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">2</Thickness>
 
             <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
         </ResourceDictionary>


### PR DESCRIPTION
Updates the ellipsis styling to match the figma (and MenuFlyout item for the dropdown)

## Description
* Adds a style definition for the FlyoutPresenter so it can match the style of the MenuFlyout
* Adds a method to retrieve the FlyoutPresenter style 
* Updates HorizontalAlignment for ContentPresenter to highlight the whole element

## Motivation and Context
??

## How Has This Been Tested?
Tested manually?

## Screenshots (if appropriate):

### Light theme
![image](https://user-images.githubusercontent.com/35784165/109240420-50d20500-778c-11eb-9226-b3b16e3c24f8.png)

![image](https://user-images.githubusercontent.com/35784165/109354676-0ce60b00-7833-11eb-8d03-6a6237984e30.png)

### Dark theme
![image](https://user-images.githubusercontent.com/35784165/109240480-69dab600-778c-11eb-84d3-d30233671439.png)

![image](https://user-images.githubusercontent.com/35784165/109354732-1e2f1780-7833-11eb-9c49-267ea309cd9f.png)


### Right-To-Left support
![image](https://user-images.githubusercontent.com/35784165/109240534-7ced8600-778c-11eb-8c04-bd529fc919f6.png)

![image](https://user-images.githubusercontent.com/35784165/109354785-2f782400-7833-11eb-8889-279a6e97129e.png)


### Hovering over a dropdown element
![image](https://user-images.githubusercontent.com/35784165/109240604-9abaeb00-778c-11eb-816c-61b898ef84aa.png)

![image](https://user-images.githubusercontent.com/35784165/109354935-61898600-7833-11eb-94bc-23fd3a4158ee.png)
