### PR TITLE
Skip TDBuild artifact upload

### DIFF
--- a/build/Localization/LocalizationAutomation.proj
+++ b/build/Localization/LocalizationAutomation.proj
@@ -46,7 +46,7 @@
   </Target>
   <!-- Run localization build by interacting with the Touchdown Build service -->
   <Target Name="LocalizeBuild" DependsOnTargets="CheckForLocalizeBuild">
-    <Exec Command="set LocRoot=$(LocRoot) &amp; &quot;$(TdBuildClientPath)\TdBuildClient.exe&quot; /c:&quot;$(LocConfigFile)&quot; /auth:&quot;oAuth&quot; /clientid:&quot;e8416663-8a55-4cb6-9bba-12038b37a6ed&quot; /appkey:&quot;$(MAPPED_LOC_KEY)&quot; /o:&quot;$(LocOutput)&quot;" />
+    <Exec Command="set LocRoot=$(LocRoot) &amp; &quot;$(TdBuildClientPath)\TdBuildClient.exe&quot; /c:&quot;$(LocConfigFile)&quot; /auth:&quot;oAuth&quot; /clientid:&quot;e8416663-8a55-4cb6-9bba-12038b37a6ed&quot; /appkey:&quot;$(MAPPED_LOC_KEY)&quot; /o:&quot;$(LocOutput)&quot; /skipvstsdrop"  />
   </Target>
   <!-- Check-in localized resource files resulted from Touchdown build -->
   <Target Name="CheckinLocFiles">


### PR DESCRIPTION
## Description
Skipping the artifact upload step when using the TDBuild client.

## Motivation and Context
Touchdown team is removing support for artifact upload via TDBuild client. Disabling this step as per their instructions to keep the pipeline running. Moving to a different method of artifact upload is upcoming in a second PR.