### PR TITLE
Slider: fix thumb cut off and wrong colored patch of color

### DIFF
--- a/dev/CommonStyles/Slider_themeresources.xaml
+++ b/dev/CommonStyles/Slider_themeresources.xaml
@@ -182,10 +182,10 @@
     <x:Double x:Key="SliderInnerThumbHeight">12</x:Double>
     <x:Double x:Key="SliderHorizontalHeight">32</x:Double>
     <x:Double x:Key="SliderVerticalWidth">32</x:Double>   
-    <x:Double x:Key="SliderHorizontalThumbWidth">20</x:Double>
-    <x:Double x:Key="SliderHorizontalThumbHeight">20</x:Double>
-    <x:Double x:Key="SliderVerticalThumbWidth">20</x:Double>
-    <x:Double x:Key="SliderVerticalThumbHeight">20</x:Double>
+    <x:Double x:Key="SliderHorizontalThumbWidth">18</x:Double>
+    <x:Double x:Key="SliderHorizontalThumbHeight">18</x:Double>
+    <x:Double x:Key="SliderVerticalThumbWidth">18</x:Double>
+    <x:Double x:Key="SliderVerticalThumbHeight">18</x:Double>
     <x:Double x:Key="SliderInnerThumbWidth">12</x:Double>
     <x:Double x:Key="SliderInnerThumbHeight">12</x:Double>
 
@@ -215,7 +215,7 @@
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">
                                             <Border
-                                                Margin="-1"
+                                                Margin="-2"
                                                 Background="{ThemeResource SliderOuterThumbBackground}"
                                                 BorderBrush="{ThemeResource SliderThumbBorderBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -439,8 +439,7 @@
                         <Grid x:Name="SliderContainer"
                             Grid.Row="1"
                             Background="{ThemeResource SliderContainerBackground}"
-                            Control.IsTemplateFocusTarget="True"
-                            CornerRadius="{StaticResource ControlCornerRadius}">
+                            Control.IsTemplateFocusTarget="True">
                             <Grid x:Name="HorizontalTemplate" MinHeight="{ThemeResource SliderHorizontalHeight}">
 
                                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed corner radius on the slider container so the thumb is not cut off when at 0 and 100.
Increased negative margin on the thumb to fix #1765.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #1765 as well as thumb doesn't look cut off at 0 and 100 anymore.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.