### PR TITLE
NumberBox: Visual updates

### DIFF
--- a/dev/NumberBox/APITests/NumberBoxTests.cs
+++ b/dev/NumberBox/APITests/NumberBoxTests.cs
@@ -50,66 +50,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        public void VerifyNumberBoxCornerRadius()
-        {
-            if (Common.PlatformConfiguration.IsOSVersionLessThan(Common.OSVersion.Redstone5))
-            {
-                Log.Warning("NumberBox CornerRadius property is not available pre-rs5");
-                return;
-            }
-
-            var numberBox = SetupNumberBox();
-
-            RepeatButton spinButtonDown = null;
-            TextBox textBox = null;
-            RunOnUIThread.Execute(() =>
-            {
-                // first test: Uniform corner radius of '2' with no spin buttons shown
-                numberBox.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Hidden;
-                numberBox.CornerRadius = new CornerRadius(2);
-
-                Content.UpdateLayout();
-
-                textBox = TestUtilities.FindDescendents<TextBox>(numberBox).Where(e => e.Name == "InputBox").Single();
-                Verify.AreEqual(new CornerRadius(2, 2, 2, 2), textBox.CornerRadius);
-
-                // second test: Uniform corner radius of '2' with spin buttons in inline mode (T-rule applies now)
-                numberBox.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline;
-                Content.UpdateLayout();
-
-                spinButtonDown = TestUtilities.FindDescendents<RepeatButton>(numberBox).Where(e => e.Name == "DownSpinButton").Single();
-
-                Verify.AreEqual(new CornerRadius(2, 0, 0, 2), textBox.CornerRadius);
-                Verify.AreEqual(new CornerRadius(0, 2, 2, 0), spinButtonDown.CornerRadius);
-
-                // third test: Set uniform corner radius to '4' with spin buttons in inline mode
-                numberBox.CornerRadius = new CornerRadius(4);
-            });
-            IdleSynchronizer.Wait();
-
-            RunOnUIThread.Execute(() =>
-            {
-                // This check makes sure that updating the CornerRadius values of the numberbox in inline mode
-                // does not break the T-rule.
-                Verify.AreEqual(new CornerRadius(4, 0, 0, 4), textBox.CornerRadius);
-                Verify.AreEqual(new CornerRadius(0, 4, 4, 0), spinButtonDown.CornerRadius);
-
-                // fourth test: Update the spin button placement mode to 'compact' and verify that all corners
-                // of the textbox are now rounded again
-                numberBox.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Compact;
-                Content.UpdateLayout();
-
-                Verify.AreEqual(new CornerRadius(4), textBox.CornerRadius);
-
-                // fifth test: Check corner radius of 0 in compact mode.
-                numberBox.CornerRadius = new CornerRadius(0);
-                Content.UpdateLayout();
-
-                Verify.AreEqual(new CornerRadius(0), textBox.CornerRadius);
-            });
-        }
-
-        [TestMethod]
         public void VerifyInputScopePropogates()
         {
             var numberBox = SetupNumberBox();

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -214,6 +214,8 @@ void NumberBox::OnApplyTemplate()
 
     UpdateVisualStateForIsEnabledChange();
 
+    ReevaluateForwardedUIAName();
+
     if (ReadLocalValue(s_ValueProperty) == winrt::DependencyProperty::UnsetValue()
         && ReadLocalValue(s_TextProperty) != winrt::DependencyProperty::UnsetValue())
     {

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -68,7 +68,6 @@ private:
     void OnNumberBoxGotFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnNumberBoxLostFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnNumberBoxScroll(winrt::IInspectable const& sender, winrt::PointerRoutedEventArgs const& args);
-    void OnCornerRadiusPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
     void OnIsEnabledChanged(const winrt::IInspectable&, const winrt::DependencyPropertyChangedEventArgs&);
     void OnAutomationPropertiesNamePropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&);
 
@@ -111,8 +110,6 @@ private:
     winrt::TextBox::KeyUp_revoker m_textBoxKeyUpRevoker{};
     winrt::RepeatButton::Click_revoker m_popupUpButtonClickRevoker{};
     winrt::RepeatButton::Click_revoker m_popupDownButtonClickRevoker{};
-
-    PropertyChanged_revoker m_cornerRadiusChangedRevoker{};
 
     winrt::Control::IsEnabledChanged_revoker m_isEnabledChangedRevoker{};
 };

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -170,7 +170,7 @@
                             HorizontalAlignment="Left">
 
                             <Grid x:Name="PopupContentRoot"
-                                Padding="8"
+                                Padding="6"
                                 Background="{ThemeResource NumberBoxPopupBackground}"
                                 BorderBrush="{ThemeResource NumberBoxPopupBorderBrush}"
                                 BorderThickness="{ThemeResource NumberBoxPopupBorderThickness}"
