### PR TITLE
[Website] Add a11y labels for feature table

### DIFF
--- a/about.html
+++ b/about.html
@@ -141,75 +141,75 @@
                             </tr>
                             <tr>
                               <th scope="row">Supported on all Windows device families</th>
-                              <td><i class="icon-check text-icon" style="margin-left: 11px;"></i> *</td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td></td>
-                              <td></td>
-                              <td></td>
+                              <td aria-label="Available in a future version of WinUI 3"><i class="icon-check text-icon" style="margin-left: 11px;"></i> *</td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"></td>
+                              <td aria-label="Unavailable"></td>
+                              <td aria-label="Unavailable"></td>
                             </tr>
                             <tr>
                               <th scope="row">Native C/C++</th>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td> </td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
                             </tr>
                             <tr>
                               <th scope="row">.NET 5 Support</th>
-                              <td><i class="icon-check text-icon"></i></td>
-                              <td> </td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
+                              <td aria-label="Available"><i class="icon-check text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>
                               <th scope="row">WebView2<br/>(Chromium-based engine)</th>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
-                              <td><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
-                              <td> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Available as work in progress"><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
+                              <td aria-label="Available as work in progress"><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
+                              <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>
                               <th scope="row">Built-in Fluent Design controls</th>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td> </td>
-                              <td> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>
                               <th scope="row">Built-in support for modern input<br/>(e.g. touch, pen, gamepad*)</th>
-                              <td><i class="icon-check my-auto text-icon"></i></td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td> </td>
-                              <td> </td>
+                              <td aria-label="Available"><i class="icon-check my-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>
                               <th scope="row">Uses latest DirectX version for graphics performance</th>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td> </td>
-                              <td> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>
                               <th scope="row">High performance data binding<br/>(x:Bind)</th>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td> </td>
-                              <td> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>
                               <th scope="row">Input Validation</th>
-                              <td><i class="icon-check m-auto text-icon"></i></td>
-                              <td> </td>
-                              <td><i class="icon-check m-auto text-icon"></i> </td>
-                              <td><i class="icon-check m-auto text-icon"></i> </td>
-                              <td><i class="icon-check m-auto text-icon"></i> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
+                              <td aria-label="Unavailable"> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i> </td>
+                              <td aria-label="Available"><i class="icon-check m-auto text-icon"></i> </td>
                             </tr>
                           </tbody>
                         </table>

--- a/about.html
+++ b/about.html
@@ -167,8 +167,8 @@
                               <th scope="row">WebView2<br/>(Chromium-based engine)</th>
                               <td aria-label="Available"><i class="icon-check m-auto text-icon"></i></td>
                               <td aria-label="Unavailable"> </td>
-                              <td aria-label="Available as work in progress"><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
-                              <td aria-label="Available as work in progress"><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
+                              <td aria-label="Currently a work in progress"><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
+                              <td aria-label="Currently a work in progress"><i class="icon-check text-icon" style="margin-left:18px;"></i> **</td>
                               <td aria-label="Unavailable"> </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where the feature table was not usable for people using screen readers as most table entries were not read out since there was no text contained. Adding aria-labels fixes this.

@anawishnoff FYI
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Improve website a11y
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually using narrator
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->