### PR TITLE
Fixing build break

### DIFF
--- a/test/MUXControlsReleaseTest/XamlIslandsTestApp/WpfApp/WpfApp.Package.wapproj
+++ b/test/MUXControlsReleaseTest/XamlIslandsTestApp/WpfApp/WpfApp.Package.wapproj
@@ -63,6 +63,9 @@
     <ProjectReference Include="WpfApp.csproj">
       <SkipGetTargetFrameworkProperties>True</SkipGetTargetFrameworkProperties>
       <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
+      <!-- A recent update to MSBuild targets caused this property not to get set on all instances of MSBuild calls to WpfApp.csproj,
+           making us pick up the wrong value for $(OutDir) and causing a build error.  Let's make sure we set it. -->
+      <SetTargetFramework>IsBeingPackaged=true</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />


### PR DESCRIPTION
An MSBuild targets update looks to have broken WpfApp.Package.wapproj, in that a property telling us that we're packaging to pick up a different $(OutDir) value isn't being set everywhere anymore.  To unblock the build, I've added a property to the project reference that ensures we always set it.