### PR TITLE
Adjust private AcrylicBrushFactory parameters

### DIFF
--- a/dev/Materials/Acrylic/AcrylicBrushFactory.cpp
+++ b/dev/Materials/Acrylic/AcrylicBrushFactory.cpp
@@ -16,27 +16,10 @@ winrt::CompositionEffectBrush AcrylicBrushFactory::CreateBackdropAcrylicEffectBr
     winrt::Color const& initialFallbackColor,
     bool willTintColorAlwaysBeOpaque)
 {
-    // Pass nullptr to let it auto-calculate luminosity opacity.
-    const winrt::Color initialLuminosityColor = GetLuminosityColor(initialTintColor, nullptr);
-
     return CreateBackdropAcrylicEffectBrushWithLuminosity(
         compositor,
         initialTintColor,
-        initialLuminosityColor,
-        initialFallbackColor,
-        willTintColorAlwaysBeOpaque);
-
-    // Update tintColor's alpha with the modifier
-    winrt::Color tintColor = initialTintColor;
-    const double tintOpacityModifier = GetTintOpacityModifier(tintColor);
-    tintColor.A = static_cast<uint8_t>(round(tintOpacityModifier * tintColor.A));
-
-    return AcrylicBrush::CreateAcrylicBrushWorker(
-        compositor,
-        false, // useWindowAcrylic
-        false, // useCrossFadeEffect
-        tintColor,
-        initialLuminosityColor,
+        nullptr, // luminosityOpacity. Pass nullptr to let it auto-calculate luminosity opacity.
         initialFallbackColor,
         willTintColorAlwaysBeOpaque);
 }
@@ -44,10 +27,12 @@ winrt::CompositionEffectBrush AcrylicBrushFactory::CreateBackdropAcrylicEffectBr
 winrt::CompositionEffectBrush AcrylicBrushFactory::CreateBackdropAcrylicEffectBrushWithLuminosity(
     winrt::Compositor const& compositor,
     winrt::Color const& initialTintColor,
-    winrt::Color const& initialLuminosityColor,
+    winrt::IReference<double> const& luminosityOpacity,
     winrt::Color const& initialFallbackColor,
     bool willTintColorAlwaysBeOpaque)
 {
+    const winrt::Color initialLuminosityColor = GetLuminosityColor(initialTintColor, luminosityOpacity);
+    
     // Update tintColor's alpha with the modifier
     winrt::Color tintColor = initialTintColor;
     const double tintOpacityModifier = GetTintOpacityModifier(tintColor);

--- a/dev/Materials/Acrylic/AcrylicBrushFactory.h
+++ b/dev/Materials/Acrylic/AcrylicBrushFactory.h
@@ -20,7 +20,7 @@ public:
     winrt::CompositionEffectBrush CreateBackdropAcrylicEffectBrushWithLuminosity(
         winrt::Compositor const& compositor,
         winrt::Color const& initialTintColor,
-        winrt::Color const& initialLuminosityColor,
+        winrt::IReference<double> const& luminosityOpacity,
         winrt::Color const& initialFallbackColor,
         bool willTintColorAlwaysBeOpaque);
 };

--- a/dev/Materials/Acrylic/AcrylicTestApi.idl
+++ b/dev/Materials/Acrylic/AcrylicTestApi.idl
@@ -20,7 +20,7 @@ runtimeclass AcrylicTestApi : Windows.UI.Xaml.DependencyObject
 interface IAcrylicBrushStaticsPrivate
 {
     Windows.UI.Composition.CompositionEffectBrush CreateBackdropAcrylicEffectBrush(Windows.UI.Composition.Compositor compositor, Windows.UI.Color initialTintColor, Windows.UI.Color initialFallbackColor, Boolean willTintColorAlwaysBeOpaque);
-    Windows.UI.Composition.CompositionEffectBrush CreateBackdropAcrylicEffectBrushWithLuminosity(Windows.UI.Composition.Compositor compositor, Windows.UI.Color initialTintColor, Windows.UI.Color initialLuminosityColor, Windows.UI.Color initialFallbackColor, Boolean willTintColorAlwaysBeOpaque);
+    Windows.UI.Composition.CompositionEffectBrush CreateBackdropAcrylicEffectBrushWithLuminosity(Windows.UI.Composition.Compositor compositor, Windows.UI.Color initialTintColor, Windows.Foundation.IReference<double> luminosityOpacity, Windows.UI.Color initialFallbackColor, Boolean willTintColorAlwaysBeOpaque);
 }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Porting the changes about adjusting the parameters in `AcrylicBrushFactory`. Please also see PR 5727532 in OS repo for related changes. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The parameter LuminosityOpacity is added in 19H1 to `Windows.UI.Xaml.Media.AcrylicBrush` but this factory method is taking in a `Windows.UI.Color` parameter, which is not very convenient for just changing the opacity itself. 

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
