### PR TITLE
Fix initial flow direction not being applied to Animated Icon.

### DIFF
--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -522,6 +522,8 @@ bool AnimatedIcon::ConstructAndInsertVisual()
         winrt::ElementCompositionPreview::SetElementChildVisual(rootPanel, visual);
     }
 
+    UpdateMirrorTransform();
+
     if (visual)
     {
         m_canDisplayPrimaryContent = true;
@@ -550,8 +552,6 @@ bool AnimatedIcon::ConstructAndInsertVisual()
         m_canDisplayPrimaryContent = false;
         return false;
     }
-
-    UpdateMirrorTransform();
 }
 
 void AnimatedIcon::OnFallbackIconSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs&)

--- a/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
+++ b/dev/AnimatedIcon/TestUI/AnimatedIconPage.xaml
@@ -13,7 +13,8 @@
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     xmlns:myAnimatedvisuals="using:AnimatedVisuals"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    FlowDirection="RightToLeft">
     <Page.Resources>
         <SolidColorBrush x:Key="TestIconForeground" Color="{StaticResource TestIconForegroundColor}"/>
         <Color x:Key="TestIconForegroundColor">#80808080</Color>
@@ -173,7 +174,7 @@
                     </Flyout>
                 </Button.Flyout>
             </Button>
-            <CheckBox Content="Is LeftToRight" IsChecked="True" Checked="IsLeftToRightChecked" Unchecked="IsLeftToRightUnchecked" HorizontalAlignment="Center" Grid.Row="8"/>
+            <CheckBox Content="Is LeftToRight" IsChecked="False" Checked="IsLeftToRightChecked" Unchecked="IsLeftToRightUnchecked" HorizontalAlignment="Center" Grid.Row="8"/>
             <ScrollViewer Grid.Row="9">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" Windows10FallCreatorsUpdate:Spacing="5">


### PR DESCRIPTION
The scale transform that is used to apply the correct flow direction wasn't getting applied on initial load. We didn't catch this before because our test page starts in LTR and changing to RTL did work. fixes #5258