### PR TITLE
Update ControlStroke brushes in dark mode

### DIFF
--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -54,8 +54,8 @@
             
             <Color x:Key="AccentAAFillColorDisabled">#28FFFFFF</Color>
 
-            <Color x:Key="ControlStrokeColorDefault">#14FFFFFF</Color>
-            <Color x:Key="ControlStrokeColorSecondary">#4C000000</Color>
+            <Color x:Key="ControlStrokeColorDefault">#12FFFFFF</Color>
+            <Color x:Key="ControlStrokeColorSecondary">#18FFFFFF</Color>
             <Color x:Key="ControlStrokeColorOnAccentDefault">#14FFFFFF</Color>
             <Color x:Key="ControlStrokeColorOnAccentSecondary">#23000000</Color>
             <Color x:Key="ControlStrokeColorOnAccentTertiary">#37000000</Color>
@@ -208,9 +208,6 @@
             <!-- Elevation border brushes-->
 
             <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
-                <LinearGradientBrush.RelativeTransform>
-                    <ScaleTransform ScaleY="-1" CenterY="0.5"/>
-                </LinearGradientBrush.RelativeTransform>
                 <LinearGradientBrush.GradientStops>
                     <GradientStop Offset="0.33" Color="{StaticResource ControlStrokeColorSecondary}"/>
                     <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}"/>
@@ -219,8 +216,8 @@
 
             <LinearGradientBrush x:Key="CircleElevationBorderBrush" MappingMode="RelativeToBoundingBox" StartPoint="0,0" EndPoint="0,1">
                 <LinearGradientBrush.GradientStops>
-                    <GradientStop Offset="0.50" Color="{StaticResource ControlStrokeColorDefault}"/>
                     <GradientStop Offset="0.70" Color="{StaticResource ControlStrokeColorSecondary}"/>
+                    <GradientStop Offset="0.50" Color="{StaticResource ControlStrokeColorDefault}"/>
                 </LinearGradientBrush.GradientStops>
             </LinearGradientBrush>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Elevation brush in dark mode did not look very good and made controls that use it look smaller because of the darker bottom stroke of the border.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
This change aims at fixing this visual issue by making the top stroke of the control that use elevation brush to be a little lighter instead of making bottom stroke darker.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
ComboBox (**ControlElevationBorderBrush**) before and after:
![image](https://user-images.githubusercontent.com/21356912/110700108-70155d00-81a4-11eb-9a19-7ed597e6905c.png)
![image](https://user-images.githubusercontent.com/21356912/110699488-c3d37680-81a3-11eb-82d7-5190b592c1c4.png)

RadioButton - interior black circle's stroke (to show example of **CircleElevationBorderBrush**) before and after:
![image](https://user-images.githubusercontent.com/21356912/110700191-84f1f080-81a4-11eb-8565-03eb098ed94d.png)
![image](https://user-images.githubusercontent.com/21356912/110699531-cfbf3880-81a3-11eb-95ed-adbf2281b0d9.png)