### PR TITLE
Fixing UniformGridLayout items-per-line evaluation

### DIFF
--- a/dev/Repeater/InteractionTests/RepeaterTests.cs
+++ b/dev/Repeater/InteractionTests/RepeaterTests.cs
@@ -36,6 +36,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             TestEnvironment.Initialize(testContext);
         }
 
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            TestCleanupHelper.Cleanup();
+        }
+
         [TestMethod]
         public void VerifyUniformGridLayoutDoesNotCreateHoles()
         {
@@ -68,9 +74,96 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        public void TestCleanup()
+        [TestMethod]
+        public void VerifyUniformGridLayoutScrolling()
         {
-            TestCleanupHelper.Cleanup();
+            using (var setup = new TestSetupHelper("ItemsRepeater Tests"))
+            {
+                // Open page
+                FindElement.ByName("UniformGridLayoutDemo").Click();
+
+                // Set ScrollViewer HorizontalScrollBarVisibility to Disabled.
+                Log.Comment("Retrieving CmbScrollViewerHorizontalScrollBarVisibility");
+                UIObject CmbScrollViewerHorizontalScrollBarVisibilityUIObject = FindElement.ByName("CmbScrollViewerHorizontalScrollBarVisibility");
+                ComboBox CmbScrollViewerHorizontalScrollBarVisibility = new ComboBox(CmbScrollViewerHorizontalScrollBarVisibilityUIObject);
+                Verify.IsNotNull(CmbScrollViewerHorizontalScrollBarVisibility, "Verifying that CmbScrollViewerHorizontalScrollBarVisibility ComboBox was found");
+
+                Log.Comment("Changing ScrollViewer HorizontalScrollBarVisibility to Disabled");
+                CmbScrollViewerHorizontalScrollBarVisibility.SelectItemByName("Disabled");
+                Log.Comment("Selection is now {0}", CmbScrollViewerHorizontalScrollBarVisibility.Selection[0].Name);
+
+                // Set ScrollViewer MaxWidth to 500.
+                Log.Comment("Retrieving ScrollViewerMaxWidth");
+                UIObject ScrollViewerMaxWidthUIObject = FindElement.ByName("ScrollViewerMaxWidth");
+                Edit ScrollViewerMaxWidthTextBox = new Edit(ScrollViewerMaxWidthUIObject);
+                Verify.IsNotNull(ScrollViewerMaxWidthTextBox, "Verifying that ScrollViewerMaxWidth Edit was found");
+                ScrollViewerMaxWidthTextBox.SetValue("500");
+                Wait.ForIdle();
+                Log.Comment("ScrollViewerMaxWidth: " + ScrollViewerMaxWidthTextBox.Value);
+
+                Log.Comment("Retrieving SetScrollViewerMaxWidth");
+                UIObject SetScrollViewerMaxWidthUIObject = FindElement.ByName("SetScrollViewerMaxWidth");
+                Button SetScrollViewerMaxWidthButton = new Button(SetScrollViewerMaxWidthUIObject);
+                Verify.IsNotNull(SetScrollViewerMaxWidthUIObject, "Verifying that SetScrollViewerMaxWidth Button was found");
+                Log.Comment("Updating ScrollViewerMaxWidth");
+                SetScrollViewerMaxWidthButton.Invoke();
+                Wait.ForIdle();
+
+                // Set UniformGridLayout ItemsStretch to Fill.
+                Log.Comment("Retrieving CmbUniformGridLayoutItemsStretch");
+                UIObject CmbUniformGridLayoutItemsStretchUIObject = FindElement.ByName("CmbUniformGridLayoutItemsStretch");
+                ComboBox CmbUniformGridLayoutItemsStretch = new ComboBox(CmbUniformGridLayoutItemsStretchUIObject);
+                Verify.IsNotNull(CmbUniformGridLayoutItemsStretch, "Verifying that CmbUniformGridLayoutItemsStretch ComboBox was found");
+
+                Log.Comment("Changing UniformGridLayout ItemsStretch to Fill");
+                CmbUniformGridLayoutItemsStretch.SelectItemByName("Fill");
+                Log.Comment("Selection is now {0}", CmbUniformGridLayoutItemsStretch.Selection[0].Name);
+
+                // Set UniformGridLayout MinColumnSpacing to 50.
+                Log.Comment("Retrieving UniformGridLayoutMinColumnSpacing");
+                UIObject UniformGridLayoutMinColumnSpacingUIObject = FindElement.ByName("UniformGridLayoutMinColumnSpacing");
+                Edit UniformGridLayoutMinColumnSpacingTextBox = new Edit(UniformGridLayoutMinColumnSpacingUIObject);
+                Verify.IsNotNull(UniformGridLayoutMinColumnSpacingTextBox, "Verifying that UniformGridLayoutMinColumnSpacing Edit was found");
+                UniformGridLayoutMinColumnSpacingTextBox.SetValue("50");
+                Wait.ForIdle();
+                Log.Comment("UniformGridLayoutMinColumnSpacing: " + UniformGridLayoutMinColumnSpacingTextBox.Value);
+
+                Log.Comment("Retrieving SetUniformGridLayoutMinColumnSpacing");
+                UIObject SetUniformGridLayoutMinColumnSpacingUIObject = FindElement.ByName("SetUniformGridLayoutMinColumnSpacing");
+                Button SetUniformGridLayoutMinColumnSpacingButton = new Button(SetUniformGridLayoutMinColumnSpacingUIObject);
+                Verify.IsNotNull(SetUniformGridLayoutMinColumnSpacingUIObject, "Verifying that SetUniformGridLayoutMinColumnSpacing Button was found");
+                Log.Comment("Updating UniformGridLayoutMinColumnSpacing");
+                SetUniformGridLayoutMinColumnSpacingButton.Invoke();
+                Wait.ForIdle();
+
+                // Set ScrollViewer VerticalOffset to 1000.
+                Log.Comment("Retrieving ScrollViewerVerticalOffset");
+                UIObject ScrollViewerVerticalOffsetUIObject = FindElement.ByName("ScrollViewerVerticalOffset");
+                Edit ScrollViewerVerticalOffsetTextBox = new Edit(ScrollViewerVerticalOffsetUIObject);
+                Verify.IsNotNull(ScrollViewerVerticalOffsetTextBox, "Verifying that ScrollViewerVerticalOffset Edit was found");
+                ScrollViewerVerticalOffsetTextBox.SetValue("1000");
+                Wait.ForIdle();
+                Log.Comment("ScrollViewerVerticalOffset: " + ScrollViewerVerticalOffsetTextBox.Value);
+
+                Log.Comment("Retrieving SetScrollViewerVerticalOffset");
+                UIObject SetScrollViewerVerticalOffsetUIObject = FindElement.ByName("SetScrollViewerVerticalOffset");
+                Button SetScrollViewerVerticalOffsetButton = new Button(SetScrollViewerVerticalOffsetUIObject);
+                Verify.IsNotNull(SetScrollViewerVerticalOffsetUIObject, "Verifying that SetScrollViewerVerticalOffset Button was found");
+                Log.Comment("Scrolling to ScrollViewer VerticalOffset 1000 by invoking SetScrollViewerVerticalOffset Button");
+                SetScrollViewerVerticalOffsetButton.Invoke();
+                Wait.ForIdle();
+
+                Log.Comment("Retrieving GetScrollViewerVerticalOffset");
+                UIObject GetScrollViewerVerticalOffsetUIObject = FindElement.ByName("GetScrollViewerVerticalOffset");
+                Button GetScrollViewerVerticalOffsetButton = new Button(GetScrollViewerVerticalOffsetUIObject);
+                Verify.IsNotNull(GetScrollViewerVerticalOffsetUIObject, "Verifying that GetScrollViewerVerticalOffset Button was found");
+                Log.Comment("Retrieving ScrollViewer VerticalOffset by invoking GetScrollViewerVerticalOffset Button");
+                GetScrollViewerVerticalOffsetButton.Invoke();
+                Wait.ForIdle();
+                Log.Comment("ScrollViewerVerticalOffset: " + ScrollViewerVerticalOffsetTextBox.Value);
+
+                Verify.AreEqual("1000", ScrollViewerVerticalOffsetTextBox.Value, "Verifying that final ScrollViewer VerticalOffset is requested 1000.");
+            }
         }
 
         [TestMethod]

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -48,7 +48,7 @@
                 <TextBox x:Name="lineSpacing" Text="10"></TextBox>
                 <TextBlock>LineAlignment</TextBlock>
                 <TextBlock>(Start/Center/End/SpaceEvenly/SpaceAround/SpaceBetween)</TextBlock>
-                <TextBox x:Name="lineAlingment" Text="Start"></TextBox>
+                <TextBox x:Name="lineAlignment" Text="Start"></TextBox>
                 <ToggleSwitch x:Name="orientation" OnContent="Horizontal" OffContent="Vertical">Scroll Orientation</ToggleSwitch>
             </StackPanel>
             <StackPanel Orientation="Horizontal">

--- a/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
+++ b/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
@@ -256,7 +256,7 @@ namespace MUXControlsTestApp
                     MinItemHeight = 150,
                     MinRowSpacing = double.Parse(itemSpacing.Text),
                     MinColumnSpacing = double.Parse(lineSpacing.Text),
-                    ItemsJustification = (UniformGridLayoutItemsJustification)Enum.Parse(typeof(UniformGridLayoutItemsJustification), lineAlingment.Text),
+                    ItemsJustification = (UniformGridLayoutItemsJustification)Enum.Parse(typeof(UniformGridLayoutItemsJustification), lineAlignment.Text),
                     Orientation = orientation.IsOn ?  Orientation.Vertical: Orientation.Horizontal,
                 };
             }
