### PR TITLE
Change IconSource.CreateIconElement to a "dynamic" factory.

### DIFF
--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -27,6 +27,7 @@ AnimatedIcon::AnimatedIcon()
 void AnimatedIcon::OnApplyTemplate()
 {
     __super::OnApplyTemplate();
+    OnSourcePropertyChanged(nullptr);
     auto const panel = winrt::VisualTreeHelper::GetChild(*this, 0).as<winrt::Panel>();
     m_rootPanel.set(panel);
     m_currentState = GetState(*this);
@@ -460,7 +461,8 @@ void AnimatedIcon::OnSourcePropertyChanged(const winrt::DependencyPropertyChange
         progressAnimation.SetReferenceParameter(L"_", m_progressPropertySet);
         visual.Properties().StartAnimation(s_progressPropertyName, progressAnimation);
     }
-    else
+    // If we were previously able to display primary content and now cannot, use the fallback icon.
+    else if (m_canDisplayPrimaryContent)
     {
         m_canDisplayPrimaryContent = false;
         SetRootPanelChildToFallbackIcon();

--- a/dev/AnimatedIcon/TestUI/AnimatedIconHost.cs
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconHost.cs
@@ -52,6 +52,19 @@ namespace MUXControlsTestApp
           null
         );
 
+        public String FallbackGlyph
+        {
+            get { return (String)GetValue(FallbackGlyphProperty); }
+            set { SetValue(FallbackGlyphProperty, value); }
+        }
+
+        public static readonly DependencyProperty FallbackGlyphProperty = DependencyProperty.Register(
+          "FallbackGlyph",
+          typeof(String),
+          typeof(AnimatedIconHost),
+          null
+        );
+
         public AnimatedIconHost()
         {
             this.DefaultStyleKey = typeof(AnimatedIconHost);

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
@@ -665,8 +665,7 @@
                                     <controls:AnimatedIconSource FallbackIconSource="{StaticResource MyFontIconSource}"/>
                                 </local:AnimatedIconHost.IconSource>
                             </local:AnimatedIconHost>
-                            <controls:AnimatedIcon FallbackIconSource="{StaticResource MyFontIconSource}">
-                            </controls:AnimatedIcon>
+                            <controls:AnimatedIcon FallbackIconSource="{StaticResource MyFontIconSource}"/>
                             <Button Content="Change FallbackGlyph" Click="ChangeFallbackGlyphButton_Click"/>
                         </StackPanel>
                     </StackPanel>

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
@@ -656,6 +656,19 @@
                                 </controls:AnimatedIcon>
                             </StackPanel>
                         </Button>
+                        <StackPanel>
+                            <StackPanel.Resources>
+                                <controls:FontIconSource x:Name="MyFontIconSource" Glyph="{Binding ElementName=boundFallback, Path=FallbackGlyph}"/>
+                            </StackPanel.Resources>
+                            <local:AnimatedIconHost Foreground="{StaticResource TestIconForeground}"  x:Name="boundFallback" Title="AnimatedFindVisualSource" Background="DarkSlateGray" FallbackGlyph="&#xE001;">
+                                <local:AnimatedIconHost.IconSource>
+                                    <controls:AnimatedIconSource FallbackIconSource="{StaticResource MyFontIconSource}"/>
+                                </local:AnimatedIconHost.IconSource>
+                            </local:AnimatedIconHost>
+                            <controls:AnimatedIcon FallbackIconSource="{StaticResource MyFontIconSource}">
+                            </controls:AnimatedIcon>
+                            <Button Content="Change FallbackGlyph" Click="ChangeFallbackGlyphButton_Click"/>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
             </ScrollViewer>

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml.cs
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml.cs
@@ -269,5 +269,10 @@ namespace MUXControlsTestApp
                 AnimatedIconTestHooks.SetSpeedUpMultiplier(CheckIcon, (float)e.NewValue);
             }
         }
+
+        private void ChangeFallbackGlyphButton_Click(object sender, RoutedEventArgs e)
+        {
+            boundFallback.FallbackGlyph = "\uE9AE";
+        }
     }
 }

--- a/dev/CommonStyles/CheckBox_themeresources.xaml
+++ b/dev/CommonStyles/CheckBox_themeresources.xaml
@@ -363,7 +363,7 @@
 
     <x:Double x:Key="CheckBoxBorderThickness">1</x:Double>
     <x:Double x:Key="CheckBoxSize">20</x:Double>
-    <x:Double x:Key="CheckBoxGlyphSize">16</x:Double>
+    <x:Double x:Key="CheckBoxGlyphSize">12</x:Double>
     <x:Double x:Key="CheckBoxHeight">32</x:Double>
     <x:Double x:Key="CheckBoxMinWidth">120</x:Double>
     <Thickness x:Key="CheckBoxPadding">8,5,0,0</Thickness>
@@ -419,12 +419,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillUnchecked}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalOff"/>
@@ -448,12 +445,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillUncheckedPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedPointerOver}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedPointerOver}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PointerOverOff"/>
@@ -477,12 +471,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillUncheckedPressed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedPressed}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedPressed}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PressedOff"/>
@@ -506,12 +497,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillUncheckedDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedDisabled}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundUncheckedDisabled}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
@@ -536,16 +524,13 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillChecked}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundChecked}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundChecked}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalOn"/>
@@ -569,16 +554,13 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillCheckedPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedPointerOver}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedPointerOver}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PointerOverOn"/>
@@ -602,16 +584,13 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillCheckedPressed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedPressed}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedPressed}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PressedOn"/>
@@ -635,16 +614,13 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillCheckedDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedDisabled}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundCheckedDisabled}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
@@ -669,19 +645,16 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillIndeterminate}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminate}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource CheckBoxIndeterminateGlyph}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminate}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalIndeterminate"/>
@@ -705,19 +678,16 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillIndeterminatePointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminatePointerOver}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource CheckBoxIndeterminateGlyph}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminatePointerOver}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PointerOverIndeterminate"/>
@@ -741,19 +711,16 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillIndeterminatePressed}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminatePressed}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource CheckBoxIndeterminateGlyph}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminatePressed}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PressedIndeterminate"/>
@@ -777,19 +744,16 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NormalRectangle" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckBackgroundFillIndeterminateDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DownLevelCheckGlyph" Storyboard.TargetProperty="Glyph">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource CheckBoxIndeterminateGlyph}" />
-                                        </contract7NotPresent:ObjectAnimationUsingKeyFrames>
-                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="DownLevelCheckGlyph"
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <contract7NotPresent:DoubleAnimation Storyboard.TargetName="CheckGlyph"
                                             Storyboard.TargetProperty="Opacity"
                                             To="1"
                                             Duration="0" />
