### PR TITLE
Add borderthickness binding to untargeted TeachingTip

### DIFF
--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -13,7 +13,6 @@
         <Setter Property="Background" Value="{ThemeResource TeachingTipBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{ThemeResource TeachingTipForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource TeachingTipBorderBrush}"/>
-        <Setter Property="BorderBrush" Value="{ThemeResource TeachingTipBorderBrush}"/>
         <Setter Property="BorderThickness" Value="{ThemeResource TeachingTipContentBorderThicknessUntargeted}"/>
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
         <Setter Property="ActionButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>

--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -13,6 +13,8 @@
         <Setter Property="Background" Value="{ThemeResource TeachingTipBackgroundBrush}"/>
         <Setter Property="Foreground" Value="{ThemeResource TeachingTipForegroundBrush}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource TeachingTipBorderBrush}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource TeachingTipBorderBrush}"/>
+        <Setter Property="BorderThickness" Value="{ThemeResource TeachingTipContentBorderThicknessUntargeted}"/>
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
         <Setter Property="ActionButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>
         <Setter Property="CloseButtonStyle" Value="{ThemeResource DefaultButtonStyle}"/>
@@ -461,7 +463,6 @@
                                 </VisualState>
                                 <VisualState x:Name="Untargeted">
                                     <VisualState.Setters>
-                                        <Setter Target="ContentRootGrid.BorderThickness" Value="{StaticResource TeachingTipContentBorderThicknessUntargeted}"/>
                                         <Setter Target="TailEdgeBorder.Visibility" Value="Collapsed"/>
                                         <Setter Target="TopTailPolygonHighlight.Visibility" Value="Collapsed"/>
                                         <Setter Target="TopHighlightRight.Visibility" Value="Collapsed"/>
@@ -537,6 +538,7 @@
                                       AutomationProperties.LandmarkType="Custom"
                                       Background="{TemplateBinding Background}"
                                       BorderBrush="{TemplateBinding BorderBrush}"
+                                      BorderThickness="{TemplateBinding BorderThickness}"
                                       FlowDirection="{TemplateBinding FlowDirection}"
                                       Grid.Row="1"
                                       Grid.Column="1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added binding to BorderThickness for TeachingTip when untargeted. Unfortunately, the other cases are more difficult and binding to BorderThickness would break the visuals as we deliberately need to hide the border on the side with the "tail".
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #4369 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually, code:

```XAML
<muxc:TeachingTip x:Name="TestTeachingTip" Title="Title" BorderThickness="0,10,0,0" IsLightDismissEnabled="{x:Bind (x:Boolean)IsLightDismissEnabledCheckBox.IsChecked, Mode=OneWay}" />
```

Result:

![Image of TeachingTip showing the usage of border thickness](https://user-images.githubusercontent.com/16122379/110206449-fc124680-7e7d-11eb-8929-8a897bbd5dd1.png)

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->