### PR TITLE
Selection isn't properly applied if items haven't been realized yet.

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -4778,7 +4778,7 @@ template<typename T> T NavigationView::GetContainerForData(const winrt::IInspect
     auto itemIndex = GetIndexFromItem(mainRepeater, data);
     if (itemIndex >= 0)
     {
-        if (auto container = mainRepeater.TryGetElement(itemIndex))
+        if (auto container = mainRepeater.GetOrCreateElement(itemIndex))
         {
             return container.try_as<T>();
         }
@@ -4789,7 +4789,7 @@ template<typename T> T NavigationView::GetContainerForData(const winrt::IInspect
     itemIndex = GetIndexFromItem(footerRepeater, data);
     if (itemIndex >= 0)
     {
-        if (auto container = footerRepeater.TryGetElement(itemIndex))
+        if (auto container = footerRepeater.GetOrCreateElement(itemIndex))
         {
             return container.try_as<T>();
         }
@@ -4817,12 +4817,12 @@ winrt::UIElement NavigationView::SearchEntireTreeForContainer(const winrt::Items
     const auto index = GetIndexFromItem(rootRepeater, data);
     if (index != -1)
     {
-        return rootRepeater.TryGetElement(index);
+        return rootRepeater.GetOrCreateElement(index);
     }
 
     for (int i = 0; i < GetContainerCountInRepeater(rootRepeater); i++)
     {
-        if (auto const container = rootRepeater.TryGetElement(i))
+        if (auto const container = rootRepeater.GetOrCreateElement(i))
         {
             if (auto const nvi = container.try_as<winrt::NavigationViewItem>())
             {
@@ -4843,7 +4843,7 @@ winrt::IndexPath NavigationView::SearchEntireTreeForIndexPath(const winrt::Items
 {
     for (int i = 0; i < GetContainerCountInRepeater(rootRepeater); i++)
     {
-        if (auto const container = rootRepeater.TryGetElement(i))
+        if (auto const container = rootRepeater.GetOrCreateElement(i))
         {
             if (auto const nvi = container.try_as<winrt::NavigationViewItem>())
             {
@@ -4871,7 +4871,7 @@ winrt::IndexPath NavigationView::SearchEntireTreeForIndexPath(const winrt::Navig
             areChildrenRealized = true;
             for (int i = 0; i < GetContainerCountInRepeater(childrenRepeater); i++)
             {
-                if (auto const container = childrenRepeater.TryGetElement(i))
+                if (auto const container = childrenRepeater.GetOrCreateElement(i))
                 {
                     if (auto const nvi = container.try_as<winrt::NavigationViewItem>())
                     {
@@ -5077,15 +5077,15 @@ winrt::UIElement NavigationView::GetContainerForIndex(int index, bool inFooter)
             const auto irIndex = inFooter ? index : m_topDataProvider.ConvertOriginalIndexToIndex(index);
 
         // Get the container of the first item
-        if (auto const container = ir.TryGetElement(irIndex))
+        if (auto const container = ir.GetOrCreateElement(irIndex))
         {
             return container;
         }
     }
     else
     {
-        if (auto container = inFooter ? m_leftNavFooterMenuRepeater.get().TryGetElement(index)
-            : m_leftNavRepeater.get().TryGetElement(index))
+        if (auto container = inFooter ? m_leftNavFooterMenuRepeater.get().GetOrCreateElement(index)
+            : m_leftNavRepeater.get().GetOrCreateElement(index))
         {
             return container.try_as<winrt::NavigationViewItemBase>();
         }

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -728,7 +728,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
 
         [TestMethod]
-        public void VerifySelectionFromLoaded()
+        public void VerifyTopSelectionFromLoaded()
         {
             NavigationView navView = null;
             RunOnUIThread.Execute(() =>
@@ -753,15 +753,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 navView.MenuItemTemplate = template;
                 navView.IsPaneOpen = false;
                 navView.IsSettingsVisible = false;
+                navView.PaneDisplayMode = NavigationViewPaneDisplayMode.Top;
 
                 RoutedEventHandler loaded = null;
                 loaded = (object sender, RoutedEventArgs args) =>
                 {
                     navView.Loaded -= loaded;
 
-                    var items = new List<object>() { new object() }; ;
-                    var footerItems = new List<object>() { new object() };
-                    navView.SelectedItem = footerItems[0];
+                    var items = new List<object>() { new object(), new object(), new object() }; ;
+                    var footerItems = new List<object>() { new object(), new object(), new object() };
+                    navView.SelectedItem = footerItems[1];
                     navView.MenuItemsSource = items;
                     navView.FooterMenuItemsSource = footerItems;
                 };
@@ -770,11 +771,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Content.UpdateLayout();
             });
             IdleSynchronizer.Wait();
-            IdleSynchronizer.Wait();
 
             RunOnUIThread.Execute(() =>
             {
-                var footerRepeater = VisualTreeUtils.FindVisualChildByName(navView, "FooterMenuItemsHost") as FrameworkElement;
+                var footerRepeater = VisualTreeUtils.FindVisualChildByName(navView, "TopFooterMenuItemsHost") as FrameworkElement;
                 var menuItem = VisualTreeHelper.GetChild(footerRepeater, 0) as FrameworkElement;
                 var menuItemLayoutRoot = VisualTreeHelper.GetChild(menuItem, 0) as FrameworkElement;
                 var navItemPresenter = VisualTreeHelper.GetChild(menuItemLayoutRoot, 0) as FrameworkElement;


### PR DESCRIPTION
When getting the container for an item, make sure we create it if it hasn't been created yet.

## Description
When setting the MenuItemSource or FooterMenuItemsSource in the Loaded event, selection isn't updated properly as none of the repeater children have been created.

## Motivation and Context
YourPhone is running into bugs like these as we set the items in the Loaded event and it causes the selection to not be updated properly.

## How Has This Been Tested?
Added test case for this scenario.