### PR TITLE
Fix CommandBar background/foreground and appbar brush issue

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -77,7 +77,7 @@
             <StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="SystemControlBackgroundBaseLowBrush"/>
             <StaticResource x:Key="CommandBarFlyoutForeground" ResourceKey="SystemControlForegroundBaseHighBrush"/>
             <StaticResource x:Key="CommandBarFlyoutBorderBrush" ResourceKey="SystemControlForegroundTransparentBrush"/>
-            <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackground" ResourceKey="SystemControlForegroundTransparentBrush"/>
+            <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackground" ResourceKey="SystemControlTransparentBrush"/>
             <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackgroundPointerOver" ResourceKey="SystemControlBackgroundBaseLowBrush"/>
             <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumLowBrush"/>
             <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackgroundDisabled" ResourceKey="SystemControlBackgroundBaseLowBrush"/>
@@ -699,9 +699,9 @@
     </Style>
 
     <Style x:Key="DefaultCommandBarFlyoutCommandBarStyle" TargetType="local:CommandBarFlyoutCommandBar">
-        <Setter Property="Background" Value="{ThemeResource AcrylicInAppFillColorDefaultBrush}" />
-        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource SystemControlTransientBorderBrush}" />
+        <Setter Property="Background" Value="{ThemeResource CommandBarFlyoutBackground}" />
+        <Setter Property="Foreground" Value="{ThemeResource CommandBarFlyoutForeground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource CommandBarFlyoutBorderBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="VerticalAlignment" Value="Top" />


### PR DESCRIPTION
Fix CommandBarFlyout 'blank' issue on HC 

SystemControlForegroundTransparentBrush is not actually transparent in HC

CommandBarFlyoutBackground/CommandBarFlyoutForeground/CommandBarFlyoutBorderBrush is defined but never be used. Change the reference to them.

HC White
![image](https://user-images.githubusercontent.com/6290692/118056569-0ac61f80-b33f-11eb-99fc-b3f21711b1e5.png)

HC Dark
![image](https://user-images.githubusercontent.com/6290692/118056476-dce0db00-b33e-11eb-97c9-60f99b364e3a.png)

Light
![image](https://user-images.githubusercontent.com/6290692/118056705-406b0880-b33f-11eb-860b-f30cf86dc117.png)


Dark
![image](https://user-images.githubusercontent.com/6290692/118056662-31845600-b33f-11eb-8e00-b9c613ee2bb4.png)
