### PR TITLE
[RS4, RS5] Disable CommandBar animations

### DIFF
--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -141,7 +141,7 @@
                                 </VisualState>
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="DisplayModeStates">
-                                <VisualStateGroup.Transitions>
+                                <contract8Present:VisualStateGroup.Transitions>
                                     <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Background">
@@ -576,7 +576,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                </VisualStateGroup.Transitions>
+                                </contract8Present:VisualStateGroup.Transitions>
                                 <VisualState x:Name="CompactClosed" />
                                 <VisualState x:Name="CompactOpenUp">
                                     <Storyboard>


### PR DESCRIPTION
This PR addresses a bug with CommandBar in RS4 and RS5 where the entrance animation starts way below where it should be starting. This is due to some animation key frames being already disabled for RS4/RS5 because of the specific CommandBarTemplateSettings used that's only available on Windows versions > RS5. As a result, we'll be disabling CommandBar's animations for these versions for now.

Verified on RS4, RS5, and 19H1 VMs.