### PR TITLE
AnimatedVisualPlayer destructor bug

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -15,7 +15,7 @@ AnimatedVisualPlayer::AnimationPlay::AnimationPlay(
     float fromProgress,
     float toProgress,
     bool looped)
-    : m_owner{ owner }
+    : m_owner{ &owner }
     , m_fromProgress(fromProgress)
     , m_toProgress(toProgress)
     , m_looped(looped)
@@ -25,7 +25,7 @@ AnimatedVisualPlayer::AnimationPlay::AnimationPlay(
     // so the time is calculated as fromProgress..end + start..toProgress.
     const auto durationAsProgress = fromProgress > toProgress ? ((1 - fromProgress) + toProgress) : (toProgress - fromProgress);
     // NOTE: this relies on the Duration() being set on the owner.
-    m_playDuration = std::chrono::duration_cast<winrt::TimeSpan>(m_owner.Duration() * durationAsProgress);
+    m_playDuration = std::chrono::duration_cast<winrt::TimeSpan>(m_owner->Duration() * durationAsProgress);
 }
 
 float AnimatedVisualPlayer::AnimationPlay::FromProgress()
@@ -36,6 +36,8 @@ float AnimatedVisualPlayer::AnimationPlay::FromProgress()
 // REENTRANCE SIDE EFFECT: IsPlaying DP.
 void AnimatedVisualPlayer::AnimationPlay::Start()
 {
+    // m_owner should be alive since we are calling Start() from owner only
+    MUX_ASSERT(m_owner);
     MUX_ASSERT(!m_controller);
 
     // If the duration is really short (< 20ms) don't bother trying to animate.
@@ -43,14 +45,14 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
     {
         // Nothing to play. Jump to the from position.
         // This will have the side effect of completing this play immediately.
-        m_owner.SetProgress(m_fromProgress);
+        m_owner->SetProgress(m_fromProgress);
         // Do not do anything after calling SetProgress()... the AnimationPlay is destructed already.
         return;
     }
     else
     {
         // Create an animation to drive the Progress property.
-        auto compositor = m_owner.m_progressPropertySet.Compositor();
+        auto compositor = m_owner->m_progressPropertySet.Compositor();
         auto animation = compositor.CreateScalarKeyFrameAnimation();
         animation.Duration(m_playDuration);
         auto linearEasing = compositor.CreateLinearEasingFunction();
@@ -90,9 +92,9 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
             : compositor.CreateScopedBatch(winrt::CompositionBatchTypes::Animation);
 
         // Start the animation and get the controller.
-        m_owner.m_progressPropertySet.StartAnimation(L"Progress", animation);
+        m_owner->m_progressPropertySet.StartAnimation(L"Progress", animation);
 
-        m_controller = m_owner.m_progressPropertySet.TryGetAnimationController(L"Progress");
+        m_controller = m_owner->m_progressPropertySet.TryGetAnimationController(L"Progress");
 
         if (m_isPaused || m_isPausedBecauseHidden)
         {
@@ -101,7 +103,7 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
         }
 
         // Set the playback rate.
-        const auto playbackRate = static_cast<float>(m_owner.PlaybackRate());
+        const auto playbackRate = static_cast<float>(m_owner->PlaybackRate());
         m_controller.PlaybackRate(playbackRate);
 
         if (playbackRate < 0)
@@ -135,13 +137,13 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
         }
 
         // WARNING - this may cause reentrance.
-        m_owner.IsPlaying(true);
+        m_owner->IsPlaying(true);
     }
 }
 
 bool AnimatedVisualPlayer::AnimationPlay::IsCurrentPlay()
 {
-    return m_owner.m_nowPlaying.get() == this;
+    return m_owner && m_owner->m_nowPlaying.get() == this;
 }
 
 void AnimatedVisualPlayer::AnimationPlay::SetPlaybackRate(float value)
