### PR TITLE
Context menus spacing fixes

### DIFF
--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -356,14 +356,14 @@
     <Thickness x:Key="ComboBoxItemThemeTouchPadding">11,11,11,13</Thickness>
     <Thickness x:Key="ComboBoxItemThemeGameControllerPadding">11,11,11,13</Thickness>
     <Thickness x:Key="ComboBoxBackgroundBorderThicknessFocused">2</Thickness>
-    <Thickness x:Key="ComboBoxDropdownContentMargin">0,4</Thickness>
+    <Thickness x:Key="ComboBoxDropdownContentMargin">0,2</Thickness>
     <Thickness x:Key="ComboBoxTopHeaderMargin">0,0,0,8</Thickness>
     <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
     <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
 
-    <CornerRadius x:Key="ComboBoxHiglightBorderCornerRadius">7</CornerRadius>
+    <CornerRadius x:Key="ComboBoxHiglightBorderCornerRadius">8</CornerRadius>
     <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
-    <CornerRadius x:Key="ComboBoxItemCornerRadius">3</CornerRadius>
+    <CornerRadius x:Key="ComboBoxItemCornerRadius">4</CornerRadius>
     <CornerRadius x:Key="ComboBoxItemPillCornerRadius">1.5</CornerRadius>
     
     <FontWeight x:Key="ComboBoxHeaderThemeFontWeight">Normal</FontWeight>
@@ -658,7 +658,6 @@
 
                         <Rectangle x:Name="Pill"
                             Style="{StaticResource ComboBoxItemPill}"
-                            Margin="1,0,0,0"
                             Grid.Row="1" Grid.Column="0"
                             Opacity="0">
                             <Rectangle.RenderTransform>
@@ -790,7 +789,7 @@
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        Margin="5,2,5,2"
+                        Margin="4,2"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                         Control.IsTemplateFocusTarget="True">

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -111,7 +111,7 @@
     </ResourceDictionary.ThemeDictionaries>
 
     <Thickness x:Key="CommandBarFlyoutAppBarButtonInnerBorderMargin">2</Thickness>
-    <Thickness x:Key="CommandBarFlyoutAppBarEllipsisButtonInnerBorderMargin">2,2,6,2</Thickness>
+    <Thickness x:Key="CommandBarFlyoutAppBarEllipsisButtonInnerBorderMargin">2</Thickness>
     <contract12Present:ThemeShadow x:Key="CommandBarFlyoutOverflowShadow"/>
 
     <Style x:Key="CommandBarFlyoutAppBarButtonStyleBase" TargetType="AppBarButton">
@@ -124,7 +124,7 @@
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Width" Value="NaN" />
-        <Setter Property="Height" Value="40" />
+        <Setter Property="Height" Value="36" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="AllowFocusOnInteraction" Value="False" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
@@ -280,7 +280,7 @@
                             </contract7Present:Border.BackgroundTransition>
                         </Border>
 
-                        <Grid x:Name="ContentRoot" Width="40">
+                        <Grid x:Name="ContentRoot" Width="44">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
@@ -352,7 +352,7 @@
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Width" Value="NaN" />
-        <Setter Property="Height" Value="40" />
+        <Setter Property="Height" Value="36" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="AllowFocusOnInteraction" Value="False" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
@@ -633,7 +633,7 @@
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             AutomationProperties.AccessibilityView="Raw">
                             <ItemsPresenter x:Name="ItemsPresenter"
-                                Margin="3"/>
+                                Margin="2"/>
                         </ScrollViewer>
                     </Grid>
                 </ControlTemplate>
@@ -667,7 +667,7 @@
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             AutomationProperties.AccessibilityView="Raw">
                             <ItemsPresenter x:Name="ItemsPresenter"
-                                Margin="3"/>
+                                Margin="2"/>
                         </ScrollViewer>
                     </Grid>
                 </ControlTemplate>
@@ -680,8 +680,8 @@
         <Setter Property="Foreground" Value="{ThemeResource CommandBarFlyoutAppBarButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CommandBarFlyoutAppBarButtonBorderBrush}" />
         <Setter Property="Padding" Value="0" />
-        <Setter Property="Width" Value="44" />
-        <Setter Property="Height" Value="40" />
+        <Setter Property="Width" Value="40" />
+        <Setter Property="Height" Value="32" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -763,7 +763,7 @@
         <Setter Property="ExitDisplayModeOnAccessKeyInvoked" Value="False" />
         <Setter Property="DefaultLabelPosition" Value="Collapsed" />
         <Setter Property="MaxWidth" Value="440" />
-        <Setter Property="Height" Value="48" />
+        <Setter Property="Height" Value="40" />
         <Setter Property="IsDynamicOverflowEnabled" Value="True" />
         <contract7Present:Setter Property="CommandBarOverflowPresenterStyle" Value="{StaticResource CommandBarFlyoutCommandBarOverflowPresenterStyle}" />
         <contract7NotPresent:Setter Property="CommandBarOverflowPresenterStyle" Value="{StaticResource CommandBarFlyoutCommandBarOverflowPresenterStyleRS4}" />
