### PR TITLE
TabView: remove shadowcaster when using updated style

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -90,7 +90,10 @@ void TabView::OnApplyTemplate()
 
     if (!SharedHelpers::Is21H1OrHigher())
     {
-        m_shadowReceiver.set(GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected));
+        if (auto shadowReceiver = GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected))
+        {
+            m_shadowReceiver.set(shadowReceiver);
+        }
     }
 
     m_listView.set([this, controlProtected]() {

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -9,6 +9,7 @@
 #include "DoubleUtil.h"
 #include "RuntimeProfiler.h"
 #include "ResourceAccessor.h"
+#include "XamlControlsResources.h"
 #include "SharedHelpers.h"
 #include <Vector.h>
 
@@ -139,7 +140,7 @@ void TabView::OnApplyTemplate()
 
     if (SharedHelpers::IsThemeShadowAvailable())
     {
-        if (!SharedHelpers::Is21H1OrHigher())
+        if (!SharedHelpers::Is21H1OrHigher() && !XamlControlsResources::IsUsingControlsResourcesVersion2())
         {
             if (auto shadowCaster = GetTemplateChildT<winrt::Grid>(L"ShadowCaster", controlProtected))
             {
@@ -150,6 +151,8 @@ void TabView::OnApplyTemplate()
 
                 const auto currentTranslation = shadowCaster.Translation();
                 const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
+
+                shadowCaster.Visibility(winrt::Visibility::Visible);
                 shadowCaster.Translation(translation);
 
                 shadowCaster.Shadow(shadow);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -90,10 +90,7 @@ void TabView::OnApplyTemplate()
 
     if (!SharedHelpers::Is21H1OrHigher())
     {
-        if (auto shadowReceiver = GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected))
-        {
-            m_shadowReceiver.set(shadowReceiver);
-        }
+        m_shadowReceiver.set(GetTemplateChildT<winrt::Grid>(L"ShadowReceiver", controlProtected));
     }
 
     m_listView.set([this, controlProtected]() {

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -140,7 +140,7 @@ void TabView::OnApplyTemplate()
 
     if (SharedHelpers::IsThemeShadowAvailable())
     {
-        if (!SharedHelpers::Is21H1OrHigher() && !XamlControlsResources::IsUsingControlsResourcesVersion2())
+        if (!SharedHelpers::Is21H1OrHigher())
         {
             if (auto shadowCaster = GetTemplateChildT<winrt::Grid>(L"ShadowCaster", controlProtected))
             {
@@ -152,7 +152,6 @@ void TabView::OnApplyTemplate()
                 const auto currentTranslation = shadowCaster.Translation();
                 const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
 
-                shadowCaster.Visibility(winrt::Visibility::Visible);
                 shadowCaster.Translation(translation);
 
                 shadowCaster.Shadow(shadow);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -9,7 +9,6 @@
 #include "DoubleUtil.h"
 #include "RuntimeProfiler.h"
 #include "ResourceAccessor.h"
-#include "XamlControlsResources.h"
 #include "SharedHelpers.h"
 #include <Vector.h>
 
@@ -151,7 +150,6 @@ void TabView::OnApplyTemplate()
 
                 const auto currentTranslation = shadowCaster.Translation();
                 const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
-
                 shadowCaster.Translation(translation);
 
                 shadowCaster.Shadow(shadow);

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -87,6 +87,7 @@
 
                         <!-- We don't want this to take space on the second row in case the user isn't using tab content. -->
                         <Grid x:Name="ShadowCaster"
+                            Visibility="Collapsed"
                             Grid.Row="0"
                             Height="10"
                             Margin="0,0,0,-10"

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -45,9 +45,6 @@
                                 Content="{TemplateBinding TabStripHeader}"
                                 ContentTemplate="{TemplateBinding TabStripHeaderTemplate}"/>
 
-                            <Grid x:Name="ShadowReceiver"
-                                 Grid.ColumnSpan="4"/>
-
                             <primitives:TabViewListView
                                 Grid.Column="1"
                                 x:Name="TabListView"
@@ -84,15 +81,6 @@
                                 ContentTemplate="{TemplateBinding TabStripFooterTemplate}"/>
 
                         </Grid>
-
-                        <!-- We don't want this to take space on the second row in case the user isn't using tab content. -->
-                        <Grid x:Name="ShadowCaster"
-                            Visibility="Collapsed"
-                            Grid.Row="0"
-                            Height="10"
-                            Margin="0,0,0,-10"
-                            VerticalAlignment="Bottom"
-                            Background="Transparent"/>
 
                         <ContentPresenter x:Name="TabContentPresenter"
                             Grid.Row="1"

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -71,7 +71,10 @@ void TabViewItem::OnApplyTemplate()
                 winrt::ThemeShadow shadow;
                 if (!SharedHelpers::Is21H1OrHigher())
                 {
-                    shadow.Receivers().Append(internalTabView->GetShadowReceiver());
+                    if (auto shadowReceiver = internalTabView->GetShadowReceiver())
+                    {
+                        shadow.Receivers().Append(shadowReceiver);
+                    }
                 }
                 m_shadow = shadow;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the shadowCaster and shadowReceiver when using updated style.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Because we don't need the shadow with the updated TabView I removed both ShadowCaster and ShadowReceiver
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.