### PR TITLE
[AppBarSeparator] Update margins for AppBarSeparator

### DIFF
--- a/dev/CommonStyles/AppBarSeparator_themeresources.xaml
+++ b/dev/CommonStyles/AppBarSeparator_themeresources.xaml
@@ -13,7 +13,7 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="AppBarSeparatorMargin">16,12,15,12</Thickness>
+    <Thickness x:Key="AppBarSeparatorMargin">2,8,2,8</Thickness>
     <Thickness x:Key="AppBarOverflowSeparatorMargin">0,4,0,4</Thickness>
     <x:Double x:Key="AppBarSeparatorWidth">1</x:Double>
     <x:Double x:Key="AppBarOverflowSeparatorHeight">1</x:Double>

--- a/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-7.xml
+++ b/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-7.xml
@@ -134,7 +134,7 @@
               FocusVisualPrimaryThickness=2,2,2,2
               FocusVisualPrimaryBrush=#E4000000
               Visibility=Visible
-              RenderSize=208,64
+              RenderSize=181,64
             [Windows.UI.Xaml.Controls.ItemsPresenter]
                 Padding=0,0,0,0
                 Margin=0,0,0,0
@@ -143,7 +143,7 @@
                 FocusVisualPrimaryThickness=2,2,2,2
                 FocusVisualPrimaryBrush=#E4000000
                 Visibility=Visible
-                RenderSize=208,64
+                RenderSize=181,64
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000
@@ -170,7 +170,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=208,64
+                  RenderSize=181,64
                 [Windows.UI.Xaml.Controls.AppBarToggleButton]
                     Padding=0,0,0,0
                     Foreground=#E4000000
@@ -532,7 +532,7 @@
                     FocusVisualPrimaryThickness=2,2,2,2
                     FocusVisualPrimaryBrush=#E4000000
                     Visibility=Visible
-                    RenderSize=32,54
+                    RenderSize=5,54
                   [Windows.UI.Xaml.Controls.Grid]
                       Padding=0,0,0,0
                       CornerRadius=0,0,0,0
@@ -546,18 +546,18 @@
                       FocusVisualPrimaryThickness=2,2,2,2
                       FocusVisualPrimaryBrush=#E4000000
                       Visibility=Visible
-                      RenderSize=32,54
+                      RenderSize=5,54
                     [Windows.UI.Xaml.Shapes.Rectangle]
                         StrokeThickness=1
                         Width=1
                         Name=SeparatorRectangle
-                        Margin=16,12,15,12
+                        Margin=2,8,2,8
                         FocusVisualSecondaryThickness=1,1,1,1
                         FocusVisualSecondaryBrush=#B3FFFFFF
                         FocusVisualPrimaryThickness=2,2,2,2
                         FocusVisualPrimaryBrush=#E4000000
                         Visibility=Visible
-                        RenderSize=1,30
+                        RenderSize=1,38
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000
@@ -794,7 +794,7 @@
               FocusVisualPrimaryThickness=2,2,2,2
               FocusVisualPrimaryBrush=#E4000000
               Visibility=Visible
-              RenderSize=208,64
+              RenderSize=181,64
             [Windows.UI.Xaml.Controls.ItemsPresenter]
                 Padding=0,0,0,0
                 Margin=0,0,0,0
@@ -803,7 +803,7 @@
                 FocusVisualPrimaryThickness=2,2,2,2
                 FocusVisualPrimaryBrush=#E4000000
                 Visibility=Visible
-                RenderSize=208,64
+                RenderSize=181,64
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000
@@ -830,7 +830,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=208,64
+                  RenderSize=181,64
                 [Windows.UI.Xaml.Controls.AppBarToggleButton]
                     Padding=0,0,0,0
                     Foreground=#E4000000
@@ -1192,7 +1192,7 @@
                     FocusVisualPrimaryThickness=2,2,2,2
                     FocusVisualPrimaryBrush=#E4000000
                     Visibility=Visible
-                    RenderSize=32,54
+                    RenderSize=5,54
                   [Windows.UI.Xaml.Controls.Grid]
                       Padding=0,0,0,0
                       CornerRadius=0,0,0,0
@@ -1207,18 +1207,18 @@
                       FocusVisualPrimaryThickness=2,2,2,2
                       FocusVisualPrimaryBrush=#E4000000
                       Visibility=Visible
-                      RenderSize=32,48
+                      RenderSize=5,48
                     [Windows.UI.Xaml.Shapes.Rectangle]
                         StrokeThickness=1
                         Width=1
                         Name=SeparatorRectangle
-                        Margin=16,12,15,12
+                        Margin=2,8,2,8
                         FocusVisualSecondaryThickness=1,1,1,1
                         FocusVisualSecondaryBrush=#B3FFFFFF
                         FocusVisualPrimaryThickness=2,2,2,2
                         FocusVisualPrimaryBrush=#E4000000
                         Visibility=Visible
