### PR TITLE
Fix tooltip jumping on NavigationView when mouse is over the boundary of NavigationView

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -224,7 +224,11 @@ void NavigationViewItem::UpdateNavigationViewItemToolTip()
     {
         if (ShouldEnableToolTip())
         {
-            winrt::ToolTipService::SetToolTip(*this, m_suggestedToolTipContent.get());
+            // Don't SetToolTip with the same parameter because it close/re-open the ToolTip
+            if (toolTipContent != m_suggestedToolTipContent.get())
+            {
+                winrt::ToolTipService::SetToolTip(*this, m_suggestedToolTipContent.get());
+            }
         }
         else
         {


### PR DESCRIPTION
When pointer is over the boundary of NavigationView, the tooltip will be closed, then re-opened.

if the tooltip content is the same, don't call SetToolTip