### PR TITLE
Revert smoke color back to dark smoke

### DIFF
--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -79,7 +79,7 @@
             <Color x:Key="CardBackgroundFillColorDefault">#0DFFFFFF</Color>
             <Color x:Key="CardBackgroundFillColorSecondary">#08FFFFFF</Color>
 
-            <Color x:Key="SmokeFillColorDefault">#332C2C2C</Color>
+            <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
 
             <Color x:Key="LayerFillColorDefault">#4C3A3A3A</Color>
             <Color x:Key="LayerFillColorAlt">#0DFFFFFF</Color>
@@ -317,7 +317,7 @@
             <Color x:Key="CardBackgroundFillColorDefault">#B3FFFFFF</Color>
             <Color x:Key="CardBackgroundFillColorSecondary">#80F6F6F6</Color>
 
-            <Color x:Key="SmokeFillColorDefault">#4DFFFFFF</Color>
+            <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
 
             <Color x:Key="LayerFillColorDefault">#80FFFFFF</Color>
             <Color x:Key="LayerFillColorAlt">#FFFFFF</Color>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR reverts smoke color back to dark smoke.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Based on user's feedback design decided to revert smoke color to dark smoke for dialog.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.