### PR TITLE
Font ramp update

### DIFF
--- a/dev/CommonStyles/TextBlock_themeresources.xaml
+++ b/dev/CommonStyles/TextBlock_themeresources.xaml
@@ -11,46 +11,42 @@
 
     <Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="XamlAutoFontFamily" />
+        <Setter Property="FontSize" Value="{StaticResource BodyTextBlockFontSize}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="TextTrimming" Value="CharacterEllipsis" />
         <Setter Property="TextWrapping" Value="Wrap" />
         <Setter Property="LineStackingStrategy" Value="MaxHeight" />
         <Setter Property="TextLineBounds" Value="Full" />
-        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 
     <Style x:Key="CaptionTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource CaptionTextBlockFontSize}" />
         <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="OpticalMarginAlignment" Value="None" />
     </Style>
 
     <Style x:Key="BodyTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
-        <Setter Property="FontSize" Value="{StaticResource BodyTextBlockFontSize}" />
         <Setter Property="FontWeight" Value="Normal" />
-        <Setter Property="OpticalMarginAlignment" Value="None" />
     </Style>
 
-    <Style x:Key="BodyStrongTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyTextBlockStyle}">
-        <Setter Property="FontWeight" Value="SemiBold" />
-    </Style>
+    <Style x:Key="BodyStrongTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
 
     <Style x:Key="SubtitleTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource SubtitleTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 
     <Style x:Key="TitleTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource TitleTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 
     <Style x:Key="TitleLargeTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource TitleLargeTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 
     <Style x:Key="DisplayTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource DisplayTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 </ResourceDictionary>

--- a/dev/CommonStyles/TextBlock_themeresources_v2.5.xaml
+++ b/dev/CommonStyles/TextBlock_themeresources_v2.5.xaml
@@ -6,20 +6,18 @@
     <x:Double x:Key="TitleLargeTextBlockFontSize">40</x:Double>
     <x:Double x:Key="DisplayTextBlockFontSize">68</x:Double>
 
-    <Style x:Key="BodyStrongTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyTextBlockStyle}">
+    <Style x:Key="BodyStrongTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource BodyStrongTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="OpticalMarginAlignment" Value="None" />
     </Style>
 
     <Style x:Key="TitleLargeTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource TitleLargeTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 
     <Style x:Key="DisplayTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
         <Setter Property="FontSize" Value="{StaticResource DisplayTextBlockFontSize}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings" />
     </Style>
 </ResourceDictionary>
 

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-4.xml
@@ -376,7 +376,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=32,22
+                  RenderSize=28,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-7.xml
@@ -307,7 +307,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=32,22
+                  RenderSize=28,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-8.xml
@@ -307,7 +307,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=32,22
+                  RenderSize=28,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-4.xml
@@ -319,7 +319,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Collapsed
-                  RenderSize=32,22
+                  RenderSize=28,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-5.xml
@@ -319,7 +319,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Collapsed
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-7.xml
@@ -259,7 +259,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Collapsed
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-8.xml
@@ -259,7 +259,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Collapsed
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-4.xml
@@ -376,7 +376,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-5.xml
@@ -376,7 +376,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-7.xml
@@ -307,7 +307,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-8.xml
@@ -307,7 +307,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=22,22
+                  RenderSize=20,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-4.xml
@@ -319,7 +319,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=0,21.28125
+                  RenderSize=0,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-7.xml
@@ -259,7 +259,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=0,21.28125
+                  RenderSize=0,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-8.xml
@@ -259,7 +259,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=0,21.28125
+                  RenderSize=0,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-4.xml
@@ -319,7 +319,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=0,21.28125
+                  RenderSize=0,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0
@@ -1409,7 +1409,7 @@
                                       FocusVisualPrimaryThickness=2,2,2,2
                                       FocusVisualPrimaryBrush=#E4000000
                                       Visibility=Visible
-                                      RenderSize=53,40
+                                      RenderSize=49,40
                                     [Windows.UI.Xaml.Controls.TextBlock]
                                         Padding=0,0,0,0
                                         Foreground=#E4000000
@@ -1420,7 +1420,7 @@
                                         FocusVisualPrimaryThickness=2,2,2,2
                                         FocusVisualPrimaryBrush=#E4000000
                                         Visibility=Visible
-                                        RenderSize=53,20
+                                        RenderSize=49,19
                               [Microsoft.UI.Xaml.Controls.NavigationViewItem]
                                   Padding=0,0,0,0
                                   Foreground=#E4000000
@@ -3042,7 +3042,7 @@
                                       FocusVisualPrimaryThickness=2,2,2,2
                                       FocusVisualPrimaryBrush=#E4000000
                                       Visibility=Visible
-                                      RenderSize=57,40
+                                      RenderSize=53,40
                                     [Windows.UI.Xaml.Controls.TextBlock]
                                         Padding=0,0,0,0
                                         Foreground=#E4000000
@@ -3053,7 +3053,7 @@
                                         FocusVisualPrimaryThickness=2,2,2,2
                                         FocusVisualPrimaryBrush=#E4000000
                                         Visibility=Visible
-                                        RenderSize=57,20
+                                        RenderSize=53,19
                               [Microsoft.UI.Xaml.Controls.NavigationViewItem]
                                   Padding=0,0,0,0
                                   Foreground=#E4000000

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-7.xml
@@ -259,7 +259,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=0,21.28125
+                  RenderSize=0,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-8.xml
@@ -259,7 +259,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=0,21.28125
+                  RenderSize=0,19
         [Windows.UI.Xaml.Controls.Grid]
             Padding=0,0,0,0
             CornerRadius=0,0,0,0


### PR DESCRIPTION
This PR fixes a regression in BaseTextBlockStyle which causes TextBlocks in legacy code (with style BaseTextBlockStyle) to not be SemiBold.

STYLE IN GENERIC
`<Style x:Key="BaseTextBlockStyle" TargetType="TextBlock">
        <Setter Property="FontFamily" Value="XamlAutoFontFamily" />
        <Setter Property="FontWeight" Value="SemiBold" />
        <Setter Property="FontSize" Value="14" />
        <Setter Property="TextTrimming" Value="None" />
        <Setter Property="TextWrapping" Value="Wrap" />
        <Setter Property="LineStackingStrategy" Value="MaxHeight" />
        <Setter Property="TextLineBounds" Value="Full" />
    </Style>`

Before
![image](https://user-images.githubusercontent.com/76921770/115444268-308d5800-a1c9-11eb-9340-881ee4195d4f.png)

After
![image](https://user-images.githubusercontent.com/76921770/115444308-3edb7400-a1c9-11eb-88cb-2d9995646a56.png)
