### PR TITLE
Expander: add divider between Header and Content

### DIFF
--- a/dev/Expander/Expander.xaml
+++ b/dev/Expander/Expander.xaml
@@ -38,6 +38,9 @@
                             <VisualStateGroup x:Name="ExpandStates">
                                 <VisualState x:Name="ExpandUp">
                                     <VisualState.Setters>
+                                        <Setter Target="Divider.Visibility" Value="Visible"/>
+                                        <Setter Target="ExpanderHeader.Padding" Value="{ThemeResource ExpanderHeaderPaddingExpandedUp}"/>
+                                        <Setter Target="ExpanderHeader.BorderThickness" Value="{ThemeResource ExpanderContentDownBorderThickness}" />
                                         <contract7Present:Setter Target="ExpanderHeader.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
                                     </VisualState.Setters>
                                     <VisualState.Storyboard>
@@ -71,6 +74,9 @@
                                 </VisualState>
                                 <VisualState x:Name="ExpandDown">
                                     <VisualState.Setters>
+                                        <Setter Target="Divider.Visibility" Value="Visible"/>
+                                        <Setter Target="ExpanderHeader.Padding" Value="{ThemeResource ExpanderHeaderPaddingExpandedDown}"/>
+                                        <Setter Target="ExpanderHeader.BorderThickness" Value="{ThemeResource ExpanderContentUpBorderThickness}" />
                                         <contract7Present:Setter Target="ExpanderHeader.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
                                     </VisualState.Setters>
                                     <VisualState.Storyboard>
@@ -167,6 +173,13 @@
                                 </Border.RenderTransform>
                             </Border>
                         </Border>
+                        <Border x:Name="Divider"
+                                BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
+                                BorderBrush="{ThemeResource ExpanderDividerBorderBrush}"
+                                Margin="{ThemeResource ExpanderDividerMargin}"
+                                Height="{ThemeResource ExpanderDividerHeight}"
+                                VerticalAlignment="Bottom"
+                                Visibility="Collapsed" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/dev/Expander/Expander_themeresources.xaml
+++ b/dev/Expander/Expander_themeresources.xaml
@@ -37,6 +37,11 @@
             <StaticResource x:Key="ExpanderContentBackground" ResourceKey="CardBackgroundFillColorSecondaryBrush" />
             <StaticResource x:Key="ExpanderContentBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
 
+            <!-- Divider -->
+            <StaticResource x:Key="ExpanderDividerBorderBrush" ResourceKey="ControlStrokeColorSecondaryBrush"/>
+            <Thickness x:Key="ExpanderDividerMargin">1,0,1,0</Thickness>
+            <x:Double x:Key="ExpanderDividerHeight">1</x:Double>
+
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
@@ -67,6 +72,11 @@
             <!-- Content -->
             <StaticResource x:Key="ExpanderContentBackground" ResourceKey="CardBackgroundFillColorSecondaryBrush" />
             <StaticResource x:Key="ExpanderContentBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
+
+            <!-- Divider -->
+            <StaticResource x:Key="ExpanderDividerBorderBrush" ResourceKey="ControlStrokeColorSecondaryBrush"/>
+            <Thickness x:Key="ExpanderDividerMargin">1,0,1,0</Thickness>
+            <x:Double x:Key="ExpanderDividerHeight">1</x:Double>
 
         </ResourceDictionary>
 
@@ -99,6 +109,11 @@
             <StaticResource x:Key="ExpanderContentBackground" ResourceKey="SystemColorWindowColorBrush" />
             <StaticResource x:Key="ExpanderContentBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />
 
+            <!-- Divider -->
+            <StaticResource x:Key="ExpanderDividerBorderBrush" ResourceKey="SystemColorButtonTextColorBrush"/>
+            <Thickness x:Key="ExpanderDividerMargin">2,0,2,0</Thickness>
+            <x:Double x:Key="ExpanderDividerHeight">2</x:Double>
+
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -109,6 +124,8 @@
     <HorizontalAlignment x:Key="ExpanderHeaderHorizontalContentAlignment">Stretch</HorizontalAlignment>
     <VerticalAlignment x:Key="ExpanderHeaderVerticalContentAlignment">Center</VerticalAlignment>
     <Thickness x:Key="ExpanderHeaderPadding">16,0,0,0</Thickness>
+    <Thickness x:Key="ExpanderHeaderPaddingExpandedUp">16,1,0,0</Thickness>
+    <Thickness x:Key="ExpanderHeaderPaddingExpandedDown">16,0,0,1</Thickness>
     <Thickness x:Key="ExpanderChevronMargin">20,0,8,0</Thickness>
     <x:String x:Key="ExpanderChevronUpGlyph">&#xE70E;</x:String>
     <x:String x:Key="ExpanderChevronDownGlyph">&#xE70D;</x:String>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a divider between Header and Content.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
To assign correct color to the line laying between the Header and the Content we need add one more component to the Expander. I've added a Border to give the line between the Header and the Content correct color.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
Dark:
![image](https://user-images.githubusercontent.com/21356912/116955087-71b04e00-ac46-11eb-916c-fa94f41fbff8.png)
![image](https://user-images.githubusercontent.com/21356912/116955090-7543d500-ac46-11eb-82de-16d6e84907ef.png)

Light:
![image](https://user-images.githubusercontent.com/21356912/116955069-652bf580-ac46-11eb-8613-29b51ca567c2.png)
![image](https://user-images.githubusercontent.com/21356912/116955079-6c530380-ac46-11eb-985d-2ac02c6aedce.png)