### PR TITLE
Fixing IconSource.Foreground property set error

### DIFF
--- a/dev/IconSource/IconSource.idl
+++ b/dev/IconSource/IconSource.idl
@@ -1,6 +1,7 @@
 ﻿namespace MU_XC_NAMESPACE
 {
 
+[bindable]
 [MUX_PUBLIC]
 [webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]


### PR DESCRIPTION





<!--- Provide a general summary of your changes in the Title above -->
In recent WinUI versions, some apps are hitting errors like this:

```
WinRT originate error - 0x802B000A : 'Failed to assign to property 'Microsoft.UI.Xaml.Controls.IconSource.Foreground'. [Line: 19399 Position: 45]'.

Exception thrown at 0x7680A6F2 in Files.exe: Microsoft C++ exception: winrt::hresult_error at memory location 0x06CFB450.
```

This change adds the `Windows.UI.Xaml.Data.Bindable` attribute to fix this error.



## Description
<!--- Describe your changes in detail -->
The IXamlMetadataProvider interface is generated and implemented on the App object of an application by the Xaml compiler, allowing the core Xaml framework to retrieve type information about user-defined types. It does this by analyzing the source .xaml files of the project to determine what types are needed at runtime by the framework. However, the Xaml compiler can't determine the full closure of types needed by an application it's building since it doesn't have access to the source .xaml files of referenced control libraries. Instead, when building those control libraries, the Xaml compiler will generate a separate metadata provider class that handles all types for .xaml files defined in that control library. Then when the control library is used in an application, the Xaml compiler will also check the metadata providers from referenced control libraries so it can resolve all type information that is needed by the application if it uses controls from those libraries.

Additionally, to avoid generating an abundance of type information, the compiler will generate incomplete "stub" types for types that are needed by other types required by the framework, but aren't used by the framework directly (e.g. we'd generate a "stub" type for the base type of a control used in markup). When resolving a type, we try to ignore "stub" types and search metadata providers to see if they have a non-stub version, since if a non-stub version exists some component actually needs to use that type even if other components don't.

However, we don't have a public API to determine if an IXamlType is a "stub" type, and instead conflate it with IsConstructible. This isn't correct, since IsConstructible is a valid property set to false for non-constructible types like Microsoft.UI.Xaml.Controls.IconSource. When encountering a non-constructible type, we can mistakenly use a stub type instead of a non-stub type from a different metadata provider. `IconSource` is one such non-constructible type, and when WinUI 2's theme resources `Setters` try to access its metadata to set the `Foreground` property, the metadata is from the "stub" type and doesn't contain information about `Foreground`.

By adding the `Bindable` attribute to `IconSource`, the Xaml compiler is forced to generate all type information for `IconSource` directly in the application's metadata provider, avoiding the use of any "stub" types.  This is a surgical workaround - the real fix should be on the Xaml compiler, but would require a new Windows API and wouldn't be available downlevel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The crash mentioned in the blurb at the top of the PR.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #4759

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Using one of the original repros with its workaround for the issue removed, https://github.com/files-community/Files

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->