### PR TITLE
Add a MirroredWhenRightToLeft API to AnimatedIcon

### DIFF
--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -20,7 +20,6 @@ AnimatedIcon::AnimatedIcon()
     m_progressPropertySet = winrt::Window::Current().Compositor().CreatePropertySet();
     m_progressPropertySet.InsertScalar(s_progressPropertyName, 0);
     Loaded({ this, &AnimatedIcon::OnLoaded });
-    SizeChanged({ this, &AnimatedIcon::OnSizeChanged });
 
     RegisterPropertyChangedCallback(winrt::IconElement::ForegroundProperty(), { this, &AnimatedIcon::OnForegroundPropertyChanged});
     RegisterPropertyChangedCallback(winrt::FrameworkElement::FlowDirectionProperty(), { this, &AnimatedIcon::OnFlowDirectionPropertyChanged });
@@ -98,14 +97,6 @@ void AnimatedIcon::OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs c
     OnFallbackIconSourcePropertyChanged(nullptr);
 }
 
-void AnimatedIcon::OnSizeChanged(winrt::IInspectable const&, winrt::SizeChangedEventArgs const&)
-{
-    if (auto const scaleTransform = m_scaleTransform.get())
-    {
-        scaleTransform.CenterX(ActualWidth() / 2);
-        scaleTransform.CenterY(ActualHeight() / 2);
-    }
-}
 
 winrt::Size AnimatedIcon::MeasureOverride(winrt::Size const& availableSize)
 {
@@ -464,15 +455,15 @@ void AnimatedIcon::UpdateMirrorTransform()
             // Initialize the scale transform that will be used for mirroring and the
             // render transform origin as center in order to have the icon mirrored in place.
             winrt::Windows::UI::Xaml::Media::ScaleTransform scaleTransform;
-            scaleTransform.CenterX(ActualWidth() / 2);
-            scaleTransform.CenterY(ActualHeight() / 2);
 
             RenderTransform(scaleTransform);
+            RenderTransformOrigin({ 0.5, 0.5 });
             m_scaleTransform.set(scaleTransform);
             return scaleTransform;
         }
         return m_scaleTransform.get();
     }();
+
 
     scaleTransform.ScaleX(FlowDirection() == winrt::FlowDirection::RightToLeft && !MirroredWhenRightToLeft() && m_canDisplayPrimaryContent ? -1.0f : 1.0f);
 }

--- a/dev/AnimatedIcon/AnimatedIcon.h
+++ b/dev/AnimatedIcon/AnimatedIcon.h
@@ -21,14 +21,16 @@ public:
     // IFrameworkElement
     void OnApplyTemplate();
     void OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&);
+    void OnSizeChanged(winrt::IInspectable const&, winrt::SizeChangedEventArgs const&);
     void OnLayoutUpdatedAfterStateChanged(winrt::IInspectable const& sender, winrt::IInspectable const& args);
 
     // FrameworkElement overrides
     winrt::Size MeasureOverride(winrt::Size const& availableSize);
     winrt::Size ArrangeOverride(winrt::Size const& finalSize);
 
-    void OnSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void OnFallbackIconSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs&);
+    void OnFallbackIconSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs&);
+    void OnMirroredWhenRightToLeftPropertyChanged(const winrt::DependencyPropertyChangedEventArgs&);
     static void OnAnimatedIconStatePropertyChanged(
         const winrt::DependencyObject& sender,
         const winrt::DependencyPropertyChangedEventArgs& args);
@@ -55,11 +57,14 @@ private:
     void TrySetForegroundProperty(winrt::IAnimatedVisualSource2 const& source = nullptr);
     void OnAnimationCompleted(winrt::IInspectable const&, winrt::CompositionBatchCompletedEventArgs const&);
     void OnForegroundPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
+    void OnFlowDirectionPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void OnForegroundBrushColorPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void SetRootPanelChildToFallbackIcon();
+    void UpdateMirrorTransform();
 
     tracker_ref<winrt::IAnimatedVisual> m_animatedVisual{ this };
     tracker_ref<winrt::Panel> m_rootPanel{ this };
+    tracker_ref<winrt::Windows::UI::Xaml::Media::ScaleTransform> m_scaleTransform{ this };
 
     winrt::hstring m_currentState{ L"" };
     winrt::hstring m_previousState{ L"" };

