### PR TITLE
Fixing SplitButton's handling on keyboard input

### DIFF
--- a/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -88,12 +88,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Click primary button to execute command");
                 ClickPrimaryButton(splitButton);
                 Verify.AreEqual("1", executeCountTextBlock.DocumentText);
-                
+
+                Log.Comment("Click primary button with SPACE key to execute command");
+                ClickPrimaryButtonWithKey(splitButton, "SPACE");
+                Verify.AreEqual("2", executeCountTextBlock.DocumentText);
+
+                Log.Comment("Click primary button with ENTER key to execute command");
+                ClickPrimaryButtonWithKey(splitButton, "ENTER");
+                Verify.AreEqual("3", executeCountTextBlock.DocumentText);
+
                 Log.Comment("Verify that setting CanExecute to false disables the primary button");
                 canExecuteCheckBox.Uncheck();
                 Wait.ForIdle();
                 ClickPrimaryButton(splitButton);
-                Verify.AreEqual("1", executeCountTextBlock.DocumentText);
+                Verify.AreEqual("3", executeCountTextBlock.DocumentText);
             }
         }
 
@@ -267,6 +275,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             Log.Comment("Click primary button area");
             splitButton.Click(PointerButtons.Primary, 5, splitButton.BoundingRectangle.Height / 2);
+            Wait.ForIdle();
+        }
+
+        public void ClickPrimaryButtonWithKey(SplitButton splitButton, string key)
+        {
+            Log.Comment("Click primary button area with %s key", key);
+            splitButton.SendKeys("{" + key + "}");
             Wait.ForIdle();
         }
 

--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -239,6 +239,19 @@ void SplitButton::CloseFlyout()
     }
 }
 
+void SplitButton::ExecuteCommand()
+{
+    if (const auto& command = Command())
+    {
+        const auto& commandParameter = CommandParameter();
+
+        if (command.CanExecute(commandParameter))
+        {
+            command.Execute(commandParameter);
+        }
+    }
+}
+
 void SplitButton::OnFlyoutOpened(const winrt::IInspectable& sender, const winrt::IInspectable& args)
 {
     m_isFlyoutOpen = true;
@@ -313,6 +326,7 @@ void SplitButton::OnSplitButtonKeyUp(const winrt::IInspectable& sender, const wi
         if (IsEnabled())
         {
             OnClickPrimary(nullptr, nullptr);
+            ExecuteCommand();
             args.Handled(true);
         }
     }

--- a/dev/SplitButton/SplitButton.h
+++ b/dev/SplitButton/SplitButton.h
@@ -34,15 +34,15 @@ public:
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
-private:
-
-    void OnVisualPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
-
 protected:
     bool m_hasLoaded{ false };
 
 private:
+    void ExecuteCommand();
+    void RegisterFlyoutEvents();
     void UnregisterEvents();
+
+    void OnVisualPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
 
     // Internal event handlers
     void OnClickSecondary(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
@@ -55,8 +55,6 @@ private:
     void OnPointerEvent(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
     void OnSplitButtonKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
     void OnSplitButtonKeyUp(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
-
-    void RegisterFlyoutEvents();
 
     tracker_ref<winrt::Button> m_primaryButton{ this };
     tracker_ref<winrt::Button> m_secondaryButton{ this };


### PR DESCRIPTION
The SplitButton did not trigger its Command with keyboard input. It now does the same processing as the OS Xaml ButtonBase. 
Updated the interactive test accordingly. 