### PR TITLE
NavigationView: fix space reservation for top and bottom footer

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1496,7 +1496,6 @@ void NavigationView::UpdatePaneLayout()
             return 0.0;
         }();
 
-
         // Only continue if we have a positive amount of space to manage.
         if (totalAvailableHeight > 0)
         {

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1483,23 +1483,19 @@ void NavigationView::UpdatePaneLayout()
         const auto totalAvailableHeight = [this]() {
             if (const auto &paneContentRow = m_itemsContainerRow.get())
             {
-                // 20px is the padding between the two item lists
                 if (const auto &paneFooter = m_leftNavFooterContentBorder.get())
                 {
-                    // TODO: This number (29) should be equal to the margin that NavView takes (top and bottom)
-                    // In order to do calculations right we need to do the following: only deduct
-                    // the top + bottom margin instead of 29 here and later on
-                    // if the Separator line is visible - deduct the separator line height.
-                    return paneContentRow.ActualHeight() - 29 - paneFooter.ActualHeight();
+                    return paneContentRow.ActualHeight() - 8 - paneFooter.ActualHeight();
                 }
                 else
                 {
                     // TODO: Same as above
-                    return paneContentRow.ActualHeight() - 29;
+                    return paneContentRow.ActualHeight() - 8;
                 }
             }
             return 0.0;
         }();
+
 
         // Only continue if we have a positive amount of space to manage.
         if (totalAvailableHeight > 0)
@@ -1517,6 +1513,7 @@ void NavigationView::UpdatePaneLayout()
                         {
                             const auto footersActualHeight = footerItemsRepeater.ActualHeight();
                             const auto menuItemsActualHeight = menuItems.ActualHeight();
+                            const auto separatorLineHeight = GetItemSeparatorHeight();
                             if (totalAvailableHeight > menuItemsActualHeight + footersActualHeight)
                             {
                                 // We have enough space for two so let everyone get as much as they need.
@@ -1531,40 +1528,58 @@ void NavigationView::UpdatePaneLayout()
                             {
                                 // Footer items exceed over the half, so let's limit them.
                                 footerItemsScrollViewer.MaxHeight(totalAvailableHeight - menuItemsActualHeight);
+                                double separatorLineActualHeight = 0.0;
                                 if (const auto& separator = m_visualItemsSeparator.get())
                                 {
                                     if (footersActualHeight > 0)
                                     {
                                         separator.Visibility(winrt::Visibility::Visible);
+                                        separatorLineActualHeight = separatorLineHeight;
+                                    }
+                                    else
+                                    {
+                                        separator.Visibility(winrt::Visibility::Collapsed);
                                     }
                                 }
-                                return menuItemsActualHeight;
+                                return menuItemsActualHeight - separatorLineActualHeight;
                             }
                             else if (footersActualHeight <= totalAvailableHeightHalf)
                             {
                                 // Menu items exceed over the half, so let's limit them.
                                 footerItemsScrollViewer.MaxHeight(footersActualHeight);
+                                double separatorLineActualHeight = 0.0;
                                 if (const auto& separator = m_visualItemsSeparator.get())
                                 {
                                     if (footersActualHeight > 0)
                                     {
                                         separator.Visibility(winrt::Visibility::Visible);
+                                        separatorLineActualHeight = separatorLineHeight;
+                                    }
+                                    else
+                                    {
+                                        separator.Visibility(winrt::Visibility::Collapsed);
                                     }
                                 }
-                                return totalAvailableHeight - footersActualHeight;
+                                return totalAvailableHeight - footersActualHeight - separatorLineActualHeight;
                             }
                             else
                             {
                                 // Both are more than half the height, so split evenly.
                                 footerItemsScrollViewer.MaxHeight(totalAvailableHeightHalf);
+                                double separatorLineActualHeight = 0.0;
                                 if (const auto& separator = m_visualItemsSeparator.get())
                                 {
                                     if (footersActualHeight > 0)
                                     {
                                         separator.Visibility(winrt::Visibility::Visible);
+                                        separatorLineActualHeight = separatorLineHeight;
+                                    }
+                                    else
+                                    {
+                                        separator.Visibility(winrt::Visibility::Collapsed);
                                     }
                                 }
-                                return totalAvailableHeightHalf;
+                                return totalAvailableHeightHalf - separatorLineActualHeight;
                             }
                         }
                         else
@@ -3790,6 +3805,22 @@ double NavigationView::GetPaneToggleButtonWidth()
 double NavigationView::GetPaneToggleButtonHeight()
 {
     return unbox_value<double>(SharedHelpers::FindInApplicationResources(L"PaneToggleButtonHeight", box_value(c_paneToggleButtonHeight)));
+}
+
+double NavigationView::GetItemSeparatorHeight()
+{
+    double itemSeparatorHeight = unbox_value<double>(ResourceAccessor::ResourceLookup(*this, box_value(L"NavigationViewItemSeparatorHeight")));
+    winrt::Thickness separatorMargin;
+    if (m_isClosedCompact)
+    {
+        separatorMargin = unbox_value<winrt::Thickness>(ResourceAccessor::ResourceLookup(*this, box_value(L"NavigationViewCompactItemSeparatorMargin")));
+    }
+    else
+    {
+        separatorMargin = unbox_value<winrt::Thickness>(ResourceAccessor::ResourceLookup(*this, box_value(L"NavigationViewItemSeparatorMargin")));
+    }
+    return itemSeparatorHeight + separatorMargin.Top + separatorMargin.Bottom;
+
 }
 
 void NavigationView::UpdateTopNavigationWidthCache()

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -886,7 +886,6 @@ void NavigationView::UpdateFooterRepeaterItemsSource(bool sourceCollectionReset,
     {
         if (const auto repeater = m_leftNavFooterMenuRepeater.get())
         {
-            auto actHeight1 = repeater.ActualHeight();
             UpdateItemsRepeaterItemsSource(m_leftNavFooterMenuRepeater.get(), m_selectionModelSource.GetAt(1));
 
             // Footer items changed and we need to recalculate the layout.
@@ -894,7 +893,6 @@ void NavigationView::UpdateFooterRepeaterItemsSource(bool sourceCollectionReset,
             repeater.InvalidateMeasure();
             repeater.UpdateLayout();
 
-            auto actHeight2 = repeater.ActualHeight();
             // Footer items changed, so let's update the pane layout.
             UpdatePaneLayout();
         }
@@ -1488,12 +1486,16 @@ void NavigationView::UpdatePaneLayout()
                 // 20px is the padding between the two item lists
                 if (const auto &paneFooter = m_leftNavFooterContentBorder.get())
                 {
-                    auto const mHeight = paneContentRow.ActualHeight();
-                    return paneContentRow.ActualHeight() - 8 - paneFooter.ActualHeight();
+                    // TODO: This number (29) should be equal to the margin that NavView takes (top and bottom)
+                    // In order to do calculations right we need to do the following: only deduct
+                    // the top + bottom margin instead of 29 here and later on
+                    // if the Separator line is visible - deduct the separator line height.
+                    return paneContentRow.ActualHeight() - 29 - paneFooter.ActualHeight();
                 }
                 else
                 {
-                    return paneContentRow.ActualHeight() - 8;
+                    // TODO: Same as above
+                    return paneContentRow.ActualHeight() - 29;
                 }
             }
             return 0.0;
@@ -1513,7 +1515,6 @@ void NavigationView::UpdatePaneLayout()
                         // We know the actual height of footer items, so use that to determine how to split pane.
                         if (const auto& menuItems = m_leftNavRepeater.get())
                         {
-                            const auto repeaterHeight = footerItemsRepeater.Height();
                             const auto footersActualHeight = footerItemsRepeater.ActualHeight();
                             const auto menuItemsActualHeight = menuItems.ActualHeight();
                             if (totalAvailableHeight > menuItemsActualHeight + footersActualHeight)

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -886,6 +886,7 @@ void NavigationView::UpdateFooterRepeaterItemsSource(bool sourceCollectionReset,
     {
         if (const auto repeater = m_leftNavFooterMenuRepeater.get())
         {
+            auto actHeight1 = repeater.ActualHeight();
             UpdateItemsRepeaterItemsSource(m_leftNavFooterMenuRepeater.get(), m_selectionModelSource.GetAt(1));
 
             // Footer items changed and we need to recalculate the layout.
@@ -893,6 +894,7 @@ void NavigationView::UpdateFooterRepeaterItemsSource(bool sourceCollectionReset,
             repeater.InvalidateMeasure();
             repeater.UpdateLayout();
 
+            auto actHeight2 = repeater.ActualHeight();
             // Footer items changed, so let's update the pane layout.
             UpdatePaneLayout();
         }
@@ -1486,11 +1488,12 @@ void NavigationView::UpdatePaneLayout()
                 // 20px is the padding between the two item lists
                 if (const auto &paneFooter = m_leftNavFooterContentBorder.get())
                 {
-                    return paneContentRow.ActualHeight() - 29 - paneFooter.ActualHeight();
+                    auto const mHeight = paneContentRow.ActualHeight();
+                    return paneContentRow.ActualHeight() - 8 - paneFooter.ActualHeight();
                 }
                 else
                 {
-                    return paneContentRow.ActualHeight() - 29;
+                    return paneContentRow.ActualHeight() - 8;
                 }
             }
             return 0.0;
@@ -1510,6 +1513,7 @@ void NavigationView::UpdatePaneLayout()
                         // We know the actual height of footer items, so use that to determine how to split pane.
                         if (const auto& menuItems = m_leftNavRepeater.get())
                         {
+                            const auto repeaterHeight = footerItemsRepeater.Height();
                             const auto footersActualHeight = footerItemsRepeater.ActualHeight();
                             const auto menuItemsActualHeight = menuItems.ActualHeight();
                             if (totalAvailableHeight > menuItemsActualHeight + footersActualHeight)
@@ -1528,7 +1532,10 @@ void NavigationView::UpdatePaneLayout()
                                 footerItemsScrollViewer.MaxHeight(totalAvailableHeight - menuItemsActualHeight);
                                 if (const auto& separator = m_visualItemsSeparator.get())
                                 {
-                                    separator.Visibility(winrt::Visibility::Visible);
+                                    if (footersActualHeight > 0)
+                                    {
+                                        separator.Visibility(winrt::Visibility::Visible);
+                                    }
                                 }
                                 return menuItemsActualHeight;
                             }
@@ -1538,7 +1545,10 @@ void NavigationView::UpdatePaneLayout()
                                 footerItemsScrollViewer.MaxHeight(footersActualHeight);
                                 if (const auto& separator = m_visualItemsSeparator.get())
                                 {
-                                    separator.Visibility(winrt::Visibility::Visible);
+                                    if (footersActualHeight > 0)
+                                    {
+                                        separator.Visibility(winrt::Visibility::Visible);
+                                    }
                                 }
                                 return totalAvailableHeight - footersActualHeight;
                             }
@@ -1548,7 +1558,10 @@ void NavigationView::UpdatePaneLayout()
                                 footerItemsScrollViewer.MaxHeight(totalAvailableHeightHalf);
                                 if (const auto& separator = m_visualItemsSeparator.get())
                                 {
-                                    separator.Visibility(winrt::Visibility::Visible);
+                                    if (footersActualHeight > 0)
+                                    {
+                                        separator.Visibility(winrt::Visibility::Visible);
+                                    }
                                 }
                                 return totalAvailableHeightHalf;
                             }
@@ -3935,6 +3948,7 @@ void NavigationView::OnPropertyChanged(const winrt::DependencyPropertyChangedEve
         {
             m_autoSuggestBoxSuggestionChosenRevoker = newAutoSuggestBox.SuggestionChosen(winrt::auto_revoke, {this, &NavigationView::OnAutoSuggestBoxSuggestionChosen });
         }
+        UpdateVisualState();
     }
     else if (property == s_SelectionFollowsFocusProperty)
     {

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -97,6 +97,8 @@ public:
 
 private:
 
+    double GetItemSeparatorHeight();
+
     // Selection handling functions
     void OnNavigationViewItemIsSelectedPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void OnSelectionModelSelectionChanged(const winrt::SelectionModel& selectionModel, const winrt::SelectionModelSelectionChangedEventArgs& e);

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -71,7 +71,13 @@
                             </VisualStateGroup>
 
                             <VisualStateGroup x:Name="TogglePaneGroup">
-                                <VisualState x:Name="TogglePaneButtonVisible" />
+                                <VisualState x:Name="TogglePaneButtonVisible">
+                                    <VisualState.Setters>
+                                        <!-- Might not need this setter when all the margins/paddings will be adequately set. -->
+                                        <!-- This MinHeight setter is only here to ensure that AutoSuggestBox doesn't draw over ToggelButton. -->
+                                        <Setter Target="PaneContentGridToggleButtonRow.MinHeight" Value="{StaticResource NavigationViewPaneHeaderRowMinHeight}"/>
+                                    </VisualState.Setters>
+                                </VisualState>
                                 <VisualState x:Name="TogglePaneButtonCollapsed" />
                             </VisualStateGroup>
 
@@ -433,10 +439,8 @@
                                         BorderBrush="{ThemeResource NavigationViewItemSeparatorForeground}"
                                         BorderThickness="0,0,1,0">
                                         <Grid.RowDefinitions>
-                                            <!--<RowDefinition Height="Auto"/>-->
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="0"/> <!-- above button margin + back button space -->
-                                            <!--<RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" MinHeight="{StaticResource NavigationViewPaneHeaderRowMinHeight}"/> -->
                                             <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
@@ -451,7 +455,6 @@
                                             <Grid.RowDefinitions>
                                                 <RowDefinition x:Name="PaneHeaderContentBorderRow"/>
                                             </Grid.RowDefinitions>
-<!--> <-->
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition x:Name="PaneHeaderCloseButtonColumn"/>
                                                 <ColumnDefinition x:Name="PaneHeaderToggleButtonColumn"/>
@@ -508,14 +511,12 @@
                                         <!-- "Non header" content -->
                                         <Grid x:Name="ItemsContainerGrid" Grid.Row="6" Margin="0,0,0,8">
                                             <Grid.RowDefinitions>
-                                                <!--<RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/>--> <!-- MenuItems -->
-                                                <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/>
-                                                <!--<RowDefinition Height="*" MinHeight="21" /> -->
-                                                <RowDefinition Height="*"/>
-                                                <!-- Fill spacing -->
+                                                <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/> <!-- MenuItems -->
+                                                <RowDefinition Height="*"/> <!-- Fill spacing -->
                                                 <RowDefinition Height="Auto" /> <!-- PaneFooter -->
-                                                <!-- <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/> --> <!-- FooterItems -->
-                                                <RowDefinition Height="Auto"/>
+                                                <!-- Do we need to set minHeight for footerItems when we actally have them? -->
+                                                <!-- I've tested all the possible scenarious and coudln't find when we actually would need it. Any ideas?-->
+                                                <RowDefinition Height="Auto"/> <!-- FooterItems -->
                                             </Grid.RowDefinitions>
 
                                             <!-- MenuItems -->
@@ -535,9 +536,8 @@
 
                                           
                                                 <local:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
-                                                 VerticalAlignment="Center"
-                                                Grid.Row="1"
-                                                Visibility="Collapsed" HorizontalAlignment="Stretch"/>
+                                                    VerticalAlignment="Center" Grid.Row="1"
+                                                    Visibility="Collapsed" HorizontalAlignment="Stretch"/>
 
 
                                             <!-- PaneFooter -->

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -534,10 +534,9 @@
                                                 </ScrollViewer>
                                             </local:ItemsRepeaterScrollHost>
 
-                                          
-                                                <local:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
-                                                    VerticalAlignment="Center" Grid.Row="1"
-                                                    Visibility="Collapsed" HorizontalAlignment="Stretch"/>
+                                            <local:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
+                                                Grid.Row="1" VerticalAlignment="Center"
+                                                Visibility="Collapsed" HorizontalAlignment="Stretch"/>
 
 
                                             <!-- PaneFooter -->
@@ -550,7 +549,7 @@
                                             <!-- FooterItems -->
                                             <local:ItemsRepeaterScrollHost Grid.Row="3">
                                                 <ScrollViewer x:Name="FooterItemsScrollViewer"
-                                                              VerticalScrollBarVisibility="Auto"
+                                                        VerticalScrollBarVisibility="Auto"
                                                         contract7Present:VerticalAnchorRatio="1">
                                                     <local:ItemsRepeater
                                                         x:Name="FooterMenuItemsHost"

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -433,9 +433,11 @@
                                         BorderBrush="{ThemeResource NavigationViewItemSeparatorForeground}"
                                         BorderThickness="0,0,1,0">
                                         <Grid.RowDefinitions>
+                                            <!--<RowDefinition Height="Auto"/>-->
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="0"/> <!-- above button margin + back button space -->
-                                            <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" MinHeight="{StaticResource NavigationViewPaneHeaderRowMinHeight}"/>
+                                            <!--<RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto" MinHeight="{StaticResource NavigationViewPaneHeaderRowMinHeight}"/> -->
+                                            <RowDefinition x:Name="PaneContentGridToggleButtonRow" Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="Auto"/>
                                             <RowDefinition Height="8"/> <!-- above list margin -->
@@ -449,7 +451,7 @@
                                             <Grid.RowDefinitions>
                                                 <RowDefinition x:Name="PaneHeaderContentBorderRow"/>
                                             </Grid.RowDefinitions>
-
+<!--> <-->
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition x:Name="PaneHeaderCloseButtonColumn"/>
                                                 <ColumnDefinition x:Name="PaneHeaderToggleButtonColumn"/>
@@ -506,10 +508,14 @@
                                         <!-- "Non header" content -->
                                         <Grid x:Name="ItemsContainerGrid" Grid.Row="6" Margin="0,0,0,8">
                                             <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/> <!-- MenuItems -->
-                                                <RowDefinition Height="*" MinHeight="21"/> <!-- Fill spacing -->
+                                                <!--<RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/>--> <!-- MenuItems -->
+                                                <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/>
+                                                <!--<RowDefinition Height="*" MinHeight="21" /> -->
+                                                <RowDefinition Height="*"/>
+                                                <!-- Fill spacing -->
                                                 <RowDefinition Height="Auto" /> <!-- PaneFooter -->
-                                                <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/> <!-- FooterItems -->
+                                                <!-- <RowDefinition Height="Auto" MinHeight="{ThemeResource NavigationViewItemOnLeftMinHeight}"/> --> <!-- FooterItems -->
+                                                <RowDefinition Height="Auto"/>
                                             </Grid.RowDefinitions>
 
                                             <!-- MenuItems -->
@@ -527,9 +533,12 @@
                                                 </ScrollViewer>
                                             </local:ItemsRepeaterScrollHost>
 
-                                            <local:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
-                                                Grid.Row="1" VerticalAlignment="Center"
+                                          
+                                                <local:NavigationViewItemSeparator x:Name="VisualItemsSeparator"
+                                                 VerticalAlignment="Center"
+                                                Grid.Row="1"
                                                 Visibility="Collapsed" HorizontalAlignment="Stretch"/>
+
 
                                             <!-- PaneFooter -->
                                             <ContentControl x:Name="FooterContentBorder"
@@ -541,6 +550,7 @@
                                             <!-- FooterItems -->
                                             <local:ItemsRepeaterScrollHost Grid.Row="3">
                                                 <ScrollViewer x:Name="FooterItemsScrollViewer"
+                                                              VerticalScrollBarVisibility="Auto"
                                                         contract7Present:VerticalAnchorRatio="1">
                                                     <local:ItemsRepeater
                                                         x:Name="FooterMenuItemsHost"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes Navigation View free the space for top and bottom footer if it's not being used.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Previously, Navigation View would reserve space for top and bottom footer even if they're not being used. It also will draw Separator line between main items and bottom footer even when footer is not present.
This PR addresses that.

NOTE: This PR only fixes the space reservation and not properly adjusts all the margins/paddings to correctly display all elements. It will be addressed in another PR.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
With toggle, back, autosuggestbox and settings on:
![image](https://user-images.githubusercontent.com/21356912/113547299-7380e600-95a2-11eb-8bca-fe76af910018.png)

Without:
![image](https://user-images.githubusercontent.com/21356912/113551968-50f2cb00-95aa-11eb-9f0f-d8dec344b760.png)