### PR TITLE
ItemsRepeater: Avoid layout cycle exception with variable sized children in StackLayout

### DIFF
--- a/dev/Repeater/APITests/Common/Mocks/MockStackLayout.cs
+++ b/dev/Repeater/APITests/Common/Mocks/MockStackLayout.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Windows.Foundation;
+
+using StackLayout = Microsoft.UI.Xaml.Controls.StackLayout;
+using VirtualizingLayoutContext = Microsoft.UI.Xaml.Controls.VirtualizingLayoutContext;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common.Mocks
+{
+    class MockStackLayout : StackLayout
+    {
+        public Func<Size, VirtualizingLayoutContext, Size> MeasureLayoutFunc { get; set; }
+        public Func<Size, VirtualizingLayoutContext, Size> ArrangeLayoutFunc { get; set; }
+
+        public new void InvalidateMeasure()
+        {
+            base.InvalidateMeasure();
+        }
+
+        protected override Size MeasureOverride(VirtualizingLayoutContext context, Size availableSize)
+        {
+            return MeasureLayoutFunc != null ? MeasureLayoutFunc(availableSize, context) : default(Size);
+        }
+
+        protected override Size ArrangeOverride(VirtualizingLayoutContext context, Size finalSize)
+        {
+            return ArrangeLayoutFunc != null ? ArrangeLayoutFunc(finalSize, context) : default(Size);
+        }
+    }
+}

