### PR TITLE
Updating acrylic usage for XAML islands

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -14,7 +14,8 @@
     
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="SystemControlTransientBackgroundBrush"/>
+            <contract7NotPresent:StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush"/>
+            <contract7Present:StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush"/>
             <StaticResource x:Key="CommandBarFlyoutForeground" ResourceKey="TextFillColorPrimaryBrush"/>
             <StaticResource x:Key="CommandBarFlyoutBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush"/>
             <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackground" ResourceKey="SubtleFillColorTransparentBrush"/>
@@ -45,7 +46,8 @@
             <StaticResource x:Key="CommandBarFlyoutButtonBackground" ResourceKey="SystemControlTransparentBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="SystemControlTransientBackgroundBrush"/>
+            <contract7NotPresent:StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush"/>
+            <contract7Present:StaticResource x:Key="CommandBarFlyoutBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush"/>
             <StaticResource x:Key="CommandBarFlyoutForeground" ResourceKey="TextFillColorPrimaryBrush"/>
             <StaticResource x:Key="CommandBarFlyoutBorderBrush" ResourceKey="ControlStrokeColorDefaultBrush"/>
             <StaticResource x:Key="CommandBarFlyoutAppBarButtonBackground" ResourceKey="SubtleFillColorTransparentBrush"/>

--- a/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
@@ -10,7 +10,18 @@
     xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
+        <Grid.Background>
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                <GradientStop Color="Red" Offset="0.000" />
+                <GradientStop Color="Orange" Offset="0.167" />
+                <GradientStop Color="Yellow" Offset="0.333" />
+                <GradientStop Color="Green" Offset="0.500" />
+                <GradientStop Color="Blue" Offset="0.667" />
+                <GradientStop Color="Indigo" Offset="0.833" />
+                <GradientStop Color="Violet" Offset="1.000" />
+            </LinearGradientBrush>
+        </Grid.Background>
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition Height="Auto" />

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -25,7 +25,7 @@
             <StaticResource x:Key="CommandBarEllipsisIconForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
-            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <Thickness x:Key="CommandBarOverflowPresenterBorderThickness">1</Thickness>
@@ -74,7 +74,7 @@
             <StaticResource x:Key="CommandBarEllipsisIconForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
-            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <Thickness x:Key="CommandBarOverflowPresenterBorderThickness">1</Thickness>

--- a/dev/CommonStyles/CommandBar_themeresources_v1.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources_v1.xaml
@@ -17,7 +17,7 @@
             <StaticResource x:Key="CommandBarEllipsisIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
-            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <Thickness x:Key="CommandBarOverflowPresenterBorderThickness">1</Thickness>
@@ -59,7 +59,7 @@
             <StaticResource x:Key="CommandBarEllipsisIconForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7NotPresent:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
-            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <contract7Present:StaticResource x:Key="CommandBarOverflowPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
             <Thickness x:Key="CommandBarOverflowPresenterBorderThickness">1</Thickness>

--- a/dev/CommonStyles/Deprecated_themeresources_any.xaml
+++ b/dev/CommonStyles/Deprecated_themeresources_any.xaml
@@ -3,12 +3,16 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
+    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <!-- 2.5 controls should not depend on brushes on this file except for new controls like Expander -->
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <AcrylicBrush
+            <contract7NotPresent:StaticResource
+                x:Key="SystemControlTransientBackgroundBrush"
+                ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:AcrylicBrush
                 x:Key="SystemControlTransientBackgroundBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
@@ -52,7 +56,10 @@
             <SolidColorBrush x:Key="ControlAAStrokeColorDisabledBrush" Color="{StaticResource ControlAAStrokeColorDisabled}" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <AcrylicBrush
+            <contract7NotPresent:StaticResource
+                x:Key="SystemControlTransientBackgroundBrush"
+                ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
+            <contract7Present:AcrylicBrush
                 x:Key="SystemControlTransientBackgroundBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"

