### PR TITLE
Upgrading internal Windows SDK from version 10.0.21307 to 10.0.21330

### DIFF
--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -7,7 +7,7 @@
     <SDKVersionRS4>10.0.17134.0</SDKVersionRS4>
     <SDKVersionRS5>10.0.17763.0</SDKVersionRS5>
     <SDKVersion19H1>10.0.18362.0</SDKVersion19H1>
-    <SDKVersionInsider>10.0.21307.0</SDKVersionInsider>
+    <SDKVersionInsider>10.0.21330.0</SDKVersionInsider>
   </PropertyGroup>
   <PropertyGroup>
     <!-- By default we use the publicly shipped SDK version which is 19H1 now -->

--- a/tools/InternalWindowsSDKNuget/MergeNupkgParts.cmd
+++ b/tools/InternalWindowsSDKNuget/MergeNupkgParts.cmd
@@ -2,11 +2,11 @@
 SETLOCAL
 set ERRORLEVEL=
 
-echo robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part1.1.0.2\windowssdk-21307.1000.210201-1505-part1 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
-call robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part1.1.0.2\windowssdk-21307.1000.210201-1505-part1 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
+echo robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part1.1.0.3\windowssdk-21330.1000.210303-1505-part1 %~dp0..\..\packages\InternalWindowsSDK.1.0.3
+call robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part1.1.0.3\windowssdk-21330.1000.210303-1505-part1 %~dp0..\..\packages\InternalWindowsSDK.1.0.3
 
-echo robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part2.1.0.2\windowssdk-21307.1000.210201-1505-part2 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
-call robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part2.1.0.2\windowssdk-21307.1000.210201-1505-part2 %~dp0..\..\packages\InternalWindowsSDK.1.0.2
+echo robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part2.1.0.3\windowssdk-21330.1000.210303-1505-part2 %~dp0..\..\packages\InternalWindowsSDK.1.0.3
+call robocopy /E %~dp0..\..\packages\InternalWindowsSDK-part2.1.0.3\windowssdk-21330.1000.210303-1505-part2 %~dp0..\..\packages\InternalWindowsSDK.1.0.3
 
 REM robocopy returns:
 REM - 0x0 for no files copied,

--- a/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part1.nuspec
+++ b/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part1.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>InternalWindowsSDK-part1</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>InternalWindowsSDK-part1</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -12,6 +12,6 @@
     <copyright>Copyright 2021</copyright>
   </metadata>
   <files>
-    <file target="windowssdk-21307.1000.210201-1505-part1" src="..\windowssdk-21307.1000.210201-1505-part1\**\*.*"/>
+    <file target="windowssdk-21330.1000.210303-1505-part1" src="..\windowssdk-21330.1000.210303-1505-part1\**\*.*"/>
   </files>
 </package>

--- a/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part2.nuspec
+++ b/tools/InternalWindowsSDKNuget/NuSpecs/InternalWindowsSDK-part2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>InternalWindowsSDK-part2</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>InternalWindowsSDK-part2</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -12,6 +12,6 @@
     <copyright>Copyright 2021</copyright>
   </metadata>
   <files>
-    <file target="windowssdk-21307.1000.210201-1505-part2" src="..\windowssdk-21307.1000.210201-1505-part2\**\*.*"/>
+    <file target="windowssdk-21330.1000.210303-1505-part2" src="..\windowssdk-21330.1000.210303-1505-part2\**\*.*"/>
   </files>
 </package>

--- a/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
+++ b/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
@@ -2,8 +2,8 @@
 SETLOCAL
 set ERRORLEVEL=
 
-echo executing %~dp0..\..\packages\InternalWindowsSDK.1.0.2\winsdksetup.exe /quiet
-call %~dp0..\..\packages\InternalWindowsSDK.1.0.2\winsdksetup.exe /quiet
+echo executing %~dp0..\..\packages\InternalWindowsSDK.1.0.3\winsdksetup.exe /quiet
+call %~dp0..\..\packages\InternalWindowsSDK.1.0.3\winsdksetup.exe /quiet
 
 :END
 exit /B %ERRORLEVEL%


### PR DESCRIPTION
This is just an upgrade for the internal Windows SDK version from 10.0.21307 to 10.0.21330.

MUXControls.sln built and MUXControlsTestApp ran fine.