-                                        <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CheckGlyph" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CheckBoxCheckGlyphForegroundIndeterminateDisabled}" />
-                                        </contract7Present:ObjectAnimationUsingKeyFrames>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
@@ -819,18 +783,18 @@
                                 contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
                                 contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                 contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"/>
-                            <contract7NotPresent:FontIcon
-                                x:Name="DownLevelCheckGlyph"
-                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                Glyph="{StaticResource CheckBoxCheckedGlyph}"
-                                FontSize="{StaticResource CheckBoxGlyphSize}"
-                                Foreground="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}"
-                                Opacity="0" />
                             <local:AnimatedIcon x:Name="CheckGlyph"
                                                 Foreground="{ThemeResource CheckBoxCheckGlyphForegroundUnchecked}"
                                                 Margin="4"
-                                                contract7NotPresent:Visibility="Collapsed">
+                                                contract7NotPresent:Opacity="0">
                                 <animatedvisuals:AnimatedAcceptVisualSource/>
+                                <local:AnimatedIcon.FallbackIconSource>
+                                    <local:FontIconSource
+                                        x:Name="DownLevelCheckGlyph"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        Glyph="{StaticResource CheckBoxCheckedGlyph}"
+                                        FontSize="{StaticResource CheckBoxGlyphSize}"/>
+                                </local:AnimatedIcon.FallbackIconSource>
                             </local:AnimatedIcon>
 
                         </Grid>

--- a/dev/DropDownButton/DropDownButton.xaml
+++ b/dev/DropDownButton/DropDownButton.xaml
@@ -120,7 +120,6 @@
                                 <local:FontIconSource
                                     FontSize="8"
                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                    Foreground="{ThemeResource ButtonForegroundPressed}"
                                     Glyph="&#xE96E;"
                                     IsTextScaleFactorEnabled="False"/>
                             </local:AnimatedIcon.FallbackIconSource>

--- a/dev/Generated/AnimatedIconSource.properties.cpp
+++ b/dev/Generated/AnimatedIconSource.properties.cpp
@@ -33,7 +33,7 @@ void AnimatedIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::AnimatedIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::IconSource>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnFallbackIconSourcePropertyChanged));
     }
     if (!s_SourceProperty)
     {
@@ -44,7 +44,7 @@ void AnimatedIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::AnimatedIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::IAnimatedVisualSource2>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnSourcePropertyChanged));
     }
 }
 
@@ -53,6 +53,22 @@ void AnimatedIconSourceProperties::ClearProperties()
     s_FallbackIconSourceProperty = nullptr;
     s_SourceProperty = nullptr;
     IconSource::ClearProperties();
+}
+
+void AnimatedIconSourceProperties::OnFallbackIconSourcePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::AnimatedIconSource>();
+    winrt::get_self<AnimatedIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void AnimatedIconSourceProperties::OnSourcePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::AnimatedIconSource>();
+    winrt::get_self<AnimatedIconSource>(owner)->OnPropertyChanged(args);
 }
 
 void AnimatedIconSourceProperties::FallbackIconSource(winrt::IconSource const& value)

--- a/dev/Generated/AnimatedIconSource.properties.h
+++ b/dev/Generated/AnimatedIconSource.properties.h
@@ -23,4 +23,12 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnFallbackIconSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/Generated/BitmapIconSource.properties.cpp
+++ b/dev/Generated/BitmapIconSource.properties.cpp
@@ -33,7 +33,7 @@ void BitmapIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::BitmapIconSource>(),
                 false /* isAttached */,
                 ValueHelper<bool>::BoxValueIfNecessary(true),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnShowAsMonochromePropertyChanged));
     }
     if (!s_UriSourceProperty)
     {
@@ -44,7 +44,7 @@ void BitmapIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::BitmapIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::Uri>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnUriSourcePropertyChanged));
     }
 }
 
@@ -53,6 +53,22 @@ void BitmapIconSourceProperties::ClearProperties()
     s_ShowAsMonochromeProperty = nullptr;
     s_UriSourceProperty = nullptr;
     IconSource::ClearProperties();
+}
+
+void BitmapIconSourceProperties::OnShowAsMonochromePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::BitmapIconSource>();
+    winrt::get_self<BitmapIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void BitmapIconSourceProperties::OnUriSourcePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::BitmapIconSource>();
+    winrt::get_self<BitmapIconSource>(owner)->OnPropertyChanged(args);
 }
 
 void BitmapIconSourceProperties::ShowAsMonochrome(bool value)

--- a/dev/Generated/BitmapIconSource.properties.h
+++ b/dev/Generated/BitmapIconSource.properties.h
@@ -23,4 +23,12 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnShowAsMonochromePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnUriSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/Generated/FontIconSource.properties.cpp
+++ b/dev/Generated/FontIconSource.properties.cpp
@@ -38,7 +38,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::FontFamily>::BoxValueIfNecessary(winrt::FontFamily{ c_fontIconSourceDefaultFontFamily }),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnFontFamilyPropertyChanged));
     }
     if (!s_FontSizeProperty)
     {
@@ -49,7 +49,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<double>::BoxValueIfNecessary(20.0),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnFontSizePropertyChanged));
     }
     if (!s_FontStyleProperty)
     {
@@ -60,7 +60,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::FontStyle>::BoxValueIfNecessary(winrt::FontStyle::Normal),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnFontStylePropertyChanged));
     }
     if (!s_FontWeightProperty)
     {
@@ -71,7 +71,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::FontWeight>::BoxValueIfNecessary({ 400 }),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnFontWeightPropertyChanged));
     }
     if (!s_GlyphProperty)
     {
@@ -82,7 +82,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::hstring>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnGlyphPropertyChanged));
     }
     if (!s_IsTextScaleFactorEnabledProperty)
     {
@@ -93,7 +93,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<bool>::BoxValueIfNecessary(true),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnIsTextScaleFactorEnabledPropertyChanged));
     }
     if (!s_MirroredWhenRightToLeftProperty)
     {
@@ -104,7 +104,7 @@ void FontIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::FontIconSource>(),
                 false /* isAttached */,
                 ValueHelper<bool>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnMirroredWhenRightToLeftPropertyChanged));
     }
 }
 
@@ -118,6 +118,62 @@ void FontIconSourceProperties::ClearProperties()
     s_IsTextScaleFactorEnabledProperty = nullptr;
     s_MirroredWhenRightToLeftProperty = nullptr;
     IconSource::ClearProperties();
