### PR TITLE
ProgressBar: fix Error color persistence after showError has been toggled

### DIFF
--- a/dev/ProgressBar/ProgressBar.xaml
+++ b/dev/ProgressBar/ProgressBar.xaml
@@ -105,7 +105,7 @@
                                 <VisualState x:Name="Updating" />
                                 <VisualState x:Name="UpdatingError">
                                     <VisualState.Setters>
-                                        <Setter Target="DeterminateProgressBarIndicator.Fill" Value="{ThemeResource ProgressBarErrorForegroundColor}" />
+                                        <Setter Target="DeterminateProgressBarIndicator.(Shape.Fill).(SolidColorBrush.Color)" Value="{ThemeResource ProgressBarErrorForegroundColor}" />
                                     </VisualState.Setters>
                                 </VisualState>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changing from Error to any other state other than Error will not set the color to the appropriate state but keep the Error color on the progress bar. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
This PR fixes the Error color persistence after **ShowError** is set to false after being true.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
