### PR TITLE
Add FullXamlMetadataProvider to our IXMP implementation

### DIFF
--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -168,6 +168,7 @@ namespace MU_X_XTI_NAMESPACE
 {
     [MUX_PUBLIC]
     [webhosthidden]
+    [Windows.UI.Xaml.Markup.FullXamlMetadataProvider]
     [default_interface]
     runtimeclass XamlControlsXamlMetaDataProvider
     // IXMP needs to be implemented by a public type in our assembly, but it doesn't need to be


### PR DESCRIPTION
[This attribute](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.markup.fullxamlmetadataproviderattribute?view=winrt-19041) was added a while back as an optimization to indicate that your component has a complete IXamlMetadataProvider implementation and therefore app consumers don't need to generate all the metadata for that component into the app's XamlTypeInfo.g.cs.

This is also helpful because I've seen some cases where the app's generated IXMP for our types is incomplete *and* those apps have some custom code which is choosing the app generated IXMP info over the "OtherProviders". This is a rare case to be sure but I'd rather not have to investigate such a problem again. At least this way either the type info will be complete or missing (if the app forgot to chain on to OtherProviders).