### PR TITLE
fix last breadcrumb item showing empty flyout issue

### DIFF
--- a/dev/Breadcrumb/APITests/BreadcrumbTests.cs
+++ b/dev/Breadcrumb/APITests/BreadcrumbTests.cs
@@ -297,24 +297,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 invokationPattern?.Invoke();                          
             });
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
+            // GetOpenPopups returns empty list in RS3. The scenario works, this just seems to be a
+            // test/infra issue in RS3, so filtering it out for now.
+            if (PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
             {
-                var flyout = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
-                Verify.IsNotNull(flyout, "Flyout could not be retrieved");
-                var ellipsisItemsRepeater = TestUtilities.FindDescendents<ItemsRepeater>(flyout).Single();                
-                Verify.IsNotNull(ellipsisItemsRepeater, "The underlying flyout items repeater (1) could not be retrieved");
+                IdleSynchronizer.Wait();
 
-                ellipsisItemsRepeater.Loaded += (object sender, RoutedEventArgs e) => {
-                    TextBlock ellipsisNode1 = ellipsisItemsRepeater.TryGetElement(0) as TextBlock;
-                    Verify.IsNotNull(ellipsisNode1, "Our flyout ItemTemplate (1) should have been wrapped in a TextBlock.");
+                RunOnUIThread.Execute(() =>
+                {
+                    var flyout = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
+                    Verify.IsNotNull(flyout, "Flyout could not be retrieved");
+                    var ellipsisItemsRepeater = TestUtilities.FindDescendents<ItemsRepeater>(flyout).Single();
+                    Verify.IsNotNull(ellipsisItemsRepeater, "The underlying flyout items repeater (1) could not be retrieved");
+
+                    ellipsisItemsRepeater.Loaded += (object sender, RoutedEventArgs e) =>
+                    {
+                        TextBlock ellipsisNode1 = ellipsisItemsRepeater.TryGetElement(0) as TextBlock;
+                        Verify.IsNotNull(ellipsisNode1, "Our flyout ItemTemplate (1) should have been wrapped in a TextBlock.");
 
                     // change this conditions
                     bool testCondition = !(ellipsisNode1.Foreground is SolidColorBrush brush && brush.Color == Colors.Blue);
-                    Verify.IsTrue(testCondition, "Default foreground color of the BreadcrumbBarItem should not have been [blue].");
-                };
-            });
+                        Verify.IsTrue(testCondition, "Default foreground color of the BreadcrumbBarItem should not have been [blue].");
+                    };
+                });
+            }
         }
 
         [TestMethod]
@@ -362,24 +368,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 invokationPattern?.Invoke();
             });
 
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
+            // GetOpenPopups returns empty list in RS3. The scenario works, this just seems to be a
+            // test/infra issue in RS3, so filtering it out for now.
+            if (PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone3))
             {
-                var flyout = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
-                Verify.IsNotNull(flyout, "Flyout could not be retrieved");
-                var ellipsisItemsRepeater = TestUtilities.FindDescendents<ItemsRepeater>(flyout).Single();
-                Verify.IsNotNull(ellipsisItemsRepeater, "The underlying flyout items repeater (1) could not be retrieved");
+                IdleSynchronizer.Wait();
 
-                ellipsisItemsRepeater.Loaded += (object sender, RoutedEventArgs e) => {
-                    TextBlock ellipsisNode1 = ellipsisItemsRepeater.TryGetElement(0) as TextBlock;
-                    Verify.IsNotNull(ellipsisNode1, "Our flyout ItemTemplate (1) should have been wrapped in a TextBlock.");
+                RunOnUIThread.Execute(() =>
+                {
+                    var flyout = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
+                    Verify.IsNotNull(flyout, "Flyout could not be retrieved");
+                    var ellipsisItemsRepeater = TestUtilities.FindDescendents<ItemsRepeater>(flyout).Single();
+                    Verify.IsNotNull(ellipsisItemsRepeater, "The underlying flyout items repeater (1) could not be retrieved");
+
+                    ellipsisItemsRepeater.Loaded += (object sender, RoutedEventArgs e) =>
+                    {
+                        TextBlock ellipsisNode1 = ellipsisItemsRepeater.TryGetElement(0) as TextBlock;
+                        Verify.IsNotNull(ellipsisNode1, "Our flyout ItemTemplate (1) should have been wrapped in a TextBlock.");
 
                     // change this conditions
                     bool testCondition = !(ellipsisNode1.Foreground is SolidColorBrush brush && brush.Color == Colors.Blue);
-                    Verify.IsTrue(testCondition, "Default foreground color of the BreadcrumbBarItem should not have been [blue].");
-                };
-            });
+                        Verify.IsTrue(testCondition, "Default foreground color of the BreadcrumbBarItem should not have been [blue].");
+                    };
+                });
+            }
         }
 
     }

