### PR TITLE
Fix TeachingTip title and sub title not being initially collapsed.

### DIFF
--- a/dev/TeachingTip/InteractionTests/TeachingTipFocusTestPageElements.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipFocusTestPageElements.cs
@@ -52,6 +52,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
         private CheckBox isLightDismissEnabledCheckBox;
 
+        public UIObject GetTitleVisibilityTextBlock()
+        {
+            return GetElement(ref titleVisibilityTextBlock, "TitleVisibilityTextBlock");
+        }
+        private UIObject titleVisibilityTextBlock;
+
+        public UIObject GetSubtitleVisibilityTextBlock()
+        {
+            return GetElement(ref subtitleVisibilityTextBlock, "SubtitleVisibilityTextBlock");
+        }
+        private UIObject subtitleVisibilityTextBlock;
+
         private T GetElement<T>(ref T element, string elementName) where T : UIObject
         {
             if (element == null)

--- a/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
+++ b/dev/TeachingTip/InteractionTests/TeachingTipTests.cs
@@ -856,6 +856,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        public void VerifyTeachingTipInitialEmptyHeaderCollapsed()
+        {
+            using (var setup = new TestSetupHelper(new[] { "TeachingTip Tests", "TeachingTipFocus Test" }))
+            {
+                var elements = new TeachingTipFocusTestPageElements();
+                var openTeachingTipButton = elements.GetOpenButton();
+
+                OpenTeachingTip();
+                Verify.AreEqual("Collapsed", elements.GetTitleVisibilityTextBlock().GetText());
+                Verify.AreEqual("Collapsed", elements.GetSubtitleVisibilityTextBlock().GetText());
+
+                void OpenTeachingTip()
+                {
+                    if (elements.GetIsOpenCheckBox().ToggleState != ToggleState.On)
+                    {
+                        openTeachingTipButton.InvokeAndWait();
+                        WaitForChecked(elements.GetIsOpenCheckBox());
+                        WaitForChecked(elements.GetIsIdleCheckBox());
+                    }
+                }
+            }
+        }
+
         private void TestAutoPlacementForWindowOrScreenBounds(Vector4 targetRect, bool forWindowBounds)
         {
             TestAutoPlacementForWindowOrScreenBounds(targetRect, forWindowBounds, null);

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -112,6 +112,16 @@ void TeachingTip::OnApplyTemplate()
 
     EstablishShadows();
 
+    if (ToggleVisibilityForEmptyContent(m_titleTextBox.get(), Title()))
+    {
+        TeachingTipTestHooks::NotifyTitleVisibilityChanged(*this);
+    }
+    if (ToggleVisibilityForEmptyContent(m_subtitleTextBox.get(), Subtitle()))
+    {
+        TeachingTipTestHooks::NotifySubtitleVisibilityChanged(*this);
+    }
+
+
     m_isTemplateApplied = true;
 }
 

--- a/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml
+++ b/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml
@@ -12,7 +12,9 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid Margin="10">
-        <muxc:TeachingTip x:Name="TestTeachingTip" Title="Title" IsLightDismissEnabled="{x:Bind (x:Boolean)IsLightDismissEnabledCheckBox.IsChecked, Mode=OneWay}" />
+        <muxc:TeachingTip x:Name="TestTeachingTip" IsLightDismissEnabled="{x:Bind (x:Boolean)IsLightDismissEnabledCheckBox.IsChecked, Mode=OneWay}" >
+            <TextBlock Text="Content"/>
+        </muxc:TeachingTip>
 
         <StackPanel>
             <TextBlock Text="TeachingTip special focus test page" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,0,0,15"/>
@@ -27,6 +29,14 @@
 
             <TextBlock Text="TeachingTip configuration:" Margin="0,10,0,0"/>
             <CheckBox x:Name="IsLightDismissEnabledCheckBox" AutomationProperties.Name="IsLightDismissEnabledCheckBox" Content="IsLightDismissEnabled" IsChecked="False" IsTabStop="False"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Title Vis:"/>
+                <TextBlock x:Name="TitleVisibilityTextBlock" AutomationProperties.Name="TitleVisibilityTextBlock"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Subtitle Vis:"/>
+                <TextBlock x:Name="SubtitleVisibilityTextBlock" AutomationProperties.Name="SubtitleVisibilityTextBlock"/>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </local:TestPage>

--- a/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipFocusPage.xaml.cs
@@ -14,6 +14,7 @@ namespace MUXControlsTestApp
             this.InitializeComponent();
             TeachingTipTestHooks.IdleStatusChanged += TeachingTipTestHooks_IdleStatusChanged;
             TeachingTipTestHooks.OpenedStatusChanged += TeachingTipTestHooks_OpenedStatusChanged;
+            TestTeachingTip.Loaded += TestTeachingTip_Loaded;
 
             this.Loaded += OnLoaded;
         }
@@ -61,6 +62,12 @@ namespace MUXControlsTestApp
             {
                 this.IsIdleCheckBox.IsChecked = false;
             }
+        }
+
+        private void TestTeachingTip_Loaded(object sender, RoutedEventArgs e)
+        {
+            this.TitleVisibilityTextBlock.Text = TeachingTipTestHooks.GetTitleVisibility(TestTeachingTip).ToString();
+            this.SubtitleVisibilityTextBlock.Text = TeachingTipTestHooks.GetSubtitleVisibility(TestTeachingTip).ToString();
         }
     }
 }


### PR DESCRIPTION
Set Title and Subtitle TextBlocks visibility to collapsed in OnApplyTemplate if they are empty. Add a test.