@@ -272,7 +272,7 @@ namespace MUXControlsTestApp
                 {
                     MinRowSpacing = double.Parse(itemSpacing.Text),
                     MinColumnSpacing = double.Parse(lineSpacing.Text),
-                    LineAlignment = (FlowLayoutLineAlignment)Enum.Parse(typeof(FlowLayoutLineAlignment), lineAlingment.Text),
+                    LineAlignment = (FlowLayoutLineAlignment)Enum.Parse(typeof(FlowLayoutLineAlignment), lineAlignment.Text),
                     Orientation = orientation.IsOn ? Orientation.Vertical : Orientation.Horizontal,
                 };
             }

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml
@@ -1,11 +1,12 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<Page
+<local:TestPage
     x:Class="MUXControlsTestApp.Samples.BasicDemo"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls">
 
-    <Page.Resources>
+    <local:TestPage.Resources>
         <controls:RecyclePool x:Key="RecyclePool" />
         <DataTemplate x:Key="odd" x:DataType="x:String">
             <Button Content="{x:Bind}" Foreground="Red" Width="100" Height="100" />
@@ -21,7 +22,7 @@
                 <StaticResource x:Key="even" ResourceKey="even" />
             </controls:RecyclingElementFactory.Templates>
         </controls:RecyclingElementFactory>