--- a/dev/CommonStyles/Deprecated_themeresources_any.xaml
+++ b/dev/CommonStyles/Deprecated_themeresources_any.xaml
@@ -3,18 +3,17 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:local="using:Microsoft.UI.Xaml.Media">
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
 
     <!-- 2.5 controls should not depend on brushes on this file except for new controls like Expander -->
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlTransientBackgroundBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
                 FallbackColor="#2C2C2C"
-                BackgroundSource="HostBackdrop"/>
+                BackgroundSource="Backdrop"/>
 
             <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
             <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
@@ -53,12 +52,12 @@
             <SolidColorBrush x:Key="ControlAAStrokeColorDisabledBrush" Color="{StaticResource ControlAAStrokeColorDisabled}" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlTransientBackgroundBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"
                 FallbackColor="#FCFCFC"
-                BackgroundSource="HostBackdrop"/>
+                BackgroundSource="Backdrop"/>
 
             <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
             <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>

--- a/dev/CommonStyles/Deprecated_themeresources_any.xaml
+++ b/dev/CommonStyles/Deprecated_themeresources_any.xaml
@@ -13,7 +13,7 @@
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
                 FallbackColor="#2C2C2C"
-                BackgroundSource="Backdrop"/>
+                BackgroundSource="HostBackdrop"/>
 
             <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
             <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
@@ -57,7 +57,7 @@
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"
                 FallbackColor="#FCFCFC"
-                BackgroundSource="Backdrop"/>
+                BackgroundSource="HostBackdrop"/>
 
             <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
             <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>

--- a/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
+++ b/dev/CommonStyles/FlyoutPresenter_themeresources.xaml
@@ -7,7 +7,7 @@
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
             <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
         </ResourceDictionary>
@@ -17,7 +17,7 @@
             <Thickness x:Key="FlyoutBorderThemeThickness">2</Thickness>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="FlyoutPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <StaticResource x:Key="FlyoutBorderThemeBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
             <Thickness x:Key="FlyoutBorderThemeThickness">1</Thickness>
         </ResourceDictionary>

--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -38,7 +38,7 @@
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
             <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
 
@@ -204,7 +204,7 @@
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
             <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
 

--- a/dev/CommonStyles/MenuFlyout_themeresources_v1.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources_v1.xaml
@@ -54,7 +54,7 @@
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <Thickness x:Key="MenuFlyoutItemThemePadding">11,9,11,10</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,7</Thickness>
-            <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <contract7NotPresent:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <contract7NotPresent:StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />
@@ -220,7 +220,7 @@
             <StaticResource x:Key="MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <Thickness x:Key="MenuFlyoutItemThemePadding">11,9,11,10</Thickness>
             <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,7</Thickness>
-            <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <contract7NotPresent:StaticResource x:Key="MenuFlyoutPresenterBackground" ResourceKey="SystemControlBackgroundChromeMediumLowBrush" />
             <contract7Present:StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <contract7NotPresent:StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemControlForegroundChromeHighBrush" />

--- a/dev/CommonStyles/TestUI/CommandBarPage.xaml
+++ b/dev/CommonStyles/TestUI/CommandBarPage.xaml
@@ -10,14 +10,24 @@
   xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
   xmlns:contract6NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,6)"
   xmlns:contract5NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
 
     <Page.Resources>
     </Page.Resources>
 
     <Grid>
+        <Grid.Background>
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                <GradientStop Color="Red" Offset="0.000" />
+                <GradientStop Color="Orange" Offset="0.167" />
+                <GradientStop Color="Yellow" Offset="0.333" />
+                <GradientStop Color="Green" Offset="0.500" />
+                <GradientStop Color="Blue" Offset="0.667" />
+                <GradientStop Color="Indigo" Offset="0.833" />
+                <GradientStop Color="Violet" Offset="1.000" />
+            </LinearGradientBrush>
+        </Grid.Background>
         <StackPanel Orientation="Vertical">
 
             <CommandBar>

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
@@ -9,7 +9,18 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
+    <Grid Margin="12">
+        <Grid.Background>
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                <GradientStop Color="Red" Offset="0.000" />
+                <GradientStop Color="Orange" Offset="0.167" />
+                <GradientStop Color="Yellow" Offset="0.333" />
+                <GradientStop Color="Green" Offset="0.500" />
+                <GradientStop Color="Blue" Offset="0.667" />
+                <GradientStop Color="Indigo" Offset="0.833" />
+                <GradientStop Color="Violet" Offset="1.000" />
+            </LinearGradientBrush>
+        </Grid.Background>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>

