### PR TITLE
Fix issue where animated icon without a source set wouldn't show fallback icon.

### DIFF
--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -27,6 +27,7 @@ AnimatedIcon::AnimatedIcon()
 void AnimatedIcon::OnApplyTemplate()
 {
     __super::OnApplyTemplate();
+    OnSourcePropertyChanged(nullptr);
     auto const panel = winrt::VisualTreeHelper::GetChild(*this, 0).as<winrt::Panel>();
     m_rootPanel.set(panel);
     m_currentState = GetState(*this);

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
@@ -656,6 +656,13 @@
                                 </controls:AnimatedIcon>
                             </StackPanel>
                         </Button>
+                        <StackPanel Background="Maroon">
+                            <controls:AnimatedIcon Height="100" Width="100" Foreground="Pink">
+                                <controls:AnimatedIcon.FallbackIconSource>
+                                    <controls:SymbolIconSource Symbol="AddFriend" Foreground="Purple"/>
+                                </controls:AnimatedIcon.FallbackIconSource>
+                            </controls:AnimatedIcon>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>


### PR DESCRIPTION
AnimatedIcon only checked if the fallback icon was needed in the Source property changed callback. This means if you never set the source we would never check if we needed to show the fallback.