### PR TITLE
NumberBox: Add property propagation

### DIFF
--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -15,10 +15,12 @@
         <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}" />
         <contract7Present:Setter Property="SelectionFlyout" Value="{StaticResource TextControlCommandBarSelectionFlyout}" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}"/>
+        <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderBrush}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:NumberBox">
-                    <Grid>
+                    <Grid Height="{TemplateBinding Height}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
@@ -90,7 +92,7 @@
 
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
@@ -125,6 +127,9 @@
                             FontSize="{TemplateBinding FontSize}"
                             FontWeight="{TemplateBinding FontWeight}"
                             FontFamily="{TemplateBinding FontFamily}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            Foreground="{TemplateBinding Foreground}"
                             TextAlignment="{TemplateBinding TextAlignment}"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
 
@@ -163,6 +168,7 @@
                             Grid.Column="1"
                             Visibility="Collapsed"
                             FontSize="{TemplateBinding FontSize}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             Content="&#xE70E;"
                             Style="{StaticResource NumberBoxSpinButtonStyle}"
                             contract7Present:CornerRadius="0"/>
@@ -172,6 +178,7 @@
                             Grid.Column="2"
                             Visibility="Collapsed"
                             FontSize="{TemplateBinding FontSize}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             Content="&#xE70D;"
                             Style="{StaticResource NumberBoxSpinButtonStyle}"
                             contract7Present:CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
@@ -205,7 +212,6 @@
             <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
             <Setter Property="IsTabStop" Value="False"/>
             <Setter Property="Width" Value="40"/>
-            <Setter Property="Height" Value="32"/>
             <Setter Property="Background" Value="{ThemeResource NumberBoxPopupSpinButtonBackground}"/>
             <Setter Property="BorderThickness" Value="{ThemeResource NumberBoxPopupSpinButtonBorderThickness}"/>
             <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
@@ -452,6 +458,7 @@
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw"
                             FontSize="{TemplateBinding FontSize}"
+                            HorizontalAlignment="Right"
                             MinWidth="34"
                             VerticalAlignment="Stretch" />
                         <contract7Present:ContentPresenter x:Name="DescriptionPresenter"

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -129,6 +129,7 @@
                             FontFamily="{TemplateBinding FontFamily}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             BorderBrush="{TemplateBinding BorderBrush}"
+                            Padding="{TemplateBinding Padding}"
                             Foreground="{TemplateBinding Foreground}"
                             TextAlignment="{TemplateBinding TextAlignment}"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -432,6 +432,7 @@
                             IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                             Margin="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"
+                            Foreground="{TemplateBinding Foreground}"
                             IsTabStop="False"
                             AutomationProperties.AccessibilityView="Raw"
                             ZoomMode="Disabled" />

--- a/dev/NumberBox/TestUI/NumberBoxPage.xaml
+++ b/dev/NumberBox/TestUI/NumberBoxPage.xaml
@@ -161,8 +161,15 @@
                     <controls:NumberBox x:Name="HeaderTemplateTestingNumberBox"/>
                 </StackPanel>
 
-                <!-- FontSize propagation -->
-                <controls:NumberBox Header="Header text" FontSize="50"/>
+                <!-- Property propagation -->
+                <StackPanel Orientation="Horizontal">
+                    <TextBox Header="Header text" FontSize="14" Foreground="{ThemeResource SystemAccentColor}"
+                        Padding="20" Margin="20" BorderThickness="5" BorderBrush="Red"
+                        Height="100" Width="200"/>
+                    <controls:NumberBox Header="Header text" FontSize="14" Foreground="{ThemeResource SystemAccentColor}" SpinButtonPlacementMode="Inline"
+                        Padding="20" Margin="20" BorderThickness="5" BorderBrush="Red"
+                        Height="100" Width="200"/>
+                </StackPanel>
             </StackPanel>
         </Grid>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds "support" for the following properties:
- Width
- Height
- BorderThickness (partially, inline buttons not supported due to their special borders)
- BorderBrush
- Foreground
- Padding
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #4289 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually:

![Image showing customized TextBox and NumberBox side by side](https://user-images.githubusercontent.com/16122379/110640660-5dedeb80-81b1-11eb-8cae-792a9322c1cc.png)


## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->