### PR TITLE
Revert MenuFlyoutItem placeholder margin to ThemeResource in Version2 styles

### DIFF
--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -44,7 +44,10 @@
 
             <Thickness x:Key="MenuFlyoutItemBorderThickness">0</Thickness>
             <Thickness x:Key="MenuFlyoutSubItemBorderThickness">0</Thickness>
-            
+
+            <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">28,0,0,0</Thickness>
+            <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">56,0,0,0</Thickness>
+
             <!-- Legacy resources -->
             <Thickness x:Key="MenuFlyoutItemRevealBorderThickness">1</Thickness>
             <Thickness x:Key="ToggleMenuFlyoutItemRevealBorderThickness">1</Thickness>
@@ -127,6 +130,9 @@
 
             <Thickness x:Key="MenuFlyoutItemBorderThickness">0</Thickness>
             <Thickness x:Key="MenuFlyoutSubItemBorderThickness">0</Thickness>
+
+            <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">28,0,0,0</Thickness>
+            <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">56,0,0,0</Thickness>
             
             <!-- Legacy resources -->
             <Thickness x:Key="MenuFlyoutItemRevealBorderThickness">1</Thickness>
@@ -210,6 +216,9 @@
 
             <Thickness x:Key="MenuFlyoutItemBorderThickness">0</Thickness>
             <Thickness x:Key="MenuFlyoutSubItemBorderThickness">0</Thickness>
+
+            <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">28,0,0,0</Thickness>
+            <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">56,0,0,0</Thickness>
             
             <!-- Legacy resources -->
             <Thickness x:Key="MenuFlyoutItemRevealBorderThickness">1</Thickness>
@@ -261,9 +270,7 @@
     <Thickness x:Key="MenuFlyoutPresenterThemePadding">0,2,0,2</Thickness>
     <x:Double x:Key="MenuFlyoutThemeMinHeight">32</x:Double>
     <Thickness x:Key="MenuFlyoutItemChevronMargin">24,0,0,0</Thickness>
-    <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">28,0,0,0</Thickness>
     <Thickness x:Key="MenuFlyoutSeparatorThemePadding">-4,1,-4,1</Thickness>
-    <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">56,0,0,0</Thickness>
     <Thickness x:Key="MenuFlyoutItemMargin">4,2,4,2</Thickness>
     <Thickness x:Key="MenuFlyoutItemThemePadding">11,8,11,9</Thickness>
     <Thickness x:Key="MenuFlyoutItemThemePaddingNarrow">11,4,11,5</Thickness>
@@ -372,19 +379,19 @@
                                 <VisualState x:Name="NoPlaceholder" />
                                 <VisualState x:Name="CheckPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckAndIconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
+                                        <Setter Target="IconRoot.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -654,19 +661,19 @@
                                 <VisualState x:Name="NoPlaceholder" />
                                 <VisualState x:Name="CheckPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckAndIconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
+                                        <Setter Target="IconRoot.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -797,19 +804,19 @@
                                 <VisualState x:Name="NoPlaceholder" />
                                 <VisualState x:Name="CheckPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckAndIconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
+                                        <Setter Target="IconRoot.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -936,13 +943,13 @@
                                 </VisualState>
                                 <VisualState x:Name="UncheckedWithIcon">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckedWithIcon">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                         <Setter Target="CheckGlyph.Opacity" Value="1" />
                                     </VisualState.Setters>
@@ -1083,19 +1090,19 @@
                                 <VisualState x:Name="NoPlaceholder" />
                                 <VisualState x:Name="CheckPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="CheckAndIconPlaceholder">
                                     <VisualState.Setters>
-                                        <Setter Target="TextBlock.Margin" Value="{StaticResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
-                                        <Setter Target="IconRoot.Margin" Value="{StaticResource MenuFlyoutItemPlaceholderThemeThickness}" />
+                                        <Setter Target="TextBlock.Margin" Value="{ThemeResource MenuFlyoutItemDoublePlaceholderThemeThickness}" />
+                                        <Setter Target="IconRoot.Margin" Value="{ThemeResource MenuFlyoutItemPlaceholderThemeThickness}" />
                                         <Setter Target="IconRoot.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR changes the MenuFlyout resources MenuFlyoutItemDoublePlaceholderThemeThickness and MenuFlyoutItemPlaceholderThemeThickness to be applied with `ThemeResource` in the new Version2 styles, to re-enable easy theming that was possible in Version1.

## Motivation and Context
To create a menu design in which check boxes and radio buttons align with icons, it is necessary to adjust the resources MenuFlyoutItemDoublePlaceholderThemeThickness and MenuFlyoutItemPlaceholderThemeThickness on your MenuFlyoutItems. Prior to the Version2 styles in WinUI 2.6, this could be done without any retemplating, however, the new styles apply these resources as `StaticResource` instead of `ThemeResource` like the old styles. This PR restores the functionality already present in the Version1 styles (as well as the generic.xaml system style).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
Tested in MUXControlsTestApp manually. Minimal sample menu:
```xaml
<MenuFlyout>
    <MenuFlyoutItem Icon="Emoji2" Text="Item with icon">
        <MenuFlyoutItem.Resources>
            <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">0</Thickness>
            <Thickness x:Key="MenuFlyoutItemDoublePlaceholderThemeThickness">28,0,0,0</Thickness>
        </MenuFlyoutItem.Resources>
    </MenuFlyoutItem>
    <ToggleMenuFlyoutItem IsChecked="True" Text="Item with check">
        <ToggleMenuFlyoutItem.Resources>
            <Thickness x:Key="MenuFlyoutItemPlaceholderThemeThickness">0</Thickness>
        </ToggleMenuFlyoutItem.Resources>
    </ToggleMenuFlyoutItem>
</MenuFlyout>
```

## Screenshots (if appropriate):
This is my use case below (with radio buttons added to demonstrate):
![Disorienting menu with icons and checkboxes in different columns](https://user-images.githubusercontent.com/18747724/123928522-fcb67780-d95b-11eb-9750-91cf6b8c479c.png)
As you can see, the icons do not line up and this menu is not pleasant to look at.

Intended look:
![image](https://user-images.githubusercontent.com/18747724/123928115-929dd280-d95b-11eb-9db7-ff576db67575.png)
With the control of the styles restored, I can make the menu look how I want it to.