### PR TITLE
failfast when is21H1OrHigher is not true for CBS package

### DIFF
--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -116,7 +116,14 @@ void XamlControlsResources::UpdateSource()
 
             if (isInCBSPackage && !is21H1OrHigher)
             {
-                MUX_FAIL_FAST_MSG("CBS package can run only on os when is21H1OrHigher is true");
+                if (SharedHelpers::Is21H1OrHigher())
+                {
+                    MUX_FAIL_FAST_MSG("CBS package can run only on os when IsSelectionIndicatorModeAvailable is true");
+                }
+                else
+                {
+                    MUX_FAIL_FAST_MSG("CBS package can run only on os when is21H1OrHigher is true");                
+                }
             }
             return packagePrefix + releasePrefix + compactPrefix + postfix;
         }()

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -114,6 +114,10 @@ void XamlControlsResources::UpdateSource()
                 releasePrefix = L"rs2_";
             }
 
+            if (isInCBSPackage && !is21H1OrHigher)
+            {
+                MUX_FAIL_FAST_MSG("CBS package can run only on os when is21H1OrHigher is true");
+            }
             return packagePrefix + releasePrefix + compactPrefix + postfix;
         }()
     };


### PR DESCRIPTION
In CBS package, 19h1 and below themeresources are removed from the package to save disk space.
so only 21h1 or above os is supported.
It's observed that some app occasionally loaded 19h1 or below themeresources in CBS, but have no idea why. Failfast to see if it will provide more information in crash