### PR TITLE
Update some controls to have rounded focus rects.

### DIFF
--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -20,6 +20,7 @@
                     <Grid Background="{TemplateBinding Background}">
                         <Grid.Resources>
                             <Style x:Key="ColorPickerSliderStyle" TargetType="primitives:ColorPickerSlider">
+                                <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Slider">
@@ -90,7 +91,12 @@
                                                     </VisualStateGroup>
                                                 </VisualStateManager.VisualStateGroups>
                                                 <ContentPresenter x:Name="HeaderContentPresenter" ContentTemplate="{TemplateBinding HeaderTemplate}" Content="{TemplateBinding Header}" Foreground="{ThemeResource SliderHeaderForeground}" FontWeight="{ThemeResource SliderHeaderThemeFontWeight}" Margin="{ThemeResource SliderHeaderThemeMargin}" TextWrapping="Wrap" Visibility="Collapsed" x:DeferLoadStrategy="Lazy"/>
-                                                <Grid x:Name="SliderContainer" Background="Transparent" Control.IsTemplateFocusTarget="True" Grid.Row="1">
+                                                <Grid x:Name="SliderContainer"
+                                                      Background="Transparent"
+                                                      Control.IsTemplateFocusTarget="True"
+                                                      Grid.Row="1"
+                                                      contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                      contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
                                                     <Grid x:Name="HorizontalTemplate" MinHeight="44">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>

--- a/dev/CommonStyles/CalendarView_themeresources.xaml
+++ b/dev/CommonStyles/CalendarView_themeresources.xaml
@@ -160,6 +160,8 @@
                                 <Setter Property="FontSize" Value="20" />
                                 <Setter Property="Background" Value="{ThemeResource CalendarViewNavigationButtonBackground}" />
                                 <contract7Present:Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
+                                <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+                                <Setter Property="FocusVisualMargin" Value="2,2,2,0"/>
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Button">
@@ -173,7 +175,9 @@
                                                 Margin="{TemplateBinding Padding}"
                                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                AutomationProperties.AccessibilityView="Raw">
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                                contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />

--- a/dev/CommonStyles/MediaTransportControls_themeresources.xaml
+++ b/dev/CommonStyles/MediaTransportControls_themeresources.xaml
@@ -58,7 +58,7 @@
                                 <Setter Property="AllowFocusOnInteraction" Value="True" />
                             </Style>
                             <!-- New CommandBar Style -->
-                            <Style x:Key="CommandBarStyle" TargetType="CommandBar">
+                            <Style x:Key="CommandBarStyle" TargetType="CommandBar" BasedOn="{StaticResource DefaultCommandBarStyle}">
                                 <Setter Property="Height" Value="{ThemeResource MTCMediaButtonHeight}" />
                                 <Setter Property="Background" Value="Transparent" />
                             </Style>
@@ -72,7 +72,7 @@
                                 <Setter Property="IsTextScaleFactorEnabled" Value="False" />
                             </Style>
                             <!-- Style for Position slider used in Media Transport Controls -->
-                            <Style x:Key="MediaSliderStyle" TargetType="Slider">
+                            <Style x:Key="MediaSliderStyle" TargetType="Slider" BasedOn="{StaticResource DefaultSliderStyle}">
                                 <Setter Property="Background" Value="{ThemeResource SliderTrackFill}" />
                                 <Setter Property="BorderThickness" Value="{ThemeResource SliderBorderThemeThickness}" />
                                 <Setter Property="Foreground" Value="{ThemeResource SliderTrackValueFill}" />
@@ -108,7 +108,7 @@
                                                         <Setter Property="Background" Value="Transparent" />
                                                         <Setter Property="BorderBrush" Value="Transparent" />
                                                         <Setter Property="BorderThickness" Value="1" />
-                                                    </Style>
+                                                    </Style>         
                                                 </Grid.Resources>
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto" />
@@ -325,12 +325,12 @@
                                 </Setter>
                             </Style>
                             <!-- Style for Volume Flyout used in Media Transport Controls -->
