### PR TITLE
CommandBarFlyoutCommandBar should honor the "Show animations in Windows" setting on open and close

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -426,7 +426,7 @@ void CommandBarFlyoutCommandBar::DetachEventHandlers()
 
 bool CommandBarFlyoutCommandBar::HasOpenAnimation()
 {
-    return static_cast<bool>(m_openingStoryboard);
+    return static_cast<bool>(m_openingStoryboard) && SharedHelpers::IsAnimationsEnabled();
 }
 
 void CommandBarFlyoutCommandBar::PlayOpenAnimation()
@@ -442,7 +442,7 @@ void CommandBarFlyoutCommandBar::PlayOpenAnimation()
 
 bool CommandBarFlyoutCommandBar::HasCloseAnimation()
 {
-    return static_cast<bool>(m_closingStoryboard);
+    return static_cast<bool>(m_closingStoryboard) && SharedHelpers::IsAnimationsEnabled();
 }
 
 void CommandBarFlyoutCommandBar::PlayCloseAnimation(

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -426,7 +426,7 @@ void CommandBarFlyoutCommandBar::DetachEventHandlers()
 
 bool CommandBarFlyoutCommandBar::HasOpenAnimation()
 {
-    return static_cast<bool>(m_openingStoryboard) && AreAnimationsEnabled();
+    return static_cast<bool>(m_openingStoryboard) && SharedHelpers::IsAnimationsEnabled();
 }
 
 void CommandBarFlyoutCommandBar::PlayOpenAnimation()
@@ -442,7 +442,7 @@ void CommandBarFlyoutCommandBar::PlayOpenAnimation()
 
 bool CommandBarFlyoutCommandBar::HasCloseAnimation()
 {
-    return static_cast<bool>(m_closingStoryboard) && AreAnimationsEnabled();
+    return static_cast<bool>(m_closingStoryboard) && SharedHelpers::IsAnimationsEnabled();
 }
 
 void CommandBarFlyoutCommandBar::PlayCloseAnimation(
@@ -1361,16 +1361,4 @@ void CommandBarFlyoutCommandBar::BindOwningFlyoutPresenterToCornerRadius()
             }
         }
     }
-}
-
-bool CommandBarFlyoutCommandBar::AreAnimationsEnabled()
-{
-    bool areAnimationsEnabled = SharedHelpers::IsAnimationsEnabled();
-
-    if (auto owningFlyout = m_owningFlyout.get())
-    {
-        areAnimationsEnabled = areAnimationsEnabled && owningFlyout.AreOpenCloseAnimationsEnabled();
-    }
-
-    return areAnimationsEnabled;
 }

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -426,7 +426,7 @@ void CommandBarFlyoutCommandBar::DetachEventHandlers()
 
 bool CommandBarFlyoutCommandBar::HasOpenAnimation()
 {
-    return static_cast<bool>(m_openingStoryboard) && SharedHelpers::IsAnimationsEnabled();
+    return static_cast<bool>(m_openingStoryboard) && AreAnimationsEnabled();
 }
 
 void CommandBarFlyoutCommandBar::PlayOpenAnimation()
@@ -442,7 +442,7 @@ void CommandBarFlyoutCommandBar::PlayOpenAnimation()
 
 bool CommandBarFlyoutCommandBar::HasCloseAnimation()
 {
-    return static_cast<bool>(m_closingStoryboard) && SharedHelpers::IsAnimationsEnabled();
+    return static_cast<bool>(m_closingStoryboard) && AreAnimationsEnabled();
 }
 
 void CommandBarFlyoutCommandBar::PlayCloseAnimation(
@@ -1361,4 +1361,16 @@ void CommandBarFlyoutCommandBar::BindOwningFlyoutPresenterToCornerRadius()
             }
         }
     }
+}
+
+bool CommandBarFlyoutCommandBar::AreAnimationsEnabled()
+{
+    bool areAnimationsEnabled = SharedHelpers::IsAnimationsEnabled();
+
+    if (auto owningFlyout = m_owningFlyout.get())
+    {
+        areAnimationsEnabled = areAnimationsEnabled && owningFlyout.AreOpenCloseAnimationsEnabled();
+    }
+
+    return areAnimationsEnabled;
 }

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -79,8 +79,6 @@ private:
     void UpdateProjectedShadow();
     void ClearProjectedShadow();
 
-    bool AreAnimationsEnabled();
-
     tracker_ref<winrt::FrameworkElement> m_primaryItemsRoot{ this };
     tracker_ref<winrt::Popup> m_overflowPopup{ this };
     tracker_ref<winrt::FrameworkElement> m_secondaryItemsRoot{ this };

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -79,6 +79,8 @@ private:
     void UpdateProjectedShadow();
     void ClearProjectedShadow();
 
+    bool AreAnimationsEnabled();
+
     tracker_ref<winrt::FrameworkElement> m_primaryItemsRoot{ this };
     tracker_ref<winrt::Popup> m_overflowPopup{ this };
     tracker_ref<winrt::FrameworkElement> m_secondaryItemsRoot{ this };


### PR DESCRIPTION
XAML's VisualStateManager handles the honoring of most animations, but in the case of CommandBarFlyout, we have open and close animations that we play manually external to the VisualStateManager.  In that case, we should check for animations being enabled before reporting that they exist and having them be played.

This is a purely visual change that relies on a system setting being set that we don't have test infrastructure for, so I haven't added any automated testing here, but I manually verified that the open/close animation no longer plays when that setting is turned off, and then resumes playing when it's turned back on.