### PR TITLE
TeachingTip: update Action/Close button placement and add word wrapping to the buttons

### DIFF
--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -48,26 +48,26 @@
                                     <VisualState.Setters>
                                         <Setter Target="CloseButton.Visibility" Value="Collapsed"/>
                                         <Setter Target="ActionButton.Visibility" Value="Visible"/>
-                                        <Setter Target="ActionButton.(Grid.Column)" Value="1"/>
-                                        <Setter Target="ActionButton.Margin" Value="{StaticResource TeachingTipRightButtonMargin}"/>
+                                        <Setter Target="ActionButton.(Grid.ColumnSpan)" Value="2"/>
+                                        <Setter Target="ActionButton.Margin" Value="{ThemeResource TeachingTipButtonPanelMargin}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CloseButtonVisible">
                                     <VisualState.Setters>
                                         <Setter Target="CloseButton.Visibility" Value="Visible"/>
-                                        <Setter Target="CloseButton.Margin" Value="{StaticResource TeachingTipRightButtonMargin}"/>
-
+                                        <Setter Target="CloseButton.Margin" Value="{ThemeResource TeachingTipButtonPanelMargin}"/>
+                                        <Setter Target="CloseButton.(Grid.Column)" Value="0"/>
+                                        <Setter Target="CloseButton.(Grid.ColumnSpan)" Value="2"/>
                                         <Setter Target="ActionButton.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="BothButtonsVisible">
                                     <VisualState.Setters>
                                         <Setter Target="CloseButton.Visibility" Value="Visible"/>
-                                        <Setter Target="CloseButton.Margin" Value="{StaticResource TeachingTipRightButtonMargin}"/>
-
+                                        <Setter Target="CloseButton.Margin" Value="{ThemeResource TeachingTipRightButtonMargin}"/>
                                         <Setter Target="ActionButton.Visibility" Value="Visible"/>
                                         <Setter Target="ActionButton.(Grid.Column)" Value="0"/>
-                                        <Setter Target="ActionButton.Margin" Value="{StaticResource TeachingTipLeftButtonMargin}"/>
+                                        <Setter Target="ActionButton.Margin" Value="{ThemeResource TeachingTipLeftButtonMargin}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -390,17 +390,19 @@
                                                     </Grid.ColumnDefinitions>
                                                     <Button x:Name="ActionButton"
                                                             HorizontalAlignment="Stretch"
-                                                            Content="{TemplateBinding ActionButtonContent}"
                                                             Style="{TemplateBinding ActionButtonStyle}" 
                                                             Command="{TemplateBinding ActionButtonCommand}"
-                                                            CommandParameter="{TemplateBinding ActionButtonCommandParameter}"/>
+                                                            CommandParameter="{TemplateBinding ActionButtonCommandParameter}">
+                                                            <ContentPresenter TextWrapping="WrapWholeWords" Content="{TemplateBinding ActionButtonContent}"/>
+						    </Button>
                                                     <Button x:Name="CloseButton"
                                                             HorizontalAlignment="Stretch"
-                                                            Content="{TemplateBinding CloseButtonContent}"
                                                             Style="{TemplateBinding CloseButtonStyle}"
                                                             Command="{TemplateBinding CloseButtonCommand}"
                                                             CommandParameter="{TemplateBinding CloseButtonCommandParameter}"
-                                                            Grid.Column="1"/>
+                                                            Grid.Column="1">
+					    		    <ContentPresenter TextWrapping="WrapWholeWords" Content="{TemplateBinding CloseButtonContent}"/>
+						    </Button>
                                                 </Grid>
                                             </StackPanel>
                                         </ScrollViewer>

--- a/dev/TeachingTip/TeachingTip_rs1_themeresources.xaml
+++ b/dev/TeachingTip/TeachingTip_rs1_themeresources.xaml
@@ -43,6 +43,7 @@
     <x:Double x:Key="TeachingTipMinWidth">320</x:Double>
     <x:Double x:Key="TeachingTipMaxWidth">336</x:Double>
 
+    <Thickness x:Key="TeachingTipButtonPanelMargin">0,12,0,0</Thickness>
     <Thickness x:Key="TeachingTipRightButtonMargin">4,12,0,0</Thickness>
     <Thickness x:Key="TeachingTipLeftButtonMargin">0,12,4,0</Thickness>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates Close/Action button placement when there is only one of them.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #3513. Before this fix, when there's only Close or Action button - it will not take all the space given but will be aligned in the right column. Now it will take all the space it has. User can supply their own style of the button to limit the size if desired.
 This PR also adds word wrapping to the buttons so they can wrap bigger text than their default size allows.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.