-                            <Style x:Key="FlyoutStyle" TargetType="FlyoutPresenter">
+                            <Style x:Key="FlyoutStyle" TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}">
                                 <Setter Property="Background" Value="{ThemeResource MediaTransportControlsFlyoutBackground}" />
                                 <Setter Property="Padding" Value="0" />
                                 <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
                             </Style>
-                            <Style x:Key="MediaControlAppBarButtonStyle" TargetType="AppBarButton" >
+                            <Style x:Key="MediaControlAppBarButtonStyle" TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}">
                                 <Setter Property="Background" Value="{ThemeResource AppBarButtonBackground}" />
                                 <Setter Property="Foreground" Value="{ThemeResource AppBarButtonForeground}" />
                                 <Setter Property="BorderBrush" Value="{ThemeResource AppBarButtonBorderBrush}" />

--- a/dev/CommonStyles/RadioButton_themeresources.xaml
+++ b/dev/CommonStyles/RadioButton_themeresources.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -204,10 +205,16 @@
         <Setter Property="MinWidth" Value="120" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />
+        <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="RadioButton">
-                    <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}">
+                    <Grid x:Name="RootGrid"
+                          Background="{TemplateBinding Background}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                          contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">

--- a/dev/CommonStyles/Slider_themeresources.xaml
+++ b/dev/CommonStyles/Slider_themeresources.xaml
@@ -439,7 +439,8 @@
                         <Grid x:Name="SliderContainer"
                             Grid.Row="1"
                             Background="{ThemeResource SliderContainerBackground}"
-                            Control.IsTemplateFocusTarget="True">
+                            Control.IsTemplateFocusTarget="True"
+                            CornerRadius="{StaticResource ControlCornerRadius}">
                             <Grid x:Name="HorizontalTemplate" MinHeight="{ThemeResource SliderHorizontalHeight}">
 
                                 <Grid.ColumnDefinitions>
@@ -494,6 +495,7 @@
                                     DataContext="{TemplateBinding Value}"
                                     Height="{ThemeResource SliderHorizontalThumbHeight}"
                                     Width="{ThemeResource SliderHorizontalThumbWidth}"
+                                    contract7Present:CornerRadius="{StaticResource ControlCornerRadius}"
                                     Grid.Row="0"
                                     Grid.RowSpan="3"
                                     Grid.Column="1"
@@ -557,6 +559,7 @@
                                     DataContext="{TemplateBinding Value}"
                                     Width="{ThemeResource SliderVerticalThumbWidth}"
                                     Height="{ThemeResource SliderVerticalThumbHeight}"
+                                    contract7Present:CornerRadius="{StaticResource ControlCornerRadius}"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Grid.ColumnSpan="3"

--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -214,8 +214,7 @@
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ManipulationMode" Value="System,TranslateX" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-        <!--<Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />-->
-        <Setter Property="FocusVisualMargin" Value="1"/>
+        <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleSwitch">
@@ -575,6 +574,8 @@
                                 Grid.RowSpan="3"
                                 Grid.ColumnSpan="3"
                                 Margin="0,5"
+                                CornerRadius="4"
+                                Control.IsTemplateFocusTarget="True"
                                 Background="{ThemeResource ToggleSwitchContainerBackground}" />
                             <ContentPresenter x:Name="OffContentPresenter"
                                 Grid.RowSpan="3"
@@ -598,26 +599,15 @@
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 AutomationProperties.AccessibilityView="Raw" />
-                            <Border
+                            <Rectangle x:Name="OuterBorder"
                                 Grid.Row="1"
                                 Height="20"
                                 Width="40"