--- a/dev/CommonStyles/ToolTip_rs5_themeresources.xaml
+++ b/dev/CommonStyles/ToolTip_rs5_themeresources.xaml
@@ -6,14 +6,14 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <StaticResource x:Key="ToolTipForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="ToolTipBackgroundBrush" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="ToolTipBackgroundBrush" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <StaticResource x:Key="ToolTipBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
 
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="ToolTipForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="ToolTipBackgroundBrush" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+            <StaticResource x:Key="ToolTipBackgroundBrush" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
             <StaticResource x:Key="ToolTipBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
         </ResourceDictionary>
 

--- a/dev/Materials/Acrylic/APITests/AcrylicBrushTests.cs
+++ b/dev/Materials/Acrylic/APITests/AcrylicBrushTests.cs
@@ -84,6 +84,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 #endif
         public void VerifyAcrylicBrushHasCorrectFallbackColor()
         {
+            if (PlatformConfiguration.IsOsVersionGreaterThan(OSVersion.Redstone2))
+            {
+                Log.Comment("Using system XAML AcrylicBrushes post-RS2, so nothing to test.");
+                return;
+            }
+
             RunOnUIThread.Execute(() =>
             {
                 // only select the pair whose <fallback color> is not empty

--- a/dev/Materials/Acrylic/AcrylicBrush.vcxitems
+++ b/dev/Materials/Acrylic/AcrylicBrush.vcxitems
@@ -45,6 +45,11 @@
       <Type>ThemeResources</Type>
       <Priority>2</Priority>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)AcrylicBrush_rs3_themeresources.xaml">
+      <Version>RS3</Version>
+      <Type>ThemeResources</Type>
+      <Priority>2</Priority>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)AcrylicBrush_19h1_themeresources.xaml">
       <Version>19H1</Version>
       <Type>ThemeResources</Type>

--- a/dev/Materials/Acrylic/AcrylicBrush_19h1_themeresources.xaml
+++ b/dev/Materials/Acrylic/AcrylicBrush_19h1_themeresources.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.UI.Xaml.Media">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <!--
         Due to a low level compiler bug, setting nullable doubles does not work on all platforms.
@@ -10,61 +9,61 @@
     -->
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultInverseBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultInverseBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorBaseBrush"
                 TintColor="#1C1C1C"
                 TintOpacity="0.75"
                 FallbackColor="#1C1C1C"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorBaseBrush"
                 TintColor="#1C1C1C"
                 TintOpacity="0.75"
                 FallbackColor="#1C1C1C"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorDark1}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark1}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorDark1}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark1}"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorDark2}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark2}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorDark2}"
                 TintOpacity="0.8"
@@ -73,61 +72,61 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="Light">
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.0"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultInverseBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultInverseBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.15"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorBaseBrush"
                 TintColor="#F3F3F3"
                 TintOpacity="0.0"
                 FallbackColor="#EEEEEE"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorBaseBrush"
                 TintColor="#F3F3F3"
                 TintOpacity="0.0"
                 FallbackColor="#EEEEEE"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"

--- a/dev/Materials/Acrylic/AcrylicBrush_rs2_themeresources.xaml
+++ b/dev/Materials/Acrylic/AcrylicBrush_rs2_themeresources.xaml
@@ -1,8 +1,7 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.UI.Xaml.Media">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -10,266 +9,266 @@
             <Color x:Key="SystemChromeAltMediumHighColor">#CC1F1F1F</Color>
             <Color x:Key="SystemChromeAltHighColor">#FF1C1C1C</Color>
 
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicElementBrush"
                 BackgroundSource="Backdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAccentAcrylicWindowAccentMediumHighBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentAcrylicElementAccentMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicWindowAccentDark1Brush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicElementAccentDark1Brush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicWindowAccentDark2MediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicElementAccentDark2MediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAltHighAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
             <SolidColorBrush x:Key="SystemControlTransientBorderBrush" Color="#000000" Opacity="0.36" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultInverseBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultInverseBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorBaseBrush"
                 TintColor="#1C1C1C"
                 TintOpacity="0.8"
                 FallbackColor="#1C1C1C"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorBaseBrush"
                 TintColor="#1C1C1C"
                 TintOpacity="0.8"
                 FallbackColor="#1C1C1C"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorDark1}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark1}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorDark1}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark1}"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorDark2}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark2}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorDark2}"
                 TintOpacity="0.8"
