### PR TITLE
Removing use of ScrollViewerScrollBarMargin in test markup

### DIFF
--- a/test/MUXControlsTestApp/App.xaml
+++ b/test/MUXControlsTestApp/App.xaml
@@ -24,6 +24,8 @@
                 <ResourceDictionary x:Name="_styleOverridesPlaceholder"/>
             </ResourceDictionary.MergedDictionaries>
 
+            <Thickness x:Key="AppScrollViewerScrollBarMargin">1</Thickness> <!-- use 0 when switching to Version1 -->
+
             <Style x:Key="StandardGroupHeader" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="22"/>
                 <Setter Property="Margin" Value="0,0,0,8"/>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStyles.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStyles.xaml
@@ -40,7 +40,7 @@
                             <Grid
                                 Grid.Column="1"
                                 Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                                Padding="{ThemeResource ScrollViewerScrollBarMargin}">
+                                Padding="{ThemeResource AppScrollViewerScrollBarMargin}">
                                 <ScrollBar x:Name="VerticalScrollBar"
                                     IsTabStop="False"
                                     Maximum="{TemplateBinding ScrollableHeight}"
@@ -53,7 +53,7 @@
                             <Grid
                                 Grid.Row="1"
                                 Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-                                Padding="{ThemeResource ScrollViewerScrollBarMargin}">
+                                Padding="{ThemeResource AppScrollViewerScrollBarMargin}">
                                 <ScrollBar x:Name="HorizontalScrollBar"
                                     IsTabStop="False"
                                     Maximum="{TemplateBinding ScrollableWidth}"


### PR DESCRIPTION
The changes from https://github.com/microsoft/microsoft-ui-xaml/pull/4495 introduced a problem with MUXControlsTestApp when Version1 is used. 
The resource "ScrollViewerScrollBarMargin" should only be referenced when using Version2. So I am changing the DisableAnimationsStyles.xaml test markup so it no longer uses that resource. Instead it uses an app resource, that can optionally be changed in the event the app is recompiled with Version1.