-                                CornerRadius="10"
-                                Control.IsTemplateFocusTarget="True"
-                                BorderBrush="Transparent"
-                                BorderThickness="1"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center">
-                                <Rectangle x:Name="OuterBorder"
-                                    Grid.Row="1"
-                                    Height="20"
-                                    Width="40"
-                                    RadiusX="10"
-                                    RadiusY="10"
-                                    Fill="{ThemeResource ToggleSwitchFillOff}"
-                                    Stroke="{ThemeResource ToggleSwitchStrokeOff}"
-                                    StrokeThickness="{ThemeResource ToggleSwitchOuterBorderStrokeThickness}" />
-                            </Border>
+                                RadiusX="10"
+                                RadiusY="10"
+                                Fill="{ThemeResource ToggleSwitchFillOff}"
+                                Stroke="{ThemeResource ToggleSwitchStrokeOff}"
+                                StrokeThickness="{ThemeResource ToggleSwitchOuterBorderStrokeThickness}" />
                             <Rectangle x:Name="SwitchKnobBounds"
                                 Grid.Row="1"
                                 Height="20"

--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -214,7 +214,8 @@
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ManipulationMode" Value="System,TranslateX" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-        <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />
+        <!--<Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />-->
+        <Setter Property="FocusVisualMargin" Value="1"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleSwitch">
@@ -574,7 +575,6 @@
                                 Grid.RowSpan="3"
                                 Grid.ColumnSpan="3"
                                 Margin="0,5"
-                                Control.IsTemplateFocusTarget="True"
                                 Background="{ThemeResource ToggleSwitchContainerBackground}" />
                             <ContentPresenter x:Name="OffContentPresenter"
                                 Grid.RowSpan="3"
@@ -598,15 +598,26 @@
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 AutomationProperties.AccessibilityView="Raw" />
-                            <Rectangle x:Name="OuterBorder"
+                            <Border
                                 Grid.Row="1"
                                 Height="20"
                                 Width="40"
-                                RadiusX="10"
-                                RadiusY="10"
-                                Fill="{ThemeResource ToggleSwitchFillOff}"
-                                Stroke="{ThemeResource ToggleSwitchStrokeOff}"
-                                StrokeThickness="{ThemeResource ToggleSwitchOuterBorderStrokeThickness}" />
+                                CornerRadius="10"
+                                Control.IsTemplateFocusTarget="True"
+                                BorderBrush="Transparent"
+                                BorderThickness="1"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center">
+                                <Rectangle x:Name="OuterBorder"
+                                    Grid.Row="1"
+                                    Height="20"
+                                    Width="40"
+                                    RadiusX="10"
+                                    RadiusY="10"
+                                    Fill="{ThemeResource ToggleSwitchFillOff}"
+                                    Stroke="{ThemeResource ToggleSwitchStrokeOff}"
+                                    StrokeThickness="{ThemeResource ToggleSwitchOuterBorderStrokeThickness}" />
+                            </Border>
                             <Rectangle x:Name="SwitchKnobBounds"
                                 Grid.Row="1"
                                 Height="20"

--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -3,6 +3,7 @@
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+  xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
   xmlns:contract6NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,6)">
     <ResourceDictionary.ThemeDictionaries>
@@ -215,6 +216,7 @@
         <Setter Property="ManipulationMode" Value="System,TranslateX" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />
+        <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleSwitch">
@@ -574,7 +576,8 @@
                                 Grid.RowSpan="3"
                                 Grid.ColumnSpan="3"
                                 Margin="0,5"
-                                CornerRadius="4"
+                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                                contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}"
                                 Control.IsTemplateFocusTarget="True"
                                 Background="{ThemeResource ToggleSwitchContainerBackground}" />
                             <ContentPresenter x:Name="OffContentPresenter"

--- a/dev/PagerControl/PagerControl_themeresources.xaml
+++ b/dev/PagerControl/PagerControl_themeresources.xaml
@@ -47,11 +47,15 @@
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
-
+                    <Grid x:Name="RootGrid"
+                          Background="{TemplateBinding Background}"
+                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                          contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
+                        
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />

--- a/dev/PipsPager/PipsPager_themeresources.xaml
+++ b/dev/PipsPager/PipsPager_themeresources.xaml
@@ -1,7 +1,9 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
@@ -130,6 +132,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Width" Value="{StaticResource PipsPagerNavigationButtonWidth}" />
         <Setter Property="Height" Value="{StaticResource PipsPagerNavigationButtonHeight}" />