--- a/dev/AnimatedIcon/AnimatedIcon.h
+++ b/dev/AnimatedIcon/AnimatedIcon.h
@@ -21,7 +21,6 @@ public:
     // IFrameworkElement
     void OnApplyTemplate();
     void OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&);
-    void OnSizeChanged(winrt::IInspectable const&, winrt::SizeChangedEventArgs const&);
     void OnLayoutUpdatedAfterStateChanged(winrt::IInspectable const& sender, winrt::IInspectable const& args);
 
     // FrameworkElement overrides

--- a/dev/AnimatedIcon/AnimatedIcon.idl
+++ b/dev/AnimatedIcon/AnimatedIcon.idl
@@ -22,6 +22,9 @@ unsealed runtimeclass AnimatedIcon : Windows.UI.Xaml.Controls.IconElement
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     IconSource FallbackIconSource{ get; set; };
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Boolean MirroredWhenRightToLeft{ get; set; };
+
     [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnAnimatedIconStatePropertyChanged")]
     static Windows.UI.Xaml.DependencyProperty StateProperty{ get; };
     static void SetState(Windows.UI.Xaml.DependencyObject object, String value);
@@ -29,6 +32,7 @@ unsealed runtimeclass AnimatedIcon : Windows.UI.Xaml.Controls.IconElement
 
     static Windows.UI.Xaml.DependencyProperty SourceProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty FallbackIconSourceProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty MirroredWhenRightToLeftProperty{ get; };
 }
 
 }

--- a/dev/AnimatedIcon/TestUI/AnimatedIconHost.cs
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconHost.cs
@@ -96,21 +96,7 @@ namespace MUXControlsTestApp
         {
             if (m_iconPresenter != null)
             {
-                AnimatedIcon animatedIcon = new AnimatedIcon();
-                AnimatedIconSource source = (AnimatedIconSource)IconSource;
-                if (source.Source != null)
-                {
-                    animatedIcon.Source = source.Source;
-                }
-                if (source.FallbackIconSource != null)
-                {
-                    animatedIcon.FallbackIconSource = source.FallbackIconSource;
-                }
-                if (source.Foreground != null)
-                {
-                    animatedIcon.Foreground = source.Foreground;
-                }
-                m_iconPresenter.Child = animatedIcon;
+                m_iconPresenter.Child = IconSource.CreateIconElement();
             }
         }
     }

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
@@ -149,6 +149,7 @@
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <TextBlock HorizontalAlignment="Center" Text="Animation Duration Multiplier" Grid.Row="0"/>
@@ -168,7 +169,8 @@
                     </Flyout>
                 </Button.Flyout>
             </Button>
-            <ScrollViewer Grid.Row="6">
+            <CheckBox Content="Is LeftToRight" IsChecked="True" Checked="IsLeftToRightChecked" Unchecked="IsLeftToRightUnchecked" HorizontalAlignment="Center" Grid.Row="6"/>
+            <ScrollViewer Grid.Row="7">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" Windows10FallCreatorsUpdate:Spacing="5">
                         <StackPanel>
@@ -441,7 +443,7 @@
                         <StackPanel>
                             <local:AnimatedIconHost x:Name="BackIcon_Cut" Title="AnimatedBackVisualSource" Background="DarkSlateGray" Foreground="{Binding ElementName=ForegoundColorPicker, Path=Color, Converter={StaticResource ColorToSolidColorBrushConverter}}">
                                 <local:AnimatedIconHost.IconSource>
-                                    <controls:AnimatedIconSource>
+                                    <controls:AnimatedIconSource MirroredWhenRightToLeft="True">
                                         <controls:AnimatedIconSource.Source>
                                             <animatedvisuals:AnimatedBackVisualSource/>
                                         </controls:AnimatedIconSource.Source>
@@ -458,7 +460,7 @@
                         <StackPanel>
                             <local:AnimatedIconHost x:Name="BackIcon_Queue" Title="AnimatedBackVisualSource" Background="DarkSlateGray" Foreground="{Binding ElementName=ForegoundColorPicker, Path=Color, Converter={StaticResource ColorToSolidColorBrushConverter}}">
                                 <local:AnimatedIconHost.IconSource>
-                                    <controls:AnimatedIconSource>
+                                    <controls:AnimatedIconSource MirroredWhenRightToLeft="True">
                                         <controls:AnimatedIconSource.Source>
                                             <animatedvisuals:AnimatedBackVisualSource/>
                                         </controls:AnimatedIconSource.Source>
