### PR TITLE
Temporarily disabling test ApiTests.CalendarViewTests.VerifyVisualTree

### DIFF
--- a/dev/CommonStyles/APITests/CalendarViewTests.cs
+++ b/dev/CommonStyles/APITests/CalendarViewTests.cs
@@ -22,7 +22,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
     public class CalendarViewTests : ApiTestBase
-    {        
+    {
         [TestMethod]
         [TestProperty("Ignore", "True")] // Internal bug 33335709 - Address inconsistent property order in dump.
         public void VerifyVisualTree()

--- a/dev/CommonStyles/APITests/CalendarViewTests.cs
+++ b/dev/CommonStyles/APITests/CalendarViewTests.cs
@@ -22,8 +22,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
     [TestClass]
     public class CalendarViewTests : ApiTestBase
-    {
+    {        
         [TestMethod]
+        [TestProperty("Ignore", "True")] // Internal bug 33335709 - Address inconsistent property order in dump.
         public void VerifyVisualTree()
         {
             CalendarView calendarView = null;


### PR DESCRIPTION
This test was failing in some pipelines because the properties get dumped in an inconsistent order. Internal bug 33335709 is tracking this issue.