-    </Page.Resources>
+    </local:TestPage.Resources>
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
@@ -31,7 +32,6 @@
         </Grid.RowDefinitions>
 
         <StackPanel>
-            <Button x:Name="goBackButton">Back</Button>
             <Button Click="OnAddRecipeButton_Click" AutomationProperties.Name="InsertAtStartButton">Insert item at start</Button>
             <TextBlock x:Name="InsertAtStartChildCountLabel" AutomationProperties.Name="InsertAtStartChildCountLabel" Text="0"/>
         </StackPanel>
@@ -82,4 +82,4 @@
             </controls:ItemsRepeater>
         </-->
     </Grid>
-</Page>
+</local:TestPage>

--- a/dev/Repeater/TestUI/Samples/BasicDemo.xaml.cs
+++ b/dev/Repeater/TestUI/Samples/BasicDemo.xaml.cs
@@ -5,21 +5,19 @@ using Microsoft.UI.Xaml.Controls;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
 using SelectTemplateEventArgs = Microsoft.UI.Xaml.Controls.SelectTemplateEventArgs;
 
 namespace MUXControlsTestApp.Samples
 {
-    public sealed partial class BasicDemo : Page
+    public sealed partial class BasicDemo : TestPage
     {
         public ObservableCollection<string> simpleStringsList = new ObservableCollection<string>();
 
         public BasicDemo()
         {
             this.InitializeComponent();
-            goBackButton.Click += delegate { Frame.GoBack(); };
             repeater.ItemTemplate = elementFactory;
             var stack = repeater.Layout as StackLayout;
             int numItems = (stack != null && stack.DisableVirtualization) ? 10 : 10000;

--- a/dev/Repeater/TestUI/Samples/UniformGridLayoutDemo.cs
+++ b/dev/Repeater/TestUI/Samples/UniformGridLayoutDemo.cs
@@ -91,7 +91,7 @@ namespace MUXControlsTestApp.Samples
 
         private void SetScrollViewerHorizontalOffsetButtonClick(object sender, RoutedEventArgs e)
         {
-            ScrollViewer.ChangeView(double.Parse(ScrollViewerHorizontalOffset.Text), null, null);
+            ScrollViewer.ChangeView(double.Parse(ScrollViewerHorizontalOffset.Text), null, null, true);
         }
 
         private void GetScrollViewerVerticalOffsetButtonClick(object sender, RoutedEventArgs e)
@@ -101,7 +101,7 @@ namespace MUXControlsTestApp.Samples
 
         private void SetScrollViewerVerticalOffsetButtonClick(object sender, RoutedEventArgs e)
         {
-            ScrollViewer.ChangeView(null, double.Parse(ScrollViewerVerticalOffset.Text), null);
+            ScrollViewer.ChangeView(null, double.Parse(ScrollViewerVerticalOffset.Text), null, true);
         }
 
         private void CmbUniformGridLayoutItemsStretch_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/dev/Repeater/TestUI/Samples/UniformGridLayoutDemo.cs
+++ b/dev/Repeater/TestUI/Samples/UniformGridLayoutDemo.cs
@@ -1,19 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.UI.Xaml.Controls;
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using RecyclingElementFactory = Microsoft.UI.Xaml.Controls.RecyclingElementFactory;
-using SelectTemplateEventArgs = Microsoft.UI.Xaml.Controls.SelectTemplateEventArgs;
 
 namespace MUXControlsTestApp.Samples
 {
-    public sealed partial class UniformGridLayoutDemo : Page
+    public sealed partial class UniformGridLayoutDemo : TestPage
     {
         public IEnumerable<int> collection;
 
@@ -26,6 +22,122 @@ namespace MUXControlsTestApp.Samples
         public void GetRepeaterActualHeightButtonClick(object sender, RoutedEventArgs e)
         {
             RepeaterActualHeightLabel.Text = UniformGridRepeater.ActualHeight.ToString();
+        }
+
+        private void GetUniformGridLayoutMinColumnSpacingButtonClick(object sender, RoutedEventArgs e)
+        {
+            UniformGridLayoutMinColumnSpacing.Text = (UniformGridRepeater.Layout as UniformGridLayout).MinColumnSpacing.ToString();
+        }
+
+        private void SetUniformGridLayoutMinColumnSpacingButtonClick(object sender, RoutedEventArgs e)
+        {
+            LayoutHelper.SetMinColumnSpacing(UniformGridRepeater.Layout, double.Parse(UniformGridLayoutMinColumnSpacing.Text));
+        }
+
+        private void GetUniformGridLayoutMinRowSpacingButtonClick(object sender, RoutedEventArgs e)
+        {
+            UniformGridLayoutMinRowSpacing.Text = (UniformGridRepeater.Layout as UniformGridLayout).MinRowSpacing.ToString();
+        }
+
+        private void SetUniformGridLayoutMinRowSpacingButtonClick(object sender, RoutedEventArgs e)
+        {
+            LayoutHelper.SetMinRowSpacing(UniformGridRepeater.Layout, double.Parse(UniformGridLayoutMinRowSpacing.Text));
+        }
+
+        private void GetUniformGridLayoutMinItemWidthButtonClick(object sender, RoutedEventArgs e)
+        {
+            UniformGridLayoutMinItemWidth.Text = (UniformGridRepeater.Layout as UniformGridLayout).MinItemWidth.ToString();
+        }
+
+        private void SetUniformGridLayoutMinItemWidthButtonClick(object sender, RoutedEventArgs e)
+        {
+            (UniformGridRepeater.Layout as UniformGridLayout).MinItemWidth = double.Parse(UniformGridLayoutMinItemWidth.Text);
+        }
+
+        private void GetUniformGridLayoutMinItemHeightButtonClick(object sender, RoutedEventArgs e)
+        {
+            UniformGridLayoutMinItemHeight.Text = (UniformGridRepeater.Layout as UniformGridLayout).MinItemHeight.ToString();
+        }
+
+        private void SetUniformGridLayoutMinItemHeightButtonClick(object sender, RoutedEventArgs e)
+        {
+            (UniformGridRepeater.Layout as UniformGridLayout).MinItemHeight = double.Parse(UniformGridLayoutMinItemHeight.Text);
+        }
+
+        private void GetScrollViewerMaxWidthButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewerMaxWidth.Text = ScrollViewer.MaxWidth.ToString();
+        }
+        
+        private void SetScrollViewerMaxWidthButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewer.MaxWidth = double.Parse(ScrollViewerMaxWidth.Text);
+        }
+
+        private void GetScrollViewerMaxHeightButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewerMaxHeight.Text = ScrollViewer.MaxHeight.ToString();
+        }
+
+        private void SetScrollViewerMaxHeightButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewer.MaxHeight = double.Parse(ScrollViewerMaxHeight.Text);
+        }
+
+        private void GetScrollViewerHorizontalOffsetButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewerHorizontalOffset.Text = ScrollViewer.HorizontalOffset.ToString();
+        }
+
+        private void SetScrollViewerHorizontalOffsetButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewer.ChangeView(double.Parse(ScrollViewerHorizontalOffset.Text), null, null);
+        }
+
+        private void GetScrollViewerVerticalOffsetButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewerVerticalOffset.Text = ScrollViewer.VerticalOffset.ToString();
+        }
+
+        private void SetScrollViewerVerticalOffsetButtonClick(object sender, RoutedEventArgs e)
+        {
+            ScrollViewer.ChangeView(null, double.Parse(ScrollViewerVerticalOffset.Text), null);
+        }
+
+        private void CmbUniformGridLayoutItemsStretch_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (UniformGridRepeater != null)
+            {
+                var itemsStretch = (CmbUniformGridLayoutItemsStretch.SelectedItem as ComboBoxItem).Content.ToString();
+
+                LayoutHelper.SetItemsStretch(UniformGridRepeater.Layout, itemsStretch);
+            }
+        }
+
+        private void CmbUniformGridLayoutItemsJustification_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (UniformGridRepeater != null)
+            {
+                var itemsJustification = (CmbUniformGridLayoutItemsJustification.SelectedItem as ComboBoxItem).Content.ToString();
+
+                LayoutHelper.SetLineAlignment(UniformGridRepeater.Layout, itemsJustification);
+            }
+        }
+
+        private void CmbUniformGridLayoutOrientation_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (UniformGridRepeater != null)
+            {
+                (UniformGridRepeater.Layout as UniformGridLayout).Orientation = CmbUniformGridLayoutOrientation.SelectedIndex == 0 ? Orientation.Vertical : Orientation.Horizontal;
+            }
+        }
+
+        private void CmbScrollViewerHorizontalScrollBarVisibility_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (ScrollViewer != null)
+            {
+                ScrollViewer.HorizontalScrollBarVisibility = (ScrollBarVisibility)CmbScrollViewerHorizontalScrollBarVisibility.SelectedIndex;
+            }
         }
     }
 }