@@ -228,7 +228,7 @@
 
                                 <RepeatButton x:Name="PopupUpSpinButton"
                                     Style="{StaticResource NumberBoxPopupSpinButtonStyle}"
-                                    Margin="0,0,0,8"
+                                    Margin="0,0,0,4"
                                     Content="&#xE70E;"/>
 
                                 <RepeatButton x:Name="PopupDownSpinButton"
@@ -245,6 +245,8 @@
                             Visibility="Collapsed"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
+                            Margin="4,0,0,0"
+                            IsTabStop="False"
                             AutomationProperties.AccessibilityView="Raw">
                             <Button.Template>
                                 <ControlTemplate TargetType="Button">
@@ -301,8 +303,8 @@
         <Style.Setters>
             <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
             <Setter Property="IsTabStop" Value="False"/>
-            <Setter Property="Width" Value="30"/>
-            <Setter Property="Height" Value="30"/>
+            <Setter Property="Width" Value="36"/>
+            <Setter Property="Height" Value="36"/>
             <Setter Property="Padding" Value="0"/>
             <Setter Property="BorderThickness" Value="{ThemeResource NumberBoxPopupSpinButtonBorderThickness}"/>
             <Setter Property="FontSize" Value="16"/>

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -38,7 +38,7 @@
                                     <VisualState.Setters>
                                         <Setter Target="DownSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="UpSpinButton.Visibility" Value="Visible" />
-                                        <contract7Present:Setter Target="InputBox.CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}" />
+                                        <Setter Target="InputEater.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -74,18 +74,42 @@
                             <ResourceDictionary>
                                 <ResourceDictionary.ThemeDictionaries>
                                     <ResourceDictionary x:Key="Light">
-                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlBorderBrush"/>
-                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlBorderBrush"/>
+                                        <StaticResource x:Key="RepeatButtonBackground" ResourceKey="TextControlButtonBackground" />
+                                        <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="TextControlButtonBackgroundPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="TextControlButtonBackgroundPressed" />
+                                        <StaticResource x:Key="RepeatButtonForeground" ResourceKey="TextControlButtonForeground" />
+                                        <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="TextControlButtonForegroundPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="TextControlButtonForegroundPressed" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="TextControlButtonBorderBrush" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlButtonBorderBrushPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlButtonBorderBrushPressed" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="TextControlButtonBorderBrush" />
                                     </ResourceDictionary>
 
                                     <ResourceDictionary x:Key="Dark">
-                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlBorderBrush"/>
-                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlBorderBrush"/>
+                                        <StaticResource x:Key="RepeatButtonBackground" ResourceKey="TextControlButtonBackground" />
+                                        <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="TextControlButtonBackgroundPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="TextControlButtonBackgroundPressed" />
+                                        <StaticResource x:Key="RepeatButtonForeground" ResourceKey="TextControlButtonForeground" />
+                                        <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="TextControlButtonForegroundPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="TextControlButtonForegroundPressed" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="TextControlButtonBorderBrush" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlButtonBorderBrushPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlButtonBorderBrushPressed" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="TextControlButtonBorderBrush" />
                                     </ResourceDictionary>
 
                                     <ResourceDictionary x:Key="HighContrast">
-                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
-                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
+                                        <StaticResource x:Key="RepeatButtonBackground" ResourceKey="TextControlButtonBackground" />
+                                        <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="TextControlButtonBackgroundPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="TextControlButtonBackgroundPressed" />
+                                        <StaticResource x:Key="RepeatButtonForeground" ResourceKey="TextControlButtonForeground" />
+                                        <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="TextControlButtonForegroundPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="TextControlButtonForegroundPressed" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="TextControlButtonBorderBrush" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlButtonBorderBrushPointerOver" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlButtonBorderBrushPressed" />
+                                        <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="TextControlButtonBorderBrush" />
                                     </ResourceDictionary>
                                 </ResourceDictionary.ThemeDictionaries>
                             </ResourceDictionary>
@@ -119,6 +143,8 @@
 
                         <TextBox x:Name="InputBox"
                             Grid.Row="1"
+                            Grid.ColumnSpan="3"
+                            Style="{StaticResource NumberBoxTextBoxStyle}"
                             InputScope="{TemplateBinding InputScope}"
                             PlaceholderText="{TemplateBinding PlaceholderText}"
                             contract7Present:SelectionFlyout="{TemplateBinding SelectionFlyout}"
@@ -144,6 +170,7 @@
                             HorizontalAlignment="Left">
 
                             <Grid x:Name="PopupContentRoot"
+                                Padding="8"
                                 Background="{ThemeResource NumberBoxPopupBackground}"
                                 BorderBrush="{ThemeResource NumberBoxPopupBorderBrush}"
                                 BorderThickness="{ThemeResource NumberBoxPopupBorderThickness}"
