### PR TITLE
CommandBar changes for DropShadows

### DIFF
--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -909,8 +909,8 @@
                                     </RectangleGeometry>
                                 </contract12NotPresent:Grid.Clip>
                                 <contract12NotPresent:CommandBarOverflowPresenter x:Name="SecondaryItemsControl"
-                                        Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
-                                        IsTabStop="False">
+                                    Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
+                                    IsTabStop="False">
                                     <CommandBarOverflowPresenter.RenderTransform>
                                         <TranslateTransform x:Name="OverflowContentTransform" />
                                     </CommandBarOverflowPresenter.RenderTransform>

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -897,26 +897,30 @@
                                     <RowDefinition />
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
-                                <Grid.Clip>
-                                    <RectangleGeometry Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentClipRect}">
-                                        <RectangleGeometry.Transform>
-                                            <TransformGroup>
-                                                <TranslateTransform x:Name="OverflowContentRootClipTransform" />
-                                            </TransformGroup>
-                                        </RectangleGeometry.Transform>
-                                    </RectangleGeometry>
-                                </Grid.Clip>
-                                <CommandBarOverflowPresenter x:Name="SecondaryItemsControl"
-                                    Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
-                                    IsTabStop="False">
-                                    <CommandBarOverflowPresenter.RenderTransform>
-                                        <TranslateTransform x:Name="OverflowContentTransform" />
-                                    </CommandBarOverflowPresenter.RenderTransform>
-                                    <CommandBarOverflowPresenter.Resources>
-                                        <Style TargetType="AppBarButton" BasedOn="{StaticResource AppBarButtonOverflowStyle}" />
-                                        <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonOverflowStyle}" />
-                                    </CommandBarOverflowPresenter.Resources>
-                                </CommandBarOverflowPresenter>
+                                <Grid x:Name="SecondaryItemsControlShadowWrapper"
+                                      contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}"
+                                      contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
+                                    <Grid.Clip>
+                                        <RectangleGeometry Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentClipRect}">
+                                            <RectangleGeometry.Transform>
+                                                <TransformGroup>
+                                                    <TranslateTransform x:Name="OverflowContentRootClipTransform" />
+                                                </TransformGroup>
+                                            </RectangleGeometry.Transform>
+                                        </RectangleGeometry>
+                                    </Grid.Clip>
+                                    <CommandBarOverflowPresenter x:Name="SecondaryItemsControl"
+                                        Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
+                                        IsTabStop="False">
+                                        <CommandBarOverflowPresenter.RenderTransform>
+                                            <TranslateTransform x:Name="OverflowContentTransform" />
+                                        </CommandBarOverflowPresenter.RenderTransform>
+                                        <CommandBarOverflowPresenter.Resources>
+                                            <Style TargetType="AppBarButton" BasedOn="{StaticResource AppBarButtonOverflowStyle}" />
+                                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonOverflowStyle}" />
+                                        </CommandBarOverflowPresenter.Resources>
+                                    </CommandBarOverflowPresenter>
+                                </Grid>
                                 <!-- In order to give us extra space in the windowed popup to translate things down,
                                      we add a rectangle to make the HWND taller than it otherwise would be. -->
                                 <Rectangle x:Name="WindowedPopupPadding" Grid.Row="1" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.ContentHeight}" />

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -5,6 +5,8 @@
   xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+  xmlns:contract12Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,12)"
+  xmlns:contract12NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,12)"  
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -897,7 +899,28 @@
                                     <RowDefinition />
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
-                                <Grid x:Name="SecondaryItemsControlShadowWrapper"
+                                <contract12NotPresent:Grid.Clip>
+                                    <RectangleGeometry Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.OverflowContentClipRect}">
+                                        <RectangleGeometry.Transform>
+                                            <TransformGroup>
+                                                <TranslateTransform x:Name="OverflowContentRootClipTransform" />
+                                            </TransformGroup>
+                                        </RectangleGeometry.Transform>
+                                    </RectangleGeometry>
+                                </contract12NotPresent:Grid.Clip>
+                                <contract12NotPresent:CommandBarOverflowPresenter x:Name="SecondaryItemsControl"
+                                        Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
+                                        IsTabStop="False">
+                                    <CommandBarOverflowPresenter.RenderTransform>
+                                        <TranslateTransform x:Name="OverflowContentTransform" />
+                                    </CommandBarOverflowPresenter.RenderTransform>
+                                    <CommandBarOverflowPresenter.Resources>
+                                        <Style TargetType="AppBarButton" BasedOn="{StaticResource AppBarButtonOverflowStyle}" />
+                                        <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonOverflowStyle}" />
+                                    </CommandBarOverflowPresenter.Resources>
+                                </contract12NotPresent:CommandBarOverflowPresenter>
+                                <!--For 21H1 and up, we'll need to wrap the clip and presenter in a Grid which will host the Drop Shadow.-->
+                                <contract12Present:Grid x:Name="SecondaryItemsControlShadowWrapper"
                                       contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}"
                                       contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.Clip>
@@ -920,7 +943,7 @@
                                             <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonOverflowStyle}" />
                                         </CommandBarOverflowPresenter.Resources>
                                     </CommandBarOverflowPresenter>
-                                </Grid>
+                                </contract12Present:Grid>
                                 <!-- In order to give us extra space in the windowed popup to translate things down,
                                      we add a rectangle to make the HWND taller than it otherwise would be. -->
                                 <Rectangle x:Name="WindowedPopupPadding" Grid.Row="1" Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.ContentHeight}" />


### PR DESCRIPTION
This PR adds a parent Grid to the CommandBarOverflowPresenter and Clip elements in order for its drop shadow to render correctly. Since this change doesn't play too nicely with projected shadows, I've gated the parent Grid to 21H1 or higher builds only. Unfortunately, this means I'd need to duplicate the code that declares the CommandBarOverflowPresenter and the Clip.

Manually tested the MUXControlsTestApp on a 20H2 device to see that projected shadows appear as usual, and on a 21H1 device to see that drop shadows appear correctly.