### PR TITLE
MenuFlyout: blurry stroke

### DIFF
--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -292,8 +292,10 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="MenuFlyoutPresenter">
-                    <Grid
+                    <Border
                         Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         contract7Present:BackgroundSizing="InnerBorderEdge">
                         <ScrollViewer x:Name="MenuFlyoutPresenterScrollViewer"
@@ -309,12 +311,7 @@
                             AutomationProperties.AccessibilityView="Raw">
                             <ItemsPresenter />
                         </ScrollViewer>
-                        <Border
-                            x:Name="MenuFlyoutPresenterBorder"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
-                    </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have a blurry stroke on menuflyout because shadow draws over the border stroke.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
This PR removes the child border element of the menuflyout presenter and sets the border to be the parent element that makes it draw over the shadow properly.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
Before:
![image](https://user-images.githubusercontent.com/21356912/115297851-8b637880-a111-11eb-9940-a667cc2663c3.png)
After:
![image](https://user-images.githubusercontent.com/21356912/115297829-83a3d400-a111-11eb-92e7-4609b7bcbe1f.png)