--- a/dev/Repeater/TestUI/Samples/UniformGridLayoutDemo.xaml
+++ b/dev/Repeater/TestUI/Samples/UniformGridLayoutDemo.xaml
@@ -1,11 +1,12 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<Page
+<local:TestPage
     x:Class="MUXControlsTestApp.Samples.UniformGridLayoutDemo"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls">
 
-    <Page.Resources>
+    <local:TestPage.Resources>
         <!-- The Layout specifications used: -->
         <controls:UniformGridLayout x:Name="UniformGridLayout"
                                 MinRowSpacing="8" MinColumnSpacing="8"
@@ -19,9 +20,131 @@
                     FontSize="20"/>
             </Grid>
         </DataTemplate>
-    </Page.Resources>
+    </local:TestPage.Resources>
+    
     <StackPanel Orientation="Horizontal">
-        <ScrollViewer HorizontalScrollBarVisibility="Auto" 
+        <StackPanel>
+            <StackPanel Orientation="Horizontal">
+                <Button AutomationProperties.Name="GetRepeaterActualHeightButton"
+                        Click="GetRepeaterActualHeightButtonClick" Margin="2">Get actual ItemsRepeater height</Button>
+                <TextBlock x:Name="RepeaterActualHeightLabel" AutomationProperties.Name="RepeaterActualHeightLabel" VerticalAlignment="Center" Margin="2"/>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.MinColumnSpacing:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="UniformGridLayoutMinColumnSpacing" Text="8" AutomationProperties.Name="UniformGridLayoutMinColumnSpacing" Margin="2"/>
+                <Button AutomationProperties.Name="GetUniformGridLayoutMinColumnSpacing"
+                        Click="GetUniformGridLayoutMinColumnSpacingButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetUniformGridLayoutMinColumnSpacing"
+                        Click="SetUniformGridLayoutMinColumnSpacingButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.MinRowSpacing:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="UniformGridLayoutMinRowSpacing" Text="8" AutomationProperties.Name="UniformGridLayoutMinRowSpacing" Margin="2"/>
+                <Button AutomationProperties.Name="GetUniformGridLayoutMinRowSpacing"
+                        Click="GetUniformGridLayoutMinRowSpacingButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetUniformGridLayoutMinRowSpacing"
+                        Click="SetUniformGridLayoutMinRowSpacingButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.MinItemWidth:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="UniformGridLayoutMinItemWidth" Text="0" AutomationProperties.Name="UniformGridLayoutMinItemWidth" Margin="2"/>
+                <Button AutomationProperties.Name="GetUniformGridLayoutMinItemWidth"
+                        Click="GetUniformGridLayoutMinItemWidthButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetUniformGridLayoutMinItemWidth"
+                        Click="SetUniformGridLayoutMinItemWidthButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.MinItemHeight:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="UniformGridLayoutMinItemHeight" Text="0" AutomationProperties.Name="UniformGridLayoutMinItemHeight" Margin="2"/>
+                <Button AutomationProperties.Name="GetUniformGridLayoutMinItemHeight"
+                        Click="GetUniformGridLayoutMinItemHeightButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetUniformGridLayoutMinItemHeight"
+                        Click="SetUniformGridLayoutMinItemHeightButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.ItemsStretch:" VerticalAlignment="Center" Margin="2"/>
+                <ComboBox x:Name="CmbUniformGridLayoutItemsStretch" AutomationProperties.Name="CmbUniformGridLayoutItemsStretch" SelectedIndex="0" SelectionChanged="CmbUniformGridLayoutItemsStretch_SelectionChanged" Margin="2">
+                    <ComboBoxItem>None</ComboBoxItem>
+                    <ComboBoxItem>Fill</ComboBoxItem>
+                    <ComboBoxItem>Uniform</ComboBoxItem>
+                </ComboBox>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.ItemsJustification:" VerticalAlignment="Center" Margin="2"/>
+                <ComboBox x:Name="CmbUniformGridLayoutItemsJustification" AutomationProperties.Name="CmbUniformGridLayoutItemsJustification" SelectedIndex="0" SelectionChanged="CmbUniformGridLayoutItemsJustification_SelectionChanged" Margin="2">
+                    <ComboBoxItem>Start</ComboBoxItem>
+                    <ComboBoxItem>Center</ComboBoxItem>
+                    <ComboBoxItem>End</ComboBoxItem>
+                    <ComboBoxItem>SpaceAround</ComboBoxItem>
+                    <ComboBoxItem>SpaceBetween</ComboBoxItem>
+                    <ComboBoxItem>SpaceEvenly</ComboBoxItem>
+                </ComboBox>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="UniformGridLayout.Orientation:" VerticalAlignment="Center" Margin="2"/>
+                <ComboBox x:Name="CmbUniformGridLayoutOrientation" AutomationProperties.Name="CmbUniformGridLayoutOrientation" SelectedIndex="1" SelectionChanged="CmbUniformGridLayoutOrientation_SelectionChanged" Margin="2">
+                    <ComboBoxItem>Vertical</ComboBoxItem>
+                    <ComboBoxItem>Horizontal</ComboBoxItem>
+                </ComboBox>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="ScrollViewer.MaxWidth:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="ScrollViewerMaxWidth" Text="0" AutomationProperties.Name="ScrollViewerMaxWidth" Margin="2"/>
+                <Button AutomationProperties.Name="GetScrollViewerMaxWidth"
+                        Click="GetScrollViewerMaxWidthButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetScrollViewerMaxWidth"
+                        Click="SetScrollViewerMaxWidthButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="ScrollViewer.MaxHeight:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="ScrollViewerMaxHeight" Text="0" AutomationProperties.Name="ScrollViewerMaxHeight" Margin="2"/>
+                <Button AutomationProperties.Name="GetScrollViewerMaxHeight"
+                        Click="GetScrollViewerMaxHeightButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetScrollViewerMaxHeight"
+                        Click="SetScrollViewerMaxHeightButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="ScrollViewer.HorizontalOffset:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="ScrollViewerHorizontalOffset" Text="0" AutomationProperties.Name="ScrollViewerHorizontalOffset" Margin="2"/>
+                <Button AutomationProperties.Name="GetScrollViewerHorizontalOffset"
+                        Click="GetScrollViewerHorizontalOffsetButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetScrollViewerHorizontalOffset"
+                        Click="SetScrollViewerHorizontalOffsetButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="ScrollViewer.VerticalOffset:" VerticalAlignment="Center" Margin="2"/>
+                <TextBox x:Name="ScrollViewerVerticalOffset" Text="0" AutomationProperties.Name="ScrollViewerVerticalOffset" Margin="2"/>
+                <Button AutomationProperties.Name="GetScrollViewerVerticalOffset"
+                        Click="GetScrollViewerVerticalOffsetButtonClick" Margin="2">Get</Button>
+                <Button AutomationProperties.Name="SetScrollViewerVerticalOffset"
+                        Click="SetScrollViewerVerticalOffsetButtonClick" Margin="2">Set</Button>
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="ScrollViewer.HorizontalScrollBarVisibility:" VerticalAlignment="Center" Margin="2"/>
+                <ComboBox x:Name="CmbScrollViewerHorizontalScrollBarVisibility" AutomationProperties.Name="CmbScrollViewerHorizontalScrollBarVisibility" SelectedIndex="1" SelectionChanged="CmbScrollViewerHorizontalScrollBarVisibility_SelectionChanged" Margin="2">
+                    <ComboBoxItem>Disabled</ComboBoxItem>
+                    <ComboBoxItem>Auto</ComboBoxItem>
+                    <ComboBoxItem>Hidden</ComboBoxItem>
+                    <ComboBoxItem>Visible</ComboBoxItem>
+                </ComboBox>
+            </StackPanel>
+        </StackPanel>
+
+        <ScrollViewer
+            x:Name="ScrollViewer"
+            HorizontalScrollBarVisibility="Auto" 
             HorizontalScrollMode="Auto" 
             IsVerticalScrollChainingEnabled="False"
             AutomationProperties.Name="RepeaterScrollViewer"
