### PR TITLE
Make Padding settable for AppBarSeparator

### DIFF
--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -377,7 +377,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                         <CommandBar Background='Green' CornerRadius='5,10,5,10' IsOpen='False'>
                         <AppBarToggleButton Icon='Shuffle' Label='Shuffle'  />
                         <AppBarToggleButton Icon='RepeatAll' Label='Repeat' />
-                        <AppBarSeparator Margin='20,10,20,0' Foreground='Yellow'/>
+                        <AppBarSeparator Margin='20,10,20,0' Padding='16,12,15,12' Foreground='Yellow'/>
 
                         <CommandBar.Content>
                             <TextBlock Text='Now playing...' Margin='12,14'/>

--- a/dev/CommonStyles/AppBarSeparator_themeresources.xaml
+++ b/dev/CommonStyles/AppBarSeparator_themeresources.xaml
@@ -23,6 +23,7 @@
 
     <Style x:Key="DefaultAppBarSeparatorStyle" TargetType="AppBarSeparator">
         <Setter Property="Foreground" Value="{ThemeResource AppBarSeparatorForeground}" />
+        <Setter Property="Padding" Value="{ThemeResource AppBarSeparatorMargin}" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
@@ -56,7 +57,7 @@
                             Width="{StaticResource AppBarSeparatorWidth}"
                             VerticalAlignment="Stretch"
                             Fill="{TemplateBinding Foreground}"
-                            Margin="{StaticResource AppBarSeparatorMargin}"/>
+                            Margin="{TemplateBinding Padding}"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-7.xml
+++ b/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-7.xml
@@ -520,7 +520,7 @@
                           Visibility=Collapsed
                           RenderSize=0,0
                 [Windows.UI.Xaml.Controls.AppBarSeparator]
-                    Padding=0,0,0,0
+                    Padding=16,12,15,12
                     Foreground=#FFFFFF00
                     BorderThickness=0,0,0,0
                     BorderBrush=[NULL]
@@ -1180,7 +1180,7 @@
                           Visibility=Collapsed
                           RenderSize=0,0
                 [Windows.UI.Xaml.Controls.AppBarSeparator]
-                    Padding=0,0,0,0
+                    Padding=16,12,15,12
                     Foreground=#FFFFFF00
                     BorderThickness=0,0,0,0
                     BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-8.xml
+++ b/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-8.xml
@@ -520,7 +520,7 @@
                           Visibility=Collapsed
                           RenderSize=0,0
                 [Windows.UI.Xaml.Controls.AppBarSeparator]
-                    Padding=0,0,0,0
+                    Padding=16,12,15,12
                     Foreground=#FFFFFF00
                     BorderThickness=0,0,0,0
                     BorderBrush=[NULL]
@@ -1180,7 +1180,7 @@
                           Visibility=Collapsed
                           RenderSize=0,0
                 [Windows.UI.Xaml.Controls.AppBarSeparator]
-                    Padding=0,0,0,0
+                    Padding=16,12,15,12
                     Foreground=#FFFFFF00
                     BorderThickness=0,0,0,0
                     BorderBrush=[NULL]


### PR DESCRIPTION
Allow user to set padding for AppBarSeparator which will overwrite the AppBarSeparatorMargin
```
<AppBarSeparator Padding="1,1,1,1" />
```