### PR TITLE
ColorPicker: transparency slider is too far away from brightness slider

### DIFF
--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -97,16 +97,16 @@
                                                       Grid.Row="1"
                                                       contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                                                       contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
-                                                    <Grid x:Name="HorizontalTemplate" MinHeight="44">
+                                                    <Grid x:Name="HorizontalTemplate" MinHeight="38">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition Width="Auto"/>
                                                             <ColumnDefinition />
                                                         </Grid.ColumnDefinitions>
                                                         <Grid.RowDefinitions>
-                                                            <RowDefinition Height="18"/>
+                                                            <RowDefinition Height="14"/>
                                                             <RowDefinition Height="Auto"/>
-                                                            <RowDefinition Height="18"/>
+                                                            <RowDefinition Height="14"/>
                                                         </Grid.RowDefinitions>
                                                         <Rectangle x:Name="HorizontalTrackRect" Grid.ColumnSpan="3" Fill="Transparent" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Opacity="0"
                                                             contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
@@ -256,7 +256,7 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <StackPanel>
-                            <Grid x:Name="ColorSpectrumGrid">
+                            <Grid x:Name="ColorSpectrumGrid" Margin="0,0,0,15" >
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
                                     <ColumnDefinition Width="Auto" />
@@ -310,7 +310,7 @@
                                                contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
                                 </Grid>
                             </Grid>
-                            <Grid Margin="0,12,0,0" x:Name="ThirdDimensionSliderGrid">
+                            <Grid x:Name="ThirdDimensionSliderGrid">
                                 <Rectangle Height="11" VerticalAlignment="Center"
                                            contract7Present:RadiusX="{Binding Source={ThemeResource ColorPickerSliderCornerRadius}, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                            contract7Present:RadiusY="{Binding Source={ThemeResource ColorPickerSliderCornerRadius}, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
@@ -322,7 +322,7 @@
                                 </Rectangle>
                                 <primitives:ColorPickerSlider x:Name="ThirdDimensionSlider" Minimum="0" Maximum="100" ColorChannel="Value" Style="{StaticResource ColorPickerSliderStyle}" IsThumbToolTipEnabled="False" />
                             </Grid>
-                            <Grid Margin="0,12,0,0" x:Name="AlphaSliderGrid">
+                            <Grid Margin="0,0,0,3" x:Name="AlphaSliderGrid">
                                 <Rectangle Height="11" VerticalAlignment="Center"
                                            contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                            contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"


### PR DESCRIPTION
ColorPicker: transparency slider is too far away from brightness slider

## Description
- Moved margin from the slider to the gradient picker box so if either slider were to be removed, the placement would be equal
- Adjusted height of grid rows above and below slider track to achieve correct distance between sliders when both present

## Motivation and Context
Transparency slider was placed too far away from the color slider, to achieve correct visual spacing they needed to be tightened up.

## How Has This Been Tested?
MUXControlTextApp

## Screenshots (if appropriate):
BEFORE
![ColorPicker_before](https://user-images.githubusercontent.com/26553342/116771097-c53c5500-aa16-11eb-9d40-33ec57b960ab.png)

AFTER
![ColorPicker_after](https://user-images.githubusercontent.com/26553342/116771102-cbcacc80-aa16-11eb-800f-d6fbc7be4385.png)
