### PR TITLE
Updating CommandBarFlyout keyboarding and UIA to account for AlwaysExpanded hiding the more button

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -7,6 +7,7 @@
 #include "CommandBarFlyoutCommandBar.h"
 #include "CommandBarFlyoutCommandBarTemplateSettings.h"
 #include "TypeLogging.h"
+#include "Vector.h"
 
 CommandBarFlyoutCommandBar::CommandBarFlyoutCommandBar()
 {
@@ -279,87 +280,7 @@ void CommandBarFlyoutCommandBar::AttachEventHandlers()
                     case winrt::VirtualKey::Down:
                     case winrt::VirtualKey::Up:
                     {
-                        if (SecondaryCommands().Size() > 1)
-                        {
-                            winrt::Control focusedControl = nullptr;
-                            int startIndex = 0;
-                            int endIndex = static_cast<int>(SecondaryCommands().Size());
-                            int deltaIndex = 1;
-                            int loopCount = 0;
-
-                            if (args.Key() == winrt::VirtualKey::Up)
-                            {
-                                deltaIndex = -1;
-                                startIndex = endIndex - 1;
-                                endIndex = -1;
-                            }
-
-                            do
-                            {
-                                // Give keyboard focus to the previous or next secondary command if possible
-                                for (int index = startIndex; index != endIndex; index += deltaIndex)
-                                {
-                                    auto secondaryCommand = SecondaryCommands().GetAt(index);
-
-                                    if (auto secondaryCommandAsControl = secondaryCommand.try_as<winrt::Control>())
-                                    {
-                                        if (secondaryCommandAsControl.FocusState() != winrt::FocusState::Unfocused)
-                                        {
-                                            focusedControl = secondaryCommandAsControl;
-                                        }
-                                        else if (focusedControl && IsControlFocusable(secondaryCommandAsControl, false /*checkTabStop*/) &&
-                                                 focusedControl != secondaryCommandAsControl)
-                                        {
-                                            if (FocusControl(
-                                                    secondaryCommandAsControl /*newFocus*/,
-                                                    focusedControl /*oldFocus*/,
-                                                    winrt::FocusState::Keyboard /*focusState*/,
-                                                    true /*updateTabStop*/))
-                                            {
-                                                args.Handled(true);
-                                                return;
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (loopCount == 0 && PrimaryCommands().Size() > 0)
-                                {
-                                    auto moreButton = m_moreButton.get();
-
-                                    if (deltaIndex == 1 &&
-                                        FocusCommand(
-                                            PrimaryCommands() /*commands*/,
-                                            moreButton /*moreButton*/,
-                                            winrt::FocusState::Keyboard /*focusState*/,
-                                            true /*firstCommand*/,
-                                            true /*ensureTabStopUniqueness*/))
-                                    {
-                                        // Being on the last secondary command, keyboard focus was given to the first primary command
-                                        args.Handled(true);
-                                        return;
-                                    }
-                                    else if (deltaIndex == -1 &&
-                                        focusedControl &&
-                                        moreButton &&
-                                        IsControlFocusable(moreButton, false /*checkTabStop*/) &&
-                                        FocusControl(
-                                            moreButton /*newFocus*/,
-                                            focusedControl /*oldFocus*/,
-                                            winrt::FocusState::Keyboard /*focusState*/,
-                                            true /*updateTabStop*/))
-                                    {
-                                        // Being on the first secondary command, keyboard focus was given to the MoreButton
-                                        args.Handled(true);
-                                        return;
-                                    }
-                                }
-
-                                loopCount++; // Looping again when focus could not be given to a MoreButton going up or primary command going down.
-                            }
-                            while (loopCount < 2 && focusedControl);
-                        }
-                        args.Handled(true);
+                        OnKeyDown(args);
                         break;
                     }
                     }
@@ -523,7 +444,7 @@ void CommandBarFlyoutCommandBar::UpdateFlowsFromAndFlowsTo()
 
         // If we have a more button and at least one focusable primary item, then
         // we'll use the more button as the last element in our primary items list.
-        if (moreButton && m_currentPrimaryItemsEndElement)
+        if (moreButton && moreButton.Visibility() == winrt::Visibility::Visible && m_currentPrimaryItemsEndElement)
         {
             m_currentPrimaryItemsEndElement.set(moreButton);
         }
@@ -797,7 +718,7 @@ void CommandBarFlyoutCommandBar::EnsureAutomationSetCountAndPosition()
         }
     }
 
-    if (moreButton)
+    if (moreButton && moreButton.Visibility() == winrt::Visibility::Visible)
     {
         // Accounting for the MoreButton
         sizeOfSet++;
@@ -822,7 +743,7 @@ void CommandBarFlyoutCommandBar::EnsureAutomationSetCountAndPosition()
         }
     }
 
-    if (moreButton)
+    if (moreButton && moreButton.Visibility() == winrt::Visibility::Visible)
     {
         winrt::AutomationProperties::SetSizeOfSet(moreButton, sizeOfSet);
         winrt::AutomationProperties::SetPositionInSet(moreButton, sizeOfSet);
@@ -920,110 +841,115 @@ void CommandBarFlyoutCommandBar::OnKeyDown(
         const bool isDown = args.Key() == winrt::VirtualKey::Down;
         const bool isUp = args.Key() == winrt::VirtualKey::Up;
 
-        auto moreButton = m_moreButton.get();
+        // The primary commands and the more button are the only controls accessible
+        // using left and right arrow keys. All of the commands are accessible using
+        // the up and down arrow keys.
+        auto horizontallyAccessibleControls = winrt::make<Vector<winrt::Control>>();
+        auto verticallyAccessibleControls = winrt::make<Vector<winrt::Control>>();
 
-        if (isDown &&
-            moreButton &&
-            moreButton.FocusState() != winrt::FocusState::Unfocused &&
-            SecondaryCommands().Size() > 0)
+        for (winrt::ICommandBarElement const& command : PrimaryCommands())
         {
-            // When on the MoreButton, give keyboard focus to the first focusable secondary command
-            // First ensure the secondary commands flyout is open
-            if (!IsOpen())
+            if (auto const& commandAsControl = command.try_as<winrt::Control>())
             {
-                IsOpen(true);
-            }
-
-            if (FocusCommand(
-                    SecondaryCommands() /*commands*/,
-                    nullptr /*moreButton*/,
-                    winrt::FocusState::Keyboard /*focusState*/,
-                    true /*firstCommand*/,
-                    SharedHelpers::IsRS3OrHigher() /*ensureTabStopUniqueness*/))
-            {
-                args.Handled(true);
+                if (IsControlFocusable(commandAsControl, false /*checkTabStop*/))
+                {
+                    horizontallyAccessibleControls.Append(commandAsControl);
+                    verticallyAccessibleControls.Append(commandAsControl);
+                }
             }
         }
 
-        if (!args.Handled() && PrimaryCommands().Size() > 0)
+        auto const& moreButton = m_moreButton.get();
+
+        if (moreButton && IsControlFocusable(moreButton, false /*checkTabStop*/))
         {
-            winrt::Control focusedControl = nullptr;
-            int startIndex = 0;
-            int endIndex = static_cast<int>(PrimaryCommands().Size());
-            int deltaIndex = 1;
+            horizontallyAccessibleControls.Append(moreButton);
+            verticallyAccessibleControls.Append(moreButton);
+        }
 
-            if (isLeft || isUp)
+        for (winrt::ICommandBarElement const& command : SecondaryCommands())
+        {
+            if (auto const& commandAsControl = command.try_as<winrt::Control>())
             {
-                deltaIndex = -1;
-                startIndex = endIndex - 1;
-                endIndex = -1;
-
-                if (moreButton && moreButton.FocusState() != winrt::FocusState::Unfocused)
+                if (IsControlFocusable(commandAsControl, false /*checkTabStop*/))
                 {
-                    focusedControl = moreButton;
+                    verticallyAccessibleControls.Append(commandAsControl);
+                }
+            }
+        }
+
+        // To avoid code duplication, we'll use the key directionality to determine
+        // both which control list to use and in which direction to iterate through
+        // it to find the next control to focus.  Then we'll do that iteration
+        // to focus the next control.
+        auto const& accessibleControls{ isUp || isDown ? verticallyAccessibleControls : horizontallyAccessibleControls };
+        int const startIndex = isLeft || isUp ? accessibleControls.Size() - 1 : 0;
+        int const endIndex = isLeft || isUp ? -1 : accessibleControls.Size();
+        int const deltaIndex = isLeft || isUp ? -1 : 1;
+        bool const shouldLoop = isUp || isDown;
+        winrt::Control focusedControl{ nullptr };
+        int focusedControlIndex = -1;
+
+        for (int i = startIndex;
+            // We'll stop looping at the end index unless we're looping,
+            // in which case we want to wrap back around to the start index.
+            (i != endIndex || shouldLoop) ||
+            // If we found a focused control but have looped all the way back around,
+            // then there wasn't another control to focus, so we should quit.
+            (focusedControlIndex > 0 && i == focusedControlIndex);
+            i += deltaIndex)
+        {
+            // If we've reached the end index, that means we want to loop.
+            // We'll wrap around to the start index.
+            if (i == endIndex)
+            {
+                MUX_ASSERT(shouldLoop);
+
+                if (focusedControl)
+                {
+                    i = startIndex;
+                }
+                else
+                {
+                    // If no focused control was found after going through the entire list of controls,
+                    // then we have nowhere for focus to go.  Let's early-out in that case.
+                    break;
                 }
             }
 
-            // Give focus to the previous or next command if possible
-            for (int index = startIndex; index != endIndex; index += deltaIndex)
-            {
-                auto primaryCommand = PrimaryCommands().GetAt(index);
+            auto const& control = accessibleControls.GetAt(i);
 
-                if (auto primaryCommandAsControl = primaryCommand.try_as<winrt::Control>())
+            // If we've yet to find the focused control, we'll keep looking for it.
+            // Otherwise, we'll try to focus the next control after it.
+            if (!focusedControl)
+            {
+                if (control.FocusState() != winrt::FocusState::Unfocused)
                 {
-                    if (primaryCommandAsControl.FocusState() != winrt::FocusState::Unfocused)
-                    {
-                        focusedControl = primaryCommandAsControl;
-                    }
-                    else if (focusedControl &&
-                        IsControlFocusable(primaryCommandAsControl, false /*checkTabStop*/) &&
-                        FocusControl(
-                            primaryCommandAsControl /*newFocus*/,
-                            focusedControl /*oldFocus*/,
-                            winrt::FocusState::Keyboard /*focusState*/,
-                            true /*updateTabStop*/))
-                    {
-                        args.Handled(true);
-                        break;
-                    }
+                    focusedControl = control;
+                    focusedControlIndex = i;
                 }
             }
-
-            if (!args.Handled())
+            else
             {
-                if ((isRight || isDown) &&
-                    focusedControl &&
-                    moreButton &&
-                    IsControlFocusable(moreButton, false /*checkTabStop*/))
+                // If the control we're trying to focus is in the secondary command list,
+                // then we'll make sure that that list is open before trying to focus the control.
+                if (auto const& controlAsCommandBarElement = control.try_as<winrt::ICommandBarElement>())
                 {
-                    // When on last primary command, give keyboard focus to the MoreButton
-                    if (FocusControl(
-                            moreButton /*newFocus*/,
-                            focusedControl /*oldFocus*/,
-                            winrt::FocusState::Keyboard /*focusState*/,
-                            true /*updateTabStop*/))
-                    {
-                        args.Handled(true);
-                    }
-                }
-                else if (isUp && SecondaryCommands().Size() > 0)
-                {
-                    // When on first primary command, give keyboard focus to the last focusable secondary command
-                    // First ensure the secondary commands flyout is open
-                    if (!IsOpen())
+                    uint32_t index = 0;
+                    if (SecondaryCommands().IndexOf(controlAsCommandBarElement, index) && !IsOpen())
                     {
                         IsOpen(true);
                     }
+                }
 
-                    if (FocusCommand(
-                            SecondaryCommands() /*commands*/,
-                            nullptr /*moreButton*/,
-                            winrt::FocusState::Keyboard /*focusState*/,
-                            false /*firstCommand*/,
-                            SharedHelpers::IsRS3OrHigher() /*ensureTabStopUniqueness*/))
-                    {
-                        args.Handled(true);
-                    }
+                if (FocusControl(
+                    accessibleControls.GetAt(i) /*newFocus*/,
+                    focusedControl /*oldFocus*/,
+                    winrt::FocusState::Keyboard /*focusState*/,
+                    true /*updateTabStop*/))
+                {
+                    args.Handled(true);
+                    break;
                 }
             }
         }

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -52,6 +52,7 @@ private:
     void UpdateTemplateSettings();
     void EnsureAutomationSetCountAndPosition();
     void EnsureFocusedPrimaryCommand();
+    void PopulateAccessibleControls();
 
     void SetPresenterName(winrt::FlyoutPresenter const& presenter);
 
@@ -113,4 +114,7 @@ private:
     winrt::Storyboard::Completed_revoker m_expandedDownToCollapsedStoryboardRevoker{};
     winrt::Storyboard::Completed_revoker m_collapsedToExpandedUpStoryboardRevoker{};
     winrt::Storyboard::Completed_revoker m_collapsedToExpandedDownStoryboardRevoker{};
+
+    winrt::IVector<winrt::Control> m_horizontallyAccessibleControls{ nullptr };
+    winrt::IVector<winrt::Control> m_verticallyAccessibleControls{ nullptr };
 };

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -727,7 +727,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Button undoButton9 = FindElement.ById<Button>("UndoButton9");
 
-                if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone3))
+                if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))
                 {
                     Log.Comment("Press Down key to move focus to first secondary command: Undo.");
                     KeyboardHelper.PressKey(Key.Down);

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -698,5 +698,203 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.Tap(showCommandBarFlyoutButton);
             }
         }