+}
+
+void FontIconSourceProperties::OnFontFamilyPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void FontIconSourceProperties::OnFontSizePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void FontIconSourceProperties::OnFontStylePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void FontIconSourceProperties::OnFontWeightPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void FontIconSourceProperties::OnGlyphPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void FontIconSourceProperties::OnIsTextScaleFactorEnabledPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void FontIconSourceProperties::OnMirroredWhenRightToLeftPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::FontIconSource>();
+    winrt::get_self<FontIconSource>(owner)->OnPropertyChanged(args);
 }
 
 void FontIconSourceProperties::FontFamily(winrt::FontFamily const& value)

--- a/dev/Generated/FontIconSource.properties.h
+++ b/dev/Generated/FontIconSource.properties.h
@@ -48,4 +48,32 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnFontFamilyPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnFontSizePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnFontStylePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnFontWeightPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnGlyphPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnIsTextScaleFactorEnabledPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnMirroredWhenRightToLeftPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/Generated/IconSource.properties.cpp
+++ b/dev/Generated/IconSource.properties.cpp
@@ -31,13 +31,21 @@ void IconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::IconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::Brush>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnForegroundPropertyChanged));
     }
 }
 
 void IconSourceProperties::ClearProperties()
 {
     s_ForegroundProperty = nullptr;
+}
+
+void IconSourceProperties::OnForegroundPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::IconSource>();
+    winrt::get_self<IconSource>(owner)->OnPropertyChanged(args);
 }
 
 void IconSourceProperties::Foreground(winrt::Brush const& value)

--- a/dev/Generated/IconSource.properties.h
+++ b/dev/Generated/IconSource.properties.h
@@ -18,4 +18,8 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnForegroundPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/Generated/ImageIconSource.properties.cpp
+++ b/dev/Generated/ImageIconSource.properties.cpp
@@ -32,7 +32,7 @@ void ImageIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::ImageIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::ImageSource>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnImageSourcePropertyChanged));
     }
 }
 
@@ -40,6 +40,14 @@ void ImageIconSourceProperties::ClearProperties()
 {
     s_ImageSourceProperty = nullptr;
     IconSource::ClearProperties();
+}
+
+void ImageIconSourceProperties::OnImageSourcePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::ImageIconSource>();
+    winrt::get_self<ImageIconSource>(owner)->OnPropertyChanged(args);
 }
 
 void ImageIconSourceProperties::ImageSource(winrt::ImageSource const& value)

--- a/dev/Generated/ImageIconSource.properties.h
+++ b/dev/Generated/ImageIconSource.properties.h
@@ -18,4 +18,8 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnImageSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/Generated/PathIconSource.properties.cpp
+++ b/dev/Generated/PathIconSource.properties.cpp
@@ -32,7 +32,7 @@ void PathIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::PathIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::Geometry>::BoxedDefaultValue(),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnDataPropertyChanged));
     }
 }
 
@@ -40,6 +40,14 @@ void PathIconSourceProperties::ClearProperties()
 {
     s_DataProperty = nullptr;
     IconSource::ClearProperties();
+}
+
+void PathIconSourceProperties::OnDataPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::PathIconSource>();
+    winrt::get_self<PathIconSource>(owner)->OnPropertyChanged(args);
 }
 
 void PathIconSourceProperties::Data(winrt::Geometry const& value)

--- a/dev/Generated/PathIconSource.properties.h
+++ b/dev/Generated/PathIconSource.properties.h
@@ -18,4 +18,8 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnDataPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/Generated/SymbolIconSource.properties.cpp
+++ b/dev/Generated/SymbolIconSource.properties.cpp
@@ -32,7 +32,7 @@ void SymbolIconSourceProperties::EnsureProperties()
                 winrt::name_of<winrt::SymbolIconSource>(),
                 false /* isAttached */,
                 ValueHelper<winrt::Symbol>::BoxValueIfNecessary(winrt::Symbol::Emoji),
-                nullptr);
+                winrt::PropertyChangedCallback(&OnSymbolPropertyChanged));
     }
 }
 
@@ -40,6 +40,14 @@ void SymbolIconSourceProperties::ClearProperties()
 {
     s_SymbolProperty = nullptr;
     IconSource::ClearProperties();
+}
+
+void SymbolIconSourceProperties::OnSymbolPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::SymbolIconSource>();
+    winrt::get_self<SymbolIconSource>(owner)->OnPropertyChanged(args);
 }
 
 void SymbolIconSourceProperties::Symbol(winrt::Symbol const& value)

