### PR TITLE
[ColorPicker] Fix issue where selection indicator was placed wrongly

### DIFF
--- a/dev/ColorPicker/ColorSpectrum.cpp
+++ b/dev/ColorPicker/ColorSpectrum.cpp
@@ -714,7 +714,7 @@ void ColorSpectrum::UpdateEllipse()
         // we inverted the direction of that axis in order to put more hue on the outside of the ring,
         // so we need to do similarly here when positioning the ellipse.
         if (m_componentsFromLastBitmapCreation == winrt::ColorSpectrumComponents::HueSaturation ||
-            m_componentsFromLastBitmapCreation == winrt::ColorSpectrumComponents::ValueHue)
+            m_componentsFromLastBitmapCreation == winrt::ColorSpectrumComponents::SaturationHue)
         {
             sThetaValue = 360 - sThetaValue;
             sRValue = -sRValue - 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The wrong property was chosen in selection due to a faulty if case. This is fixed now.

The issue reported in #4765 was also present when setting the ColorPicker to Saturation Hue mode. This is also being fixed by this PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #4765
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->