### PR TITLE
PipsPager scrolling fix event bubble up

### DIFF
--- a/dev/PipsPager/PipsPager.cpp
+++ b/dev/PipsPager/PipsPager.cpp
@@ -104,7 +104,7 @@ void PipsPager::OnApplyTemplate()
     }(GetTemplateChildT<winrt::ItemsRepeater>(c_pipsPagerRepeaterName, *this));
 
     m_scrollViewerBringIntoViewRequestedRevoker.revoke();
-    [this](winrt::FxScrollViewer scrollViewer)
+    [this](const winrt::FxScrollViewer scrollViewer)
     {
         m_pipsPagerScrollViewer.set(scrollViewer);
         if (scrollViewer && SharedHelpers::IsRS4OrHigher())
@@ -624,6 +624,10 @@ bool PipsPager::IsOutOfControlBounds(const winrt::Point& point)
         point.Y  > actualHeight - tolerance;
 }
 
+// In order to handle undesired scrolling when a user
+// tabs into the pipspager/focuses a pip using keyboard
+// we'll check for offsets and if they're NAN -
+// meaning it was not scroll initiated by us, we handle it.
 void PipsPager::OnPipsAreaBringIntoViewRequested(const IInspectable& sender, const winrt::BringIntoViewRequestedEventArgs& args)
 {
     if (
@@ -635,6 +639,11 @@ void PipsPager::OnPipsAreaBringIntoViewRequested(const IInspectable& sender, con
     }
 }
 
+// Inner scrollviewer will bubble BringIntoView event to 
+// parent scrollviewers (if they exist) if the scrolling was
+// not complete (could not scroll to specified offset because
+// the beginning/end of the scrollable area was already reached).
+// To avoid that, we handle BringIntoViewRequested on inner scrollviewer.
 void PipsPager::OnScrollViewerBringIntoViewRequested(const IInspectable& sender, const winrt::BringIntoViewRequestedEventArgs& args)
 {
     args.Handled(true);

--- a/dev/PipsPager/PipsPager.cpp
+++ b/dev/PipsPager/PipsPager.cpp
@@ -103,7 +103,15 @@ void PipsPager::OnApplyTemplate()
         }
     }(GetTemplateChildT<winrt::ItemsRepeater>(c_pipsPagerRepeaterName, *this));
 
-    m_pipsPagerScrollViewer.set(GetTemplateChildT<winrt::FxScrollViewer>(c_pipsPagerScrollViewerName, *this));
+    m_scrollViewerBringIntoViewRequestedRevoker.revoke();
+    [this](winrt::FxScrollViewer scrollViewer)
+    {
+        m_pipsPagerScrollViewer.set(scrollViewer);
+        if (scrollViewer && SharedHelpers::IsRS4OrHigher())
+        {
+            m_scrollViewerBringIntoViewRequestedRevoker = scrollViewer.BringIntoViewRequested(winrt::auto_revoke, { this, &PipsPager::OnScrollViewerBringIntoViewRequested });
+        }
+    }(GetTemplateChildT<winrt::FxScrollViewer>(c_pipsPagerScrollViewerName, *this));
 
     m_defaultPipSize = GetDesiredPipSize(NormalPipStyle());
     m_selectedPipSize = GetDesiredPipSize(SelectedPipStyle());
@@ -625,6 +633,11 @@ void PipsPager::OnPipsAreaBringIntoViewRequested(const IInspectable& sender, con
     {
         args.Handled(true);
     }
+}
+
+void PipsPager::OnScrollViewerBringIntoViewRequested(const IInspectable& sender, const winrt::BringIntoViewRequestedEventArgs& args)
+{
+    args.Handled(true);
 }
 
 void PipsPager::OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)

--- a/dev/PipsPager/PipsPager.h
+++ b/dev/PipsPager/PipsPager.h
@@ -75,6 +75,7 @@ private:
     void OnNextButtonClicked(const IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnPipsAreaGettingFocus(const IInspectable& sender, const winrt::GettingFocusEventArgs& args);
     void OnPipsAreaBringIntoViewRequested(const IInspectable& sender, const winrt::BringIntoViewRequestedEventArgs& args);
+    void OnScrollViewerBringIntoViewRequested(const IInspectable& sender, const winrt::BringIntoViewRequestedEventArgs& args);
 
     /* Pips Logic */
     void UpdatePipsItems(const int numberOfPages, int maxVisualIndicators);
@@ -93,6 +94,7 @@ private:
     winrt::ItemsRepeater::ElementPrepared_revoker m_pipsPagerElementPreparedRevoker{};
     winrt::UIElement::GettingFocus_revoker m_pipsAreaGettingFocusRevoker{};
     winrt::ItemsRepeater::BringIntoViewRequested_revoker m_pipsAreaBringIntoViewRequestedRevoker{};
+    winrt::FxScrollViewer::BringIntoViewRequested_revoker m_scrollViewerBringIntoViewRequestedRevoker{};
     /* Items */
     winrt::IObservableVector<int> m_pipsPagerItems{};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
PipsPager inner ScrollViewer causes outer ScrollViewers scroll if the inner ScrollViewer cannot fully fulfill the scroll request. It happens when offsets are bigger than what ScrollViewer can actually scroll by.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
This PR closes #4246. It handles the `BringIntoViewRequested` event and stops its bubbling up.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.