-                        RenderSize=1,24
+                        RenderSize=1,32
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000

--- a/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-8.xml
+++ b/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-8.xml
@@ -134,7 +134,7 @@
               FocusVisualPrimaryThickness=2,2,2,2
               FocusVisualPrimaryBrush=#E4000000
               Visibility=Visible
-              RenderSize=208,64
+              RenderSize=181,64
             [Windows.UI.Xaml.Controls.ItemsPresenter]
                 Padding=0,0,0,0
                 Margin=0,0,0,0
@@ -143,7 +143,7 @@
                 FocusVisualPrimaryThickness=2,2,2,2
                 FocusVisualPrimaryBrush=#E4000000
                 Visibility=Visible
-                RenderSize=208,64
+                RenderSize=181,64
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000
@@ -170,7 +170,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=208,64
+                  RenderSize=181,64
                 [Windows.UI.Xaml.Controls.AppBarToggleButton]
                     Padding=0,0,0,0
                     Foreground=#E4000000
@@ -532,7 +532,7 @@
                     FocusVisualPrimaryThickness=2,2,2,2
                     FocusVisualPrimaryBrush=#E4000000
                     Visibility=Visible
-                    RenderSize=32,54
+                    RenderSize=5,54
                   [Windows.UI.Xaml.Controls.Grid]
                       Padding=0,0,0,0
                       CornerRadius=0,0,0,0
@@ -546,18 +546,18 @@
                       FocusVisualPrimaryThickness=2,2,2,2
                       FocusVisualPrimaryBrush=#E4000000
                       Visibility=Visible
-                      RenderSize=32,54
+                      RenderSize=5,54
                     [Windows.UI.Xaml.Shapes.Rectangle]
                         StrokeThickness=1
                         Width=1
                         Name=SeparatorRectangle
-                        Margin=16,12,15,12
+                        Margin=2,8,2,8
                         FocusVisualSecondaryThickness=1,1,1,1
                         FocusVisualSecondaryBrush=#B3FFFFFF
                         FocusVisualPrimaryThickness=2,2,2,2
                         FocusVisualPrimaryBrush=#E4000000
                         Visibility=Visible
-                        RenderSize=1,30
+                        RenderSize=1,38
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000
@@ -794,7 +794,7 @@
               FocusVisualPrimaryThickness=2,2,2,2
               FocusVisualPrimaryBrush=#E4000000
               Visibility=Visible
-              RenderSize=208,64
+              RenderSize=181,64
             [Windows.UI.Xaml.Controls.ItemsPresenter]
                 Padding=0,0,0,0
                 Margin=0,0,0,0
@@ -803,7 +803,7 @@
                 FocusVisualPrimaryThickness=2,2,2,2
                 FocusVisualPrimaryBrush=#E4000000
                 Visibility=Visible
-                RenderSize=208,64
+                RenderSize=181,64
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000
@@ -830,7 +830,7 @@
                   FocusVisualPrimaryThickness=2,2,2,2
                   FocusVisualPrimaryBrush=#E4000000
                   Visibility=Visible
-                  RenderSize=208,64
+                  RenderSize=181,64
                 [Windows.UI.Xaml.Controls.AppBarToggleButton]
                     Padding=0,0,0,0
                     Foreground=#E4000000
@@ -1192,7 +1192,7 @@
                     FocusVisualPrimaryThickness=2,2,2,2
                     FocusVisualPrimaryBrush=#E4000000
                     Visibility=Visible
-                    RenderSize=32,54
+                    RenderSize=5,54
                   [Windows.UI.Xaml.Controls.Grid]
                       Padding=0,0,0,0
                       CornerRadius=0,0,0,0
@@ -1207,18 +1207,18 @@
                       FocusVisualPrimaryThickness=2,2,2,2
                       FocusVisualPrimaryBrush=#E4000000
                       Visibility=Visible
-                      RenderSize=32,48
+                      RenderSize=5,48
                     [Windows.UI.Xaml.Shapes.Rectangle]
                         StrokeThickness=1
                         Width=1
                         Name=SeparatorRectangle
-                        Margin=16,12,15,12
+                        Margin=2,8,2,8
                         FocusVisualSecondaryThickness=1,1,1,1
                         FocusVisualSecondaryBrush=#B3FFFFFF
                         FocusVisualPrimaryThickness=2,2,2,2
                         FocusVisualPrimaryBrush=#E4000000
                         Visibility=Visible
-                        RenderSize=1,24
+                        RenderSize=1,32
               [Windows.UI.Xaml.Controls.ContentControl]
                   Padding=0,0,0,0
                   Foreground=#E4000000


### PR DESCRIPTION
Update margins of control to match design

## Description
* Change horizontal margins to 2 pixels
* Reduce vertical margins by 4 pixels to end up with a height of 32 px

## Motivation and Context
VSO: 32352778

## How Has This Been Tested?
Design team approval

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/35784165/116456486-31e90100-a817-11eb-98d5-47870ebf57fb.png)