### PR TITLE
CalendarView high contrast fixes - header area button styles +  item background/stroke rest state

### DIFF
--- a/dev/CommonStyles/CalendarView_themeresources_21h1.xaml
+++ b/dev/CommonStyles/CalendarView_themeresources_21h1.xaml
@@ -53,6 +53,7 @@
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundPointerOver" ResourceKey="ControlStrongFillColorDefaultBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundPressed" ResourceKey="ControlStrongFillColorDefaultBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundDisabled" ResourceKey="ControlStrongFillColorDisabledBrush" />
+            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
@@ -106,11 +107,11 @@
             <StaticResource x:Key="CalendarViewOutOfScopeForeground" ResourceKey="SystemControlHyperlinkBaseHighBrush" />
             <StaticResource x:Key="CalendarViewOutOfScopeHoverForeground" ResourceKey="SystemControlHyperlinkBaseHighBrush" />
             <StaticResource x:Key="CalendarViewOutOfScopePressedForeground" ResourceKey="SystemControlHighlightBaseHighBrush" />
-            <StaticResource x:Key="CalendarViewCalendarItemBackground" ResourceKey="SystemControlBackgroundAltHighBrush" />
+            <StaticResource x:Key="CalendarViewCalendarItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="CalendarViewCalendarItemHoverBackground" ResourceKey="SystemColorWindowColorBrush" />
             <StaticResource x:Key="CalendarViewCalendarItemPressedBackground" ResourceKey="SystemColorWindowColorBrush" />
             <StaticResource x:Key="CalendarViewCalendarItemDisabledBackground" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="CalendarViewCalendarItemBorderBrush" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="CalendarViewCalendarItemBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="CalendarViewCalendarItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="CalendarViewTodayBackground" ResourceKey="SystemColorHighlightColorBrush" />
             <StaticResource x:Key="CalendarViewTodayBlackoutBackground" ResourceKey="SystemColorHighlightColorBrush" />
@@ -125,15 +126,16 @@
             <StaticResource x:Key="CalendarViewBorderBrush" ResourceKey="SystemControlForegroundChromeMediumBrush" />
             <StaticResource x:Key="CalendarViewWeekDayForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonBackground" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="CalendarViewNavigationButtonBackgroundPointerOver" ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="CalendarViewNavigationButtonBackgroundPressed" ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="CalendarViewNavigationButtonForeground" ResourceKey="SystemControlHyperlinkBaseHighBrush" />
-            <StaticResource x:Key="CalendarViewNavigationButtonForegroundPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />
-            <StaticResource x:Key="CalendarViewNavigationButtonForegroundPressed" ResourceKey="SystemControlForegroundBaseMediumBrush" />
-            <StaticResource x:Key="CalendarViewNavigationButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPointerOver" ResourceKey="SystemControlForegroundBaseHighBrush" />
-            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPressed" ResourceKey="SystemControlForegroundBaseMediumBrush" />
-            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="CalendarViewNavigationButtonBackgroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="CalendarViewNavigationButtonBackgroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="CalendarViewNavigationButtonForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="CalendarViewNavigationButtonForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="CalendarViewNavigationButtonForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="CalendarViewNavigationButtonForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPressed" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonBorderBrushPointerOver" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonBorderBrush" ResourceKey="SystemControlTransparentBrush" />
 
@@ -209,6 +211,7 @@
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundPointerOver" ResourceKey="ControlStrongFillColorDefaultBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundPressed" ResourceKey="ControlStrongFillColorDefaultBrush" />
             <StaticResource x:Key="CalendarViewNavigationButtonForegroundDisabled" ResourceKey="ControlStrongFillColorDisabledBrush" />
+            <StaticResource x:Key="CalendarViewHeaderNavigationButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="CalendarViewHeaderNavigationButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
@@ -343,6 +346,7 @@
                                 <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
                                 <Setter Property="FontSize" Value="{ThemeResource CalendarViewHeaderNavigationButtonFontSize}" />
                                 <Setter Property="FontWeight" Value="{ThemeResource CalendarViewHeaderNavigationFontWeight}" />
+                                <Setter Property="Foreground" Value="{ThemeResource CalendarViewHeaderNavigationButtonForeground}" />
                                 <Setter Property="Background" Value="{ThemeResource CalendarViewNavigationButtonBackground}" />
                                 <Setter Property="Margin" Value="{ThemeResource CalendarViewHeaderNavigationButtonMargin}" />
                                 <Setter Property="Padding" Value="{ThemeResource CalendarViewHeaderNavigationButtonPadding}" />
@@ -354,6 +358,7 @@
                                         <ControlTemplate TargetType="Button">
                                             <ContentPresenter
                                                 x:Name="Text"
+                                                Foreground="{TemplateBinding Foreground}"
                                                 Background="{TemplateBinding Background}"
                                                 contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
                                                 BorderBrush="{ThemeResource CalendarViewNavigationButtonBorderBrush}"
@@ -715,7 +720,6 @@
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.HeaderText}"
                                     IsEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.HasMoreViews}"
                                     Style="{StaticResource HeaderNavigationButtonStyle}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     HorizontalContentAlignment="Left" />
                                 <Button x:Name="PreviousButton" Grid.Column="1"
                                     Content="&#xEDDB;"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Consulted with the high contrast designer on the calendar view header and chevron buttons - these should all follow default ghost button styling in high contrast (the same style as command bar button - visible backplate on hover and press)
- Created a resource for navigation header button rest state text to support default ghost button styling 
- While reviewing with the designer, we noticed a background and border showing in high contrast for all items at rest. Matched these styles to default styling and made them transparent


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Buttons are now in alignment with the overall high contrast color system.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Validated changes with the high contrast designer; controls test app

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
https://microsoft.sharepoint-df.com/:f:/r/teams/windows/Confidential/Shared%20Documents/Pull%20Request%20Assets/CalendarHighContrast?csf=1&web=1&e=TTFBks