--- a/dev/Generated/SymbolIconSource.properties.h
+++ b/dev/Generated/SymbolIconSource.properties.h
@@ -18,4 +18,8 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnSymbolPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/IconSource/APITests/IconSourceApiTests.cs
+++ b/dev/IconSource/APITests/IconSourceApiTests.cs
@@ -39,19 +39,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         public void SymbolIconSourceTest()
         {
             SymbolIconSource iconSource = null;
+            SymbolIcon symbolIcon = null;
 
             RunOnUIThread.Execute(() =>
             {
                 iconSource = new SymbolIconSource();
+                symbolIcon = iconSource.CreateIconElement() as SymbolIcon;
 
                 // IconSource.Foreground should be null to allow foreground inheritance from
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
+                //Verify.AreEqual(symbolIcon.Foreground, null);
 
                 Log.Comment("Validate the defaults match SymbolIcon.");
 
                 var icon = new SymbolIcon();
                 Verify.AreEqual(icon.Symbol, iconSource.Symbol);
+                Verify.AreEqual(symbolIcon.Symbol, iconSource.Symbol);
 
                 Log.Comment("Validate that you can change the properties.");
 
@@ -64,7 +68,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 Verify.IsTrue(iconSource.Foreground is SolidColorBrush);
                 Verify.AreEqual(Windows.UI.Colors.Red, (iconSource.Foreground as SolidColorBrush).Color);
+                Verify.AreEqual(Windows.UI.Colors.Red, (symbolIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual(Symbol.HangUp, iconSource.Symbol);
+                Verify.AreEqual(Symbol.HangUp, symbolIcon.Symbol);
             });
         }
 
@@ -72,25 +78,35 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         public void FontIconSourceTest()
         {
             FontIconSource iconSource = null;
+            FontIcon fontIcon = null;
 
             RunOnUIThread.Execute(() =>
             {
                 iconSource = new FontIconSource();
+                fontIcon = iconSource.CreateIconElement() as FontIcon;
 
                 // IconSource.Foreground should be null to allow foreground inheritance from
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
+                //Verify.AreEqual(fontIcon.Foreground, null);
 
                 Log.Comment("Validate the defaults match FontIcon.");
 
                 var icon = new FontIcon();
                 Verify.AreEqual(icon.Glyph, iconSource.Glyph);
+                Verify.AreEqual(fontIcon.Glyph, iconSource.Glyph);
                 Verify.AreEqual(icon.FontSize, iconSource.FontSize);
+                Verify.AreEqual(fontIcon.FontSize, iconSource.FontSize);
                 Verify.AreEqual(icon.FontStyle, iconSource.FontStyle);
+                Verify.AreEqual(fontIcon.FontStyle, iconSource.FontStyle);
                 Verify.AreEqual(icon.FontWeight.Weight, iconSource.FontWeight.Weight);
+                Verify.AreEqual(fontIcon.FontWeight.Weight, iconSource.FontWeight.Weight);
                 Verify.AreEqual(icon.FontFamily.Source, iconSource.FontFamily.Source);
+                Verify.AreEqual(fontIcon.FontFamily.Source, iconSource.FontFamily.Source);
                 Verify.AreEqual(icon.IsTextScaleFactorEnabled, iconSource.IsTextScaleFactorEnabled);
+                Verify.AreEqual(fontIcon.IsTextScaleFactorEnabled, iconSource.IsTextScaleFactorEnabled);
                 Verify.AreEqual(icon.MirroredWhenRightToLeft, iconSource.MirroredWhenRightToLeft);
+                Verify.AreEqual(fontIcon.MirroredWhenRightToLeft, iconSource.MirroredWhenRightToLeft);
 
                 Log.Comment("Validate that you can change the properties.");
 
@@ -108,14 +124,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 Verify.IsTrue(iconSource.Foreground is SolidColorBrush);
+                Verify.IsTrue(fontIcon.Foreground is SolidColorBrush);
                 Verify.AreEqual(Windows.UI.Colors.Red, (iconSource.Foreground as SolidColorBrush).Color);
+                Verify.AreEqual(Windows.UI.Colors.Red, (fontIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual("&#xE114;", iconSource.Glyph);
+                Verify.AreEqual("&#xE114;", fontIcon.Glyph);
                 Verify.AreEqual(25, iconSource.FontSize);
+                Verify.AreEqual(25, fontIcon.FontSize);
                 Verify.AreEqual(FontStyle.Oblique, iconSource.FontStyle);
+                Verify.AreEqual(FontStyle.Oblique, fontIcon.FontStyle);
                 Verify.AreEqual(250, iconSource.FontWeight.Weight);
+                Verify.AreEqual(250, fontIcon.FontWeight.Weight);
                 Verify.AreEqual("Segoe UI Symbol", iconSource.FontFamily.Source);
+                Verify.AreEqual("Segoe UI Symbol", fontIcon.FontFamily.Source);
                 Verify.AreEqual(true, iconSource.IsTextScaleFactorEnabled);
+                Verify.AreEqual(true, fontIcon.IsTextScaleFactorEnabled);
                 Verify.AreEqual(true, iconSource.MirroredWhenRightToLeft);
+                Verify.AreEqual(true, fontIcon.MirroredWhenRightToLeft);
             });
         }
 
@@ -123,24 +148,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         public void BitmapIconSourceTest()
         {
             BitmapIconSource iconSource = null;
+            BitmapIcon bitmapIcon = null;
             var uri = new Uri("ms-appx:///Assets/ingredient1.png");
 
             RunOnUIThread.Execute(() =>
             {
                 iconSource = new BitmapIconSource();
+                bitmapIcon = iconSource.CreateIconElement() as BitmapIcon;
 
                 // IconSource.Foreground should be null to allow foreground inheritance from
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
+                //Verify.AreEqual(bitmapIcon.Foreground, null);
 
                 Log.Comment("Validate the defaults match BitmapIcon.");
 
                 var icon = new BitmapIcon();
                 Verify.AreEqual(icon.UriSource, iconSource.UriSource);
+                Verify.AreEqual(bitmapIcon.UriSource, iconSource.UriSource);
 
                 if (ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Controls.BitmapIcon", "ShowAsMonochrome"))
                 {
                     Verify.AreEqual(icon.ShowAsMonochrome, iconSource.ShowAsMonochrome);
+                    Verify.AreEqual(bitmapIcon.ShowAsMonochrome, iconSource.ShowAsMonochrome);
                 }
 
                 Log.Comment("Validate that you can change the properties.");
@@ -154,9 +184,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 Verify.IsTrue(iconSource.Foreground is SolidColorBrush);
+                Verify.IsTrue(bitmapIcon.Foreground is SolidColorBrush);
                 Verify.AreEqual(Windows.UI.Colors.Red, (iconSource.Foreground as SolidColorBrush).Color);
+                Verify.AreEqual(Windows.UI.Colors.Red, (bitmapIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual(uri, iconSource.UriSource);
+                Verify.AreEqual(uri, bitmapIcon.UriSource);
                 Verify.AreEqual(false, iconSource.ShowAsMonochrome);
+                Verify.AreEqual(false, bitmapIcon.ShowAsMonochrome);
             });
         }
 
@@ -164,20 +198,24 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         public void ImageIconSourceTest()
         {
             ImageIconSource iconSource = null;
+            ImageIcon imageIcon = null;
             var uri = new Uri("ms-appx:///Assets/Nuclear_symbol.svg");
 
             RunOnUIThread.Execute(() =>
             {
                 iconSource = new ImageIconSource();
+                imageIcon = iconSource.CreateIconElement() as ImageIcon;
 
                 // IconSource.Foreground should be null to allow foreground inheritance from
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
+                //Verify.AreEqual(imageIcon.Foreground, null);
 
                 Log.Comment("Validate the defaults match BitmapIcon.");
 
                 var icon = new ImageIcon();
                 Verify.AreEqual(icon.Source, iconSource.ImageSource);
+                Verify.AreEqual(imageIcon.Source, iconSource.ImageSource);
 
                 Log.Comment("Validate that you can change the properties.");
 
@@ -189,8 +227,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 Verify.IsTrue(iconSource.Foreground is SolidColorBrush);
+                Verify.IsTrue(imageIcon.Foreground is SolidColorBrush);
                 Verify.AreEqual(Windows.UI.Colors.Red, (iconSource.Foreground as SolidColorBrush).Color);
+                Verify.AreEqual(Windows.UI.Colors.Red, (imageIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual(uri, ((SvgImageSource)iconSource.ImageSource).UriSource);
+                Verify.AreEqual(uri, ((SvgImageSource)imageIcon.Source).UriSource);
             });
         }
 
@@ -199,20 +240,24 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             AnimatedIconSource iconSource = null;
             IAnimatedVisualSource2 source = null;
+            AnimatedIcon animatedIcon = null;
 
             RunOnUIThread.Execute(() =>
             {
                 iconSource = new AnimatedIconSource();
                 source = new AnimatedChevronDownSmallVisualSource();
+                animatedIcon = iconSource.CreateIconElement() as AnimatedIcon;
 
                 // IconSource.Foreground should be null to allow foreground inheritance from
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
+                //Verify.AreEqual(animatedIcon.Foreground, null);
 
                 Log.Comment("Validate the defaults match BitmapIcon.");
 
                 var icon = new AnimatedIcon();
                 Verify.AreEqual(icon.Source, iconSource.Source);
+                Verify.AreEqual(animatedIcon.Source, iconSource.Source);
 
                 Log.Comment("Validate that you can change the properties.");
 
@@ -224,8 +269,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 Verify.IsTrue(iconSource.Foreground is SolidColorBrush);
+                Verify.IsTrue(animatedIcon.Foreground is SolidColorBrush);
                 Verify.AreEqual(Windows.UI.Colors.Red, (iconSource.Foreground as SolidColorBrush).Color);
+                Verify.AreEqual(Windows.UI.Colors.Red, (animatedIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual(source, iconSource.Source);
+                Verify.AreEqual(source, animatedIcon.Source);
             });
         }
 
@@ -234,19 +282,23 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             PathIconSource iconSource = null;
             RectangleGeometry rectGeometry = null;
+            PathIcon pathIcon = null;
 
             RunOnUIThread.Execute(() =>
             {
                 iconSource = new PathIconSource();
+                pathIcon = iconSource.CreateIconElement() as PathIcon;
 
                 // IconSource.Foreground should be null to allow foreground inheritance from
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
+                //Verify.AreEqual(pathIcon.Foreground, null);
 
                 Log.Comment("Validate the defaults match PathIcon.");
 
                 var icon = new PathIcon();
                 Verify.AreEqual(icon.Data, iconSource.Data);
+                Verify.AreEqual(pathIcon.Data, iconSource.Data);
 
                 Log.Comment("Validate that you can change the properties.");
 
@@ -258,8 +310,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 Verify.IsTrue(iconSource.Foreground is SolidColorBrush);
+                Verify.IsTrue(pathIcon.Foreground is SolidColorBrush);
                 Verify.AreEqual(Windows.UI.Colors.Red, (iconSource.Foreground as SolidColorBrush).Color);
+                Verify.AreEqual(Windows.UI.Colors.Red, (pathIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual(rectGeometry, iconSource.Data);
+                Verify.AreEqual(rectGeometry, pathIcon.Data);
             });
         }
 

--- a/dev/IconSource/AnimatedIconSource.cpp
+++ b/dev/IconSource/AnimatedIconSource.cpp
@@ -24,3 +24,17 @@ winrt::IconElement AnimatedIconSource::CreateIconElementCore()
     }
     return animatedIcon;
 }
+
+winrt::DependencyProperty AnimatedIconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_SourceProperty)
+    {
+        return winrt::AnimatedIcon::SourceProperty();
+    }
+    else if (sourceProperty == s_FallbackIconSourceProperty)
+    {
+        return winrt::AnimatedIcon::FallbackIconSourceProperty();
+    }
+
+    return nullptr;
+}

--- a/dev/IconSource/AnimatedIconSource.cpp
+++ b/dev/IconSource/AnimatedIconSource.cpp
@@ -36,5 +36,5 @@ winrt::DependencyProperty AnimatedIconSource::GetIconElementPropertyCore(winrt::
         return winrt::AnimatedIcon::FallbackIconSourceProperty();
     }
 
-    return nullptr;
+    return __super::GetIconElementPropertyCore(sourceProperty);
 }

--- a/dev/IconSource/AnimatedIconSource.h
+++ b/dev/IconSource/AnimatedIconSource.h
@@ -15,5 +15,6 @@ public:
     using AnimatedIconSourceProperties::EnsureProperties;
     using AnimatedIconSourceProperties::ClearProperties;
 
+    winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
     winrt::IconElement CreateIconElementCore();
 };

--- a/dev/IconSource/BitmapIconSource.cpp
+++ b/dev/IconSource/BitmapIconSource.cpp
@@ -36,5 +36,5 @@ winrt::DependencyProperty BitmapIconSource::GetIconElementPropertyCore(winrt::De
         return winrt::BitmapIcon::UriSourceProperty();
     }
 
-    return nullptr;
+    return __super::GetIconElementPropertyCore(sourceProperty);
 }

--- a/dev/IconSource/BitmapIconSource.cpp
+++ b/dev/IconSource/BitmapIconSource.cpp
@@ -24,3 +24,17 @@ winrt::IconElement BitmapIconSource::CreateIconElementCore()
     }
     return bitmapIcon;
 }
+
+winrt::DependencyProperty BitmapIconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_ShowAsMonochromeProperty)
+    {
+        return winrt::BitmapIcon::ShowAsMonochromeProperty();
+    }
+    else if (sourceProperty == s_UriSourceProperty)
+    {
+        return winrt::BitmapIcon::UriSourceProperty();
+    }
+
+    return nullptr;
+}

