### PR TITLE
fail fast instead of stowed_exception when look up AcrylicBackgroundFillColorDefaultBrush

### DIFF
--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -138,7 +138,7 @@ void XamlControlsResources::UpdateSource()
         }
         catch (winrt::hresult_error const& e)
         {
-            MUX_FAIL_FAST_MSG("Fail to update acrylic brush");
+            MUX_FAIL_FAST_MSG(e.message().c_str());
         }
     }
 

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -138,7 +138,11 @@ void XamlControlsResources::UpdateSource()
         }
         catch (winrt::hresult_error const& e)
         {
-            MUX_FAIL_FAST_MSG(e.message().c_str());
+            if (e.code() == E_FAIL)
+            {
+                MUX_FAIL_FAST_MSG(e.message().c_str());
+            }
+            throw e;
         }
     }
 

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -131,8 +131,15 @@ void XamlControlsResources::UpdateSource()
     // Since something must go horribly wrong for those lookups to fail, we just assume they exist.
     if (SharedHelpers::Is19H1OrHigher())
     {
-        UpdateAcrylicBrushesDarkTheme(ThemeDictionaries().Lookup(box_value(L"Default")));
-        UpdateAcrylicBrushesLightTheme(ThemeDictionaries().Lookup(box_value(L"Light")));
+        try
+        {
+            UpdateAcrylicBrushesDarkTheme(ThemeDictionaries().Lookup(box_value(L"Default")));
+            UpdateAcrylicBrushesLightTheme(ThemeDictionaries().Lookup(box_value(L"Light")));
+        }
+        catch (winrt::hresult_error const& e)
+        {
+            MUX_FAIL_FAST_MSG("Fail to update acrylic brush");
+        }
     }
 
     s_tlsIsControlsResourcesVersion2 = useControlsResourcesVersion2;


### PR DESCRIPTION
For the stowed exception, it's hard to investigate, so convert it to failfast if it's 80004005.

Target:
STOWED_EXCEPTION_XAML_TEXT_Cannot_find_a_resource_with_the_given_key:_AcrylicBackgroundFillColorDefaultBrush_80004005_Microsoft.UI.Xaml.dll!winrt::impl::consume_Windows_Foundation_Collections_IMap_winrt::Windows::UI::Xaml::Resou