--- a/dev/Breadcrumb/APITests/BreadcrumbTests.cs
+++ b/dev/Breadcrumb/APITests/BreadcrumbTests.cs
@@ -13,6 +13,7 @@ using Windows.UI.Xaml.Media;
 using System.Security.Cryptography.X509Certificates;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation.Provider;
+using System.Linq;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -300,10 +301,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                Flyout ellipsisFlyout = (Flyout)ellipsisButton.Flyout;
-                Verify.IsNotNull(ellipsisButton, "The ellipsis flyout (1) could not be retrieved");
-
-                ItemsRepeater ellipsisItemsRepeater = (ItemsRepeater)ellipsisFlyout.Content;
+                var flyout = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
+                Verify.IsNotNull(flyout, "Flyout could not be retrieved");
+                var ellipsisItemsRepeater = TestUtilities.FindDescendents<ItemsRepeater>(flyout).Single();                
                 Verify.IsNotNull(ellipsisItemsRepeater, "The underlying flyout items repeater (1) could not be retrieved");
 
                 ellipsisItemsRepeater.Loaded += (object sender, RoutedEventArgs e) => {
@@ -366,10 +366,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                Flyout ellipsisFlyout = (Flyout)ellipsisButton.Flyout;
-                Verify.IsNotNull(ellipsisButton, "The ellipsis flyout (1) could not be retrieved");
-
-                ItemsRepeater ellipsisItemsRepeater = (ItemsRepeater)ellipsisFlyout.Content;
+                var flyout = VisualTreeHelper.GetOpenPopups(Window.Current).Last();
+                Verify.IsNotNull(flyout, "Flyout could not be retrieved");
+                var ellipsisItemsRepeater = TestUtilities.FindDescendents<ItemsRepeater>(flyout).Single();
                 Verify.IsNotNull(ellipsisItemsRepeater, "The underlying flyout items repeater (1) could not be retrieved");
 
                 ellipsisItemsRepeater.Loaded += (object sender, RoutedEventArgs e) => {

--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -118,6 +118,57 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
+                        <Grid.Resources>
+                            <Flyout x:Name="PART_EllipsisFlyout">
+                                <Flyout.FlyoutPresenterStyle>
+                                    <Style TargetType="FlyoutPresenter">
+                                        <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
+                                        <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
+                                        <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
+                                        <Setter Property="Padding" Value="{StaticResource BreadcrumbBarEllipsisFlyoutPresenterThemePadding}" />
+                                        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
+                                        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
+                                        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+                                        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+                                        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+                                        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+                                        <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
+                                        <Setter Property="MinHeight" Value="{StaticResource BreadcrumbBarEllipsisFlyoutThemeMinHeight}" />
+                                        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="FlyoutPresenter">
+                                                    <Grid Background="{TemplateBinding Background}"
+                                                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                          contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
+                                                          contract7Present:BackgroundSizing="InnerBorderEdge">
+                                                        <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
+                                                                      Margin="{TemplateBinding Padding}"
+                                                                      HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                                                      VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                                                      IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                                                      IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                                                      ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
+                                                                      Content="{TemplateBinding Content}"
+                                                                      AutomationProperties.AccessibilityView="Raw" />
+                                                        <Border x:Name="FlyoutPresenterBorder"
+                                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                                contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"/>
+                                                    </Grid>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+
+                                    </Style>
+                                </Flyout.FlyoutPresenterStyle>
+                            </Flyout>
+                        </Grid.Resources>
+
                         <Button x:Name="PART_ItemButton"
                             x:DeferLoadStrategy="Lazy"
                             AutomationProperties.Name="BreadcrumbBarItemButton"
@@ -280,57 +331,6 @@
                                         Padding="2,2,2,2"
                                         Grid.Column="2"/>
                             </Grid>
-
-                            <Button.Flyout>
-                                <Flyout>
-                                    <Flyout.FlyoutPresenterStyle>
-                                        <Style TargetType="FlyoutPresenter">
-                                            <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
-                                            <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
-                                            <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
-                                            <Setter Property="Padding" Value="{StaticResource BreadcrumbBarEllipsisFlyoutPresenterThemePadding}" />
-                                            <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-                                            <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
-                                            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-                                            <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
-                                            <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
-                                            <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-                                            <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
-                                            <Setter Property="MinHeight" Value="{StaticResource BreadcrumbBarEllipsisFlyoutThemeMinHeight}" />
-                                            <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
-
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate TargetType="FlyoutPresenter">
-                                                        <Grid Background="{TemplateBinding Background}"
-                                                              contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                              contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
-                                                              contract7Present:BackgroundSizing="InnerBorderEdge">
-                                                            <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
-                                                                          Margin="{TemplateBinding Padding}"
-                                                                          HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                                                          HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                                          VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                                                          VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                                          IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                                                          IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                                                          ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                                                                          Content="{TemplateBinding Content}"
-                                                                          AutomationProperties.AccessibilityView="Raw" />
-                                                            <Border x:Name="FlyoutPresenterBorder"
-                                                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                                    contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"/>
-                                                        </Grid>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-
-                                        </Style>
-                                    </Flyout.FlyoutPresenterStyle>
-                                </Flyout>
-                            </Button.Flyout>
                             
                         </Button>
                         <ContentPresenter x:Name="PART_EllipsisDropDownItemContentPresenter"
@@ -341,7 +341,7 @@
                             ContentTransitions="{TemplateBinding ContentTransitions}"
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>                       
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -95,16 +95,20 @@ void BreadcrumbBarItem::OnApplyTemplate()
 {
     __super::OnApplyTemplate();
 
+    RevokePartsListeners();
+    winrt::IControlProtected controlProtected{ *this };
+
+    if (m_isEllipsisItem)
+    {
+        m_ellipsisFlyout.set(GetTemplateChildT<winrt::Flyout>(s_itemEllipsisFlyoutPartName, controlProtected));
+    }
+
     if (m_isEllipsisDropDownItem)
     {
         UpdateEllipsisDropDownItemCommonVisualState(false /*useTransitions*/);
     }
     else
     {
-        RevokePartsListeners();
-
-        winrt::IControlProtected controlProtected{ *this };
-
         m_button.set(GetTemplateChildT<winrt::Button>(s_itemButtonPartName, controlProtected));
 
         if (const auto& button = m_button.get())
@@ -528,32 +532,28 @@ void BreadcrumbBarItem::InstantiateFlyout()
     // Only if the element has been created visually, instantiate the flyout
     if (const auto& button = m_button.get())
     {
-        // Create ItemsRepeater and set the DataTemplate 
-        const auto& ellipsisItemsRepeater = winrt::ItemsRepeater();
-        ellipsisItemsRepeater.Name(s_ellipsisItemsRepeaterPartName);
-        winrt::AutomationProperties::SetName(ellipsisItemsRepeater, s_ellipsisItemsRepeaterAutomationName);
-        ellipsisItemsRepeater.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
-
-        m_ellipsisElementFactory = winrt::make_self<BreadcrumbElementFactory>();
-        ellipsisItemsRepeater.ItemTemplate(*m_ellipsisElementFactory);
-
-        const auto& stackLayout = winrt::StackLayout();
-        stackLayout.Orientation(winrt::Controls::Orientation::Vertical);
-        ellipsisItemsRepeater.Layout(stackLayout);
-
-        if (const auto& dataTemplate = m_ellipsisDropDownItemDataTemplate.get())
+        if (const auto& ellipsisFlyout = m_ellipsisFlyout.get())
         {
-            m_ellipsisElementFactory->UserElementFactory(dataTemplate);
-        }
+            // Create ItemsRepeater and set the DataTemplate 
+            const auto& ellipsisItemsRepeater = winrt::ItemsRepeater();
+            ellipsisItemsRepeater.Name(s_ellipsisItemsRepeaterPartName);
+            winrt::AutomationProperties::SetName(ellipsisItemsRepeater, s_ellipsisItemsRepeaterAutomationName);
+            ellipsisItemsRepeater.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
 
-        m_ellipsisRepeaterElementPreparedRevoker = ellipsisItemsRepeater.ElementPrepared(winrt::auto_revoke, { this, &BreadcrumbBarItem::OnFlyoutElementPreparedEvent });
-        m_ellipsisRepeaterElementIndexChangedRevoker = ellipsisItemsRepeater.ElementIndexChanged(winrt::auto_revoke, { this, &BreadcrumbBarItem::OnFlyoutElementIndexChangedEvent });
-        
-        m_ellipsisItemsRepeater.set(ellipsisItemsRepeater);
+            m_ellipsisElementFactory = winrt::make_self<BreadcrumbElementFactory>();
+            ellipsisItemsRepeater.ItemTemplate(*m_ellipsisElementFactory);
 
-        // Create the Flyout and add the ItemsRepeater as content
-        if (const auto& ellipsisFlyout = button.Flyout().try_as<winrt::Flyout>())
-        {
+            if (const auto& dataTemplate = m_ellipsisDropDownItemDataTemplate.get())
+            {
+                m_ellipsisElementFactory->UserElementFactory(dataTemplate);
+            }
+
+            m_ellipsisRepeaterElementPreparedRevoker = ellipsisItemsRepeater.ElementPrepared(winrt::auto_revoke, { this, &BreadcrumbBarItem::OnFlyoutElementPreparedEvent });
+            m_ellipsisRepeaterElementIndexChangedRevoker = ellipsisItemsRepeater.ElementIndexChanged(winrt::auto_revoke, { this, &BreadcrumbBarItem::OnFlyoutElementIndexChangedEvent });
+
+            m_ellipsisItemsRepeater.set(ellipsisItemsRepeater);
+
+            // Set the repeater as the content.
             winrt::AutomationProperties::SetName(ellipsisFlyout, s_ellipsisFlyoutAutomationName);
             ellipsisFlyout.Content(ellipsisItemsRepeater);
             ellipsisFlyout.Placement(winrt::FlyoutPlacementMode::Bottom);

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -95,20 +95,20 @@ void BreadcrumbBarItem::OnApplyTemplate()
 {
     __super::OnApplyTemplate();
 
-    RevokePartsListeners();
-    winrt::IControlProtected controlProtected{ *this };
-
-    if (m_isEllipsisItem)
-    {
-        m_ellipsisFlyout.set(GetTemplateChildT<winrt::Flyout>(s_itemEllipsisFlyoutPartName, controlProtected));
-    }
-
     if (m_isEllipsisDropDownItem)
     {
         UpdateEllipsisDropDownItemCommonVisualState(false /*useTransitions*/);
     }
     else
     {
+        RevokePartsListeners();
+        winrt::IControlProtected controlProtected{ *this };
+
+        if (m_isEllipsisItem)
+        {
+            m_ellipsisFlyout.set(GetTemplateChildT<winrt::Flyout>(s_itemEllipsisFlyoutPartName, controlProtected));
+        }
+
         m_button.set(GetTemplateChildT<winrt::Button>(s_itemButtonPartName, controlProtected));
 
         if (const auto& button = m_button.get())

--- a/dev/Breadcrumb/BreadcrumbBarItem.h
+++ b/dev/Breadcrumb/BreadcrumbBarItem.h
@@ -99,7 +99,7 @@ private:
     tracker_ref<winrt::BreadcrumbBar> m_parentBreadcrumb{ this };
 
     // Flyout content for ellipsis item
-    tracker_ref<winrt::FlyoutBase> m_ellipsisFlyout{ this };
+    tracker_ref<winrt::Flyout> m_ellipsisFlyout{ this };
     tracker_ref<winrt::ItemsRepeater> m_ellipsisItemsRepeater{ this };
     tracker_ref<winrt::DataTemplate> m_ellipsisDropDownItemDataTemplate{ this };
     com_ptr<BreadcrumbElementFactory> m_ellipsisElementFactory{ nullptr };
@@ -156,6 +156,7 @@ private:
     // Template Parts
     static constexpr std::wstring_view s_ellipsisItemsRepeaterPartName{ L"PART_EllipsisItemsRepeater"sv };
     static constexpr std::wstring_view s_itemButtonPartName{ L"PART_ItemButton"sv };
+    static constexpr std::wstring_view s_itemEllipsisFlyoutPartName{ L"PART_EllipsisFlyout"sv };
 
     // Automation Names
     static constexpr std::wstring_view s_ellipsisFlyoutAutomationName{ L"EllipsisFlyout"sv };


### PR DESCRIPTION
The last breadcrumb item is showing an empty flyout. The reason happens to be that we have a flyout in the template attached to the button and that means when you click the button we will end up showing it. We are showing the flyout in code only for the ellipsis item, so we can remove it from the button and move it as a resource.

Includes some minor cleanup. The repeater itself should probably be in markup but it is unrelated to this issue.