+
+        [TestMethod]
+        public void VerifyUpAndDownNavigationBetweenPrimaryAndSecondaryCommandsWithAlwaysExpanded()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled pre-RS2 because CommandBarFlyout is not supported pre-RS2");
+                return;
+            }
+
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with AlwaysExpanded");
+
+                Log.Comment("Tap on a button to show the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+
+                Log.Comment("Press Down key to move focus to last primary command: Underline.");
+                for (int i = 0; i < 5; i++)
+                {
+                    KeyboardHelper.PressKey(Key.Down);
+                    Wait.ForIdle();
+                }
+
+                Button underlineButton9 = FindElement.ById<Button>("UnderlineButton9");
+                Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, underlineButton9.AutomationId);
+
+                Log.Comment("Press Down key to move focus to first secondary command: Undo.");
+                KeyboardHelper.PressKey(Key.Down);
+                Wait.ForIdle();
+
+                Button undoButton9 = FindElement.ById<Button>("UndoButton9");
+                Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, undoButton9.AutomationId);
+
+                Log.Comment("Press Up key to move focus to first primary command: Cut.");
+                for (int i = 0; i < 6; i++)
+                {
+                    KeyboardHelper.PressKey(Key.Up);
+                    Wait.ForIdle();
+                }
+
+                Button cutButton9 = FindElement.ById<Button>("CutButton9");
+                Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, cutButton9.AutomationId);
+
+                Log.Comment("Press Up key to move focus to last secondary command: Favorite.");
+                KeyboardHelper.PressKey(Key.Up);
+                Wait.ForIdle();
+
+                Button favoriteToggleButton9 = FindElement.ById<Button>("FavoriteToggleButton9");
+                Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, favoriteToggleButton9.AutomationId);
+
+                Log.Comment("Press Up key to move focus to first secondary command: Undo.");
+                for (int i = 0; i < 3; i++)
+                {
+                    KeyboardHelper.PressKey(Key.Up);
+                    Wait.ForIdle();
+                }
+
+                Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, undoButton9.AutomationId);
+
+                if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone3))
+                {
+                    Log.Comment("Press Up key and remain on first secondary command: Undo.");
+                    KeyboardHelper.PressKey(Key.Up);
+                    Wait.ForIdle();
+
+                    Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, undoButton9.AutomationId);
+                }
+                else
+                {
+                    Log.Comment("Press Up key to move focus to last primary command: Underline.");
+                    KeyboardHelper.PressKey(Key.Up);
+                    Wait.ForIdle();
+
+                    Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, underlineButton9.AutomationId);
+
+                    Log.Comment("Press Down key to move focus to first primary command through all secondary commands: Cut.");
+                    for (int i = 0; i < 5; i++)
+                    {
+                        KeyboardHelper.PressKey(Key.Down);
+                        Wait.ForIdle();
+                    }
+
+                    Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, cutButton9.AutomationId);
+
+                    Log.Comment("Tapping on a button to hide the CommandBarFlyout.");
+                    InputHelper.Tap(showCommandBarFlyoutButton);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void VerifyPrimaryCommandsAutomationSetWithAlwaysExpanded()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled pre-RS2 because CommandBarFlyout is not supported pre-RS2");
+                return;
+            }
+
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with AlwaysExpanded");
+
+                Log.Comment("Tap on a button to show the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+
+                Button cutButton9 = FindElement.ById<Button>("CutButton9");
+                var focusedElement = AutomationElement.FocusedElement;
+                Verify.AreEqual(focusedElement.Current.AutomationId, cutButton9.AutomationId);
+
+                int sizeOfSet = (int)focusedElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_SizeOfSetPropertyId));
+                int positionInSet = (int)focusedElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_PositionInSetPropertyId));
+
+                Log.Comment("Verify first primary command's SizeOfSet and PositionInSet automation properties.");
+                Verify.AreEqual(sizeOfSet, 6);
+                Verify.IsTrue(positionInSet == -1 || positionInSet == 1);
+
+                Log.Comment("Press Right key to move focus to last primary command: Underline.");
+                for (int i = 0; i < 5; i++)
+                {
+                    KeyboardHelper.PressKey(Key.Right);
+                    Wait.ForIdle();
+                }
+
+                Button underlineButton9 = FindElement.ById<Button>("UnderlineButton9");
+                focusedElement = AutomationElement.FocusedElement;
+                Verify.AreEqual(focusedElement.Current.AutomationId, underlineButton9.AutomationId);
+
+                sizeOfSet = (int)focusedElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_SizeOfSetPropertyId));
+                positionInSet = (int)focusedElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_PositionInSetPropertyId));
+
+                Log.Comment("Verify last primary command's SizeOfSet and PositionInSet automation properties.");
+                Verify.AreEqual(sizeOfSet, 6);
+                Verify.IsTrue(positionInSet == -1 || positionInSet == 6);
+
+                Log.Comment("Press Right key. Focus should not move.");
+                KeyboardHelper.PressKey(Key.Right);
+                Wait.ForIdle();
+
+                focusedElement = AutomationElement.FocusedElement;
+                Verify.AreEqual(focusedElement.Current.AutomationId, underlineButton9.AutomationId);
+
+                Log.Comment("Tapping on a button to hide the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+            }
+        }
+
+        [TestMethod]
+        public void VerifyFlowsToAndFromConnectsPrimaryAndSecondaryCommandsWithAlwaysExpanded()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled pre-RS2 because CommandBarFlyout is not supported pre-RS2");
+                return;
+            }
+
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with AlwaysExpanded");
+
+                Log.Comment("Tapping on a button to show the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+
+                Log.Comment("Press Right key to move focus to last primary command: Underline.");
+                for (int i = 0; i < 5; i++)
+                {
+                    KeyboardHelper.PressKey(Key.Right);
+                    Wait.ForIdle();
+                }
+
+                Button underlineButton9 = FindElement.ById<Button>("UnderlineButton9");
+                var underlineButtonElement = AutomationElement.FocusedElement;
+                Verify.AreEqual(underlineButtonElement.Current.AutomationId, underlineButton9.AutomationId);
+
+                // Moving to the Undo button to retrieve it
+                KeyboardHelper.PressKey(Key.Down);
+                Wait.ForIdle();
+
+                Button undoButton9 = FindElement.ById<Button>("UndoButton9");
+                var undoButtonElement = AutomationElement.FocusedElement;
+                Verify.AreEqual(undoButtonElement.Current.AutomationId, undoButton9.AutomationId);
+
+                Log.Comment("Verifying that the two elements point at each other using FlowsTo and FlowsFrom.");
+                var flowsToCollection = (AutomationElementCollection)underlineButtonElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_FlowsToPropertyId));
+
+                Verify.AreEqual(1, flowsToCollection.Count);
+                Verify.AreEqual(undoButtonElement, flowsToCollection[0]);
+
+                var flowsFromCollection = (AutomationElementCollection)undoButtonElement.GetCurrentPropertyValue(AutomationProperty.LookupById(UIA_FlowsFromPropertyId));
+
+                Verify.AreEqual(1, flowsFromCollection.Count);
+                Verify.AreEqual(underlineButtonElement, flowsFromCollection[0]);
+
+                Log.Comment("Tapping on a button to hide the CommandBarFlyout.");
+                InputHelper.Tap(showCommandBarFlyoutButton);
+            }
+        }
     }
 }

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -725,18 +725,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Button underlineButton9 = FindElement.ById<Button>("UnderlineButton9");
                 Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, underlineButton9.AutomationId);
 
