### PR TITLE
ProgressRing: Add Height setter to template

### DIFF
--- a/dev/ProgressRing/ProgressRing.xaml
+++ b/dev/ProgressRing/ProgressRing.xaml
@@ -14,6 +14,7 @@
         <Setter Property="MinWidth" Value="16" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Width" Value="32" />
+        <Setter Property="Height" Value="32" />
         <Setter Property="Maximum" Value="100" />
         <Setter Property="Template">
             <Setter.Value>

--- a/dev/ProgressRing/TestUI/ProgressRingPage.xaml
+++ b/dev/ProgressRing/TestUI/ProgressRingPage.xaml
@@ -17,12 +17,18 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
         <StackPanel Orientation="Vertical">
-            <controls:ProgressRing
-                x:Name="TestProgressRing"
-                AutomationProperties.Name="TestProgressRing"
-                IsActive="{x:Bind ShowIsActiveCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
-                IsIndeterminate="{x:Bind ShowIsIndeterminateCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
-            />
+            <StackPanel Orientation="Horizontal">
+                <controls:ProgressRing
+                    x:Name="TestProgressRing"
+                    AutomationProperties.Name="TestProgressRing"
+                    IsActive="{x:Bind ShowIsActiveCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
+                    IsIndeterminate="{x:Bind ShowIsIndeterminateCheckBox.IsChecked, Converter={StaticResource NullableBooleanToBooleanConverter}, Mode=OneWay}"
+                />
+
+                <Grid VerticalAlignment="Stretch" Margin="5" Width="100" Height="100">
+                    <controls:ProgressRing IsActive="True" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                </Grid>
+            </StackPanel>
 
             <Grid Width="200px" HorizontalAlignment="Left">
                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add height setter to ProgressRing style
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #4544
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually, progressring renders in 32x32 dimension instead of being stretched.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->