@@ -282,266 +281,266 @@
             <Color x:Key="SystemChromeAltMediumHighColor">#CCFFFFFF</Color>
             <Color x:Key="SystemChromeAltHighColor">#FFFFFFFF</Color>
 
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicElementBrush"
                 BackgroundSource="Backdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAccentAcrylicWindowAccentMediumHighBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentAcrylicElementAccentMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicWindowAccentDark1Brush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicElementAccentDark1Brush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicWindowAccentDark2MediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicElementAccentDark2MediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAltHighAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
-            <local:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
             <SolidColorBrush x:Key="SystemControlTransientBorderBrush" Color="#000000" Opacity="0.14" />
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultInverseBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultInverseBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorBaseBrush"
                 TintColor="#F3F3F3"
                 TintOpacity="0.8"
                 FallbackColor="#EEEEEE"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorBaseBrush"
                 TintColor="#F3F3F3"
                 TintOpacity="0.8"
                 FallbackColor="#EEEEEE"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="Backdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="HostBackdrop"/>
-            <local:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"

--- a/dev/Materials/Acrylic/AcrylicBrush_rs3_themeresources.xaml
+++ b/dev/Materials/Acrylic/AcrylicBrush_rs3_themeresources.xaml
@@ -1,8 +1,7 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:media="using:Microsoft.UI.Xaml.Media">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -10,266 +9,266 @@
             <Color x:Key="SystemChromeAltMediumHighColor">#CC1F1F1F</Color>
             <Color x:Key="SystemChromeAltHighColor">#FF1C1C1C</Color>
 
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicElementBrush"
                 BackgroundSource="Backdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAccentAcrylicWindowAccentMediumHighBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentAcrylicElementAccentMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicWindowAccentDark1Brush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicElementAccentDark1Brush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicWindowAccentDark2MediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicElementAccentDark2MediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAltHighAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
             <SolidColorBrush x:Key="SystemControlTransientBorderBrush" Color="#000000" Opacity="0.36" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultInverseBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultInverseBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorBaseBrush"
                 TintColor="#1C1C1C"
                 TintOpacity="0.8"
                 FallbackColor="#1C1C1C"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorBaseBrush"
                 TintColor="#1C1C1C"
                 TintOpacity="0.8"
                 FallbackColor="#1C1C1C"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorDark1}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark1}"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorDark1}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark1}"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorDark2}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorDark2}"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorDark2}"
                 TintOpacity="0.8"
@@ -282,266 +281,266 @@
             <Color x:Key="SystemChromeAltMediumHighColor">#CCFFFFFF</Color>
             <Color x:Key="SystemChromeAltHighColor">#FFFFFFFF</Color>
 
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAcrylicElementBrush"
                 BackgroundSource="Backdrop"
                 TintColor="{StaticResource SystemChromeAltHighColor}"
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAccentAcrylicWindowAccentMediumHighBrush"
                 BackgroundSource="HostBackdrop"
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentAcrylicElementAccentMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicWindowAccentDark1Brush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark1AcrylicElementAccentDark1Brush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark1}" 
                 TintOpacity="0.8" 
                 FallbackColor="{ThemeResource SystemAccentColorDark1}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicWindowAccentDark2MediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAccentDark2AcrylicElementAccentDark2MediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{ThemeResource SystemAccentColorDark2}" 
                 TintOpacity="0.7" 
                 FallbackColor="{ThemeResource SystemAccentColorDark2}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumHighBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumHighBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.7" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemChromeLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeMediumAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeMediumColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlChromeHighAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemChromeHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemBaseLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlBaseMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemBaseMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicWindowBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltLowAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicWindowMediumBrush" 
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltMediumLowAcrylicElementMediumBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.6" 
                 FallbackColor="{StaticResource SystemAltMediumLowColor}" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="SystemControlAltHighAcrylicWindowBrush"
                 BackgroundSource="HostBackdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
