### PR TITLE
NumberBox SpinButton Inline Overlap Fix

### DIFF
--- a/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
+++ b/dev/CommonStyles/TestUI/BorderThicknessPage.xaml
@@ -54,6 +54,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Text="ComboBox" Style="{StaticResource SideHeader}"/>
@@ -495,6 +496,29 @@
             </Grid>
             <Grid Grid.Column="2" Grid.Row="16" Style="{StaticResource RightColumn}">
                 <Button Content="AccentButton" Style="{StaticResource AccentButtonStyle}" MinWidth="100"/>
+            </Grid>
+            <TextBlock Grid.Row="17" Text="NumberBox" Style="{StaticResource SideHeader}" />
+            <Grid Grid.Column="1" Grid.Row="17" Style="{StaticResource LeftColumn}">
+                <controls:NumberBox SpinButtonPlacementMode="Inline">
+                    <controls:NumberBox.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Default">
+                                    <x:Double x:Key="TextControlBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <x:Double x:Key="TextControlBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Light">
+                                    <x:Double x:Key="TextControlBorderThemeThickness">2</x:Double>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </controls:NumberBox.Resources>
+                </controls:NumberBox>
+            </Grid>
+            <Grid Grid.Column="2" Grid.Row="17" Style="{StaticResource RightColumn}">
+                <controls:NumberBox SpinButtonPlacementMode="Inline" />
             </Grid>
         </Grid>
     </ScrollViewer>

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -37,6 +37,8 @@ NumberBox::NumberBox()
 {
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_NumberBox);
 
+    Loaded({ this, &NumberBox::OnLoaded });
+
     NumberFormatter(GetRegionalSettingsAwareDecimalFormatter());
 
     PointerWheelChanged({ this, &NumberBox::OnNumberBoxScroll });
@@ -209,7 +211,6 @@ void NumberBox::OnApplyTemplate()
     // .NET rounds to 12 significant digits when displaying doubles, so we will do the same.
     m_displayRounder.SignificantDigits(12);
 
-    UpdateSpinButtonPlacement();
     UpdateSpinButtonEnabled();
 
     UpdateVisualStateForIsEnabledChange();
@@ -226,6 +227,12 @@ void NumberBox::OnApplyTemplate()
     {
         UpdateTextToValue();
     }
+}
+
+void NumberBox::OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
+{
+    // This is done OnLoaded so TextBox VisualStates can be updated properly.
+    UpdateSpinButtonPlacement();
 }
 
 void NumberBox::OnValuePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -391,6 +398,10 @@ void NumberBox::OnNumberBoxGotFocus(winrt::IInspectable const& sender, winrt::Ro
         {
             popup.IsOpen(true);
         }
+    }
+    else if (SpinButtonPlacementMode() == winrt::NumberBoxSpinButtonPlacementMode::Inline)
+    {
+        //UpdateSpinButtonPlacement();
     }
 }
 

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -399,10 +399,6 @@ void NumberBox::OnNumberBoxGotFocus(winrt::IInspectable const& sender, winrt::Ro
             popup.IsOpen(true);
         }
     }
-    else if (SpinButtonPlacementMode() == winrt::NumberBoxSpinButtonPlacementMode::Inline)
-    {
-        //UpdateSpinButtonPlacement();
-    }
 }
 
 void NumberBox::OnNumberBoxLostFocus(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args)

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -41,6 +41,7 @@ public:
 
     // IFrameworkElement
     void OnApplyTemplate();
+    void OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&);
 
     void OnHeaderPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnHeaderTemplatePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -39,6 +39,7 @@
                                         <Setter Target="DownSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="UpSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="InputEater.Visibility" Value="Visible" />
+                                        <Setter Target="InputBox.MinWidth" Value="{ThemeResource NumberBoxMinWidth}" />
                                     </VisualState.Setters>
                                 </VisualState>
 

--- a/dev/NumberBox/NumberBox_themeresources.xaml
+++ b/dev/NumberBox/NumberBox_themeresources.xaml
@@ -58,6 +58,7 @@
     <x:Double x:Key="NumberBoxPopupHorizonalOffset">-21</x:Double>
     <x:Double x:Key="NumberBoxPopupVerticalOffset">-27</x:Double>
     <x:Double x:Key="NumberBoxPopupShadowDepth">16</x:Double>
+    <x:Double x:Key="NumberBoxMinWidth">120</x:Double>
 
     <Thickness x:Key="NumberBoxPopupIndicatorMargin">0,0,8,0</Thickness>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add min width to InputBox when `SpinButtonPlacementMode="Inline"`
- Move `UpdateSpinButtonPlacement` to OnLoaded so TextBox visual states can be updated properly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #5293 
Fixes #5278 