### PR TITLE
allow right aligned action button in infobar when in layout is horizontal

### DIFF
--- a/dev/InfoBar/InfoBarPanel.cpp
+++ b/dev/InfoBar/InfoBarPanel.cpp
@@ -121,8 +121,12 @@ winrt::Size InfoBarPanel::ArrangeOverride(winrt::Size const& finalSize)
         const auto horizontalOrientationPadding = HorizontalOrientationPadding();
         float horizontalOffset = (float)horizontalOrientationPadding.Left;
         bool hasPreviousElement = false;
-        for (winrt::UIElement const& child : Children())
+
+        const auto children = Children();
+        const auto childCount = children.Size();
+        for (unsigned int i=0; i< childCount; i++)
         {
+            const auto child = children.GetAt(i);
             if (auto childAsFe = child.try_as<winrt::FrameworkElement>())
             {
                 auto const desiredSize = child.DesiredSize();
@@ -131,7 +135,17 @@ winrt::Size InfoBarPanel::ArrangeOverride(winrt::Size const& finalSize)
                     auto horizontalMargin = winrt::InfoBarPanel::GetHorizontalOrientationMargin(child);
 
                     horizontalOffset += hasPreviousElement ? (float)horizontalMargin.Left : 0;
-                    child.Arrange(winrt::Rect{ horizontalOffset, (float)horizontalOrientationPadding.Top + (float)horizontalMargin.Top, desiredSize.Width, desiredSize.Height });
+                    if (i < childCount - 1)
+                    {
+                        child.Arrange(winrt::Rect{ horizontalOffset, (float)horizontalOrientationPadding.Top + (float)horizontalMargin.Top, desiredSize.Width, desiredSize.Height });
+                    }
+                    else
+                    {
+                        // Give the rest of the horizontal space to the last child.
+                        child.Arrange(winrt::Rect{ horizontalOffset, (float)horizontalOrientationPadding.Top + (float)horizontalMargin.Top,
+                            std::max(desiredSize.Width, finalSize.Width - horizontalOffset), desiredSize.Height });
+                    }
+
                     horizontalOffset += desiredSize.Width + (float)horizontalMargin.Right;
 
                     hasPreviousElement = true;

--- a/dev/InfoBar/TestUI/InfoBarPage.xaml
+++ b/dev/InfoBar/TestUI/InfoBarPage.xaml
@@ -64,6 +64,8 @@
                         <ComboBoxItem Content="None" />
                         <ComboBoxItem Content="Button" />
                         <ComboBoxItem Content="Hyperlink" />
+                        <ComboBoxItem Content="RightAlignedButton" />
+                        <ComboBoxItem Content="RightAlignedHyperlink" />
                     </ComboBox>
 
                     <Button Content="Set Foreground" Click="SetForegroundClick"/>

--- a/dev/InfoBar/TestUI/InfoBarPage.xaml.cs
+++ b/dev/InfoBar/TestUI/InfoBarPage.xaml.cs
@@ -72,6 +72,21 @@ namespace MUXControlsTestApp
                 link.Content = "Informational link";
                 TestInfoBar.ActionButton = link;
             }
+            else if (ActionButtonComboBox.SelectedIndex == 3)
+            {
+                var button = new Button();
+                button.Content = "Action";
+                button.HorizontalAlignment = HorizontalAlignment.Right;
+                TestInfoBar.ActionButton = button;
+            }
+            else if (ActionButtonComboBox.SelectedIndex == 4)
+            {
+                var link = new HyperlinkButton();
+                link.NavigateUri = new Uri("http://www.microsoft.com/");
+                link.Content = "Informational link";
+                link.HorizontalAlignment = HorizontalAlignment.Right;
+                TestInfoBar.ActionButton = link;
+            }
         }
 
         private void IconComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
When layout is horizontal, we could give all the remaining space to the last child of InfoBarPanel, which will allow the child to position itself within the rest of the area using its layout properties like so.

```
<InfoBar>
  <InfoBar.ActionButton>
      <Button Content="Hello" HorizontalAlignment="Right" />
 </InfoBar.ActionButton>
</InfoBar>
```

Test: Pending.

https://user-images.githubusercontent.com/28935693/112234789-82f34d00-8bfa-11eb-93ff-695c16b14e53.mp4

