### PR TITLE
Updating cookie banner on WinUI website

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var xhttp = new XMLHttpRequest();
 xhttp.onreadystatechange = function() {
     if (this.readyState == 4 && this.status == 200) {
         var xmlResp = this.responseXML;
+        console.log("data:    " + xmlResp.getElementsByTagName("headerHtml")[0].textContent);
         var header_markup = xmlResp.getElementsByTagName("headerHtml")[0];
         document.getElementById("UHF-header").innerHTML = header_markup.textContent;
 
@@ -10,7 +11,7 @@ xhttp.onreadystatechange = function() {
         document.getElementById("UHF-footer").innerHTML = footer_markup.textContent;
     }
 };
-xhttp.open("GET", "https://uhf.microsoft.com/en-US/shell/xml/MSWinUI?headerId=MSWinUIHeader&footerid=MSWinUIFooter", true);
+xhttp.open("GET", "https://uhf.microsoft.com/en-US/shell/xml/MSWinUI?headerId=MSWinUIHeader&footerid=MSWinUIFooter&CookieComplianceEnabled=true", true);
 xhttp.send();
 
 function Include(type, src) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var xhttp = new XMLHttpRequest();
 xhttp.onreadystatechange = function() {
     if (this.readyState == 4 && this.status == 200) {
         var xmlResp = this.responseXML;
-        console.log("data:    " + xmlResp.getElementsByTagName("headerHtml")[0].textContent);
         var header_markup = xmlResp.getElementsByTagName("headerHtml")[0];
         document.getElementById("UHF-header").innerHTML = header_markup.textContent;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added an extra parameter to an API call to make sure that we're displaying the right cookie banner (banner that explains the website's use of cookies).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
The Microsoft standard cookie banner to display on all Microsoft official websites has changed, so I made a slight tweak to an API call on the website to make sure that we're displaying the correct, updated cookie banner. 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested on my machine