--- a/dev/IconSource/BitmapIconSource.h
+++ b/dev/IconSource/BitmapIconSource.h
@@ -15,5 +15,6 @@ public:
     using BitmapIconSourceProperties::EnsureProperties;
     using BitmapIconSourceProperties::ClearProperties;
 
+    winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
     winrt::IconElement CreateIconElementCore();
 };

--- a/dev/IconSource/FontIconSource.cpp
+++ b/dev/IconSource/FontIconSource.cpp
@@ -30,3 +30,37 @@ winrt::IconElement FontIconSource::CreateIconElementCore()
 
     return fontIcon;
 }
+
+winrt::DependencyProperty FontIconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_FontFamilyProperty)
+    {
+        return winrt::FontIcon::FontFamilyProperty();
+    }
+    else if (sourceProperty == s_FontSizeProperty)
+    {
+        return winrt::FontIcon::FontSizeProperty();
+    }
+    else if (sourceProperty == s_FontStyleProperty)
+    {
+        return winrt::FontIcon::FontStyleProperty();
+    }
+    else if (sourceProperty == s_FontWeightProperty)
+    {
+        return winrt::FontIcon::FontWeightProperty();
+    }
+    else if (sourceProperty == s_GlyphProperty)
+    {
+        return winrt::FontIcon::GlyphProperty();
+    }
+    else if (sourceProperty == s_IsTextScaleFactorEnabledProperty)
+    {
+        return winrt::FontIcon::IsTextScaleFactorEnabledProperty();
+    }
+    else if (sourceProperty == s_MirroredWhenRightToLeftProperty)
+    {
+        return winrt::FontIcon::MirroredWhenRightToLeftProperty();
+    }
+
+    return nullptr;
+}

--- a/dev/IconSource/FontIconSource.cpp
+++ b/dev/IconSource/FontIconSource.cpp
@@ -62,5 +62,5 @@ winrt::DependencyProperty FontIconSource::GetIconElementPropertyCore(winrt::Depe
         return winrt::FontIcon::MirroredWhenRightToLeftProperty();
     }
 
