### PR TITLE
Fixes to enable CI and Release Pipelines to work reliably

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -98,7 +98,8 @@ jobs:
       testSuite: 'NugetTestSuite'
       helixType: ${{ parameters.helixType }}
       artifactName: ${{ parameters.buildArtifactName }}
-      taefQuery: ${{ parameters.taefQuery }}
+      ${{if eq(parameters.useFrameworkPkg, 'true')}}:
+        taefQuery: "(not (@NugetPkgTestsOnly = 'true'))"
       rerunPassesRequiredToAvoidFailure: 5
       ${{if ne(parameters.test_matrix, '') }}:
         matrix: ${{ parameters.test_matrix }}

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -70,7 +70,6 @@ jobs:
     helixType: 'test/frpkg'
     dependsOn: CreateNugetPackage
     useFrameworkPkg: true
-    taefQuery: "(not (@NugetPkgTestsOnly = 'true'))"
 
 - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
   parameters:

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/NugetTestsCX.cs
@@ -50,6 +50,7 @@ namespace MUXControls.ReleaseTest
         }
 
         [TestMethod]
+        [TestProperty("Ignore", "True")] // Issue #4899: Test MUXControls.ReleaseTest.RepeaterNoCrashTest is unreliable 
         public void RepeaterNoCrashTest()
         {
             var button = new Button(FindElement.ByName("AddItemsButton"));

--- a/test/MUXControlsReleaseTest/XamlIslandsTestApp/WpfApp/WpfApp.Package.wapproj
+++ b/test/MUXControlsReleaseTest/XamlIslandsTestApp/WpfApp/WpfApp.Package.wapproj
@@ -31,7 +31,7 @@
   <PropertyGroup>
     <ProjectGuid>4454b583-39a0-4a91-881c-2078fa26c447</ProjectGuid>
     <TargetPlatformVersion>$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>$(MuxSdkVersion)</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>true</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>WpfApp.csproj</EntryPointProjectUniqueName>


### PR DESCRIPTION
A few fixes:
Disabling unreliable test: [Test MUXControls\.ReleaseTest\.RepeaterNoCrashTest is unreliable \#4899](https://github.com/microsoft/microsoft-ui-xaml/issues/4899)

XamlIslandsTestApp was failing to install on test machines due to TargetPlatformMinVersion being tied to the version of SDK.

WinUI-CI was using a 'taefQuery' parameter to skip some tests (NugetPkgTestsOnly='True') when run as a framework package test app. However, this was not being plumbed through for the Release Pipeline, which resulted in test failures. The yml is refactored a bit to avoid this problem.