### PR TITLE
Fix normally ignored errors caused by animated icon

### DIFF
--- a/dev/AnimatedIcon/TestUI/DoubleToStringConverter.cs
+++ b/dev/AnimatedIcon/TestUI/DoubleToStringConverter.cs
@@ -9,14 +9,8 @@ namespace MUXControlsTestApp
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            try
-            {
-                return Double.Parse((string)value) * 100;
-            }
-            catch
-            {
-                return 0.0;
-            }
+            double parsedValue = 0.0;
+            return Double.TryParse((string)value, out parsedValue) ? parsedValue * 100 : 0.0;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -449,7 +449,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="DropDownGlyph.(local:AnimatedIcon.State)" Value="PointerOver"/>
+                                        <Setter Target="DropDownGlyph.(controls:AnimatedIcon.State)" Value="PointerOver"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
@@ -469,7 +469,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="DropDownGlyph.(local:AnimatedIcon.State)" Value="Pressed"/>
+                                        <Setter Target="DropDownGlyph.(controls:AnimatedIcon.State)" Value="Pressed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">

--- a/dev/CommonStyles/CheckBox_themeresources.xaml
+++ b/dev/CommonStyles/CheckBox_themeresources.xaml
@@ -424,7 +424,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalOff"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="UncheckedPointerOver">
@@ -450,7 +450,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PointerOverOff"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PointerOverOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="UncheckedPressed">
@@ -476,7 +476,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PressedOff"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PressedOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="UncheckedDisabled">
@@ -503,7 +503,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalOff"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckedNormal">
@@ -533,7 +533,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalOn"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckedPointerOver">
@@ -563,7 +563,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PointerOverOn"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PointerOverOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckedPressed">
@@ -593,7 +593,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PressedOn"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PressedOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckedDisabled">
@@ -624,7 +624,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalOn"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminateNormal">
@@ -657,7 +657,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalIndeterminate"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalIndeterminate"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminatePointerOver">
@@ -690,7 +690,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PointerOverIndeterminate"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PointerOverIndeterminate"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminatePressed">
@@ -723,7 +723,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="PressedIndeterminate"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PressedIndeterminate"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminateDisabled">
@@ -757,7 +757,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
-                                        <Setter Target="CheckGlyph.(AnimatedIcon.State)" Value="NormalIndeterminate"/>
+                                        <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalIndeterminate"/>
                                     </VisualState.Setters>
                                 </VisualState>
 

--- a/dev/DropDownButton/DropDownButton.xaml
+++ b/dev/DropDownButton/DropDownButton.xaml
@@ -54,7 +54,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="ChevronIcon.(AnimatedIcon.State)" Value="PointerOver"/>
+                                        <Setter Target="ChevronIcon.(local:AnimatedIcon.State)" Value="PointerOver"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -74,7 +74,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="ChevronIcon.(AnimatedIcon.State)" Value="Pressed"/>
+                                        <Setter Target="ChevronIcon.(local:AnimatedIcon.State)" Value="Pressed"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -95,7 +95,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
-                                        <Setter Target="ChevronIcon.(AnimatedIcon.State)" Value="Normal"/>
+                                        <Setter Target="ChevronIcon.(local:AnimatedIcon.State)" Value="Normal"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/NavigationView/NavigationBackButton.xaml
+++ b/dev/NavigationView/NavigationBackButton.xaml
@@ -43,7 +43,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="Content.(AnimatedIcon.State)" Value="PointerOver"/>
+                                        <Setter Target="Content.(local:AnimatedIcon.State)" Value="PointerOver"/>
                                     </VisualState.Setters>
                                 </VisualState>
 
@@ -58,7 +58,7 @@
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                     <VisualState.Setters>
-                                        <Setter Target="Content.(AnimatedIcon.State)" Value="Pressed"/>
+                                        <Setter Target="Content.(local:AnimatedIcon.State)" Value="Pressed"/>
                                     </VisualState.Setters>
                                 </VisualState>
 

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -351,7 +351,7 @@
                                         <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationViewButtonBackgroundPointerOver}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationViewButtonForegroundPointerOver}" />
                                         <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationViewButtonForegroundPointerOver}" />
-                                        <Setter Target="Icon.(AnimatedIcon.State)" Value="PointerOver"/>
+                                        <Setter Target="Icon.(local:AnimatedIcon.State)" Value="PointerOver"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
@@ -359,7 +359,7 @@
                                         <Setter Target="LayoutRoot.Background" Value="{ThemeResource NavigationViewButtonBackgroundPressed}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource NavigationViewButtonForegroundPressed}" />
                                         <Setter Target="Icon.Foreground" Value="{ThemeResource NavigationViewButtonForegroundPressed}" />
-                                        <Setter Target="Icon.(AnimatedIcon.State)" Value="Pressed"/>
+                                        <Setter Target="Icon.(local:AnimatedIcon.State)" Value="Pressed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">

--- a/test/MUXControlsTestApp/App.xaml.cs
+++ b/test/MUXControlsTestApp/App.xaml.cs
@@ -213,6 +213,7 @@ namespace MUXControlsTestApp
 #if DEBUG
             if (System.Diagnostics.Debugger.IsAttached)
             {
+                this.DebugSettings.FailFastOnErrors = true;
                 this.DebugSettings.EnableFrameRateCounter = false;
                 this.DebugSettings.BindingFailed += (object sender, BindingFailedEventArgs args) =>
                 {


### PR DESCRIPTION
Many usages of animated icon set the state property with setters that did not specify the appropriate namespace which leads to errors which are by default ignored.