### PR TITLE
Fix for the content dialog overlay corner radius.

### DIFF
--- a/dev/CommonStyles/ContentDialog_themeresources.xaml
+++ b/dev/CommonStyles/ContentDialog_themeresources.xaml
@@ -205,8 +205,7 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="LayoutRoot"
-                            contract7Present:CornerRadius="{ThemeResource OverlayCornerRadius}">
+                        <Grid x:Name="LayoutRoot">
                             <Rectangle x:Name="SmokeLayerBackground" Fill="{ThemeResource ContentDialogSmokeFill}" />
                             <Border
                                 x:Name="BackgroundElement"


### PR DESCRIPTION
## Description
Removed the corner radius from the root layout grid from the content dialog.

## Motivation and Context
The corner radius is making the overlay background corner rounded and causing weird effect on Windows 10, since it does not have rounded windows.

Closes #5301

## How Has This Been Tested?
Tested using the MUXControlTestApp, the changes can be seen in the screenshots below.

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/29243277/123729707-ce596f00-d86b-11eb-9085-f801da249488.png)

After:
![image](https://user-images.githubusercontent.com/29243277/123729465-62770680-d86b-11eb-8f8b-3370db770d49.png)
