### PR TITLE
RadioMenuFlyoutItem destructor fix

### DIFF
--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
@@ -27,9 +27,9 @@ RadioMenuFlyoutItem::RadioMenuFlyoutItem()
 RadioMenuFlyoutItem::~RadioMenuFlyoutItem()
 {
     // If this is the checked item, remove it from the lookup.
-    if (IsChecked())
+    if (m_isChecked)
     {
-        SharedHelpers::EraseIfExists(*s_selectionMap, GroupName());
+        SharedHelpers::EraseIfExists(*s_selectionMap, m_groupName);
     }
 }
 
@@ -46,6 +46,11 @@ void RadioMenuFlyoutItem::OnPropertyChanged(const winrt::DependencyPropertyChang
             m_isSafeUncheck = false;
             UpdateCheckedItemInGroup();
         }
+        m_isChecked = IsChecked();
+    }
+    else if (property == s_GroupNameProperty)
+    {
+        m_groupName = GroupName();
     }
 }
 

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.h
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.h
@@ -59,6 +59,10 @@ private:
 
     void UpdateCheckedItemInGroup();
 
+    // Copies of IsChecked & GroupName to avoid using those dependency properties in the ~RadioMenuFlyoutItem() destructor which would lead to crashes.
+    bool m_isChecked{ false };
+    winrt::hstring m_groupName{ L"" };
+
     bool m_isSafeUncheck{ false };
 
     PropertyChanged_revoker m_InternalIsCheckedChangedRevoker{};


### PR DESCRIPTION
The RadioMenuFlyoutItem class destructor was accessing its own dependency properties IsChecked and GroupName which could lead to crashes. 
Now we make copies of those two dependency properties and use them in the destructor.  Tested with MuxControlTestApp and all looks good.

BTW, I went through all the controls and did not find any other such case to fix.