### PR TITLE
Fixing omitted version bumps for internal Windows SDK installation

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
@@ -14,14 +14,14 @@ steps:
     displayName: 'Install Insider Windows SDK Part 1'
     inputs:
       command: custom
-      arguments: 'install InternalWindowsSDK-part1 -NonInteractive -Version 1.0.2 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
+      arguments: 'install InternalWindowsSDK-part1 -NonInteractive -Version 1.0.3 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     condition: eq(variables['UseInsiderSDK'], 'true')
     displayName: 'Install Insider Windows SDK Part 2'
     inputs:
       command: custom
-      arguments: 'install InternalWindowsSDK-part2 -NonInteractive -Version 1.0.2 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
+      arguments: 'install InternalWindowsSDK-part2 -NonInteractive -Version 1.0.3 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
 
   - task: CmdLine@1
     condition: eq(variables['UseInsiderSDK'], 'true')


### PR DESCRIPTION
Forgot to bump the nuget version number from 1.0.2 to 1.0.3 in a couple of places when updating the Windows SDK version from 10.0.21307.0 to 10.0.21330.0.