### PR TITLE
Menuflyout Item mouse/touch invocation sizing regression test

### DIFF
--- a/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
+++ b/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
 using Microsoft.Windows.Apps.Test.Foundation.Patterns;
 using Microsoft.Windows.Apps.Test.Foundation.Waiters;
+using System;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {
@@ -166,6 +167,56 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 var radioButton = new RadioButton(FindElement.ById("InkToolbarBallpointPenButton"));
                 radioButton.Select();
                 Wait.ForIdle();
+            }
+        }
+
+        [TestMethod]
+        public void MenuFlyoutItemSizeTest()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone5))
+            {
+                Log.Warning("This test relies on touch input, the injection of which is only supported in RS5 and up. Test is disabled.");
+                return;
+            }
+
+            using (var setup = new TestSetupHelper("MenuFlyout Tests"))
+            {
+                Log.Comment("Mouse click on Button to verify MenuFlyoutItem size.");
+
+                var testMenuFlyoutButton = FindElement.ByName("TestMenuFlyoutButton");
+                Verify.IsNotNull(testMenuFlyoutButton, "Verifying that we found a UIElement called TestMenuFlyoutButton");
+
+                InputHelper.LeftClick(testMenuFlyoutButton);
+                Wait.ForIdle();
+
+                var testMenuFlyoutItem = FindElement.ByName("TestMenuFlyoutItem");
+                Verify.IsNotNull(testMenuFlyoutItem, "Verifying that we found a UIElement called TestMenuFlyoutItem");
+
+                InputHelper.LeftClick(testMenuFlyoutItem);
+                Wait.ForIdle();
+
+                var testMenuFlyoutItemHeightTextBlock = FindElement.ByName<TextBlock>("TestMenuFlyoutItemHeightTextBlock");
+                var testMenuFlyoutItemWidthTextBlock = FindElement.ByName<TextBlock>("TestMenuFlyoutItemWidthTextBlock");
+                
+                Verify.IsNotNull(testMenuFlyoutItemHeightTextBlock, "Verifying that we found a UIElement called TestMenuFlyoutItemHeightTextBlock");
+                Verify.IsNotNull(testMenuFlyoutItemWidthTextBlock, "Verifying that we found a UIElement called TestMenuFlyoutItemWidthTextBlock");
+
+                var width = Convert.ToDouble(testMenuFlyoutItemWidthTextBlock.GetText());
+
+                Verify.AreEqual("32", testMenuFlyoutItemHeightTextBlock.GetText(), "Comparing height of MenuFlyoutItem after Flyout was opened with mouse");
+                Verify.IsGreaterThan(width, 0.0, "Comparing height of MenuFlyoutItem after Flyout was opened with mouse");
+                Verify.IsLessThan(width, 200.0, "Comparing height of MenuFlyoutItem after Flyout was opened with mouse");
+
+                InputHelper.LeftClick(testMenuFlyoutItemHeightTextBlock);
+                Wait.ForIdle();
+                InputHelper.Tap(testMenuFlyoutButton);
+                Wait.ForIdle();
+                InputHelper.Tap(testMenuFlyoutItem);
+                Wait.ForIdle();
+
+                width = Convert.ToDouble(testMenuFlyoutItemWidthTextBlock.GetText());
+                Verify.AreEqual("40", testMenuFlyoutItemHeightTextBlock.GetText(), "Comparing height of MenuFlyoutItem after Flyout was opened with touch");
+                Verify.IsGreaterThan(width, 200.0, "Comparing width of MenuFlyoutItem after Flyout was opened with touch");
             }
         }
     }

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
@@ -12,20 +12,13 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
-        <StackPanel Grid.Column="1" HorizontalAlignment="Center">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="MenuFlyoutItem height: "/>
-                <TextBlock x:Name="TestMenuFlyoutItemHeightTextBlock" AutomationProperties.Name="TestMenuFlyoutItemHeightTextBlock" Text="0" Margin="5, 0, 0, 0"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,20,0,0">
-                <TextBlock Text="MenuFlyoutItem width: "/>
-                <TextBlock x:Name="TestMenuFlyoutItemWidthTextBlock" AutomationProperties.Name="TestMenuFlyoutItemWidthTextBlock" Text="0" Margin="5, 0, 0, 0"/>
-            </StackPanel>
-        </StackPanel>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
-        <StackPanel>
+        <StackPanel Grid.RowSpan="2">
             <Button Content="Short Text MenuFlyout" x:Name="TestMenuFlyoutButton" AutomationProperties.Name="TestMenuFlyoutButton" Margin="0,0,0,12">
                 <Button.Flyout>
                     <MenuFlyout>