@@ -244,9 +246,14 @@ void AnimatedVisualPlayer::AnimationPlay::Complete()
     //     from the batch completion event.
     //    
 
-    // Grab a copy of the pointer so the object stays alive until
-    // the method returns.
-    auto me = m_owner.m_nowPlaying;
+    // Grab a copy of the pointer so the object stays alive until the method returns.
+    // We need to copy pointer only in case if owner is alive,
+    // because we are resetting only owner's pointer in this method
+    std::shared_ptr<AnimationPlay> me;
+    if (m_owner)
+    {
+        me = m_owner->m_nowPlaying;
+    }
 
     // Unsubscribe from batch.Completed.
     if (m_batch)
@@ -257,21 +264,28 @@ void AnimatedVisualPlayer::AnimationPlay::Complete()
 
     // If this play is the one that is currently associated with the player,
     // disassociate it from the player and update the player's IsPlaying property.
-    if (IsCurrentPlay())
+    if (m_owner && IsCurrentPlay())
     {
         // Disconnect this AnimationPlay from the player.
-        m_owner.m_nowPlaying.reset();
+        m_owner->m_nowPlaying.reset();
 
         // Update the IsPlaying state. Note that this is done
         // after being disconnected so that this AnimationPlay won't be
         // reentered, however the AnimatedVisualPlayer may be reentered.
         // WARNING - this may cause reentrance.
-        m_owner.IsPlaying(false);
+        m_owner->IsPlaying(false);
     }
 
     // Allow anything waiting on this awaitable to complete.
     // This will not cause reentrance because this signals an event and does not call out.
     CompleteAwaits();
+}
+
+// This is called in AnimatedVisualPlayer destructor to prevent
+// AnimationPlay accessing owner in case if it lives longer
+void AnimatedVisualPlayer::AnimationPlay::ResetOwner()
+{
+    m_owner = nullptr;
 }
 
 AnimatedVisualPlayer::AnimatedVisualPlayer()
@@ -346,10 +360,10 @@ AnimatedVisualPlayer::~AnimatedVisualPlayer()
     if (m_nowPlaying)
     {
         // To stop and destroy m_nowPlaying we need to call Complete()
-        // We need to detach m_nowPlaying first so that Complete()
-        // will not try to call us (owner), since we already in the destructor
-        auto nowPlaying = std::move(m_nowPlaying);
-        nowPlaying->Complete();
+        // But we need to detach us (m_owner) from m_nowPlaying first so that AnimationPlay
+        // will not try to call us (m_owner), since we are already in the destructor
+        m_nowPlaying->ResetOwner();
+        m_nowPlaying->Complete();
     }
 }
 

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -65,8 +65,10 @@ private:
         // Called to indicate that the play has been completed. Unblocks awaiters.
         void Complete();
 
+        void ResetOwner();
+
     private:
-        AnimatedVisualPlayer& m_owner;
+        AnimatedVisualPlayer* m_owner;
         const float m_fromProgress{};
         const float m_toProgress{};
         const bool m_looped{};


### PR DESCRIPTION
This change should fix the [internal bug](https://microsoft.visualstudio.com/OS/_workitems/edit/32126845/)

The problem is that calling `IsPlaying(false)` inside the `AnimatedVisualPlayer`s destructor causes a crash. Basically, our goal is to reduce a number of things that destructor is doing, ideally nothing. But the problem is that we want to destroy `AnimationPlay m_nowPlaying` object (if it is alive) as well, but `AnimatedVisualPlayer::PlayAsync` keeps this object alive, because it holds reference and awaits (`co_await *thisPlay;`) for it to call `CompleteAwaits()`. Also we need to release `m_batch` listener as well, because it holds weak reference to us (line ~130).

So basically, we want to call `AnimationPlay ::Complete()` but without touching `m_owner`. But since `AnimationPlay` calls `m_owner` only if it is bound to it, we can detach it first, to ensure that we will not call anything in m_owner inside the destructor.