@@ -475,7 +477,7 @@
                         <StackPanel>
                             <local:AnimatedIconHost x:Name="BackIcon_SpeedUpQueue" Title="AnimatedBackVisualSource" Background="DarkSlateGray" Foreground="{Binding ElementName=ForegoundColorPicker, Path=Color, Converter={StaticResource ColorToSolidColorBrushConverter}}">
                                 <local:AnimatedIconHost.IconSource>
-                                    <controls:AnimatedIconSource>
+                                    <controls:AnimatedIconSource MirroredWhenRightToLeft="True">
                                         <controls:AnimatedIconSource.Source>
                                             <animatedvisuals:AnimatedBackVisualSource/>
                                         </controls:AnimatedIconSource.Source>
@@ -588,6 +590,13 @@
                                 <controls:AnimatedIcon.FallbackIconSource>
                                     <controls:SymbolIconSource Symbol="AddFriend" Foreground="Purple"/>
                                 </controls:AnimatedIcon.FallbackIconSource>
+                            </controls:AnimatedIcon>
+                        </StackPanel>
+                        <StackPanel Background="DarkGreen">
+                            <controls:AnimatedIcon Height="100" Width="100" Foreground="Pink" MirroredWhenRightToLeft="True">
+                                <controls:AnimatedIcon.Source>
+                                    <animatedvisuals:AnimatedBackVisualSource/>
+                                </controls:AnimatedIcon.Source>
                             </controls:AnimatedIcon>
                         </StackPanel>
                     </StackPanel>

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml.cs
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml.cs
@@ -270,6 +270,16 @@ namespace MUXControlsTestApp
             }
         }
 
+        public void IsLeftToRightChecked(object sender, RoutedEventArgs args)
+        {
+            this.FlowDirection = FlowDirection.LeftToRight;
+        }
+
+        public void IsLeftToRightUnchecked(object sender, RoutedEventArgs args)
+        {
+            this.FlowDirection = FlowDirection.RightToLeft;
+        }
+
         private void ChangeFallbackGlyphButton_Click(object sender, RoutedEventArgs e)
         {
             boundFallback.FallbackGlyph = "\uE9AE";

--- a/dev/Generated/AnimatedIcon.properties.cpp
+++ b/dev/Generated/AnimatedIcon.properties.cpp
@@ -14,6 +14,7 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 #include "AnimatedIcon.g.cpp"
 
 GlobalDependencyProperty AnimatedIconProperties::s_FallbackIconSourceProperty{ nullptr };
+GlobalDependencyProperty AnimatedIconProperties::s_MirroredWhenRightToLeftProperty{ nullptr };
 GlobalDependencyProperty AnimatedIconProperties::s_SourceProperty{ nullptr };
 GlobalDependencyProperty AnimatedIconProperties::s_StateProperty{ nullptr };
 
@@ -34,6 +35,17 @@ void AnimatedIconProperties::EnsureProperties()
                 false /* isAttached */,
                 ValueHelper<winrt::IconSource>::BoxedDefaultValue(),
                 winrt::PropertyChangedCallback(&OnFallbackIconSourcePropertyChanged));
+    }
+    if (!s_MirroredWhenRightToLeftProperty)
+    {
+        s_MirroredWhenRightToLeftProperty =
+            InitializeDependencyProperty(
+                L"MirroredWhenRightToLeft",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::AnimatedIcon>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxedDefaultValue(),
+                winrt::PropertyChangedCallback(&OnMirroredWhenRightToLeftPropertyChanged));
     }
     if (!s_SourceProperty)
     {
@@ -62,6 +74,7 @@ void AnimatedIconProperties::EnsureProperties()
 void AnimatedIconProperties::ClearProperties()
 {
     s_FallbackIconSourceProperty = nullptr;
+    s_MirroredWhenRightToLeftProperty = nullptr;
     s_SourceProperty = nullptr;
     s_StateProperty = nullptr;
 }
@@ -72,6 +85,14 @@ void AnimatedIconProperties::OnFallbackIconSourcePropertyChanged(
 {
     auto owner = sender.as<winrt::AnimatedIcon>();
     winrt::get_self<AnimatedIcon>(owner)->OnFallbackIconSourcePropertyChanged(args);
+}
+
+void AnimatedIconProperties::OnMirroredWhenRightToLeftPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::AnimatedIcon>();
+    winrt::get_self<AnimatedIcon>(owner)->OnMirroredWhenRightToLeftPropertyChanged(args);
 }
 
 void AnimatedIconProperties::OnSourcePropertyChanged(
@@ -93,6 +114,19 @@ void AnimatedIconProperties::FallbackIconSource(winrt::IconSource const& value)
 winrt::IconSource AnimatedIconProperties::FallbackIconSource()
 {
     return ValueHelper<winrt::IconSource>::CastOrUnbox(static_cast<AnimatedIcon*>(this)->GetValue(s_FallbackIconSourceProperty));
+}
+
+void AnimatedIconProperties::MirroredWhenRightToLeft(bool value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<AnimatedIcon*>(this)->SetValue(s_MirroredWhenRightToLeftProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+    }
+}
+
+bool AnimatedIconProperties::MirroredWhenRightToLeft()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<AnimatedIcon*>(this)->GetValue(s_MirroredWhenRightToLeftProperty));
 }
 
 void AnimatedIconProperties::Source(winrt::IAnimatedVisualSource2 const& value)

