### PR TITLE
DatePicker/TimePicker: use old style when < 19H1

### DIFF
--- a/dev/CommonStyles/DatePicker_themeresources.xaml
+++ b/dev/CommonStyles/DatePicker_themeresources.xaml
@@ -1,6 +1,8 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+  xmlns:contract8NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,8)"
   xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
@@ -391,7 +393,32 @@
                                 <RowDefinition Height="*" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
-                            <Grid>
+                            <contract8NotPresent:Grid x:Name="PickerHostGrid">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="78*" x:Name="DayColumn" />
+                                    <ColumnDefinition Width="Auto" x:Name="FirstSpacerColumn" />
+                                    <ColumnDefinition Width="132*" x:Name="MonthColumn" />
+                                    <ColumnDefinition Width="Auto" x:Name="SecondSpacerColumn" />
+                                    <ColumnDefinition Width="78*" x:Name="YearColumn" />
+                                </Grid.ColumnDefinitions>
+                                <Rectangle x:Name="HighlightRect"
+                                    Fill="{ThemeResource DatePickerFlyoutPresenterHighlightFill}"
+                                    Grid.Column="0"
+                                    Grid.ColumnSpan="5"
+                                    VerticalAlignment="Center"
+                                    Height="{ThemeResource DatePickerFlyoutPresenterHighlightHeight}" />
+                                <Rectangle x:Name="FirstPickerSpacing"
+                                    Fill="{ThemeResource DatePickerFlyoutPresenterSpacerFill}"
+                                    HorizontalAlignment="Center"
+                                    Width="{ThemeResource DatePickerSpacerThemeWidth}"
+                                    Grid.Column="1" />
+                                <Rectangle x:Name="SecondPickerSpacing"
+                                    Fill="{ThemeResource DatePickerFlyoutPresenterSpacerFill}"
+                                    HorizontalAlignment="Center"
+                                    Width="{ThemeResource DatePickerSpacerThemeWidth}"
+                                    Grid.Column="3" />
+                            </contract8NotPresent:Grid>
+                            <contract8Present:Grid>
                                 <Grid x:Name="PickerHostGrid">
 
                                     <Grid.ColumnDefinitions>
@@ -446,7 +473,7 @@
                                         VerticalAlignment="Center" IsHitTestVisible="false"/>
 
                                 </Grid>
-                            </Grid>
+                            </contract8Present:Grid>
                             <Grid Grid.Row="1" Height="{ThemeResource DatePickerFlyoutPresenterAcceptDismissHostGridHeight}" x:Name="AcceptDismissHostGrid">
 
                                 <Grid.ColumnDefinitions>

--- a/dev/CommonStyles/TimePicker_themeresources.xaml
+++ b/dev/CommonStyles/TimePicker_themeresources.xaml
@@ -1,6 +1,8 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary 
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+  xmlns:contract8NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,8)"
   xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
   xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
@@ -379,7 +381,35 @@
                                 <RowDefinition Height="*" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
-                            <Grid>
+                            <contract8NotPresent:Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" x:Name="FirstPickerHostColumn" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" x:Name="SecondPickerHostColumn" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" x:Name="ThirdPickerHostColumn" />
+                                </Grid.ColumnDefinitions>
+                                <Rectangle x:Name="HighlightRect"
+                                    Fill="{ThemeResource TimePickerFlyoutPresenterHighlightFill}"
+                                    Grid.Column="0"
+                                    Grid.ColumnSpan="5"
+                                    VerticalAlignment="Center"
+                                    Height="{ThemeResource TimePickerFlyoutPresenterHighlightHeight}" />
+                                <Border x:Name="FirstPickerHost" Grid.Column="0" />
+                                <Rectangle x:Name="FirstPickerSpacing"
+                                    Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}"
+                                    HorizontalAlignment="Center"
+                                    Width="{ThemeResource TimePickerSpacerThemeWidth}"
+                                    Grid.Column="1" />
+                                <Border x:Name="SecondPickerHost" Grid.Column="2" />
+                                <Rectangle x:Name="SecondPickerSpacing"
+                                    Fill="{ThemeResource TimePickerFlyoutPresenterSpacerFill}"
+                                    HorizontalAlignment="Center"
+                                    Width="{ThemeResource TimePickerSpacerThemeWidth}"
+                                    Grid.Column="3" />
+                                <Border x:Name="ThirdPickerHost" Grid.Column="4" />
+                            </contract8NotPresent:Grid>
+                            <contract8Present:Grid>
                                 <Grid x:Name="PickerHostGrid">
 
                                     <Grid.ColumnDefinitions>
@@ -446,7 +476,7 @@
                                     <Border x:Name="ThirdPickerHost" Grid.Column="4" />
 
                                 </Grid>
-                            </Grid>
+                            </contract8Present:Grid>
 
                             <Grid Grid.Row="1" Height="{ThemeResource TimePickerFlyoutPresenterAcceptDismissHostGridHeight}" x:Name="AcceptDismissHostGrid">
 


### PR DESCRIPTION
The MonochromaticOverlayPresenter in the DatePicker/TimePicker uses the `CreateVisualSurface` API which is only available after 1903. This results in a crash when opening one of the pickers in an RS4/RS5 machine. In this case, we'll use the old styles for the element.

Verified that the crash no longer occurs on an RS4/RS5 VM.