### PR TITLE
[TabView] Fix issue where hitting Ctrl+F4 would not resize tabs

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -806,6 +806,40 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void VerifySizingBehaviorOnTabCloseComingFromCtrlF4()
+        {
+            int pixelTolerance = 10;
+
+            using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
+            {
+
+                Log.Comment("Verifying sizing behavior when closing a tab using Ctrl+F4");
+                CloseTabAndVerifyWidth("Tab 1", 500, "True;False;");
+
+                CloseTabAndVerifyWidth("Tab 2", 500, "True;False;");
+            }
+
+            void CloseTabAndVerifyWidth(string tabName, int expectedValue, string expectedScrollbuttonStates)
+            {
+                Log.Comment("Closing tab:" + tabName);
+                FindElement.ByName(tabName).Click();
+                KeyboardHelper.PressKey(Key.F4,ModifierKey.Control);
+                Wait.ForIdle();
+                Log.Comment("Verifying TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedValue) < pixelTolerance);
+                Verify.AreEqual(expectedScrollbuttonStates, FindElement.ByName("ScrollButtonStatus").GetText());
+
+            }
+
+            double GetActualTabViewWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewWidth"));
+
+                return Double.Parse(tabviewWidth.GetText());
+            }
+        }
+
+        [TestMethod]
         public void VerifyHeaderSizeWhenClosingLastTab()
         {
             using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -782,7 +782,7 @@ void TabView::UpdateTabContent()
     }
 }
 
-void TabView::RequestCloseTab(winrt::TabViewItem const& container)
+void TabView::RequestCloseTab(winrt::TabViewItem const& container, bool updateTabWidths)
 {
     if (auto&& listView = m_listView.get())
     {
@@ -795,7 +795,7 @@ void TabView::RequestCloseTab(winrt::TabViewItem const& container)
             internalTabViewItem->RaiseRequestClose(*args);
         }
     }
-    UpdateTabWidths(false);
+    UpdateTabWidths(updateTabWidths);
 }
 
 void TabView::OnScrollDecreaseClick(const winrt::IInspectable&, const winrt::RoutedEventArgs&)
@@ -1072,7 +1072,7 @@ bool TabView::RequestCloseCurrentTab()
         if (selectedTab.IsClosable())
         {
             // Close the tab on ctrl + F4
-            RequestCloseTab(selectedTab);
+            RequestCloseTab(selectedTab, true);
             handled = true;
         }
     }

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -112,7 +112,7 @@ public:
     void OnItemsChanged(winrt::IInspectable const& item);
     void UpdateTabContent();
 
-    void RequestCloseTab(winrt::TabViewItem const& item);
+    void RequestCloseTab(winrt::TabViewItem const& item,bool updateTabWidths);
 
     winrt::UIElement GetShadowReceiver() { return m_shadowReceiver.get(); }
 

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -220,7 +220,7 @@ void TabViewItem::RequestClose()
     {
         if (auto internalTabView = winrt::get_self<TabView>(tabView))
         {
-            internalTabView->RequestCloseTab(*this);
+            internalTabView->RequestCloseTab(*this, false);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed this by updating call to UpdateTabWidths on RequestCloseTab.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #4971
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new interaction test
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->