### PR TITLE
Adjust commandbar margins and button sizing

### DIFF
--- a/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -97,8 +97,8 @@
     <Thickness x:Key="AppBarButtonOverflowTextLabelPadding">0,5,0,8</Thickness>
     <Thickness x:Key="AppBarButtonTextLabelMargin">2,0,2,8</Thickness>
     <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,16,12,10</Thickness>
-    <Thickness x:Key="AppBarButtonInnerBorderMargin">2,9,2,9</Thickness>
-    <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">2,9,2,25</Thickness>
+    <Thickness x:Key="AppBarButtonInnerBorderMargin">2,6,2,6</Thickness>
+    <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">2,6,2,22</Thickness>
     <Thickness x:Key="AppBarButtonInnerBorderOverflowMargin">4,0,4,0</Thickness>
 
     <Style TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />

--- a/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -92,13 +92,13 @@
 
     <Thickness x:Key="AppBarButtonContentViewboxMargin">12,16,0,10</Thickness>
     <Thickness x:Key="AppBarButtonContentViewboxCompactMargin">0,12,0,12</Thickness>
-    <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,16,0,4</Thickness>
+    <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,16,0,2</Thickness>
     <Thickness x:Key="AppBarButtonOverflowTextTouchMargin">0,9,0,12</Thickness>
     <Thickness x:Key="AppBarButtonOverflowTextLabelPadding">0,5,0,8</Thickness>
     <Thickness x:Key="AppBarButtonTextLabelMargin">2,0,2,8</Thickness>
     <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,16,12,10</Thickness>
-    <Thickness x:Key="AppBarButtonInnerBorderMargin">0,9,0,9</Thickness>
-    <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">0,9,0,25</Thickness>
+    <Thickness x:Key="AppBarButtonInnerBorderMargin">2,9,2,9</Thickness>
+    <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">2,9,2,25</Thickness>
     <Thickness x:Key="AppBarButtonInnerBorderOverflowMargin">4,0,4,0</Thickness>
 
     <Style TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -85,7 +85,7 @@
 
     <x:Double x:Key="AppBarThemeMinHeight">64</x:Double>
     <x:Double x:Key="AppBarThemeCompactHeight">48</x:Double>
-    <Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,9,9,9</Thickness>
+    <Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
     
     <Thickness x:Key="CommandBarOverflowPresenterMargin">0,4,0,4</Thickness>
 
@@ -94,7 +94,7 @@
     <Style x:Key="DefaultCommandBarStyle" TargetType="CommandBar">
         <Setter Property="Background" Value="{ThemeResource CommandBarBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource CommandBarForeground}" />
-        <Setter Property="Padding" Value="7,0,0,0" />
+        <Setter Property="Padding" Value="4,0,0,0" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -85,7 +85,7 @@
 
     <x:Double x:Key="AppBarThemeMinHeight">64</x:Double>
     <x:Double x:Key="AppBarThemeCompactHeight">48</x:Double>
-    <Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">0,9,9,9</Thickness>
+    <Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,9,9,9</Thickness>
     
     <Thickness x:Key="CommandBarOverflowPresenterMargin">0,4,0,4</Thickness>
 
@@ -94,7 +94,7 @@
     <Style x:Key="DefaultCommandBarStyle" TargetType="CommandBar">
         <Setter Property="Background" Value="{ThemeResource CommandBarBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource CommandBarForeground}" />
-        <Setter Property="Padding" Value="9,0,0,0" />
+        <Setter Property="Padding" Value="7,0,0,0" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />

--- a/dev/CommonStyles/TestUI/CommandBarPage.xaml
+++ b/dev/CommonStyles/TestUI/CommandBarPage.xaml
@@ -31,7 +31,7 @@
                 <AppBarButton Icon="Add" Label="Add"/>
                 <AppBarButton Icon="Remove" Label="Remove" LabelPosition="Collapsed"/>
                 <AppBarSeparator/>
-                <AppBarButton Icon="Save" Label="Save"/>
+                <AppBarButton Icon="Save" Label="Save And Quit"/>
                 <AppBarToggleButton Icon="Add" Label="Toggle"/>
                 <CommandBar.SecondaryCommands>
                     <AppBarButton Icon="Add" Label="Add"/>


### PR DESCRIPTION
Added space between AppBarButtons and adjusting spacing between the buttons and the edge of the commandbar from 9 to 6.

![image](https://user-images.githubusercontent.com/30241445/112033010-37597a00-8afa-11eb-8e49-bcaf779fdcf1.png)
