### PR TITLE
Fix CommandBarFlyout flicker on close

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -326,15 +326,6 @@ void CommandBarFlyoutCommandBar::AttachEventHandlers()
                 [this](auto const&, auto const&) { m_openingStoryboard.get().Stop(); }
             });
     }
-
-    if (m_closingStoryboard)
-    {
-        m_closingStoryboardCompletedRevoker =
-            m_closingStoryboard.get().Completed(winrt::auto_revoke,
-            {
-                [this](auto const&, auto const&) { m_closingStoryboard.get().Stop(); }
-            });
-    }
 }
 
 void CommandBarFlyoutCommandBar::DetachEventHandlers()
@@ -346,7 +337,6 @@ void CommandBarFlyoutCommandBar::DetachEventHandlers()
     m_secondaryItemsRootSizeChangedRevoker.revoke();
     m_firstItemLoadedRevoker.revoke();
     m_openingStoryboardCompletedRevoker.revoke();
-    m_closingStoryboardCompletedRevoker.revoke();
     m_closingStoryboardCompletedCallbackRevoker.revoke();
     m_expandedUpToCollapsedStoryboardRevoker.revoke();
     m_expandedDownToCollapsedStoryboardRevoker.revoke();
@@ -361,6 +351,11 @@ bool CommandBarFlyoutCommandBar::HasOpenAnimation()
 
 void CommandBarFlyoutCommandBar::PlayOpenAnimation()
 {
+    if (auto const& closingStoryboard = m_closingStoryboard.get())
+    {
+        closingStoryboard.Stop();
+    }
+
     if (auto openingStoryboard = m_openingStoryboard.get())
     {
         if (openingStoryboard.GetCurrentState() != winrt::ClockState::Active)

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -105,7 +105,6 @@ private:
     tracker_ref<winrt::Storyboard> m_openingStoryboard{ this };
     tracker_ref<winrt::Storyboard> m_closingStoryboard{ this };
     winrt::Storyboard::Completed_revoker m_openingStoryboardCompletedRevoker{};
-    winrt::Storyboard::Completed_revoker m_closingStoryboardCompletedRevoker{};
     winrt::Storyboard::Completed_revoker m_closingStoryboardCompletedCallbackRevoker{};
 
     bool m_secondaryItemsRootSized{ false };

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -795,7 +795,7 @@
                                                                     Duration="{StaticResource ControlFasterAnimationDuration}" />
                             </contract7Present:Storyboard>
 
-                            <contract7Present:Storyboard x:Name="ClosingOpacityStoryboard" FillBehavior="Stop">
+                            <contract7Present:Storyboard x:Name="ClosingOpacityStoryboard" FillBehavior="HoldEnd">
                                 <DoubleAnimation Storyboard.TargetName="LayoutRoot"
                                                                     Storyboard.TargetProperty="Opacity"
                                                                     From="1"


### PR DESCRIPTION
The CommandBarFlyout's closing animation is set to stop when complete, which can result in the situation where we revert back to the default value (fully opaque) moments before we actually hide the flyout if the animation completes before the flyout is hidden.  This leads to a flicker effect where the CommandBarFlyout is visually re-shown for a brief period before closing.

The fix is to change the completion behavior to HoldEnd, which keeps its value in place until we explicitly stop the animation.  We also should ensure we stop the animation after the flyout has been closed.  Stopping the animation right before we're about to show the flyout achieves this outcome.