### PR TITLE
Disable animation for rating control when ControlsResourcesVersion is Version2

### DIFF
--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -6,6 +6,7 @@
 #include "RatingControl.h"
 #include "RatingControlAutomationPeer.h"
 #include "RuntimeProfiler.h"
+#include "XamlControlsResources.h"
 
 #include <RatingItemFontInfo.h>
 #include <RatingItemImageInfo.h>
@@ -543,7 +544,7 @@ void RatingControl::SetRatingTo(double newRating, bool originatedFromMouse)
             Value(c_noValueSetSentinel);
         }
 
-        if (SharedHelpers::IsRS1OrHigher() && IsFocusEngaged() && SharedHelpers::IsAnimationsEnabled())
+        if (SharedHelpers::IsRS1OrHigher() && IsFocusEngaged() && ShouldEnableAnimation())
         {
             const double focalPoint = CalculateStarCenter((int)(ratingValue - 1.0));
             m_sharedPointerPropertySet.InsertScalar(L"starsScaleFocalPoint", static_cast<float>(focalPoint));
@@ -763,7 +764,7 @@ void RatingControl::OnPointerMovedOverBackgroundStackPanel(const winrt::IInspect
     {
         const auto point = args.GetCurrentPoint(m_backgroundStackPanel.get());
         const float xPosition = point.Position().X;
-        if (SharedHelpers::IsAnimationsEnabled())
+        if (ShouldEnableAnimation())
         {
             m_sharedPointerPropertySet.InsertScalar(L"starsScaleFocalPoint", xPosition);
             auto deviceType = args.Pointer().PointerDeviceType();
@@ -1033,6 +1034,12 @@ void RatingControl::OnPreviewKeyUp(winrt::KeyRoutedEventArgs const& eventArgs)
     }
 }
 
+bool RatingControl::ShouldEnableAnimation()
+{
+    // In ControlsResourceVersion2, animation is disabled.
+    return !XamlControlsResources::IsUsingControlsResourcesVersion2() && SharedHelpers::IsAnimationsEnabled();
+}
+
 void RatingControl::OnFocusEngaged(const winrt::Control& /*sender*/, const winrt::FocusEngagedEventArgs& /*args*/)
 {
     if (!IsReadOnly())
@@ -1090,7 +1097,7 @@ void RatingControl::EnterGamepadEngagementMode()
         winrt::ElementSoundPlayer::Play(winrt::ElementSoundKind::Invoke);
     }
     
-    if (SharedHelpers::IsAnimationsEnabled())
+    if (ShouldEnableAnimation())
     {
         const double focalPoint = CalculateStarCenter((int)(currentValue - 1.0));
         m_sharedPointerPropertySet.InsertScalar(L"starsScaleFocalPoint", static_cast<float>(focalPoint));

--- a/dev/RatingControl/RatingControl.h
+++ b/dev/RatingControl/RatingControl.h
@@ -112,7 +112,7 @@ public:
     void OnPreviewKeyUp(winrt::KeyRoutedEventArgs const& e);
 
 private:
-
+    bool ShouldEnableAnimation();
     void OnFocusEngaged(const winrt::Control& sender, const winrt::FocusEngagedEventArgs& args);
     void OnFocusDisengaged(const winrt::Control& sender, const winrt::FocusDisengagedEventArgs& args);
 

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -21,7 +21,7 @@ static constexpr auto c_AccentAcrylicInAppFillColorBaseBrush = L"AccentAcrylicIn
 // Controls knows nothing about XamlControlsResources, but we need a way to pass the new visual flag from XamlControlsResources to Controls
 // Assume XamlControlsResources is one per Application resource, and application is per thread, 
 // so it's OK to assume one instance of XamlControlsResources per thread.
-thread_local bool s_tlsIsControlsResourcesVersion2 = true;
+static thread_local bool s_tlsIsControlsResourcesVersion2 = true;
 
 XamlControlsResources::XamlControlsResources()
 {
@@ -359,4 +359,9 @@ void XamlControlsResources::EnsureRevealLights(winrt::UIElement const& element)
                 RevealBrush::AttachLightsToAncestor(element, false);
             });
     }
+}
+
+bool XamlControlsResources::IsUsingControlsResourcesVersion2()
+{
+    return s_tlsIsControlsResourcesVersion2;
 }

--- a/dev/dll/XamlControlsResources.h
+++ b/dev/dll/XamlControlsResources.h
@@ -17,6 +17,7 @@ public:
     void UpdateAcrylicBrushesLightTheme(const winrt::IInspectable themeDictionary);
     void UpdateAcrylicBrushesDarkTheme(const winrt::IInspectable themeDictionary);
     static void EnsureRevealLights(winrt::UIElement const& element);
+    static bool IsUsingControlsResourcesVersion2();
 private:
     void UpdateSource();
     bool IsControlsResourcesVersion2();


### PR DESCRIPTION
Only allows PointerOver scale on Version1.
In Version2, we will disable it.  
![image](https://user-images.githubusercontent.com/6290692/116453327-973af300-a813-11eb-843b-3b7cd4d85468.png)