@@ -1250,17 +1250,17 @@
                                     </RectangleGeometry>
                                 </Grid.Clip>
                                 <Grid x:Name="PrimaryItemsRoot"
+                                    Margin="2"
+                                    Height="36"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                                     contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" MinWidth="3" />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
-                                        Height="40"
-                                        Margin="3,3,0,3"
                                         Grid.Column="0"
                                         IsTabStop="False"
                                         HorizontalAlignment="Left">

--- a/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -105,7 +105,7 @@
     <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,16,12,10</Thickness>
     <Thickness x:Key="AppBarButtonInnerBorderMargin">2,6,2,6</Thickness>
     <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">2,6,2,22</Thickness>
-    <Thickness x:Key="AppBarButtonInnerBorderOverflowMargin">4,0,4,0</Thickness>
+    <Thickness x:Key="AppBarButtonInnerBorderOverflowMargin">4,2</Thickness>
 
     <Style TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />
 

--- a/dev/CommonStyles/AppBarSeparator_themeresources.xaml
+++ b/dev/CommonStyles/AppBarSeparator_themeresources.xaml
@@ -14,7 +14,7 @@
     </ResourceDictionary.ThemeDictionaries>
 
     <Thickness x:Key="AppBarSeparatorMargin">2,8,2,8</Thickness>
-    <Thickness x:Key="AppBarOverflowSeparatorMargin">0,4,0,4</Thickness>
+    <Thickness x:Key="AppBarOverflowSeparatorMargin">0,2</Thickness>
     <x:Double x:Key="AppBarSeparatorWidth">1</x:Double>
     <x:Double x:Key="AppBarOverflowSeparatorHeight">1</x:Double>
     <x:Double x:Key="AppBarSeparatorCornerRadius">0.5</x:Double>

--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -91,7 +91,7 @@
     <Thickness x:Key="AppBarEllipsisButtonInnerBorderMargin">2,6,6,6</Thickness>
     <x:Double x:Key="AppBarMoreButtonColumnMinWidth">6</x:Double>
     
-    <Thickness x:Key="CommandBarOverflowPresenterMargin">0,4,0,4</Thickness>
+    <Thickness x:Key="CommandBarOverflowPresenterMargin">0,2</Thickness>
 
     <Style TargetType="CommandBar" BasedOn="{StaticResource DefaultCommandBarStyle}" />
 

--- a/dev/CommonStyles/InkToolbar_themeresources.xaml
+++ b/dev/CommonStyles/InkToolbar_themeresources.xaml
@@ -163,7 +163,7 @@
     <x:Double x:Key="InkToolbarButtonWidth">36</x:Double>
     <x:Double x:Key="InkToolbarButtonHeight">36</x:Double>
     <x:Double x:Key="InkToolbarButtonFontSize">16</x:Double>
-    <Thickness x:Key="InkToolbarFlyoutPanelMargin">0,1,0,1</Thickness>
+    <Thickness x:Key="InkToolbarFlyoutPanelMargin">0,2</Thickness>
     <Thickness x:Key="InkToolbarFlyoutItemIconMargin">12,0,12,0</Thickness>
     <Thickness x:Key="InkToolbarFlyoutItemTextBlockMargin">0,0,12,0</Thickness>
 
@@ -199,7 +199,7 @@
         <Setter Property="MinWidth" Value="0" />
         <Setter Property="MinHeight" Value="0" />
         <Setter Property="Margin" Value="2,4,2,4" />
-        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
     </Style>
 
     <Style x:Key="InkToolbarCommonButtonStyle" TargetType="ToggleButton">
@@ -1065,8 +1065,9 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="MinWidth" Value="136" />
-        <Setter Property="Height" Value="40" />
+        <Setter Property="MinWidth" Value="132" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="Margin" Value="4,2" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Template">
@@ -1146,8 +1147,7 @@
                             BorderThickness="0"
                             Background="Transparent"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                            Control.IsTemplateFocusTarget="True"
-                            Margin ="2,2,2,2">
+                            Control.IsTemplateFocusTarget="True">
                             <Grid>
                                 <Rectangle x:Name="CurrentSelectionIcon" Style="{StaticResource InkToolbarFlyoutItemSelectionAccentStyle}" />
                                 <ContentPresenter x:Name="Content"

--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -258,13 +258,13 @@
     </ResourceDictionary.ThemeDictionaries>
 
     <x:Double x:Key="MenuFlyoutSeparatorHeight">1</x:Double>