@@ -31,10 +154,5 @@
                 Layout="{StaticResource UniformGridLayout}"
                 ItemTemplate="{StaticResource SimpleElementTemplate}"/>
         </ScrollViewer>
-        <StackPanel>
-            <Button AutomationProperties.Name="GetRepeaterActualHeightButton"
-                    Click="GetRepeaterActualHeightButtonClick">Get actual Repeater height</Button>
-            <TextBlock x:Name="RepeaterActualHeightLabel" AutomationProperties.Name="RepeaterActualHeightLabel"/>
-        </StackPanel>
     </StackPanel>
-</Page>
+</local:TestPage>

--- a/dev/Repeater/UniformGridLayout.h
+++ b/dev/Repeater/UniformGridLayout.h
@@ -61,18 +61,19 @@ public:
         const winrt::Size& /*measureSize*/,
         const winrt::Size& /*desiredSize*/,
         const winrt::Size& /*provisionalArrangeSize*/,
-        const winrt::VirtualizingLayoutContext& /*context*/)override {}
+        const winrt::VirtualizingLayoutContext& /*context*/) override {}
     void Algorithm_OnLineArranged(
         int /*startIndex*/,
         int /*countInLine*/,
         double /*lineSize*/,
-        const winrt::VirtualizingLayoutContext& /*context*/)override {}
+        const winrt::VirtualizingLayoutContext& /*context*/) override {}
 #pragma endregion
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
 private:
     // Methods
