### PR TITLE
Fix Progress Ring crash 

### DIFF
--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -69,7 +69,7 @@ void ProgressRing::OnForegroundPropertyChanged(const winrt::DependencyObject&, c
 {
     if (const auto foreground = Foreground().try_as<winrt::SolidColorBrush>())
     {
-        foreground.RegisterPropertyChangedCallback(winrt::SolidColorBrush::ColorProperty(), { this, &ProgressRing::OnForegroundColorPropertyChanged });
+        m_foregroundColorPropertyChangedRevoker = RegisterPropertyChanged(foreground, winrt::SolidColorBrush::ColorProperty(), { this, &ProgressRing::OnForegroundColorPropertyChanged });
     }
 
     OnForegroundColorPropertyChanged(nullptr, nullptr);
@@ -103,7 +103,7 @@ void ProgressRing::OnBackgroundPropertyChanged(const winrt::DependencyObject&, c
 {
     if (const auto background = Background().try_as<winrt::SolidColorBrush>())
     {
-        background.RegisterPropertyChangedCallback(winrt::SolidColorBrush::ColorProperty(), { this, &ProgressRing::OnBackgroundColorPropertyChanged });
+        m_backgroundColorPropertyChangedRevoker = RegisterPropertyChanged(background, winrt::SolidColorBrush::ColorProperty(), { this, &ProgressRing::OnBackgroundColorPropertyChanged });
     }
 
     OnBackgroundColorPropertyChanged(nullptr, nullptr);

--- a/dev/ProgressRing/ProgressRing.h
+++ b/dev/ProgressRing/ProgressRing.h
@@ -55,6 +55,9 @@ private:
     tracker_ref<winrt::Grid> m_layoutRoot{ this };
     tracker_ref<winrt::AnimatedVisualPlayer> m_player{ this };
 
+    PropertyChanged_revoker m_foregroundColorPropertyChangedRevoker{};
+    PropertyChanged_revoker m_backgroundColorPropertyChangedRevoker{};
+
     double m_oldValue{ 0 };
     bool m_rangeBasePropertyUpdating{ false };
 };


### PR DESCRIPTION
Fix Progress Ring crash when changing the color of a solid color brush that was used for a now destructed progress ring's Foreground/Background color caused by never detatching the dependency property changed handler from the brush's color property.