### PR TITLE
MenuFlyout items: Fixed icon color on press

### DIFF
--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -355,7 +355,7 @@
                                     <VisualState.Setters>
                                         <Setter Target="LayoutRoot.Background" Value="{ThemeResource MenuFlyoutItemBackgroundPressed}"/>
                                         <Setter Target="TextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundPressed}"/>
-                                        <Setter Target="IconContent.Foreground" Value="{ThemeResource MenuFlyoutItemBackgroundPressed}"/>
+                                        <Setter Target="IconContent.Foreground" Value="{ThemeResource MenuFlyoutItemForegroundPressed}"/>
                                         <contract6Present:Setter Target="KeyboardAcceleratorTextBlock.Foreground" Value="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
                                     </VisualState.Setters>
                                 </VisualState>


### PR DESCRIPTION
## Description
Updated MenuFlyoutItemBackgroundPressed to MenuFlyoutItemForegroundPressed (icons are a foreground element).

## Motivation and Context
Icons on press were "disappearing" due to incorrect color mapping. 

## How Has This Been Tested?
Validated in MUX controls test app.

## Screenshots (if appropriate):
 BEFORE
![Before_MenuItemIcon](https://user-images.githubusercontent.com/42077683/116593357-d7fb4080-a8d5-11eb-8bbc-d9db7bc41e74.PNG)

AFTER
![After_MenuItemIcon](https://user-images.githubusercontent.com/42077683/116593378-df224e80-a8d5-11eb-894f-fe3fcc0e2dde.PNG)

![After_MenuItemIcon_Dark](https://user-images.githubusercontent.com/42077683/116593397-e5b0c600-a8d5-11eb-921b-af0425fb6677.PNG)