### PR TITLE
Breadcrumb: make ellipsis inaccessible by Accessibility tools when it's hidden

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -342,11 +342,20 @@ void BreadcrumbBar::ReIndexVisibleElementsForAccessibility() const
     if (auto const& itemsRepeater = m_itemsRepeater.get())
     {
         const uint32_t visibleItemsCount{ m_itemsRepeaterLayout->GetVisibleItemsCount() };
+        const auto isEllipsisRendered = m_itemsRepeaterLayout->EllipsisIsRendered();
         uint32_t firstItemToIndex{ 1 };
 
-        if (m_itemsRepeaterLayout->EllipsisIsRendered())
+        if (isEllipsisRendered)
         {
             firstItemToIndex = m_itemsRepeaterLayout->FirstRenderedItemIndexAfterEllipsis();
+        }
+
+        // In order to make the ellipsis inaccessible to accessbility tools when it's hidden,
+        // we set the accessibilityView to raw and restore it to content when it becomes visible.
+        if (const auto ellipsisItem = m_ellipsisBreadcrumbBarItem.get())
+        {
+            const auto accessibilityView = isEllipsisRendered ? winrt::AccessibilityView::Content : winrt::AccessibilityView::Raw;
+            ellipsisItem.SetValue(winrt::AutomationProperties::AccessibilityViewProperty(), box_value(accessibilityView));
         }
 
         const auto& itemsSourceView = itemsRepeater.ItemsSourceView();

--- a/dev/Breadcrumb/InteractionTests/BreadcrumbBarTests.cs
+++ b/dev/Breadcrumb/InteractionTests/BreadcrumbBarTests.cs
@@ -610,7 +610,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             return elementGotFocus;
         }
 
-        private bool TryGetFocusForRs3(UIObject breadcrumb, int indexToFocus, bool isRightToLeft)
+        private bool TryGetFocusForRs3(UIObject breadcrumb, int indexToFocus, bool isEllipsisVisible, bool isRightToLeft)
         {
             Log.Comment("Try Set focus for RS3 build");
 
@@ -619,6 +619,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
             // For RS3 we need only one Tab key stroke
             KeyboardHelper.PressKey(Key.Tab);
+
+            if (!isEllipsisVisible)
+            {
+                if (isRightToLeft)
+                {
+                    KeyboardHelper.PressKey(Key.Left);
+                }
+                else
+                {
+                    KeyboardHelper.PressKey(Key.Right);
+                }
+            }
 
             bool elementGotFocus = breadcrumb.Children[indexToFocus].HasKeyboardFocus;
 
@@ -675,7 +687,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             bool gotFocus = TryGetFocusForRs2(breadcrumb, indexToFocus, isEllipsisVisible);
             if (!gotFocus)
             {
-                gotFocus = TryGetFocusForRs3(breadcrumb, indexToFocus, isRightToLeft);
+                gotFocus = TryGetFocusForRs3(breadcrumb, indexToFocus, isEllipsisVisible, isRightToLeft);
                 if (!gotFocus)
                 {
                     gotFocus = TryGetFocusByPressingTab(breadcrumb, indexToFocus);

--- a/dev/Breadcrumb/InteractionTests/BreadcrumbBarTests.cs
+++ b/dev/Breadcrumb/InteractionTests/BreadcrumbBarTests.cs
@@ -588,7 +588,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             UIObject anchor = RetrieveRTLCheckBox();
             FocusHelper.SetFocus(anchor);
 
-            // For RS2 we need only Tab key stroke if the ellipsis is onscreen and 2 if it's not
+            // For RS2 we need only one Tab key stroke if the ellipsis is onscreen and 2 if it's not
             KeyboardHelper.PressKey(Key.Tab);
 
             if (!isEllipsisVisible)

--- a/dev/Breadcrumb/InteractionTests/BreadcrumbBarTests.cs
+++ b/dev/Breadcrumb/InteractionTests/BreadcrumbBarTests.cs
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 UIObject breadcrumb = RetrieveBreadcrumbControl();
                 var breadcrumbItems = breadcrumb.Children;
 
-                Verify.AreEqual(2, breadcrumbItems.Count, "The breadcrumb should contain 2 items: 1 item and an ellipsis");
+                Verify.AreEqual(1, breadcrumbItems.Count, "The breadcrumb should contain 1 item.");
             }
         }
 
@@ -137,9 +137,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 UIObject breadcrumb = RetrieveBreadcrumbControl();
                 var breadcrumbItems = breadcrumb.Children;
 
-                Verify.AreEqual(2, breadcrumbItems.Count, "The breadcrumb should contain 2 items: 1 item and an ellipsis");
+                Verify.AreEqual(1, breadcrumbItems.Count, "The breadcrumb should contain 1 item.");
 
-                var currentItem = breadcrumbItems[1];
+                var currentItem = breadcrumbItems[0];
 
                 var currentBreadcrumbBarItem = ConvertTo<BreadcrumbBarItem>(currentItem);
                 Verify.IsNotNull(currentBreadcrumbBarItem, "UIElement should be a BreadcrumbBarItem");
@@ -157,14 +157,14 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             // In this test we add the nodes 'Node A', 'Node A_2', 'Node A_2_3', once the nodes have been added
             // we click on each item verify that the BreadcrumbBar contained the specified nodes. At the end, only the
-            // ellipsis item and the 'Root' item should exist
+            // ellipsis item and the 'Root' item should exist however ellipsis item is hidden from the UIA tree.
             using (var setup = new TestSetupHelper("BreadcrumbBar Tests"))
             {
                 var breadcrumb = SetUpTest();
                 
                 VerifyBreadcrumbBarItemsContain(breadcrumb.Children, new string[] { "Root", "Node A", "Node A_2", "Node A_2_3", "Node A_2_3_1" }, true);
                 
-                Verify.AreEqual(2, breadcrumb.Children.Count, "The breadcrumb should contain 2 items: the root and an ellipsis");
+                Verify.AreEqual(1, breadcrumb.Children.Count, "The breadcrumb should contain 1 item");
             }
         }
 
