### PR TITLE
[Autosuggestbox] Fix delete button margins

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -64,12 +64,13 @@
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Button">
                                             <Grid x:Name="ButtonLayoutGrid"
-                                                Margin="{ThemeResource AutoSuggestBoxInnerButtonMargin}"
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
                                                 Background="{ThemeResource TextControlButtonBackground}"
-                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}">
+                                                Margin="{ThemeResource AutoSuggestBoxInnerButtonMargin}"
+                                                Padding="{TemplateBinding Padding}"
+                                                contract7Present:CornerRadius="{ThemeResource ControlCornerRadius}"
+                                                contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />
@@ -348,15 +349,16 @@
                             IsHitTestVisible="False" />
                         <Button x:Name="DeleteButton"
                             Grid.Row="1"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                             Style="{StaticResource DeleteButtonStyle}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                             Padding="{ThemeResource HelperButtonThemePadding}"
                             IsTabStop="False"
                             Grid.Column="1"
                             Visibility="Collapsed"
                             FontSize="{TemplateBinding FontSize}"
                             Width="32"
+                            Height="28"
                             AutomationProperties.AccessibilityView="Raw"
                             VerticalAlignment="Stretch" />
                         <Button x:Name="QueryButton"

--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -35,6 +35,7 @@
 
     <Thickness x:Key="AutoSuggestBoxTopHeaderMargin">0,0,0,8</Thickness>
     <Thickness x:Key="AutoSuggestBoxInnerButtonMargin">0,3</Thickness>
+    <Thickness x:Key="AutoSuggestBoxDeleteButtonMargin">0,2</Thickness>
     <Thickness x:Key="AutoSuggestBoxQueryButtonPadding">3,2</Thickness>
     <x:Double x:Key="AutoSuggestBoxRightButtonMargin">4</x:Double>
 
@@ -67,7 +68,7 @@
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
                                                 Background="{ThemeResource TextControlButtonBackground}"
-                                                Margin="{ThemeResource AutoSuggestBoxInnerButtonMargin}"
+                                                Margin="{ThemeResource AutoSuggestBoxDeleteButtonMargin}"
                                                 Padding="{TemplateBinding Padding}"
                                                 contract7Present:CornerRadius="{ThemeResource ControlCornerRadius}"
                                                 contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
@@ -148,7 +149,6 @@
                                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                 AutomationProperties.AccessibilityView="Raw"
                                                 local:AnimatedIcon.State="Normal">
-
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />


### PR DESCRIPTION
Visual fixes for autosuggestbox

## Description
1. Fixes the 'Delete' button not rounding corners when the popup is open
2. Fixes the 'Delete' button being too small

## Motivation and Context
VSO: 30726055

## How Has This Been Tested?
Visually tested

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/35784165/114464222-53e94f00-9b9a-11eb-9589-103e2cbe3a7b.png)

![image](https://user-images.githubusercontent.com/35784165/114464451-a296e900-9b9a-11eb-9df7-c1e466072af7.png)

|  | 'Delete' button rounded corner | Buttons being the same size (spacing between buttons is not representative) |
| --- | --- | --- |
| Light theme | ![image](https://user-images.githubusercontent.com/35784165/114463229-01f3f980-9b99-11eb-8cc8-9d1147c055ee.png) | ![image](https://user-images.githubusercontent.com/35784165/114464091-22708380-9b9a-11eb-9c3d-625ef897af97.png) |
| Dark theme | ![image](https://user-images.githubusercontent.com/35784165/114463321-20f28b80-9b99-11eb-8bda-8084cee12bcf.png) | ![image](https://user-images.githubusercontent.com/35784165/114463793-c279dd00-9b99-11eb-9816-83c73e497cea.png) |
