### PR TITLE
Fixing CalendarView navigation buttons sizing

### DIFF
--- a/dev/CommonStyles/CalendarView_themeresources_21h1.xaml
+++ b/dev/CommonStyles/CalendarView_themeresources_21h1.xaml
@@ -75,9 +75,9 @@
             <Thickness x:Key="CalendarViewFirstOfYearDecadeLabelMargin">0,9,0,0</Thickness>
             <Thickness x:Key="CalendarViewHeaderNavigationButtonPadding">8,7,8,8</Thickness>
             <Thickness x:Key="CalendarViewNavigationButtonPadding">12,11.5,12,11.5</Thickness>
-            <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">7,6,4,7</Thickness>
-            <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">4,6,4,7</Thickness>
-            <Thickness x:Key="CalendarViewNavigationNextButtonMargin">4,6,7,7</Thickness>
+            <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">7,6,3,7</Thickness>
+            <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">3,6,3,7</Thickness>
+            <Thickness x:Key="CalendarViewNavigationNextButtonMargin">3,6,7,7</Thickness>
             <Thickness x:Key="CalendarViewNavigationButtonFocusVisualMargin">-2</Thickness>
             <FontWeight x:Key="CalendarViewHeaderNavigationFontWeight">SemiBold</FontWeight>
             <FontWeight x:Key="CalendarViewWeekDayFontWeight">SemiBold</FontWeight>
@@ -153,9 +153,9 @@
             <Thickness x:Key="CalendarViewFirstOfYearDecadeLabelMargin">0,9,0,0</Thickness>
             <Thickness x:Key="CalendarViewHeaderNavigationButtonPadding">8,7,8,8</Thickness>
             <Thickness x:Key="CalendarViewNavigationButtonPadding">12,11.5,12,11.5</Thickness>
-            <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">7,6,4,7</Thickness>
-            <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">4,6,4,7</Thickness>
-            <Thickness x:Key="CalendarViewNavigationNextButtonMargin">4,6,7,7</Thickness>
+            <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">7,6,3,7</Thickness>
+            <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">3,6,3,7</Thickness>
+            <Thickness x:Key="CalendarViewNavigationNextButtonMargin">3,6,7,7</Thickness>
             <Thickness x:Key="CalendarViewNavigationButtonFocusVisualMargin">-2</Thickness>
             <FontWeight x:Key="CalendarViewHeaderNavigationFontWeight">SemiBold</FontWeight>
             <FontWeight x:Key="CalendarViewWeekDayFontWeight">SemiBold</FontWeight>
@@ -231,9 +231,9 @@
             <Thickness x:Key="CalendarViewFirstOfYearDecadeLabelMargin">0,9,0,0</Thickness>
             <Thickness x:Key="CalendarViewHeaderNavigationButtonPadding">8,7,8,8</Thickness>
             <Thickness x:Key="CalendarViewNavigationButtonPadding">12,11.5,12,11.5</Thickness>
-            <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">7,6,4,7</Thickness>
-            <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">4,6,4,7</Thickness>
-            <Thickness x:Key="CalendarViewNavigationNextButtonMargin">4,6,7,7</Thickness>
+            <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">7,6,3,7</Thickness>
+            <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">3,6,3,7</Thickness>
+            <Thickness x:Key="CalendarViewNavigationNextButtonMargin">3,6,7,7</Thickness>
             <Thickness x:Key="CalendarViewNavigationButtonFocusVisualMargin">-2</Thickness>
             <FontWeight x:Key="CalendarViewHeaderNavigationFontWeight">SemiBold</FontWeight>
             <FontWeight x:Key="CalendarViewWeekDayFontWeight">SemiBold</FontWeight>
@@ -707,9 +707,9 @@
                             </Grid.RowDefinitions>
                             <Grid>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="5*" />
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <Button x:Name="HeaderButton"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.HeaderText}"


### PR DESCRIPTION
Up until now the three top components of the CalendarView, the header, the previous button & the next button, were respectively allocated 5*, 1* and 1* in a Grid.
The two navigation buttons were cut off when changing the text scaling from 100% to 225% in the Settings app's "Make text bigger" section.
See internal report 33899462.
The fix is to switch to a 1*, Auto, Auto configuration to let the two navigation buttons grow as needed.
I also fixed the empty spaces between:
. the header and previous button, 
. the previous and next buttons.
Somehow the two gaps were two narrow by 2 pixels.

Tested using the MUXControlsTestApp and Settings'  "Make text bigger". All looks good now.