### PR TITLE
Fix downstream compilation errors involving AttributeNameAttribute

### DIFF
--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -21,7 +21,6 @@ namespace features
 namespace Microsoft.UI.Xaml.CustomAttributes
 {
     [attributeusage(target_runtimeclass)]
-    [attributename("muxhascustomactivationfactory")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXHasCustomActivationFactoryAttribute
@@ -29,7 +28,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
     }
 
     [attributeusage(target_runtimeclass, target_enum, target_struct, target_interface, target_delegate, target_property, target_method)]
-    [attributename("muxpropertyneedsdependencypropertyfield")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXPropertyNeedsDependencyPropertyFieldAttribute
@@ -37,7 +35,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
     }
 
     [attributeusage(target_runtimeclass, target_enum, target_struct, target_interface, target_delegate, target_property, target_method)]
-    [attributename("muxpropertychangedcallback")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXPropertyChangedCallbackAttribute
@@ -46,7 +43,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
     }
 
     [attributeusage(target_runtimeclass, target_enum, target_struct, target_interface, target_delegate, target_property, target_method)]
-    [attributename("muxpropertychangedcallbackmethodname")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXPropertyChangedCallbackMethodNameAttribute
@@ -55,7 +51,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
     }
 
     [attributeusage(target_runtimeclass, target_enum, target_struct, target_interface, target_delegate, target_property, target_method)]
-    [attributename("muxpropertyvalidationcallback")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXPropertyValidationCallbackAttribute
@@ -64,7 +59,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
     }
 
     [attributeusage(target_property, target_method)]
-    [attributename("muxpropertydefaultvalue")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXPropertyDefaultValueAttribute
@@ -73,7 +67,6 @@ namespace Microsoft.UI.Xaml.CustomAttributes
     }
 
     [attributeusage(target_property, target_method)]
-    [attributename("muxpropertytype")]
     [version(0x00000001)]
     [webhosthidden]
     attribute MUXPropertyTypeAttribute
@@ -137,32 +130,32 @@ namespace Microsoft.UI.Xaml
 #define MUX_INTERNAL contract(Microsoft.UI.Xaml.XamlContract, 1), feature(Feature_Experimental)
 
 // If this is specified then codegen will not create or register a default activation factory.
-#define MUX_HAS_CUSTOM_FACTORY muxhascustomactivationfactory
+#define MUX_HAS_CUSTOM_FACTORY Microsoft.UI.Xaml.CustomAttributes.MUXHasCustomActivationFactory
 
 // If specified on a property that doesn't have a corresponding "{...}Property" static DependencyProperty 
 // property, a DependencyProperty field will still be generated and registered. The scenario for this is 
 // TemplateSettings objects which don't need public DependencyProperty properties but use TemplateBinding
 // under the covers and TemplateBinding understands the DP registration and will use it.
-#define MUX_PROPERTY_NEEDS_DP_FIELD muxpropertyneedsdependencypropertyfield
+#define MUX_PROPERTY_NEEDS_DP_FIELD Microsoft.UI.Xaml.CustomAttributes.MUXPropertyNeedsDependencyPropertyField
 
 // Whether the property (or, if specified on the type, all properties) should have a OnPropertyChanged callback
-#define MUX_PROPERTY_CHANGED_CALLBACK(enable) muxpropertychangedcallback(enable)
+#define MUX_PROPERTY_CHANGED_CALLBACK(enable) Microsoft.UI.Xaml.CustomAttributes.MUXPropertyChangedCallback(enable)
 
 // Normally the codegen generates a static OnPropertyChanged method which then calls an instance OnPropertyChanged
 // method on your type. For attached properties you need to specify this callback so that you can also receive the sender.
-#define MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME(name) muxpropertychangedcallbackmethodname(name)
+#define MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME(name) Microsoft.UI.Xaml.CustomAttributes.MUXPropertyChangedCallbackMethodName(name)
 
 // Specifies the default value for the DependencyProperty.Register call. If unspecified the default is the default 
 // for the property type (e.g. false for bool, 0 for int, 0.0 for double, "" for string, nullptr for reference types)
-#define MUX_DEFAULT_VALUE(value) muxpropertydefaultvalue(value)
+#define MUX_DEFAULT_VALUE(value) Microsoft.UI.Xaml.CustomAttributes.MUXPropertyDefaultValue(value)
 
 // Codegen infers the type of a property from the instance property's getter or an attached properties' 
 // Get{...} method. If neither of these exist then the IDL must specify the override type or the codegen
 // will produce a build error.
-#define MUX_PROPERTY_TYPE(value) muxpropertytype(value)
+#define MUX_PROPERTY_TYPE(value) Microsoft.UI.Xaml.CustomAttributes.MUXPropertyType(value)
 
 // Instance method on the owning type that can be used to validate or coerce the value.
-#define MUX_PROPERTY_VALIDATION_CALLBACK(value) muxpropertyvalidationcallback(value)
+#define MUX_PROPERTY_VALIDATION_CALLBACK(value) Microsoft.UI.Xaml.CustomAttributes.MUXPropertyValidationCallback(value)
 
 namespace MU_X_XTI_NAMESPACE
 {


### PR DESCRIPTION
Something weird happened with the 19041 SDK and Windows.Foundation.Metadata.AttributeNameAttribute appeared ... which means that the attributename attribute on our custom attributes now started showing up in the nupkg metadata. Previously it was absent. This means that consumers started requiring 19041 SDK to compile with WinUI 2.6 prerelease. This shouldn't be necessary.

It turns out the attributename attribute was being used because at the time I did all this I couldn't figure out how to use the type name of the attribute in MIDL. Turns out you use the fully qualified name minus the word "Attribute" at the end. 🤷

I removed the attributes and changed the usages. 