-            <media:AcrylicBrush 
+            <AcrylicBrush 
                 x:Key="SystemControlAltHighAcrylicElementBrush" 
                 BackgroundSource="Backdrop" 
                 TintColor="{StaticResource SystemChromeAltHighColor}" 
                 TintOpacity="0.8" 
                 FallbackColor="{StaticResource SystemAltHighColor}" />
             <SolidColorBrush x:Key="SystemControlTransientBorderBrush" Color="#000000" Opacity="0.14" />
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultBrush"
                 TintColor="#FCFCFC"
                 TintOpacity="0.8"
                 FallbackColor="#F9F9F9"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorDefaultInverseBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorDefaultInverseBrush"
                 TintColor="#2C2C2C"
                 TintOpacity="0.8"
                 FallbackColor="#2C2C2C"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicBackgroundFillColorBaseBrush"
                 TintColor="#F3F3F3"
                 TintOpacity="0.8"
                 FallbackColor="#EEEEEE"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AcrylicInAppFillColorBaseBrush"
                 TintColor="#F3F3F3"
                 TintOpacity="0.8"
                 FallbackColor="#EEEEEE"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorDefaultBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="Backdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicBackgroundFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"
                 FallbackColor="{ThemeResource SystemAccentColorLight3}"
                 BackgroundSource="HostBackdrop"/>
-            <media:AcrylicBrush
+            <AcrylicBrush
                 x:Key="AccentAcrylicInAppFillColorBaseBrush"
                 TintColor="{ThemeResource SystemAccentColorLight3}"
                 TintOpacity="0.8"

--- a/dev/TeachingTip/TeachingTip_rs2_themeresources.xaml
+++ b/dev/TeachingTip/TeachingTip_rs2_themeresources.xaml
@@ -5,13 +5,13 @@
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <StaticResource x:Key="TeachingTipTransientBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush"/>
+            <StaticResource x:Key="TeachingTipTransientBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <StaticResource x:Key="TeachingTipTransientBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush"/>
+            <StaticResource x:Key="TeachingTipTransientBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush"/>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="TeachingTipTransientBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush"/>
+            <StaticResource x:Key="TeachingTipTransientBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush"/>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml
+++ b/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml
@@ -25,6 +25,9 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.Resources>
+            <Flyout x:Name="Flyout">
+                <TextBlock Text="I'm a flyout!" />
+            </Flyout>
             <MenuFlyout x:Name="MenuFlyout">
                 <MenuFlyoutItem Text="Item 1" />
                 <MenuFlyoutItem Text="Item 2" />
@@ -52,15 +55,34 @@
                     <AppBarButton Label="Select all" Icon="SelectAll" />
                 </muxc:CommandBarFlyout.SecondaryCommands>
             </muxc:CommandBarFlyout>
+            <muxc:TeachingTip x:Name="TeachingTip"
+                IsLightDismissEnabled="True"
+                PreferredPlacement="Bottom"
+                Title="A TeachingTip" 
+                Subtitle="This is a TeachingTip" />
         </Grid.Resources>
         <StackPanel Orientation="Horizontal">
-            <Button Content="Open MenuFlyout" Click="OnMenuFlyoutButtonClick" VerticalAlignment="Bottom" />
-            <Button Content="Open CommandBarFlyout" Click="OnCommandBarFlyoutButtonClick"  VerticalAlignment="Bottom" />
+            <Button Content="Open Flyout" Click="OnFlyoutButtonClick" />
+            <Button Content="Open MenuFlyout" Click="OnMenuFlyoutButtonClick" />
+            <Button Content="Open CommandBarFlyout" Click="OnCommandBarFlyoutButtonClick" />
+            <Button Content="Open TeachingTip" Click="OnTeachingTipButtonClick" />
+            <Button Content="Hover for ToolTip">
+                <ToolTipService.ToolTip>
+                    <ToolTip Content="ToolTip for Button" Placement="Bottom" />
+                </ToolTipService.ToolTip>
+            </Button>
         </StackPanel>
         <Button Content="Test" AutomationProperties.AutomationId="TestButton" Click="OnTestButtonClick" Grid.Row="1" />
         <StackPanel Orientation="Horizontal" Grid.Row="2">
