### PR TITLE
Top Nav Overflow with Hierarchical NVI Crash Fix

### DIFF
--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -1249,13 +1249,13 @@
                                 <VisualState x:Name="ChevronVisibleOpen">
                                     <VisualState.Setters>
                                         <Setter Target="ExpandCollapseChevron.Visibility" Value="Visible" />
-                                        <Setter Target="ExpandCollapseChevronRotateTransform.Angle" Value="180"/>
+                                        <contract7NotPresent:Setter Target="ExpandCollapseChevronRotateTransform.Angle" Value="180"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="ChevronVisibleClosed">
                                     <VisualState.Setters>
                                         <Setter Target="ExpandCollapseChevron.Visibility" Value="Visible" />
-                                        <Setter Target="ExpandCollapseChevronRotateTransform.Angle" Value="0"/>
+                                        <contract7NotPresent:Setter Target="ExpandCollapseChevronRotateTransform.Angle" Value="0"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/NavigationView/TestUI/TopMode/NavigationViewTopNavPage.xaml
+++ b/dev/NavigationView/TestUI/TopMode/NavigationViewTopNavPage.xaml
@@ -55,6 +55,12 @@
                     </muxcontrols:NavigationViewItem.Content>
                 </muxcontrols:NavigationViewItem>
                 <muxcontrols:NavigationViewItem x:Name="IntegerItem" AutomationProperties.Name="Integer" Icon="Accept"/>
+                <muxcontrols:NavigationViewItemSeparator />
+                <muxcontrols:NavigationViewItem x:Name="HasChildItem" AutomationProperties.Name="HasChildItem" Content="Item with child">
+                    <muxcontrols:NavigationViewItem.MenuItems>
+                        <muxcontrols:NavigationViewItem x:Name="ChildItem" AutomationProperties.Name="ChildItem" Content="Child Item Content" Icon="Document" />
+                    </muxcontrols:NavigationViewItem.MenuItems>
+                </muxcontrols:NavigationViewItem>
             </muxcontrols:NavigationView.MenuItems>
 
             <ScrollViewer Margin="8,0,0,0">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Top Nav Overflow Items is missing a `contract7NotPresent` tag in front of its setter for `ExpandCollapseChevronRotateTransform`, causing crashes if there's a hierarchical NVI in overflow.