### PR TITLE
Make RadioButton style use ThemeResource correctly for Fill property

### DIFF
--- a/dev/CommonStyles/RadioButton_themeresources.xaml
+++ b/dev/CommonStyles/RadioButton_themeresources.xaml
@@ -384,7 +384,7 @@
                         </Grid.ColumnDefinitions>
 
                         <Grid VerticalAlignment="Top" Height="32">
-                            <Ellipse x:Name="OuterEllipse" Width="20" Height="20" UseLayoutRounding="False" Stroke="{ThemeResource RadioButtonOuterEllipseStroke}" Fill="{StaticResource RadioButtonOuterEllipseFill}" StrokeThickness="{ThemeResource RadioButtonBorderThemeThickness}" />
+                            <Ellipse x:Name="OuterEllipse" Width="20" Height="20" UseLayoutRounding="False" Stroke="{ThemeResource RadioButtonOuterEllipseStroke}" Fill="{ThemeResource RadioButtonOuterEllipseFill}" StrokeThickness="{ThemeResource RadioButtonBorderThemeThickness}" />
                             <!-- A seperate element is added since the two orthogonal state groups that cannot touch the same property -->
                             <Ellipse x:Name="CheckOuterEllipse" Width="20" Height="20" UseLayoutRounding="False" Stroke="{ThemeResource RadioButtonOuterEllipseCheckedStroke}" Fill="{ThemeResource RadioButtonOuterEllipseCheckedFill}" Opacity="0" StrokeThickness="{ThemeResource RadioButtonBorderThemeThickness}" />
                             <Ellipse x:Name="CheckGlyph" Width="{ThemeResource RadioButtonCheckGlyphSize}" Height="{ThemeResource RadioButtonCheckGlyphSize}" UseLayoutRounding="False" Opacity="0" Fill="{ThemeResource RadioButtonCheckGlyphFill}" Stroke="{ThemeResource RadioButtonCheckGlyphStroke}">


### PR DESCRIPTION
## Description
I filled the issue that the lightweight style RadioButtonOuterEllipseFill did not work. This tiny fix from a StaticResource to a ThemeResource should fix it.

This PR does not address the refactoring suggested in the comments of the issue.

## Motivation and Context
Fixes #4872