@@ -154,8 +181,54 @@
                                     <RowDefinition Height="*"/>
                                 </Grid.RowDefinitions>
 
+                                <Grid.Resources>
+                                    <ResourceDictionary>
+                                        <ResourceDictionary.ThemeDictionaries>
+                                            <ResourceDictionary x:Key="Light">
+                                                <StaticResource x:Key="RepeatButtonBackground" ResourceKey="TextControlButtonBackground" />
+                                                <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="TextControlButtonBackgroundPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="TextControlButtonBackgroundPressed" />
+                                                <StaticResource x:Key="RepeatButtonForeground" ResourceKey="TextControlButtonForeground" />
+                                                <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="TextControlButtonForegroundPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="TextControlButtonForegroundPressed" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="TextControlButtonBorderBrush" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlButtonBorderBrushPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlButtonBorderBrushPressed" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="TextControlButtonBorderBrush" />
+                                            </ResourceDictionary>
+
+                                            <ResourceDictionary x:Key="Dark">
+                                                <StaticResource x:Key="RepeatButtonBackground" ResourceKey="TextControlButtonBackground" />
+                                                <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="TextControlButtonBackgroundPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="TextControlButtonBackgroundPressed" />
+                                                <StaticResource x:Key="RepeatButtonForeground" ResourceKey="TextControlButtonForeground" />
+                                                <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="TextControlButtonForegroundPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="TextControlButtonForegroundPressed" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="TextControlButtonBorderBrush" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlButtonBorderBrushPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlButtonBorderBrushPressed" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="TextControlButtonBorderBrush" />
+                                            </ResourceDictionary>
+
+                                            <ResourceDictionary x:Key="HighContrast">
+                                                <StaticResource x:Key="RepeatButtonBackground" ResourceKey="TextControlButtonBackground" />
+                                                <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="TextControlButtonBackgroundPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="TextControlButtonBackgroundPressed" />
+                                                <StaticResource x:Key="RepeatButtonForeground" ResourceKey="TextControlButtonForeground" />
+                                                <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="TextControlButtonForegroundPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="TextControlButtonForegroundPressed" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="TextControlButtonBorderBrush" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="TextControlButtonBorderBrushPointerOver" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="TextControlButtonBorderBrushPressed" />
+                                                <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="TextControlButtonBorderBrush" />
+                                            </ResourceDictionary>
+                                        </ResourceDictionary.ThemeDictionaries>
+                                    </ResourceDictionary>
+                                </Grid.Resources>
+
                                 <RepeatButton x:Name="PopupUpSpinButton"
                                     Style="{StaticResource NumberBoxPopupSpinButtonStyle}"
+                                    Margin="0,0,0,8"
                                     Content="&#xE70E;"/>
 
                                 <RepeatButton x:Name="PopupDownSpinButton"
@@ -165,25 +238,40 @@
                             </Grid>
                         </Popup>
 
+                        <Button x:Name="InputEater"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            Visibility="Collapsed"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            AutomationProperties.AccessibilityView="Raw">
+                            <Button.Template>
+                                <ControlTemplate TargetType="Button">
+                                    <Grid Background="Transparent"/>
+                                </ControlTemplate>
+                            </Button.Template>
+                        </Button>
+
                         <RepeatButton x:Name="UpSpinButton"
                             Grid.Row="1"
                             Grid.Column="1"
                             Visibility="Collapsed"
                             FontSize="{TemplateBinding FontSize}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
                             Content="&#xE70E;"
                             Style="{StaticResource NumberBoxSpinButtonStyle}"
-                            contract7Present:CornerRadius="0"/>
+                            Margin="4"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"/>
 
                         <RepeatButton x:Name="DownSpinButton"
                             Grid.Row="1"
                             Grid.Column="2"
                             Visibility="Collapsed"
                             FontSize="{TemplateBinding FontSize}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
                             Content="&#xE70D;"
                             Style="{StaticResource NumberBoxSpinButtonStyle}"
-                            contract7Present:CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}" />
+                            Margin="0,4,4,4"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}" />
 
                         <ContentPresenter x:Name="DescriptionPresenter"
                             Grid.Row="2"
@@ -200,11 +288,11 @@
     <Style x:Name="NumberBoxSpinButtonStyle" TargetType="RepeatButton" BasedOn="{StaticResource DefaultRepeatButtonStyle}">
         <Style.Setters>
             <Setter Property="IsTabStop" Value="False"/>
-            <Setter Property="MinWidth" Value="34"/>
+            <Setter Property="MinWidth" Value="32"/>
+            <Setter Property="Padding" Value="0"/>
             <Setter Property="VerticalAlignment" Value="Stretch"/>
-            <Setter Property="Background" Value="{ThemeResource TextControlBackground}"/>
-            <Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}"/>
             <Setter Property="BorderThickness" Value="{ThemeResource NumberBoxSpinButtonBorderThickness}"/>