--- a/dev/Repeater/APITests/Repeater_APITests.projitems
+++ b/dev/Repeater/APITests/Repeater_APITests.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Common\OrientationBasedMeasures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\RecyclingViewGeneratorDerived.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockItemsSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockStackLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockViewGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\Mocks\MockVirtualizingLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\SharedHelpers.cs" />

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -105,6 +105,7 @@ winrt::Size ItemsRepeater::MeasureOverride(winrt::Size const& availableSize)
 
         if (stackLayout && ++m_stackLayoutMeasureCounter >= s_maxStackLayoutIterations)
         {
+            REPEATER_TRACE_INFO(L"MeasureOverride shortcut - %d\n", m_stackLayoutMeasureCounter);
             // Shortcut the apparent layout cycle by returning the previous desired size.
             // This can occur when children have variable sizes that prevent the ItemsPresenter's desired size from settling.
             const winrt::Rect layoutExtent = m_viewportManager->GetLayoutExtent();

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -101,7 +101,7 @@ winrt::Size ItemsRepeater::MeasureOverride(winrt::Size const& availableSize)
 
     if (layout)
     {
-        auto const stackLayout = layout.as<winrt::StackLayout>();
+        auto const stackLayout = layout.try_as<winrt::StackLayout>();
 
         if (stackLayout && ++m_stackLayoutMeasureCounter >= s_maxStackLayoutIterations)
         {

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -42,6 +42,7 @@ ItemsRepeater::ItemsRepeater()
 
     Loaded({ this, &ItemsRepeater::OnLoaded });
     Unloaded({ this, &ItemsRepeater::OnUnloaded });
+    LayoutUpdated({ this, &ItemsRepeater::OnLayoutUpdated });
 
     // Initialize the cached layout to the default value
     auto layout = Layout().as<winrt::VirtualizingLayout>();
@@ -96,6 +97,22 @@ winrt::Size ItemsRepeater::MeasureOverride(winrt::Size const& availableSize)
         throw winrt::hresult_error(E_FAIL, L"Cannot run layout in the middle of a collection change.");
     }
 
+    auto layout = Layout();
+
+    if (layout)
+    {
+        auto const stackLayout = layout.as<winrt::StackLayout>();
+
+        if (stackLayout && ++m_stackLayoutMeasureCounter >= s_maxStackLayoutIterations)
+        {
+            // Shortcut the apparent layout cycle by returning the previous desired size.
+            // This can occur when children have variable sizes that prevent the ItemsPresenter's desired size from settling.
+            const winrt::Rect layoutExtent = m_viewportManager->GetLayoutExtent();
+            const winrt::Size desiredSize{ layoutExtent.Width - layoutExtent.X, layoutExtent.Height - layoutExtent.Y };
+            return desiredSize;
+        }
+    }
+
     m_viewportManager->OnOwnerMeasuring();
 
     m_isLayoutInProgress = true;
@@ -108,7 +125,7 @@ winrt::Size ItemsRepeater::MeasureOverride(winrt::Size const& availableSize)
     winrt::Rect extent{};
     winrt::Size desiredSize{};
 
-    if (auto layout = Layout())
+    if (layout)
     {
         auto layoutContext = GetLayoutContext();
 
@@ -499,12 +516,20 @@ void ItemsRepeater::OnLoaded(const winrt::IInspectable& /*sender*/, const winrt:
 
 void ItemsRepeater::OnUnloaded(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/)
 {
+    m_stackLayoutMeasureCounter = 0u;
+
     ++_unloadedCounter;
     // Only reset the scrollers if this unload event is in-sync.
     if (_unloadedCounter == _loadedCounter)
     {
         m_viewportManager->ResetScrollers();
     }
+}
+
+void ItemsRepeater::OnLayoutUpdated(const winrt::IInspectable& /*sender*/, const winrt::IInspectable& /*args*/)
+{
+    // Now that the layout has settled, reset the measure counter to detect the next potential StackLayout layout cycle.
+    m_stackLayoutMeasureCounter = 0u;
 }
 
 void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& oldValue, const winrt::ItemsSourceView& newValue)
@@ -520,8 +545,6 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
     {
         m_itemsSourceViewChanged.revoke();
     }
-
-   
 
     if (newValue)
     {
@@ -669,6 +692,7 @@ void ItemsRepeater::OnLayoutChanged(const winrt::Layout& oldValue, const winrt::
         oldValue.UninitializeForContext(GetLayoutContext());
         m_measureInvalidated.revoke();
         m_arrangeInvalidated.revoke();
+        m_stackLayoutMeasureCounter = 0u;
         
         // Walk through all the elements and make sure they are cleared
         auto children = Children();

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -25,6 +25,8 @@ public:
 
     // StackLayout measurements are shortcut when m_stackLayoutMeasureCounter reaches this value
     // to prevent a layout cycle exception.
+    // The XAML Framework's iteration limit is 250, but that limit has been reached in practice
+    // with this value as small as 61. It was never reached with 60. 
     static constexpr uint8_t s_maxStackLayoutIterations = 60u;
 
     static winrt::Point ClearedElementsArrangePosition;

--- a/dev/Repeater/ItemsRepeater.h
+++ b/dev/Repeater/ItemsRepeater.h
@@ -23,6 +23,10 @@ public:
     ItemsRepeater();
     ~ItemsRepeater();
 
+    // StackLayout measurements are shortcut when m_stackLayoutMeasureCounter reaches this value
+    // to prevent a layout cycle exception.
+    static constexpr uint8_t s_maxStackLayoutIterations = 60u;
+
     static winrt::Point ClearedElementsArrangePosition;
     // A convention we use in the ItemsRepeater codebase for an invalid Rect value.
     static winrt::Rect InvalidRect;
@@ -120,6 +124,7 @@ public:
 private:
     void OnLoaded(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/);
     void OnUnloaded(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/);
+    void OnLayoutUpdated(const winrt::IInspectable& /*sender*/, const winrt::IInspectable& /*args*/);
 
     void OnDataSourcePropertyChanged(const winrt::ItemsSourceView& oldValue, const winrt::ItemsSourceView& newValue);
     void OnItemTemplateChanged(const winrt::IElementFactory& oldValue, const winrt::IElementFactory& newValue);
@@ -169,6 +174,10 @@ private:
     // events. We keep these counters to detect out-of-sync unloaded events and take action to rectify.
     int _loadedCounter{};
     int _unloadedCounter{};
+
+    // Used to avoid layout cycles with StackLayout layouts where variable sized children prevent
+    // the ItemsRepeater's layout to settle.
+    uint8_t m_stackLayoutMeasureCounter{ 0u };
 
     // Bug in framework's reference tracking causes crash during
     // UIAffinityQueue cleanup. To avoid that bug, take a strong ref

--- a/dev/Repeater/ViewportManager.h
+++ b/dev/Repeater/ViewportManager.h
@@ -15,6 +15,7 @@ public:
     virtual winrt::Rect GetLayoutRealizationWindow() const = 0;
 
     virtual void SetLayoutExtent(winrt::Rect extent) = 0;
+    virtual winrt::Rect GetLayoutExtent() const = 0;
     virtual winrt::Point GetOrigin() const = 0;
 
     virtual void OnLayoutChanged(bool isVirtualizing) = 0;

--- a/dev/Repeater/ViewportManagerDownlevel.h
+++ b/dev/Repeater/ViewportManagerDownlevel.h
@@ -28,6 +28,7 @@ public:
     winrt::Rect GetLayoutRealizationWindow() const override;
 
     void SetLayoutExtent(winrt::Rect extent) override;
+    winrt::Rect GetLayoutExtent() const override { return m_layoutExtent; }
     winrt::Point GetOrigin() const override{ return winrt::Point(m_layoutExtent.X, m_layoutExtent.Y); }
 
     void OnLayoutChanged(bool isVirtualizing) override;

--- a/dev/Repeater/ViewportManagerWithPlatformFeatures.h
+++ b/dev/Repeater/ViewportManagerWithPlatformFeatures.h
@@ -30,6 +30,7 @@ public:
     winrt::Rect GetLayoutRealizationWindow() const override;
 
     void SetLayoutExtent(winrt::Rect extent) override;
+    winrt::Rect GetLayoutExtent() const override { return m_layoutExtent; }
     winrt::Point GetOrigin() const override { return winrt::Point(m_layoutExtent.X, m_layoutExtent.Y); }
 
     void OnLayoutChanged(bool isVirtualizing) override;


### PR DESCRIPTION
## Description
Putting in a guard against the XAML framework's layout cycle exception.

## Motivation and Context
When a virtualized StackLayout has variable sized children, the estimated extent for the ItemsRepeater may not settle down during a layout pass.
This results in an app crash with the E_LAYOUTCYCLE error. We shortcut the cycle by returning the previous desired size in ItemsRepeater::MeasureOverride and escape the exception.

## How Has This Been Tested?
Ad-hoc testing with repro apps. 
A regression test is being added too.