-                Log.Comment("Press Down key to move focus to first secondary command: Undo.");
-                KeyboardHelper.PressKey(Key.Down);
-                Wait.ForIdle();
-
                 Button undoButton9 = FindElement.ById<Button>("UndoButton9");
-                Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, undoButton9.AutomationId);
 
-                Log.Comment("Press Up key to move focus to first primary command: Cut.");
-                for (int i = 0; i < 6; i++)
+                if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone3))
                 {
-                    KeyboardHelper.PressKey(Key.Up);
+                    Log.Comment("Press Down key to move focus to first secondary command: Undo.");
+                    KeyboardHelper.PressKey(Key.Down);
                     Wait.ForIdle();
+
+                    Verify.AreEqual(AutomationElement.FocusedElement.Current.AutomationId, undoButton9.AutomationId);
+
+                    Log.Comment("Press Up key to move focus to first primary command: Cut.");
+                    for (int i = 0; i < 6; i++)
+                    {
+                        KeyboardHelper.PressKey(Key.Up);
+                        Wait.ForIdle();
+                    }
+                }
+                else
+                {
+                    Log.Comment("Press Up key to move focus to first primary command: Cut.");
+                    for (int i = 0; i < 5; i++)
+                    {
+                        KeyboardHelper.PressKey(Key.Up);
+                        Wait.ForIdle();
+                    }
                 }
 
                 Button cutButton9 = FindElement.ById<Button>("CutButton9");


### PR DESCRIPTION
The `AlwaysExpanded` API hides the more button, but there are some aspects of keyboarding and UIA that assume that the more button will always be visible.  These changes update keyboarding and UIA to account for the possible absence of the more button.  While I was here, I also refactored keyboard handling to make it more understandable - now there aren't any special cases for the more button; instead, we just make two lists of controls accessible via the horizontal arrow keys and the vertical arrow keys, and then cycle through those lists in response to keyboard input.

I also added more test cases to confirm that both keyboarding and UIA functions as expected with `AlwaysExpanded` set to true.