-    return nullptr;
+    return __super::GetIconElementPropertyCore(sourceProperty);
 }

--- a/dev/IconSource/FontIconSource.h
+++ b/dev/IconSource/FontIconSource.h
@@ -17,5 +17,6 @@ public:
     using FontIconSourceProperties::EnsureProperties;
     using FontIconSourceProperties::ClearProperties;
 
+    winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
     winrt::IconElement CreateIconElementCore();
 };

--- a/dev/IconSource/IconSource.cpp
+++ b/dev/IconSource/IconSource.cpp
@@ -6,8 +6,31 @@
 #include "SharedHelpers.h"
 
 #include "IconSource.h"
+#include <Vector.h>
 
 winrt::IconElement IconSource::CreateIconElement()
 {
-    return CreateIconElementCore();
+    auto const element = CreateIconElementCore();
+    m_createdIconElements.push_back(winrt::make_weak<winrt::IconElement>(element));
+    return element;
+}
+
+void IconSource::OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
+{
+    if (auto const iconProp = GetIconElementPropertyCore(args.Property()))
+    {
+        if(m_createdIconElements.size() > 0)
+        {
+            m_createdIconElements.erase(std::remove_if(m_createdIconElements.begin(), m_createdIconElements.end(),
+                [iconProp, newValue = args.NewValue()](winrt::weak_ref<winrt::IconElement> weakElement)
+            {
+                auto const element = weakElement.get();
+                if (element)
+                {
+                    element.SetValue(iconProp, newValue);
+                }
+                return !element;
+            }));
+        }
+    }
 }

--- a/dev/IconSource/IconSource.cpp
+++ b/dev/IconSource/IconSource.cpp
@@ -19,19 +19,16 @@ void IconSource::OnPropertyChanged(const winrt::DependencyPropertyChangedEventAr
 {
     if (auto const iconProp = GetIconElementPropertyCore(args.Property()))
     {
-        if(m_createdIconElements.size() > 0)
+        m_createdIconElements.erase(std::remove_if(m_createdIconElements.begin(), m_createdIconElements.end(),
+            [iconProp, newValue = args.NewValue()](winrt::weak_ref<winrt::IconElement> weakElement)
         {
-            m_createdIconElements.erase(std::remove_if(m_createdIconElements.begin(), m_createdIconElements.end(),
-                [iconProp, newValue = args.NewValue()](winrt::weak_ref<winrt::IconElement> weakElement)
+            auto const element = weakElement.get();
+            if (element)
             {
-                auto const element = weakElement.get();
-                if (element)
-                {
-                    element.SetValue(iconProp, newValue);
-                }
-                return !element;
-            }), m_createdIconElements.end());
-        }
+                element.SetValue(iconProp, newValue);
+            }
+            return !element;
+        }), m_createdIconElements.end());
     }
 }
 

--- a/dev/IconSource/IconSource.cpp
+++ b/dev/IconSource/IconSource.cpp
@@ -30,7 +30,17 @@ void IconSource::OnPropertyChanged(const winrt::DependencyPropertyChangedEventAr
                     element.SetValue(iconProp, newValue);
                 }
                 return !element;
-            }));
+            }), m_createdIconElements.end());
         }
     }
+}
+
+winrt::DependencyProperty IconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_ForegroundProperty)
+    {
+        return winrt::IconElement::ForegroundProperty();
+    }
+
+    return nullptr;
 }

--- a/dev/IconSource/IconSource.h
+++ b/dev/IconSource/IconSource.h
@@ -13,7 +13,7 @@ class IconSource :
 public:
     winrt::IconElement CreateIconElement();
     virtual winrt::IconElement CreateIconElementCore() = 0;
-    virtual winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty) = 0;
+    virtual winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 protected:

--- a/dev/IconSource/IconSource.h
+++ b/dev/IconSource/IconSource.h
@@ -13,4 +13,9 @@ class IconSource :
 public:
     winrt::IconElement CreateIconElement();
     virtual winrt::IconElement CreateIconElementCore() = 0;
+    virtual winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty) = 0;
+
+    void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+protected:
+    std::vector<winrt::weak_ref<winrt::IconElement>> m_createdIconElements{};
 };

--- a/dev/IconSource/IconSource.idl
+++ b/dev/IconSource/IconSource.idl
@@ -3,10 +3,12 @@
 
 [MUX_PUBLIC]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass IconSource : Windows.UI.Xaml.DependencyObject
 {
     Windows.UI.Xaml.Controls.IconElement CreateIconElement();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Windows.UI.Xaml.Media.Brush Foreground { get; set; };
 
     static Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; };
