### PR TITLE
[ContentDialog] Fix title margin & fontweight and corners

### DIFF
--- a/dev/CommonStyles/ContentDialog_themeresources.xaml
+++ b/dev/CommonStyles/ContentDialog_themeresources.xaml
@@ -42,7 +42,7 @@
     <x:Double x:Key="ContentDialogMaxHeight">756</x:Double>
     <GridLength x:Key="ContentDialogButtonSpacing">8</GridLength>
     <Thickness x:Key="ContentDialogTitleMargin">0,0,0,12</Thickness>
-    <Thickness x:Key="ContentDialogPadding">24</Thickness>
+    <Thickness x:Key="ContentDialogPadding">21</Thickness>
     <Thickness x:Key="ContentDialogSeparatorThickness">0,0,0,1</Thickness>
 
     <Style TargetType="ContentDialog" BasedOn="{StaticResource DefaultContentDialogStyle}" />
@@ -205,7 +205,8 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="LayoutRoot">
+                        <Grid x:Name="LayoutRoot"
+                            contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}">
                             <Rectangle x:Name="SmokeLayerBackground" Fill="{ThemeResource ContentDialogSmokeFill}" />
                             <Border
                                 x:Name="BackgroundElement"
@@ -225,7 +226,7 @@
                                 <Border.RenderTransform>
                                     <ScaleTransform x:Name="ScaleTransform" />
                                 </Border.RenderTransform>
-                                <Grid x:Name="DialogSpace">
+                                <Grid x:Name="DialogSpace" contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="*" />
                                         <RowDefinition Height="Auto" />
@@ -252,7 +253,7 @@
                                                 ContentTemplate="{TemplateBinding TitleTemplate}"
                                                 FontSize="20"
                                                 FontFamily="XamlAutoFontFamily"
-                                                FontWeight="Normal"
+                                                FontWeight="SemiBold"
                                                 Foreground="{TemplateBinding Foreground}"
                                                 HorizontalAlignment="Left"
                                                 VerticalAlignment="Top"

--- a/dev/CommonStyles/ContentDialog_themeresources.xaml
+++ b/dev/CommonStyles/ContentDialog_themeresources.xaml
@@ -12,7 +12,7 @@
             <StaticResource x:Key="ContentDialogBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
             <StaticResource x:Key="ContentDialogSmokeFill" ResourceKey="SmokeFillColorDefaultBrush" />
             <StaticResource x:Key="ContentDialogTopOverlay" ResourceKey="LayerFillColorAltBrush" />
-            <StaticResource x:Key="ContentDialogBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ContentDialogBorderBrush" ResourceKey="SurfaceStrokeColorDefault" />
             <StaticResource x:Key="ContentDialogSeparatorBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
             <Thickness x:Key="ContentDialogBorderWidth">1</Thickness>
         </ResourceDictionary>
@@ -30,7 +30,7 @@
             <StaticResource x:Key="ContentDialogBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
             <StaticResource x:Key="ContentDialogSmokeFill" ResourceKey="SmokeFillColorDefaultBrush" />
             <StaticResource x:Key="ContentDialogTopOverlay" ResourceKey="LayerFillColorAltBrush" />
-            <StaticResource x:Key="ContentDialogBorderBrush" ResourceKey="ControlElevationBorderBrush" />
+            <StaticResource x:Key="ContentDialogBorderBrush" ResourceKey="SurfaceStrokeColorDefault" />
             <StaticResource x:Key="ContentDialogSeparatorBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
             <Thickness x:Key="ContentDialogBorderWidth">1</Thickness>
         </ResourceDictionary>

--- a/dev/CommonStyles/ContentDialog_themeresources.xaml
+++ b/dev/CommonStyles/ContentDialog_themeresources.xaml
@@ -42,7 +42,7 @@
     <x:Double x:Key="ContentDialogMaxHeight">756</x:Double>
     <GridLength x:Key="ContentDialogButtonSpacing">8</GridLength>
     <Thickness x:Key="ContentDialogTitleMargin">0,0,0,12</Thickness>
-    <Thickness x:Key="ContentDialogPadding">21</Thickness>
+    <Thickness x:Key="ContentDialogPadding">24</Thickness>
     <Thickness x:Key="ContentDialogSeparatorThickness">0,0,0,1</Thickness>
 
     <Style TargetType="ContentDialog" BasedOn="{StaticResource DefaultContentDialogStyle}" />


### PR DESCRIPTION
Fix corners, title font weight and margin between title and top border

## Description
* Fixes CornerRadius properties for inner grids
* Sets the title fontweight to SemiBold
* Changes margin to 21 to match the visual design

## Motivation and Context
VSO: 32303725

## How Has This Been Tested?
Visual tests

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/35784165/114600929-c36a4780-9c49-11eb-8f16-937e754d3aa2.png)

![image](https://user-images.githubusercontent.com/35784165/114600981-d4b35400-9c49-11eb-84da-572edbf66af9.png)