-    <Thickness x:Key="MenuFlyoutPresenterThemePadding">0,2,0,2</Thickness>
+    <Thickness x:Key="MenuFlyoutPresenterThemePadding">0,2</Thickness>
     <x:Double x:Key="MenuFlyoutThemeMinHeight">32</x:Double>
     <Thickness x:Key="MenuFlyoutItemChevronMargin">24,0,0,0</Thickness>
     <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">28,0,0,0</Thickness>
-    <Thickness x:Key="MenuFlyoutSeparatorThemePadding">-4,1,-4,1</Thickness>
+    <Thickness x:Key="MenuFlyoutSeparatorThemePadding">0,2</Thickness>
     <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">56,0,0,0</Thickness>
-    <Thickness x:Key="MenuFlyoutItemMargin">4,2,4,2</Thickness>
+    <Thickness x:Key="MenuFlyoutItemMargin">4,2</Thickness>
     <Thickness x:Key="MenuFlyoutItemThemePadding">11,8,11,9</Thickness>
     <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,5</Thickness>
 

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -513,7 +513,7 @@
                                             x:Name="AutoSuggestArea"
                                             Grid.Row="3"
                                             Height="{ThemeResource NavigationViewAutoSuggestAreaHeight}"
-                                            Margin="0,0,0,8"
+                                            Margin="0,0,0,4"
                                             VerticalAlignment="Center">
 
                                             <ContentControl

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -271,7 +271,7 @@
     <Thickness x:Key="NavigationViewItemInnerHeaderMargin">16,0</Thickness>
     <Thickness x:Key="TopNavigationViewItemInnerHeaderMargin">12,0</Thickness>
     <Thickness x:Key="NavigationViewMinimalHeaderMargin">-24,44,0,0</Thickness>
-    <Thickness x:Key="NavigationViewButtonHolderGridMargin">0,4</Thickness>
+    <Thickness x:Key="NavigationViewButtonHolderGridMargin">0,2</Thickness>
     <Thickness x:Key="NavigationViewPaneContentGridMargin">-1,3</Thickness>
     <Thickness x:Key="NavigationViewContentGridBorderThickness">1,1,0,0</Thickness>
     <Thickness x:Key="NavigationViewMinimalContentGridBorderThickness">0,1,0,0</Thickness>
@@ -283,9 +283,9 @@
     <Thickness x:Key="NavigationViewPaneTitlePresenterMargin">8,4,0,0</Thickness>
     <Thickness x:Key="NavigationViewItemMargin">0</Thickness>
     <Thickness x:Key="TopNavigationViewItemMargin">0</Thickness>
-    <Thickness x:Key="NavigationViewItemSeparatorMargin">0,3,0,4</Thickness>
-    <Thickness x:Key="NavigationViewCompactItemSeparatorMargin">0,3,0,4</Thickness>
-    <Thickness x:Key="TopNavigationViewItemSeparatorMargin">3,0,4,0</Thickness>
+    <Thickness x:Key="NavigationViewItemSeparatorMargin">0,2</Thickness>
+    <Thickness x:Key="NavigationViewCompactItemSeparatorMargin">0,2</Thickness>
+    <Thickness x:Key="TopNavigationViewItemSeparatorMargin">2,0</Thickness>
     <Thickness x:Key="TopNavigationViewOverflowButtonMargin">0</Thickness>
     <Thickness x:Key="NavigationViewItemContentPresenterMargin">4,-1,20,-1</Thickness>
     <Thickness x:Key="NavigationViewCompactItemContentPresenterMargin">0,0,0,0</Thickness>
@@ -304,8 +304,8 @@
     <CornerRadius x:Key="NavigationViewMinimalContentGridCornerRadius">0</CornerRadius>
 
     <!-- The two resources below must be defined at the app level in order to take effect. -->
-    <Thickness x:Key="TopNavigationViewOverflowMenuPadding">0,8</Thickness>
-    <Thickness x:Key="NavigationViewItemChildrenMenuFlyoutPadding">0,8</Thickness>
+    <Thickness x:Key="TopNavigationViewOverflowMenuPadding">0,2</Thickness>
+    <Thickness x:Key="NavigationViewItemChildrenMenuFlyoutPadding">0,2</Thickness>
 
     <!-- The resource below must be defined at the app level in order to affect the expand/collapse chevron font size
          used in the Top NavigationView's Overflow menu. -->


### PR DESCRIPTION
Partially fixes #4383 for the vertical menus.

Updated spacing to be consistent across different kinds of context menus: CommandBar overflow, MenuFlyout, ComboBox, NavigationView overflow, CommandBarFlyout and InkToolbar flyouts. Also changed NavigationView itself slightly.

Other ComboBox changes:
- Updated CornerRadius resources
  - resources for this are rarely used in the code, they might have stayed in the stable version by mistake
- removed Pill margin: other controls with pills (NavigationView, TreeView) don't have that 1px space on the left

InkToolbar change: flyouts now use OverlayCornerRadius