--- a/dev/Generated/AnimatedIcon.properties.h
+++ b/dev/Generated/AnimatedIcon.properties.h
@@ -12,6 +12,9 @@ public:
     void FallbackIconSource(winrt::IconSource const& value);
     winrt::IconSource FallbackIconSource();
 
+    void MirroredWhenRightToLeft(bool value);
+    bool MirroredWhenRightToLeft();
+
     void Source(winrt::IAnimatedVisualSource2 const& value);
     winrt::IAnimatedVisualSource2 Source();
 
@@ -19,10 +22,12 @@ public:
     static winrt::hstring GetState(winrt::DependencyObject const& target);
 
     static winrt::DependencyProperty FallbackIconSourceProperty() { return s_FallbackIconSourceProperty; }
+    static winrt::DependencyProperty MirroredWhenRightToLeftProperty() { return s_MirroredWhenRightToLeftProperty; }
     static winrt::DependencyProperty SourceProperty() { return s_SourceProperty; }
     static winrt::DependencyProperty StateProperty() { return s_StateProperty; }
 
     static GlobalDependencyProperty s_FallbackIconSourceProperty;
+    static GlobalDependencyProperty s_MirroredWhenRightToLeftProperty;
     static GlobalDependencyProperty s_SourceProperty;
     static GlobalDependencyProperty s_StateProperty;
 
@@ -30,6 +35,10 @@ public:
     static void ClearProperties();
 
     static void OnFallbackIconSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnMirroredWhenRightToLeftPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/Generated/AnimatedIconSource.properties.cpp
+++ b/dev/Generated/AnimatedIconSource.properties.cpp
@@ -14,6 +14,7 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 #include "AnimatedIconSource.g.cpp"
 
 GlobalDependencyProperty AnimatedIconSourceProperties::s_FallbackIconSourceProperty{ nullptr };
+GlobalDependencyProperty AnimatedIconSourceProperties::s_MirroredWhenRightToLeftProperty{ nullptr };
 GlobalDependencyProperty AnimatedIconSourceProperties::s_SourceProperty{ nullptr };
 
 AnimatedIconSourceProperties::AnimatedIconSourceProperties()
@@ -35,6 +36,17 @@ void AnimatedIconSourceProperties::EnsureProperties()
                 ValueHelper<winrt::IconSource>::BoxedDefaultValue(),
                 winrt::PropertyChangedCallback(&OnFallbackIconSourcePropertyChanged));
     }