@@ -14,11 +16,13 @@ unsealed runtimeclass IconSource : Windows.UI.Xaml.DependencyObject
 
 [MUX_PUBLIC]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass SymbolIconSource : IconSource
 {
     SymbolIconSource();
 
     [MUX_DEFAULT_VALUE("winrt::Symbol::Emoji")]
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Windows.UI.Xaml.Controls.Symbol Symbol { get; set; };
 
     static Windows.UI.Xaml.DependencyProperty SymbolProperty { get; };
@@ -26,21 +30,35 @@ unsealed runtimeclass SymbolIconSource : IconSource
 
 [MUX_PUBLIC]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass FontIconSource : IconSource
 {
     FontIconSource();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     String Glyph { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("20.0")]
     Double FontSize { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("winrt::FontFamily{ c_fontIconSourceDefaultFontFamily }")]
     Windows.UI.Xaml.Media.FontFamily FontFamily { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("{ 400 }")]
     Windows.UI.Text.FontWeight FontWeight { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("winrt::FontStyle::Normal")]
     Windows.UI.Text.FontStyle FontStyle { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("true")]
     Boolean IsTextScaleFactorEnabled { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Boolean MirroredWhenRightToLeft { get; set; };
 
     static Windows.UI.Xaml.DependencyProperty GlyphProperty { get; };
@@ -54,11 +72,15 @@ unsealed runtimeclass FontIconSource : IconSource
 
 [MUX_PUBLIC]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass BitmapIconSource : IconSource
 {
     BitmapIconSource();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Windows.Foundation.Uri UriSource { get; set; };
+
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     [MUX_DEFAULT_VALUE("true")]
     Boolean ShowAsMonochrome { get; set; };
 
@@ -68,10 +90,12 @@ unsealed runtimeclass BitmapIconSource : IconSource
 
 [MUX_PUBLIC]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass PathIconSource : IconSource
 {
     PathIconSource();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Windows.UI.Xaml.Media.Geometry Data { get; set; };
 
     static Windows.UI.Xaml.DependencyProperty DataProperty { get; };
@@ -79,10 +103,12 @@ unsealed runtimeclass PathIconSource : IconSource
 
 [MUX_PUBLIC]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass ImageIconSource : IconSource
 {
     ImageIconSource();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Windows.UI.Xaml.Media.ImageSource ImageSource{ get; set; };
 
     static Windows.UI.Xaml.DependencyProperty ImageSourceProperty{ get; };
@@ -90,11 +116,14 @@ unsealed runtimeclass ImageIconSource : IconSource
 
 [MUX_PREVIEW]
 [webhosthidden]
+[MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass AnimatedIconSource : IconSource
 {
     AnimatedIconSource();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     IAnimatedVisualSource2 Source{ get; set; };
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     IconSource FallbackIconSource{ get; set; };
 
     static Windows.UI.Xaml.DependencyProperty SourceProperty { get; };

--- a/dev/IconSource/ImageIconSource.cpp
+++ b/dev/IconSource/ImageIconSource.cpp
@@ -20,3 +20,13 @@ winrt::IconElement ImageIconSource::CreateIconElementCore()
     }
     return imageIcon;
 }
+
+winrt::DependencyProperty ImageIconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_ImageSourceProperty)
+    {
+        return winrt::ImageIcon::SourceProperty();
+    }
+
+    return nullptr;
+}

--- a/dev/IconSource/ImageIconSource.cpp
+++ b/dev/IconSource/ImageIconSource.cpp
@@ -28,5 +28,5 @@ winrt::DependencyProperty ImageIconSource::GetIconElementPropertyCore(winrt::Dep
         return winrt::ImageIcon::SourceProperty();
     }
 
-    return nullptr;
+    return __super::GetIconElementPropertyCore(sourceProperty);
 }

--- a/dev/IconSource/ImageIconSource.h
+++ b/dev/IconSource/ImageIconSource.h
@@ -15,5 +15,6 @@ public:
     using ImageIconSourceProperties::EnsureProperties;
     using ImageIconSourceProperties::ClearProperties;
 
+    winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
     winrt::IconElement CreateIconElementCore();
 };

--- a/dev/IconSource/PathIconSource.cpp
+++ b/dev/IconSource/PathIconSource.cpp
@@ -29,5 +29,5 @@ winrt::DependencyProperty PathIconSource::GetIconElementPropertyCore(winrt::Depe
         return winrt::PathIcon::DataProperty();
     }
 
-    return nullptr;
+    return __super::GetIconElementPropertyCore(sourceProperty);
 }

--- a/dev/IconSource/PathIconSource.cpp
+++ b/dev/IconSource/PathIconSource.cpp
@@ -21,3 +21,13 @@ winrt::IconElement PathIconSource::CreateIconElementCore()
     }
     return pathIcon;
 }
+
+winrt::DependencyProperty PathIconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_DataProperty)
+    {
+        return winrt::PathIcon::DataProperty();
+    }
+
+    return nullptr;
+}

--- a/dev/IconSource/PathIconSource.h
+++ b/dev/IconSource/PathIconSource.h
@@ -15,5 +15,6 @@ public:
     using PathIconSourceProperties::EnsureProperties;
     using PathIconSourceProperties::ClearProperties;
 
+    winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
     winrt::IconElement CreateIconElementCore();
 };

--- a/dev/IconSource/SymbolIconSource.cpp
+++ b/dev/IconSource/SymbolIconSource.cpp
@@ -25,5 +25,5 @@ winrt::DependencyProperty SymbolIconSource::GetIconElementPropertyCore(winrt::De
         return winrt::SymbolIcon::SymbolProperty();
     }
 
-    return nullptr;
+    return __super::GetIconElementPropertyCore(sourceProperty);
 }

--- a/dev/IconSource/SymbolIconSource.cpp
+++ b/dev/IconSource/SymbolIconSource.cpp
@@ -17,3 +17,13 @@ winrt::IconElement SymbolIconSource::CreateIconElementCore()
     }
     return symbolIcon;
 }
+
+winrt::DependencyProperty SymbolIconSource::GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty)
+{
+    if (sourceProperty == s_SymbolProperty)
+    {
+        return winrt::SymbolIcon::SymbolProperty();
+    }
+
+    return nullptr;
+}

--- a/dev/IconSource/SymbolIconSource.h
+++ b/dev/IconSource/SymbolIconSource.h
@@ -15,5 +15,6 @@ public:
     using SymbolIconSourceProperties::EnsureProperties;
     using SymbolIconSourceProperties::ClearProperties;
 
+    winrt::DependencyProperty GetIconElementPropertyCore(winrt::DependencyProperty sourceProperty);
     winrt::IconElement CreateIconElementCore();
 };

--- a/dev/InfoBar/InfoBar.cpp
+++ b/dev/InfoBar/InfoBar.cpp
@@ -206,7 +206,7 @@ void InfoBar::UpdateIcon()
     auto const templateSettings = winrt::get_self<::InfoBarTemplateSettings>(TemplateSettings());
     if (auto const source = IconSource())
     {
-        templateSettings->IconElement(source.CreateIconElement());
+        templateSettings->IconElement(SharedHelpers::MakeIconElementFrom(source));
     }
     else
     {

--- a/dev/NavigationView/NavigationBackButton.xaml
+++ b/dev/NavigationView/NavigationBackButton.xaml
@@ -83,9 +83,9 @@
                             <animatedvisuals:AnimatedBackVisualSource/>
                             <local:AnimatedIcon.FallbackIconSource>
                                 <local:FontIconSource
-                                    FontSize="16"
-                                    FontFamily="{TemplateBinding FontFamily}"
-                                    Glyph="&#xE72B;"
+                                    FontSize="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FontSize}"
+                                    FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FontFamily}"
+                                    Glyph="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}"
                                     MirroredWhenRightToLeft="True"/>
                             </local:AnimatedIcon.FallbackIconSource>
                         </local:AnimatedIcon>
@@ -99,5 +99,4 @@
         <Setter Property="Height" Value="32" />
         <Setter Property="Width" Value="32" />
     </Style>
-    
 </ResourceDictionary>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -349,7 +349,9 @@
                                                 local:AnimatedIcon.State="Normal">
                                 <animatedvisuals:AnimatedGlobalNavigationButtonVisualSource/>
                                 <local:AnimatedIcon.FallbackIconSource>
-                                    <local:FontIconSource Glyph="&#xE700;" FontSize="16"/>
+                                    <local:FontIconSource
+                                        Glyph="&#xE700;"
+                                        FontSize="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FontSize }"/>
                                 </local:AnimatedIcon.FallbackIconSource>
                             </local:AnimatedIcon>
                         </Border>

--- a/dev/SwipeControl/SwipeItem.cpp
+++ b/dev/SwipeControl/SwipeItem.cpp
@@ -79,9 +79,9 @@ void SwipeItem::GenerateControl(const winrt::AppBarButton& appBarButton, const w
         appBarButton.Foreground(Foreground());
     }
 