+            <Setter Property="FontSize" Value="12"/>
             <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
         </Style.Setters>
     </Style>
@@ -213,10 +301,13 @@
         <Style.Setters>
             <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
             <Setter Property="IsTabStop" Value="False"/>
-            <Setter Property="Width" Value="40"/>
-            <Setter Property="Background" Value="{ThemeResource NumberBoxPopupSpinButtonBackground}"/>
+            <Setter Property="Width" Value="30"/>
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="Padding" Value="0"/>
             <Setter Property="BorderThickness" Value="{ThemeResource NumberBoxPopupSpinButtonBorderThickness}"/>
+            <Setter Property="FontSize" Value="16"/>
             <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
+            <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
         </Style.Setters>
     </Style>
 
@@ -231,11 +322,12 @@
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Button">
                                             <Grid x:Name="ButtonLayoutGrid"
+                                                Margin="{ThemeResource TextBoxInnerButtonMargin}"
                                                 BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
                                                 Background="{ThemeResource TextControlButtonBackground}"
                                                 contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                contract7NotPresent:CornerRadius="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource RightCornerRadiusFilterConverter}}">
+                                                contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
                                                 <VisualStateManager.VisualStateGroups>
                                                     <VisualStateGroup x:Name="CommonStates">
                                                         <VisualState x:Name="Normal" />
@@ -362,8 +454,8 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
-
                             </VisualStateGroup>
+                            
                             <VisualStateGroup x:Name="ButtonStates">
                                 <VisualState x:Name="ButtonVisible">
 
@@ -378,7 +470,20 @@
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="ButtonCollapsed" />
+                            </VisualStateGroup>
 
+                            <VisualStateGroup x:Name="SpinButtonStates">
+                                <VisualState x:Name="SpinButtonsCollapsed" />
+                                <VisualState x:Name="SpinButtonsPopup">
+                                    <VisualState.Setters>
+                                        <Setter Target="PopupIndicator.Visibility" Value="Visible" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="SpinButtonsVisible">
+                                    <VisualState.Setters>
+                                        <Setter Target="DeleteButton.Margin" Value="0,0,72,0" />
+                                    </VisualState.Setters>
+                                </VisualState>
                             </VisualStateGroup>
 
                         </VisualStateManager.VisualStateGroups>
@@ -455,14 +560,14 @@
                             Grid.Column="1"
                             Style="{StaticResource DeleteButtonStyle}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            contract7Present:CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                             Padding="{ThemeResource HelperButtonThemePadding}"
                             IsTabStop="False"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw"
                             FontSize="{TemplateBinding FontSize}"
                             HorizontalAlignment="Right"
-                            MinWidth="34"
+                            MinWidth="40"
                             VerticalAlignment="Stretch" />
                         <contract7Present:ContentPresenter x:Name="DescriptionPresenter"
                             Grid.Row="2"
@@ -473,9 +578,10 @@
                             AutomationProperties.AccessibilityView="Raw"
                             x:Load="False"/>
 
-                        <TextBlock
+                        <TextBlock x:Name="PopupIndicator"
                             Grid.Row="1"
                             Grid.Column="2"
+                            Visibility="Collapsed"
                             Margin="{StaticResource NumberBoxPopupIndicatorMargin}"
                             Foreground="{ThemeResource NumberBoxPopupIndicatorForeground}"
                             VerticalAlignment="Center"

--- a/dev/NumberBox/NumberBox_themeresources.xaml
+++ b/dev/NumberBox/NumberBox_themeresources.xaml
@@ -55,8 +55,8 @@
     <Thickness x:Key="NumberBoxSpinButtonBorderThickness">0,1,1,1</Thickness>
     <Thickness x:Key="NumberBoxIconMargin">10,0,0,0</Thickness>
 
-    <x:Double x:Key="NumberBoxPopupHorizonalOffset">-20</x:Double>
-    <x:Double x:Key="NumberBoxPopupVerticalOffset">-16</x:Double>
+    <x:Double x:Key="NumberBoxPopupHorizonalOffset">-21</x:Double>
+    <x:Double x:Key="NumberBoxPopupVerticalOffset">-27</x:Double>
     <x:Double x:Key="NumberBoxPopupShadowDepth">16</x:Double>
 
     <Thickness x:Key="NumberBoxPopupIndicatorMargin">0,0,8,0</Thickness>


### PR DESCRIPTION
The main change here is that the inline spin buttons are hovering above the inner TextBox, so that the TextBox border extends around the entire control. The good news is that corners are now no big deal and we can remove corner-specific code. The bad news is that when the spin buttons are disabled (a likely scenario at least part of the time) we don't want the TextBox taking hover as input, so I created an InputEater button in the template which solves the problem. (I don't _love_ that it's a button; if you have alternate suggestions I'm all ears.)