+    if (!s_MirroredWhenRightToLeftProperty)
+    {
+        s_MirroredWhenRightToLeftProperty =
+            InitializeDependencyProperty(
+                L"MirroredWhenRightToLeft",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::AnimatedIconSource>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxedDefaultValue(),
+                winrt::PropertyChangedCallback(&OnMirroredWhenRightToLeftPropertyChanged));
+    }
     if (!s_SourceProperty)
     {
         s_SourceProperty =
@@ -51,11 +63,20 @@ void AnimatedIconSourceProperties::EnsureProperties()
 void AnimatedIconSourceProperties::ClearProperties()
 {
     s_FallbackIconSourceProperty = nullptr;
+    s_MirroredWhenRightToLeftProperty = nullptr;
     s_SourceProperty = nullptr;
     IconSource::ClearProperties();
 }
 
 void AnimatedIconSourceProperties::OnFallbackIconSourcePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::AnimatedIconSource>();
+    winrt::get_self<AnimatedIconSource>(owner)->OnPropertyChanged(args);
+}
+
+void AnimatedIconSourceProperties::OnMirroredWhenRightToLeftPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
@@ -82,6 +103,19 @@ void AnimatedIconSourceProperties::FallbackIconSource(winrt::IconSource const& v
 winrt::IconSource AnimatedIconSourceProperties::FallbackIconSource()
 {
     return ValueHelper<winrt::IconSource>::CastOrUnbox(static_cast<AnimatedIconSource*>(this)->GetValue(s_FallbackIconSourceProperty));
+}
+
+void AnimatedIconSourceProperties::MirroredWhenRightToLeft(bool value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<AnimatedIconSource*>(this)->SetValue(s_MirroredWhenRightToLeftProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+    }
+}
+
+bool AnimatedIconSourceProperties::MirroredWhenRightToLeft()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<AnimatedIconSource*>(this)->GetValue(s_MirroredWhenRightToLeftProperty));
 }
 
 void AnimatedIconSourceProperties::Source(winrt::IAnimatedVisualSource2 const& value)

--- a/dev/Generated/AnimatedIconSource.properties.h
+++ b/dev/Generated/AnimatedIconSource.properties.h
@@ -12,19 +12,28 @@ public:
     void FallbackIconSource(winrt::IconSource const& value);
     winrt::IconSource FallbackIconSource();
 
+    void MirroredWhenRightToLeft(bool value);
+    bool MirroredWhenRightToLeft();
+
     void Source(winrt::IAnimatedVisualSource2 const& value);
     winrt::IAnimatedVisualSource2 Source();
 
     static winrt::DependencyProperty FallbackIconSourceProperty() { return s_FallbackIconSourceProperty; }
+    static winrt::DependencyProperty MirroredWhenRightToLeftProperty() { return s_MirroredWhenRightToLeftProperty; }
     static winrt::DependencyProperty SourceProperty() { return s_SourceProperty; }
 
     static GlobalDependencyProperty s_FallbackIconSourceProperty;
+    static GlobalDependencyProperty s_MirroredWhenRightToLeftProperty;
     static GlobalDependencyProperty s_SourceProperty;
 
     static void EnsureProperties();
     static void ClearProperties();
 
     static void OnFallbackIconSourcePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnMirroredWhenRightToLeftPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/Generated/TreeViewItem.properties.cpp
+++ b/dev/Generated/TreeViewItem.properties.cpp
@@ -82,7 +82,7 @@ void TreeViewItemProperties::EnsureProperties()
                 winrt::name_of<double>(),
                 winrt::name_of<winrt::TreeViewItem>(),
                 false /* isAttached */,
-                ValueHelper<double>::BoxValueIfNecessary(12.0),
+                ValueHelper<double>::BoxValueIfNecessary(8.0),
                 nullptr);
     }
     if (!s_HasUnrealizedChildrenProperty)

--- a/dev/IconSource/APITests/IconSourceApiTests.cs
+++ b/dev/IconSource/APITests/IconSourceApiTests.cs
@@ -252,17 +252,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 // the parent to work.
                 Verify.AreEqual(iconSource.Foreground, null);
                 //Verify.AreEqual(animatedIcon.Foreground, null);
+                Verify.AreEqual(iconSource.MirroredWhenRightToLeft, false);
+                Verify.AreEqual(animatedIcon.MirroredWhenRightToLeft, false);
 
                 Log.Comment("Validate the defaults match BitmapIcon.");
 
                 var icon = new AnimatedIcon();
                 Verify.AreEqual(icon.Source, iconSource.Source);
                 Verify.AreEqual(animatedIcon.Source, iconSource.Source);
+                Verify.AreEqual(icon.MirroredWhenRightToLeft, iconSource.MirroredWhenRightToLeft);
 
                 Log.Comment("Validate that you can change the properties.");
 
                 iconSource.Foreground = new SolidColorBrush(Windows.UI.Colors.Red);
                 iconSource.Source = source;
+                iconSource.MirroredWhenRightToLeft = true;
             });
             IdleSynchronizer.Wait();
 
@@ -274,6 +278,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.AreEqual(Windows.UI.Colors.Red, (animatedIcon.Foreground as SolidColorBrush).Color);
                 Verify.AreEqual(source, iconSource.Source);
                 Verify.AreEqual(source, animatedIcon.Source);
+                Verify.IsTrue(iconSource.MirroredWhenRightToLeft);
+                Verify.IsTrue(animatedIcon.MirroredWhenRightToLeft);
             });
         }
 