@@ -119,5 +112,22 @@
                 </Button.Flyout>
             </Button>
         </StackPanel>
+
+        <Grid Grid.Column="1" Margin="20,0,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Text="MenuFlyoutItem height: "/>
+            <TextBlock x:Name="TestMenuFlyoutItemHeightTextBlock" AutomationProperties.Name="TestMenuFlyoutItemHeightTextBlock" Text="0" Grid.Column="1" Margin="5, 0, 0, 0"/>
+
+            <TextBlock Text="MenuFlyoutItem width: " Grid.Row="1"/>
+            <TextBlock x:Name="TestMenuFlyoutItemWidthTextBlock" AutomationProperties.Name="TestMenuFlyoutItemWidthTextBlock" Text="0" Grid.Row="1" Grid.Column="1" Margin="5, 0, 0, 0"/>
+        </Grid>
     </Grid>
 </local:TestPage>

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
@@ -9,7 +9,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
 
         <Grid.ColumnDefinitions>

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
@@ -10,7 +10,6 @@
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
-
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
@@ -9,37 +9,65 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="MenuFlyoutItem height: "/>
+                <TextBlock x:Name="TestMenuFlyoutItemHeightTextBlock" AutomationProperties.Name="TestMenuFlyoutItemHeightTextBlock" Text="0" Margin="5, 0, 0, 0"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,20,0,0">
+                <TextBlock Text="MenuFlyoutItem width: "/>
+                <TextBlock x:Name="TestMenuFlyoutItemWidthTextBlock" AutomationProperties.Name="TestMenuFlyoutItemWidthTextBlock" Text="0" Margin="5, 0, 0, 0"/>
+            </StackPanel>
+        </StackPanel>
+
         <StackPanel>
-        <Button Content="MenuFlyout" VerticalAlignment="Top">
-            <Button.Flyout>
-                <MenuFlyout>
-                    <MenuFlyoutItem Text="MenuFlyoutItem"/>
-                    <MenuFlyoutSubItem Text="MenuFlyoutSubItem">
-                        <MenuFlyoutItem Text="MenuFlyoutItem" />
-                        <ToggleMenuFlyoutItem Text="ToggleMenuFlyoutItem" />
+            <Button Content="Short Text MenuFlyout" x:Name="TestMenuFlyoutButton" AutomationProperties.Name="TestMenuFlyoutButton" Margin="0,0,0,12">
+                <Button.Flyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="Reset" x:Name="TestMenuFlyoutItem" AutomationProperties.Name="TestMenuFlyoutItem" Click="TestMenuFlyoutItemClick"/>
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem Text="Repeat" />
+                        <MenuFlyoutItem Text="Shuffle" />
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
+
+            <Button Content="MenuFlyout">
+                <Button.Flyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="MenuFlyoutItem"/>
                         <MenuFlyoutSubItem Text="MenuFlyoutSubItem">
                             <MenuFlyoutItem Text="MenuFlyoutItem" />
-                            <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem Text="MenuFlyoutItem" />
+                            <ToggleMenuFlyoutItem Text="ToggleMenuFlyoutItem" />
+                            <MenuFlyoutSubItem Text="MenuFlyoutSubItem">
+                                <MenuFlyoutItem Text="MenuFlyoutItem" />
+                                <MenuFlyoutSeparator/>
+                                <MenuFlyoutItem Text="MenuFlyoutItem" />
+                            </MenuFlyoutSubItem>
                         </MenuFlyoutSubItem>
