### PR TITLE
Fixing WACK failure on store submission

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -53,11 +53,27 @@
       <PackagingOutputs Include="@(XamlWinmd)" />
     </ItemGroup>
   </Target>
+  <!-- WinMD files should only go in the WinMetadata folder of the AppX if they're being supplied by a framework package. -->
+  <Target Name="_RemoveXamlWinmdFromWinMetadataFolder" Condition="'$(MicrosoftUIXamlAppxVersion)' == ''" AfterTargets="BuildNativePackage" BeforeTargets="_AddXamlWinmdToPackageLayoutRoot">
+    <ItemGroup>
+      <XamlWinmdAppxPackagePayload Include="@(AppxPackagePayload)" Condition="'%(AppxPackagePayload.TargetPath)' == '$(WinMetadataDir)\$(XamlWinmdName)'" />
+      <XamlWinmdAppxUploadPackagePayload Include="@(AppxUploadPackagePayload)" Condition="'%(AppxUploadPackagePayload.TargetPath)' == '$(WinMetadataDir)\$(XamlWinmdName)'" />
+    </ItemGroup>
+    <ItemGroup Condition="'@(XamlWinmdAppxPackagePayload)' != ''">
+      <AppxPackagePayload Remove="@(XamlWinmdAppxPackagePayload)" />
+    </ItemGroup>
+    <ItemGroup Condition="'@(XamlWinmdAppxUploadPackagePayload)' != ''">
+      <AppxUploadPackagePayload Remove="@(XamlWinmdAppxUploadPackagePayload)" />
+    </ItemGroup>
+  </Target>
   <Target Name="_AddXamlWinmdToPackageLayoutRoot" AfterTargets="BuildNativePackage">
     <ItemGroup>
       <AppxPackagePayload Include="@(XamlWinmd)">
         <TargetPath>Microsoft.UI.Xaml.winmd</TargetPath>
       </AppxPackagePayload>
+      <AppxUploadPackagePayload Include="@(XamlWinmd)">
+        <TargetPath>Microsoft.UI.Xaml.winmd</TargetPath>
+      </AppxUploadPackagePayload>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
The store expectations for WACK certification are somewhat finicky - they need a WinMD to appear in the WinMetadata folder (and in the root) when that WinMD is implemented by a framework package (which is the case for our stable releases), but they need that WinMD to *not* appear in the WinMetadata folder when that WinMD is implemented by a DLL in the AppX file (which is the case for our prereleases).

Frustratingly, this restriction appears to only be enforced when actually submitting to the store - the local app cert kit does not report any issues; it's only when you upload the appxupload/msixupload file to the store that it complains.  Additionally, there does not appear to be any way to locally run validation on that appxupload/msixupload file, so there's no way for me to add a check to ensure that we won't hit this in the future.  I've manually uploaded a test app built with these changes and submitted it to the store, and confirmed that it passed certification there.

There's also a separate item group for items to be added to the appxupload/msixupload file, which also needs to have our WinMD added to it.  I've done that, too.

Fixes #3780