--- a/dev/IconSource/AnimatedIconSource.cpp
+++ b/dev/IconSource/AnimatedIconSource.cpp
@@ -22,6 +22,8 @@ winrt::IconElement AnimatedIconSource::CreateIconElementCore()
     {
         animatedIcon.Foreground(newForeground);
     }
+    animatedIcon.MirroredWhenRightToLeft(MirroredWhenRightToLeft());
+
     return animatedIcon;
 }
 
@@ -34,6 +36,10 @@ winrt::DependencyProperty AnimatedIconSource::GetIconElementPropertyCore(winrt::
     else if (sourceProperty == s_FallbackIconSourceProperty)
     {
         return winrt::AnimatedIcon::FallbackIconSourceProperty();
+    }
+    else if (sourceProperty == s_MirroredWhenRightToLeftProperty)
+    {
+        return winrt::AnimatedIcon::MirroredWhenRightToLeftProperty();
     }
 
     return __super::GetIconElementPropertyCore(sourceProperty);

--- a/dev/IconSource/IconSource.idl
+++ b/dev/IconSource/IconSource.idl
@@ -125,9 +125,12 @@ unsealed runtimeclass AnimatedIconSource : IconSource
     IAnimatedVisualSource2 Source{ get; set; };
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     IconSource FallbackIconSource{ get; set; };
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Boolean MirroredWhenRightToLeft{ get; set; };
 
     static Windows.UI.Xaml.DependencyProperty SourceProperty { get; };
     static Windows.UI.Xaml.DependencyProperty FallbackIconSourceProperty { get; };
+    static Windows.UI.Xaml.DependencyProperty MirroredWhenRightToLeftProperty{ get; };
 }
 
 }

--- a/dev/NavigationView/NavigationBackButton.xaml
+++ b/dev/NavigationView/NavigationBackButton.xaml
@@ -76,7 +76,8 @@
                         <local:AnimatedIcon x:Name="Content"
                             Height="16"
                             Width="16"
-                            local:AnimatedIcon.State="Normal"                                            
+                            local:AnimatedIcon.State="Normal"
+                            MirroredWhenRightToLeft="True"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             AutomationProperties.AccessibilityView="Raw">

--- a/dev/NavigationView/TestUI/Common/NavigationViewPage.xaml
+++ b/dev/NavigationView/TestUI/Common/NavigationViewPage.xaml
@@ -207,6 +207,7 @@
                         <TextBlock x:Name="ToggleButtonBackgroundColor" AutomationProperties.Name="ToggleButtonBackgroundColor"  Margin="5"/>
                         <CheckBox x:Name="MoviesEnabledCheckbox" AutomationProperties.Name="MoviesEnabledCheckbox" Content="Movies+TV Enabled" Checked="MoviesEnabledCheckbox_Checked" Unchecked="MoviesEnabledCheckbox_Unchecked" IsChecked="True"  Margin="5"/>
                         <Button x:Name="SetHeaderButton" AutomationProperties.Name="SetHeaderButton" Content="Set Header" Click="SetHeaderButton_Click"/>
+                        <CheckBox IsChecked="True" Checked="FlowDirectionCheckbox_Checked" Unchecked="FlowDirectionCheckbox_Unchecked" Content="Is LeftToRight"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal">

--- a/dev/NavigationView/TestUI/Common/NavigationViewPage.xaml.cs
+++ b/dev/NavigationView/TestUI/Common/NavigationViewPage.xaml.cs
@@ -461,6 +461,16 @@ namespace MUXControlsTestApp
             TVItem.IsEnabled = false;
         }
 
+        private void FlowDirectionCheckbox_Checked(object sender, RoutedEventArgs e)
+        {
+            this.FlowDirection = FlowDirection.LeftToRight;
+        }
+
+        private void FlowDirectionCheckbox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            this.FlowDirection = FlowDirection.RightToLeft;
+        }
+
         private void IsTitleBarAutoPaddingEnabledCheckbox_Checked(object sender, RoutedEventArgs e)
         {
             NavView.IsTitleBarAutoPaddingEnabled = true;


### PR DESCRIPTION
Some animated icons should be mirrored when the flow direction is RTL, like the BackButton. Some should not, like the checkmark.  This PR adds an API to animated icon that allows opting into mirroring on a per animated icon basis.  The default is to not mirror, which is a change in behavior.