@@ -174,19 +174,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             // In this test we add the breadcrumb Items 'Node A', 'Node A_2', 'Node A_2_3' & 'Node A_2_3_1'
             // Once those items have been added, we click on the 'Node A_2' item and verify that only the
-            // ellipsis item, 'Root', 'Node A' and 'Node A_2' exist on the breadcrumb
+            // ellipsis item, 'Root', 'Node A' and 'Node A_2' exist on the breadcrumb however ellipsis item is hidden from the UIA tree.
             using (var setup = new TestSetupHelper("BreadcrumbBar Tests"))
             {
                 var breadcrumb = SetUpTest();
 
                 // Click on the Node A_2 BreadcrumbBarItem
-                var NodeA_2BreadcrumbBarItem = breadcrumb.Children[3];
+                var NodeA_2BreadcrumbBarItem = breadcrumb.Children[2];
                 NodeA_2BreadcrumbBarItem.Click();
 
                 VerifyLastClickedItemIndexIs(2);
                 VerifyLastClickedItemIs("Node A_2");
 
-                Verify.AreEqual(4, breadcrumb.Children.Count, "The breadcrumb should contain 4 items: 3 items and an ellipsis");
+                Verify.AreEqual(3, breadcrumb.Children.Count, "The breadcrumb should contain 3 items");
 
                 VerifyBreadcrumbBarItemsContain(breadcrumb.Children, new string[] { "Root", "Node A", "Node A_2" });
             }
@@ -213,6 +213,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Verify only 3 ellipsis items exist");
                 var ellipsisItem4 = FindElement.ByName("EllipsisItem4");
                 Verify.IsNull(ellipsisItem4, "EllipsisItem4 was found");
+
+                Verify.AreEqual(6, breadcrumb.Children.Count, "The breadcrumb should contain 6 items: 5 items and ellipsis");
             }
         }
 
