### PR TITLE
Disable unreliable test.

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -505,6 +505,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "B")]
+        [TestProperty("Ignore", "True")] // Disabled due to #4576: Unreliable test
         public void GamepadCanEscapeAndDoesNotSelectWithFocus()
         {
             using (var setup = new TestSetupHelper(new[] { "RadioButtons Tests", "RadioButtons Test" }))


### PR DESCRIPTION
The GamepadCanEscapeAndDoesNotSelectWithFocus test has been failing periodically blocking PR's. I'm disabling it until we can resolve the unreliability.