### PR TITLE
Fix MUXControls.ReleaseTest tests regression

### DIFF
--- a/dev/CommonStyles/ScrollViewer_themeresources_v1.xaml
+++ b/dev/CommonStyles/ScrollViewer_themeresources_v1.xaml
@@ -14,6 +14,15 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
+    <Thickness x:Key="ScrollViewerScrollBarMargin">0</Thickness>
+    
+    <x:String x:Key="ScrollViewerSeparatorExpandBeginTime">00:00:00.40</x:String>
+    <x:String x:Key="ScrollViewerSeparatorExpandDuration">00:00:00.1</x:String>
+    <x:String x:Key="ScrollViewerSeparatorContractBeginTime">00:00:02.00</x:String>
+    <x:String x:Key="ScrollViewerSeparatorContractDelay">00:00:02</x:String>
+    <x:String x:Key="ScrollViewerSeparatorContractDuration">00:00:00.1</x:String>
+    <x:String x:Key="ScrollViewerSeparatorContractFinalKeyframe">00:00:02.1</x:String>
+
     <Style TargetType="ScrollViewer" BasedOn="{StaticResource DefaultScrollViewerStyle}" />
 
     <Style x:Key="DefaultScrollViewerStyle" TargetType="ScrollViewer">

--- a/test/MUXControlsTestApp/App.xaml
+++ b/test/MUXControlsTestApp/App.xaml
@@ -24,8 +24,6 @@
                 <ResourceDictionary x:Name="_styleOverridesPlaceholder"/>
             </ResourceDictionary.MergedDictionaries>
 
-            <Thickness x:Key="AppScrollViewerScrollBarMargin">1</Thickness> <!-- use 0 when switching to Version1 -->
-
             <Style x:Key="StandardGroupHeader" TargetType="TextBlock">
                 <Setter Property="FontSize" Value="22"/>
                 <Setter Property="Margin" Value="0,0,0,8"/>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStyles.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStyles.xaml
@@ -40,7 +40,7 @@
                             <Grid
                                 Grid.Column="1"
                                 Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                                Padding="{ThemeResource AppScrollViewerScrollBarMargin}">
+                                Padding="{ThemeResource ScrollViewerScrollBarMargin}">
                                 <ScrollBar x:Name="VerticalScrollBar"
                                     IsTabStop="False"
                                     Maximum="{TemplateBinding ScrollableHeight}"
@@ -53,7 +53,7 @@
                             <Grid
                                 Grid.Row="1"
                                 Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-                                Padding="{ThemeResource AppScrollViewerScrollBarMargin}">
+                                Padding="{ThemeResource ScrollViewerScrollBarMargin}">
                                 <ScrollBar x:Name="HorizontalScrollBar"
                                     IsTabStop="False"
                                     Maximum="{TemplateBinding ScrollableWidth}"


### PR DESCRIPTION
The MUXControls.ReleaseTest tests were failing after my recent ScrollBar workaround because resources like ScrollViewerSeparatorExpandBeginTime were missing on RS2.

At the same time, I am adding the new "ScrollViewerScrollBarMargin" resource in ScrollViewer_themeresources_v1.xaml to avoid having to declare & use AppScrollViewerScrollBarMargin in MUXControlsTestApp.