-                    </MenuFlyoutSubItem>
-                    <MenuFlyoutSeparator/>
-                    <MenuFlyoutItem Text="MenuFlyoutItem"/>
-                </MenuFlyout>
-            </Button.Flyout>
-        </Button>
+                        <MenuFlyoutSeparator/>
+                        <MenuFlyoutItem Text="MenuFlyoutItem"/>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
 
-        <Button Content="Icons" Margin="0,12,0,12">
-            <Button.Flyout>
-                <MenuFlyout>
-                    <MenuFlyoutItem Text="Share">
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xE72D;"/>
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Copy" Icon="Copy"/>
-                    <MenuFlyoutItem Text="Delete" Icon="Delete"/>
+            <Button Content="Icons" Margin="0,12,0,12">
+                <Button.Flyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="Share">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE72D;"/>
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Text="Copy" Icon="Copy"/>
+                        <MenuFlyoutItem Text="Delete" Icon="Delete"/>
                         <ToggleMenuFlyoutItem Text="ToggleMenuFlyoutItem" Icon="Delete"/>
                         <ToggleMenuFlyoutItem Text="ToggleMenuFlyoutItem" Icon="Delete">
                             <ToggleMenuFlyoutItem.KeyboardAccelerators>
@@ -60,38 +88,38 @@
                             </muxc:RadioMenuFlyoutItem.KeyboardAccelerators>
                         </muxc:RadioMenuFlyoutItem>
                         <MenuFlyoutItem Text="Rename"/>
-                    <MenuFlyoutItem Text="Select"/>
-                </MenuFlyout>
-            </Button.Flyout>
-        </Button>
+                        <MenuFlyoutItem Text="Select"/>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
 
-        <Button Content="Keyboard accelerators">
-            <Button.Flyout>
-                <MenuFlyout>
-                    <MenuFlyoutItem Text="Share">
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xE72D;"/>
-                        </MenuFlyoutItem.Icon>
-                        <MenuFlyoutItem.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="S" Modifiers="Control"/>
-                        </MenuFlyoutItem.KeyboardAccelerators>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Copy" Icon="Copy">
-                        <MenuFlyoutItem.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="C" Modifiers="Control"/>
-                        </MenuFlyoutItem.KeyboardAccelerators>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Delete" Icon="Delete">
-                        <MenuFlyoutItem.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="Delete" />
-                        </MenuFlyoutItem.KeyboardAccelerators>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutSeparator/>
-                    <MenuFlyoutItem Text="Rename"/>
-                    <MenuFlyoutItem Text="Select"/>
-                </MenuFlyout>
-            </Button.Flyout>
-        </Button>
+            <Button Content="Keyboard accelerators">
+                <Button.Flyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="Share">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE72D;"/>
+                            </MenuFlyoutItem.Icon>
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator Key="S" Modifiers="Control"/>
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Text="Copy" Icon="Copy">
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator Key="C" Modifiers="Control"/>
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Text="Delete" Icon="Delete">
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator Key="Delete" />
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutSeparator/>
+                        <MenuFlyoutItem Text="Rename"/>
+                        <MenuFlyoutItem Text="Select"/>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
         </StackPanel>
     </Grid>
 </local:TestPage>

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml.cs
@@ -5,7 +5,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-
+using SplitButtonTestApi = Microsoft.UI.Private.Controls.SplitButtonTestApi;
 namespace MUXControlsTestApp
 {
 
@@ -15,6 +15,12 @@ namespace MUXControlsTestApp
         public MenuFlyoutPage()
         {
             this.InitializeComponent();
+        }
+
+        private void TestMenuFlyoutItemClick(object sender, object e)
+        {
+            TestMenuFlyoutItemHeightTextBlock.Text = $"{TestMenuFlyoutItem.ActualHeight}";
+            TestMenuFlyoutItemWidthTextBlock.Text = $"{TestMenuFlyoutItem.ActualWidth}";
         }
     }
 }

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml.cs
@@ -5,7 +5,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
-using SplitButtonTestApi = Microsoft.UI.Private.Controls.SplitButtonTestApi;
+
 namespace MUXControlsTestApp
 {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds test to verify correct sizing of menuflyout item when invoked with touch vs mouse.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
This test will make sure that we have expected size for touch vs mouse invocation for MenuFlyout items.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.