### PR TITLE
BreadcrumbBar: remove tabstop from the bar itself

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBar.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar.xaml
@@ -389,6 +389,7 @@
     
     <Style TargetType="local:BreadcrumbBar">
         <Setter Property="AutomationProperties.LandmarkType" Value="Navigation"/>
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:BreadcrumbBar">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes tabStop from the BreadcrumbBar itself.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
When focus comes from inside the BreadcrumbBar the control becomes focused. We don't want that - we only want the items inside to be focusable (kinda like ListView).
This PR removes the tabStop from the control itself.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.