-    if (IconSource())
+    if (auto const source = IconSource())
     {
-        appBarButton.Icon(IconSource().CreateIconElement());
+        appBarButton.Icon(SharedHelpers::MakeIconElementFrom(source));
     }
 
     appBarButton.Label(Text());

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -380,7 +380,7 @@ void TabViewItem::OnIconSourceChanged()
     auto const templateSettings = winrt::get_self<TabViewItemTemplateSettings>(TabViewTemplateSettings());
     if (auto const source = IconSource())
     {
-        templateSettings->IconElement(source.CreateIconElement());
+        templateSettings->IconElement(SharedHelpers::MakeIconElementFrom(source));
         winrt::VisualStateManager::GoToState(*this, L"Icon"sv, false);
     }
     else

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "pch.h"
@@ -956,7 +956,7 @@ void TeachingTip::OnIconSourceChanged()
     auto const templateSettings = winrt::get_self<::TeachingTipTemplateSettings>(TemplateSettings());
     if (auto const source = IconSource())
     {
-        templateSettings->IconElement(source.CreateIconElement());
+        templateSettings->IconElement(SharedHelpers::MakeIconElementFrom(source));
         winrt::VisualStateManager::GoToState(*this, L"Icon"sv, false);
     }
     else

--- a/dev/dll/CommandingHelpers.cpp
+++ b/dev/dll/CommandingHelpers.cpp
@@ -30,7 +30,7 @@ winrt::IInspectable CommandingHelpers::IconSourceToIconSourceElementConverter::C
         }
         else
         {
-            iconSource.CreateIconElement();
+            return SharedHelpers::MakeIconElementFrom(iconSource);
         }
     }
 

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -535,6 +535,116 @@ bool SharedHelpers::IsAncestor(
     return false;
 }
 
+#ifdef ICONSOURCE_INCLUDED
+
+winrt::IconElement SharedHelpers::MakeIconElementFrom(winrt::IconSource const& iconSource)
+{
+    if (auto fontIconSource = iconSource.try_as<winrt::FontIconSource>())
+    {
+        winrt::FontIcon fontIcon;
+
+        fontIcon.Glyph(fontIconSource.Glyph());
+        fontIcon.FontSize(fontIconSource.FontSize());
+        if (const auto newForeground = fontIconSource.Foreground())
+        {
+            fontIcon.Foreground(newForeground);
+        }
+
+        if (fontIconSource.FontFamily())
+        {
+            fontIcon.FontFamily(fontIconSource.FontFamily());
+        }
+
+        fontIcon.FontWeight(fontIconSource.FontWeight());
+        fontIcon.FontStyle(fontIconSource.FontStyle());
+        fontIcon.IsTextScaleFactorEnabled(fontIconSource.IsTextScaleFactorEnabled());
+        fontIcon.MirroredWhenRightToLeft(fontIconSource.MirroredWhenRightToLeft());
+
+        return fontIcon;
+    }
+    else if (auto symbolIconSource = iconSource.try_as<winrt::SymbolIconSource>())
+    {
+        winrt::SymbolIcon symbolIcon;
+        symbolIcon.Symbol(symbolIconSource.Symbol());
+        if (const auto newForeground = symbolIconSource.Foreground())
+        {
+            symbolIcon.Foreground(newForeground);
+        }
+        return symbolIcon;
+    }
+    else if (auto bitmapIconSource = iconSource.try_as<winrt::BitmapIconSource>())
+    {
+        winrt::BitmapIcon bitmapIcon;
+
+        if (bitmapIconSource.UriSource())
+        {
+            bitmapIcon.UriSource(bitmapIconSource.UriSource());
+        }
+
+        if (winrt::ApiInformation::IsPropertyPresent(L"Windows.UI.Xaml.Controls.BitmapIcon", L"ShowAsMonochrome"))
+        {
+            bitmapIcon.ShowAsMonochrome(bitmapIconSource.ShowAsMonochrome());
+        }
+        if (const auto newForeground = bitmapIconSource.Foreground())
+        {
+            bitmapIcon.Foreground(newForeground);
+        }
+        return bitmapIcon;
+    }
+#ifdef IMAGEICON_INCLUDED
+    else if (auto imageIconSource = iconSource.try_as<winrt::ImageIconSource>())
+    {
+        winrt::ImageIcon imageIcon;
+        if (const auto imageSource = imageIconSource.ImageSource())
+        {
+            imageIcon.Source(imageSource);
+        }
+        if (const auto newForeground = imageIconSource.Foreground())
+        {
+            imageIcon.Foreground(newForeground);
+        }
+        return imageIcon;
+    }
+#endif
+    else if (auto pathIconSource = iconSource.try_as<winrt::PathIconSource>())
+    {
+        winrt::PathIcon pathIcon;
+
+        if (pathIconSource.Data())
+        {
+            pathIcon.Data(pathIconSource.Data());
+        }
+        if (const auto newForeground = pathIconSource.Foreground())
+        {
+            pathIcon.Foreground(newForeground);
+        }
+        return pathIcon;
+    }
+#ifdef ANIMATEDICON_INCLUDED
+    else if (auto animatedIconSource = iconSource.try_as<winrt::AnimatedIconSource>())
+    {
+        winrt::AnimatedIcon animatedIcon;
+        if (auto const source = animatedIconSource.Source())
+        {
+            animatedIcon.Source(source);
+        }
+        if (auto const fallbackIconSource = animatedIconSource.FallbackIconSource())
+        {
+            animatedIcon.FallbackIconSource(fallbackIconSource);
+        }
+        if (const auto newForeground = animatedIconSource.Foreground())
+        {
+            animatedIcon.Foreground(newForeground);
+        }
+        return animatedIcon;
+    }
+#endif
+
+    return nullptr;
+}
+
+#endif
+
 void SharedHelpers::SetBinding(
     std::wstring_view const& pathString,
     winrt::DependencyObject const& target,

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -233,6 +233,10 @@ public:
 
     static winrt::hstring TryGetStringRepresentationFromObject(winrt::IInspectable obj);
 
+#ifdef ICONSOURCE_INCLUDED
+    static winrt::IconElement MakeIconElementFrom(winrt::IconSource const& iconSource);
+#endif
+
     static void SetBinding(
         std::wstring_view const& pathString,
         winrt::DependencyObject const& target,


### PR DESCRIPTION
Change IconSource's CreateIconElement to make the IconSource behave as a "dynamic" factory. IconSource now records the icons created by it and pushes properties changed on the icon source to those icon elements. To minimize Compat issues, I've reverted all of the usages of the createIconElement except animated icon's back to the shared helper.