### PR TITLE
Updated Localization Key Handling

### DIFF
--- a/build/Localization/LocalizationAutomation.proj
+++ b/build/Localization/LocalizationAutomation.proj
@@ -46,7 +46,7 @@
   </Target>
   <!-- Run localization build by interacting with the Touchdown Build service -->
   <Target Name="LocalizeBuild" DependsOnTargets="CheckForLocalizeBuild">
-    <Exec Command="set LocRoot=$(LocRoot) &amp; &quot;$(TdBuildClientPath)\TdBuildClient.exe&quot; /c:&quot;$(LocConfigFile)&quot; /auth:&quot;oAuth&quot; /clientid:&quot;d3dd8113-65b3-4526-bdca-a00a7d1c37ba&quot; /appkey:&quot;fji9zFas7MHb6kdgdy9fbPrLH6MkTebGimuE/7tuWVg=&quot; /o:&quot;$(LocOutput)&quot;" />
+    <Exec Command="set LocRoot=$(LocRoot) &amp; &quot;$(TdBuildClientPath)\TdBuildClient.exe&quot; /c:&quot;$(LocConfigFile)&quot; /auth:&quot;oAuth&quot; /clientid:&quot;e8416663-8a55-4cb6-9bba-12038b37a6ed&quot; /appkey:&quot;$(MAPPED_LOC_KEY)&quot; /o:&quot;$(LocOutput)&quot;" />
   </Target>
   <!-- Check-in localized resource files resulted from Touchdown build -->
   <Target Name="CheckinLocFiles">

--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -1,3 +1,6 @@
+variables:
+- group: WinUITeamKeyVault-Secrets
+
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: LocalizationHandoff
@@ -19,6 +22,8 @@ jobs:
     displayName: 'Run Loc Workflow'
     inputs:
       filename: '$(Build.SourcesDirectory)\tools\VSTSRunLocWorkflow.cmd'
+    env:
+      MAPPED_LOC_KEY: $(WinUILab-TouchdownLoc-Key)
 
   - powershell: |
       $changes = & git ls-files -m

--- a/tools/VSTSRunLocWorkflow.cmd
+++ b/tools/VSTSRunLocWorkflow.cmd
@@ -10,4 +10,9 @@ setlocal
 	exit /B 1
 )
 
+@if not defined MAPPED_LOC_KEY (
+	echo ERROR: Expecting MAPPED_LOC_KEY to be set
+	exit /B 1
+)
+
 call %~dp0\..\build\localization\RunLocWorkflow.cmd Daily-%BUILDDATE%.%BUILDREVISION%


### PR DESCRIPTION
Fixes #4405 

## Description
Updating Client Id and Key used for the touchdown localization service.

## Motivation and Context
Old clientid/key has been revoked. 

## How Has This Been Tested?
Manual run of the pipeline