@@ -251,35 +253,35 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 SetFocusToFirstBreadcrumbBarItem(breadcrumb, false);
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[5].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[5].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should keep the focus");
+                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should keep the focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Root' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[0].HasKeyboardFocus, "'Root' BreadcrumbBarItem should have focus");
 
                 // Bug to solve here
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Root' BreadcrumbBarItem should keep the focus");
+                Verify.IsTrue(breadcrumbItems[0].HasKeyboardFocus, "'Root' BreadcrumbBarItem should keep the focus");
             }
         }
 
@@ -297,35 +299,35 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 SetFocusToFirstBreadcrumbBarItem(breadcrumb, false, true);
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[5].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Left);
-                Verify.IsTrue(breadcrumbItems[5].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should keep the focus");
+                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3_1' BreadcrumbBarItem should keep the focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[4].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2_3' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Root' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[0].HasKeyboardFocus, "'Root' BreadcrumbBarItem should have focus");
 
                 // Bug to solve here
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Root' BreadcrumbBarItem should keep the focus");
+                Verify.IsTrue(breadcrumbItems[0].HasKeyboardFocus, "'Root' BreadcrumbBarItem should keep the focus");
             }
         }
 
@@ -440,10 +442,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 SetFocusToFirstBreadcrumbBarItem(breadcrumb, false);
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[1].HasKeyboardFocus, "'Node A' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
+                Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should have focus");
 
                 KeyboardHelper.PressKey(Key.Enter);
                 
@@ -453,7 +455,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Possible bug to solve here
                 // Verify.IsTrue(breadcrumbItems[3].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should keep focus");
 
-                Verify.AreEqual(4, breadcrumb.Children.Count, "The breadcrumb should contain 4 items: 3 items and an ellipsis");
+                Verify.AreEqual(3, breadcrumb.Children.Count, "The breadcrumb should contain 3 items.");
 
                 VerifyBreadcrumbBarItemsContain(breadcrumb.Children, new string[] { "Root", "Node A", "Node A_2" });
             }
@@ -493,7 +495,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Possible bug to solve here
                 // Verify.IsTrue(breadcrumbItems[2].HasKeyboardFocus, "'Node A_2' BreadcrumbBarItem should keep focus");
 
-                Verify.AreEqual(3, breadcrumb.Children.Count, "The breadcrumb should contain 3 items: 2 items and an ellipsis");
+                Verify.AreEqual(2, breadcrumb.Children.Count, "The breadcrumb should contain 2 items.");
 
                 VerifyBreadcrumbBarItemsContain(breadcrumb.Children, new string[] { "Root", "Node A" });
             }
@@ -519,7 +521,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 for (int i = 0; i < 5; ++i)
                 {
-                    breadcrumb.Children[1].Click();
+                    breadcrumb.Children[0].Click();
 
                     VerifyLastClickedItemIndexIs(0);
                     VerifyLastClickedItemIs("Root");
@@ -554,7 +556,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             ClickOnElements(new string[] { "Node A", "Node A_2", "Node A_2_3", "Node A_2_3_1" });
 
             var breadcrumbItems = breadcrumb.Children;
-            Verify.AreEqual(6, breadcrumbItems.Count, "The breadcrumb should contain 6 items: 5 items and an ellipsis");
+            Verify.AreEqual(5, breadcrumbItems.Count, "The breadcrumb should contain 5 items");
 
             return breadcrumb;
         }
@@ -565,6 +567,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
             UIObject slider = RetrieveWidthSlider();
             slider.Click(PointerButtons.Primary, (slider.BoundingRectangle.Width / 3) - 10, slider.BoundingRectangle.Height / 2);
+
+            Verify.AreEqual(6, breadcrumb.Children.Count, "The breadcrumb should contain 6 items: 5 items and ellipsis");
 
             return breadcrumb;
         }
@@ -584,7 +588,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             UIObject anchor = RetrieveRTLCheckBox();
             FocusHelper.SetFocus(anchor);
 
-            // For RS2 we need ony Tab key stroke if the ellipsis is onscreen and 2 if it's not
+            // For RS2 we need only Tab key stroke if the ellipsis is onscreen and 2 if it's not
             KeyboardHelper.PressKey(Key.Tab);
 
             if (!isEllipsisVisible)