+        <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -137,7 +140,9 @@
                         x:Name="RootGrid" 
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}">
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
@@ -220,6 +225,7 @@
         <Setter Property="Height" Value="{StaticResource PipsPagerButtonHeight}" />
         <Setter Property="Content" Value="{StaticResource PipsPagerNormalGlyph}" />
         <Setter Property="FontSize" Value="{StaticResource PipsPagerNormalGlyphFontSize}" />
+        <Setter Property="contract7Present:CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -227,7 +233,9 @@
                         x:Name="RootGrid" 
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}">
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />

--- a/test/MUXControlsTestApp/verification/CalendarView-4.xml
+++ b/test/MUXControlsTestApp/verification/CalendarView-4.xml
@@ -78,7 +78,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF
@@ -117,7 +117,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF
@@ -156,7 +156,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF

--- a/test/MUXControlsTestApp/verification/CalendarView-6.xml
+++ b/test/MUXControlsTestApp/verification/CalendarView-6.xml
@@ -78,7 +78,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF
@@ -117,7 +117,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF
@@ -156,7 +156,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF

--- a/test/MUXControlsTestApp/verification/CalendarView-7.xml
+++ b/test/MUXControlsTestApp/verification/CalendarView-7.xml
@@ -68,7 +68,7 @@
             BorderThickness=1,1,1,1
             BorderBrush=Windows.UI.Xaml.Media.LinearGradientBrush
             Background=#00FFFFFF
-            CornerRadius=0,0,0,0
+            CornerRadius=4,4,4,4
             Name=HeaderButton
             Margin=0,0,0,0
             FocusVisualSecondaryThickness=1,1,1,1
@@ -80,7 +80,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF
@@ -108,7 +108,7 @@
             BorderThickness=1,1,1,1
             BorderBrush=Windows.UI.Xaml.Media.LinearGradientBrush
             Background=#00FFFFFF
-            CornerRadius=0,0,0,0
+            CornerRadius=4,4,4,4
             Name=PreviousButton
             Margin=0,0,0,0
             FocusVisualSecondaryThickness=1,1,1,1
@@ -120,7 +120,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF
@@ -148,7 +148,7 @@
             BorderThickness=1,1,1,1
             BorderBrush=Windows.UI.Xaml.Media.LinearGradientBrush
             Background=#00FFFFFF
-            CornerRadius=0,0,0,0
+            CornerRadius=4,4,4,4
             Name=NextButton
             Margin=0,0,0,0
             FocusVisualSecondaryThickness=1,1,1,1
@@ -160,7 +160,7 @@
           [Windows.UI.Xaml.Controls.ContentPresenter]
               Foreground=#E4000000
               Padding=0,0,0,0
-              CornerRadius=0,0,0,0
+              CornerRadius=4,4,4,4
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
               Background=#00FFFFFF


### PR DESCRIPTION
Effected controls are:

- ColorPicker
![image](https://user-images.githubusercontent.com/7758786/112948993-936d6100-90ed-11eb-85ab-ed7334bb21b1.png)

- MediaTransportControls
![image](https://user-images.githubusercontent.com/7758786/112949090-af710280-90ed-11eb-9031-d094ef51557a.png)

- RadioButton
![image](https://user-images.githubusercontent.com/7758786/112949190-cb74a400-90ed-11eb-8e12-12fa8ec92558.png)

- Slider
![image](https://user-images.githubusercontent.com/7758786/112949281-e6471880-90ed-11eb-986e-4cc5a52fdf2f.png)

- ToggleSwitch
![image](https://user-images.githubusercontent.com/7758786/112949430-10003f80-90ee-11eb-92d0-787041740491.png)

- Pager
![image](https://user-images.githubusercontent.com/7758786/112949656-52c21780-90ee-11eb-872e-80b999d20617.png)

- PipsPager
![image](https://user-images.githubusercontent.com/7758786/112949732-640b2400-90ee-11eb-9523-1b34d73a0885.png)

A later PR will fix the Slider and MediaTransportControls focus rect sizing issue.