+    int GetItemsPerLine(winrt::Size const& availableSize, winrt::VirtualizingLayoutContext const& context);
     float GetMinorSizeWithSpacing(winrt::VirtualizingLayoutContext const& context);
     float GetMajorSizeWithSpacing(winrt::VirtualizingLayoutContext const& context);
 
@@ -96,7 +97,6 @@ private:
     double LineSpacing()
     {
         return Orientation() == winrt::Orientation::Horizontal ? m_minRowSpacing: m_minColumnSpacing;
-
     }
 
     double MinItemSpacing()


### PR DESCRIPTION
## Description
The UniformGridLayout class was incorrectly evaluating the number of displayed items per line. This caused occasional jumps when scrolling an ItemsRepeater in a ScrollViewer.

## Motivation and Context
Another side effect of this bug is that requesting an offset change with ScrollViewer.ChangeView would result in an incorrect offset.

Introduced a new UniformGridLayout::GetItemsPerLine to evaluate the items-per-line value. 
The old evaluation was ignoring the fact that when there are N columns, there are only N-1 separators in-between them and not N.  This sometimes resulted in a smaller evaluated column count in a Horizontal layout.
The key code change is "+ MinItemSpacing()".

## How Has This Been Tested?
Ad-hoc testing, new MuxControlsTestApp features for UniformGridLayout test page, new unit test with that page.

Without this fix, ScrollViewer.ChangeView(...1000...) would land at offset 1216 in the new test.