@@ -606,7 +610,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             return elementGotFocus;
         }
 
-        private bool TryGetFocusForRs3(UIObject breadcrumb, int indexToFocus, bool isEllipsisVisible, bool isRightToLeft)
+        private bool TryGetFocusForRs3(UIObject breadcrumb, int indexToFocus, bool isRightToLeft)
         {
             Log.Comment("Try Set focus for RS3 build");
 
@@ -615,18 +619,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
             // For RS3 we need only one Tab key stroke
             KeyboardHelper.PressKey(Key.Tab);
-
-            if (!isEllipsisVisible)
-            {
-                if (isRightToLeft)
-                {
-                    KeyboardHelper.PressKey(Key.Left);
-                }
-                else
-                {
-                    KeyboardHelper.PressKey(Key.Right);
-                }
-            }
 
             bool elementGotFocus = breadcrumb.Children[indexToFocus].HasKeyboardFocus;
 
@@ -677,13 +669,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             UIObject anchor = RetrieveRTLCheckBox();
             FocusHelper.SetFocus(anchor);
 
-            int indexToFocus = isEllipsisVisible ? 0 : 1;
+            int indexToFocus = 0;
 
             // The RS3 and RS2 behaviours seem a little odd on how many tabs need to be pressed 
             bool gotFocus = TryGetFocusForRs2(breadcrumb, indexToFocus, isEllipsisVisible);
             if (!gotFocus)
             {
-                gotFocus = TryGetFocusForRs3(breadcrumb, indexToFocus, isEllipsisVisible, isRightToLeft);
+                gotFocus = TryGetFocusForRs3(breadcrumb, indexToFocus, isRightToLeft);
                 if (!gotFocus)
                 {
                     gotFocus = TryGetFocusByPressingTab(breadcrumb, indexToFocus);
@@ -752,14 +744,16 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             return rtlCheckbox;
         }
 
-        private void VerifyBreadcrumbBarItemsContain(UICollection<UIObject> breadcrumbItems, string[] expectedItemValues, bool firstItemIsCurrentItem = false)
+        private void VerifyBreadcrumbBarItemsContain(UICollection<UIObject> breadcrumbItems, string[] expectedItemValues, bool firstItemIsCurrentItem = false, bool isEllipsisVisible = false)
         {
             // WARNING: this method clicks on each breadcrumb so once the verification has finished, 
             // only the ellipsis item and 'Root' should exist
 
             // As recycled breadcrumbs are not deleted, then we compare that the breadcrumb count is always bigger 
             // than the expected values count
-            Verify.IsTrue(breadcrumbItems.Count > expectedItemValues.Length, 
+            var ellipsisPresentCount = isEllipsisVisible ? 1 : 0;
+
+            Verify.IsTrue(breadcrumbItems.Count - ellipsisPresentCount >= expectedItemValues.Length, 
                 "The expected values count should at least be one less than the BreadcrumbBarItems count");
 
             bool mustVerifyItemAsLastItem = firstItemIsCurrentItem;
@@ -768,7 +762,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             // in LastClickedItemIndex and LastClickedItem textboxes.
             for (int i = expectedItemValues.Length - 1; i >= 0; --i)
             {
-                var currentItem = breadcrumbItems[i + 1];
+                var currentItem = breadcrumbItems[i + ellipsisPresentCount];
                 Verify.IsNotNull(currentItem, "Current BreadcrumbBarItem should not be null");
 
                 var currentBreadcrumbBarItem = ConvertTo<BreadcrumbBarItem>(currentItem);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes ellipsis inaccessible by Accessibility tools when it's hidden.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
At this moment, we can navigate to ellipsis button using Narrator (CAPSLOCK + Left Arrow key) even when it's hidden. This is undesired behavior and will lead to crash if user invokes ellipsis at that point (Enter or CAPSLOCK + Enter).

This PR will make ellipsis invisible for Accessibility tools when it's hidden.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.