-            <Button Content="Open MenuFlyout" Click="OnMenuFlyoutButtonClick" VerticalAlignment="Bottom" />
-            <Button Content="Open CommandBarFlyout" Click="OnCommandBarFlyoutButtonClick"  VerticalAlignment="Bottom" />
+            <Button Content="Open Flyout" Click="OnFlyoutButtonClick" />
+            <Button Content="Open MenuFlyout" Click="OnMenuFlyoutButtonClick" />
+            <Button Content="Open CommandBarFlyout" Click="OnCommandBarFlyoutButtonClick" />
+            <Button Content="Open TeachingTip" Click="OnTeachingTipButtonClick" />
+            <Button Content="Hover for ToolTip">
+                <ToolTipService.ToolTip>
+                    <ToolTip Content="ToolTip for Button" Placement="Bottom" />
+                </ToolTipService.ToolTip>
+            </Button>
         </StackPanel>
     </Grid>
 </Page>

--- a/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml
+++ b/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml
@@ -2,13 +2,65 @@
     x:Class="UwpApp.TestPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UwpApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d">
 
     <Grid>
-        <Button Content="Test" AutomationProperties.AutomationId="TestButton" Click="Button_Click" />
+        <Grid.Background>
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                <GradientStop Color="Red" Offset="0.000" />
+                <GradientStop Color="Orange" Offset="0.167" />
+                <GradientStop Color="Yellow" Offset="0.333" />
+                <GradientStop Color="Green" Offset="0.500" />
+                <GradientStop Color="Blue" Offset="0.667" />
+                <GradientStop Color="Indigo" Offset="0.833" />
+                <GradientStop Color="Violet" Offset="1.000" />
+            </LinearGradientBrush>
+        </Grid.Background>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.Resources>
+            <MenuFlyout x:Name="MenuFlyout">
+                <MenuFlyoutItem Text="Item 1" />
+                <MenuFlyoutItem Text="Item 2" />
+                <MenuFlyoutItem Text="Item 3" />
+                <MenuFlyoutItem Text="Item 4" />
+            </MenuFlyout>
+            <muxc:CommandBarFlyout x:Name="CommandBarFlyout" AlwaysExpanded="True">
+                <AppBarButton Label="Cut" Icon="Cut" />
+                <AppBarButton Label="Copy" Icon="Copy" />
+                <AppBarButton Label="Paste" Icon="Paste" />
+                <AppBarButton Label="Rename" Icon="Rename" />
+                <muxc:CommandBarFlyout.SecondaryCommands>
+                    <AppBarButton Label="Open" Icon="OpenFile" />
+                    <AppBarButton Label="Open with" Icon="OpenWith">
+                        <AppBarButton.Flyout>
+                            <MenuFlyout>
+                                <MenuFlyoutItem Text="Notepad" />
+                                <MenuFlyoutItem Text="Microsoft Visual Studio" />
+                                <MenuFlyoutItem Text="Microsoft Edge" />
+                                <MenuFlyoutItem Text="Search apps" />
+                            </MenuFlyout>
+                        </AppBarButton.Flyout>
+                    </AppBarButton>
+                    <AppBarButton Label="Edit" Icon="Edit" />
+                    <AppBarButton Label="Select all" Icon="SelectAll" />
+                </muxc:CommandBarFlyout.SecondaryCommands>
+            </muxc:CommandBarFlyout>
+        </Grid.Resources>
+        <StackPanel Orientation="Horizontal">
+            <Button Content="Open MenuFlyout" Click="OnMenuFlyoutButtonClick" VerticalAlignment="Bottom" />
+            <Button Content="Open CommandBarFlyout" Click="OnCommandBarFlyoutButtonClick"  VerticalAlignment="Bottom" />
+        </StackPanel>
+        <Button Content="Test" AutomationProperties.AutomationId="TestButton" Click="OnTestButtonClick" Grid.Row="1" />
+        <StackPanel Orientation="Horizontal" Grid.Row="2">
+            <Button Content="Open MenuFlyout" Click="OnMenuFlyoutButtonClick" VerticalAlignment="Bottom" />
+            <Button Content="Open CommandBarFlyout" Click="OnCommandBarFlyoutButtonClick"  VerticalAlignment="Bottom" />
+        </StackPanel>
     </Grid>
 </Page>

