### PR TITLE
Simplified anchor creation condition

### DIFF
--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -190,7 +190,7 @@ bool ElementManager::IsDataIndexRealized(int index) const
     else
     {
         // Non virtualized - everything is realized
-        return index >= 0 && index < m_context.ItemCount();
+        return IsIndexValidInData(index);
     }
 }
 

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -49,13 +49,10 @@ winrt::Size FlowLayoutAlgorithm::Measure(
         realizationRect.X, realizationRect.Y, realizationRect.Width, realizationRect.Height);
 
     const auto suggestedAnchorIndex = m_context.get().RecommendedAnchorIndex();
-    if (m_elementManager.IsIndexValidInData(suggestedAnchorIndex))
+    const auto anchorRealized = m_elementManager.IsDataIndexRealized(suggestedAnchorIndex);
+    if (!anchorRealized)
     {
-        const auto anchorRealized = m_elementManager.IsDataIndexRealized(suggestedAnchorIndex);
-        if (!anchorRealized)
-        {
-            MakeAnchor(m_context.get(), suggestedAnchorIndex, availableSize);
-        }
+        MakeAnchor(m_context.get(), suggestedAnchorIndex, availableSize);
     }
 
     m_elementManager.OnBeginMeasure(orientation);


### PR DESCRIPTION
This change deduplicates a condition used for `MakeAnchor`. Calling only `IsDataIndexRealized` is enought since it does the same check as `IsIndexValidInData` in case of a non-virtualized layout, and in case of a virtualized layout the realized window represents a subset of all items, so there's no reason to verify first that index belongs the whole range.