--- a/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml.cs
+++ b/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml.cs
@@ -28,6 +28,15 @@ namespace UwpApp
             button.Content = "Clicked!";
         }
 
+        private void OnFlyoutButtonClick(object sender, RoutedEventArgs e)
+        {
+            Button button = (Button)sender;
+
+            Flyout.ShowAt(button, new FlyoutShowOptions() {
+                Placement = FlyoutPlacementMode.BottomEdgeAlignedRight
+            });
+        }
+
         private void OnMenuFlyoutButtonClick(object sender, RoutedEventArgs e)
         {
             Button button = (Button)sender;
@@ -44,6 +53,14 @@ namespace UwpApp
             CommandBarFlyout.ShowAt(button, new FlyoutShowOptions() {
                 Placement = FlyoutPlacementMode.BottomEdgeAlignedLeft
             });
+        }
+
+        private void OnTeachingTipButtonClick(object sender, RoutedEventArgs e)
+        {
+            Button button = (Button)sender;
+
+            TeachingTip.Target = button;
+            TeachingTip.IsOpen = true;
         }
     }
 }

--- a/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml.cs
+++ b/test/MUXControlsReleaseTest/XamlIslandsTestApp/UwpApp/TestPage.xaml.cs
@@ -22,10 +22,28 @@ namespace UwpApp
             this.InitializeComponent();
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private void OnTestButtonClick(object sender, RoutedEventArgs e)
         {
             Button button = (Button)sender;
             button.Content = "Clicked!";
+        }
+
+        private void OnMenuFlyoutButtonClick(object sender, RoutedEventArgs e)
+        {
+            Button button = (Button)sender;
+
+            MenuFlyout.ShowAt(button, new FlyoutShowOptions() {
+                Placement = FlyoutPlacementMode.BottomEdgeAlignedRight
+            });
+        }
+
+        private void OnCommandBarFlyoutButtonClick(object sender, RoutedEventArgs e)
+        {
+            Button button = (Button)sender;
+
+            CommandBarFlyout.ShowAt(button, new FlyoutShowOptions() {
+                Placement = FlyoutPlacementMode.BottomEdgeAlignedLeft
+            });
         }
     }
 }

--- a/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-7.xml
+++ b/test/MUXControlsTestApp/verification/VerifyVisualTreeForCommandBarCornerRadius-7.xml
@@ -57,7 +57,7 @@
           CornerRadius=10,10,10,10
           BorderThickness=0,0,0,0
           BorderBrush=[NULL]
-          Background=Microsoft.UI.Xaml.Media.AcrylicBrush
+          Background=Windows.UI.Xaml.Media.AcrylicBrush
           Name=ContentRoot
           MinHeight=48
           Margin=0,0,0,0


### PR DESCRIPTION
We need to make two updates to get acrylic to work properly in XAML islands:

1. Flyouts should use in-app acrylic rather than HostBackdrop, since they're being drawn on top of other content in the app.
2. We should use the system XAML version of AcrylicBrush - that properly accounts for XAML islands, whereas the WinUI 2 version does not.

With these two changes, acrylic works properly in both a UWP app and a XAML islands app.  I modified WpfApp to add some flyouts and a rainbow background to showcase this scenario and get a XAML islands app on which this can be tested, and also modified some pages in MUXControlsTestApp to add a rainbow background there as well to make it easier to tell if acrylic is working properly.