### PR TITLE
Allow Command Bar Flyout to change sizes based on input device used

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -124,7 +124,6 @@
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Width" Value="NaN" />
-        <Setter Property="Height" Value="40" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="AllowFocusOnInteraction" Value="False" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -351,7 +351,6 @@
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Width" Value="NaN" />
-        <Setter Property="Height" Value="40" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="AllowFocusOnInteraction" Value="False" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -546,7 +546,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout");
 
                 Log.Comment("Tapping on a button to show the CommandBarFlyout.");
-                InputHelper.Tap(showCommandBarFlyoutButton);
+                showCommandBarFlyoutButton.InvokeAndWait();
 
                 // Pre-RS5, CommandBarFlyouts always open expanded,
                 // so we don't need to tap on the more button in that case.
@@ -873,7 +873,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with AlwaysExpanded");
 
                 Log.Comment("Tapping on a button to show the CommandBarFlyout.");
-                InputHelper.Tap(showCommandBarFlyoutButton);
+                showCommandBarFlyoutButton.InvokeAndWait();
 
                 Log.Comment("Press Right key to move focus to last primary command: Underline.");
                 for (int i = 0; i < 5; i++)

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -83,8 +83,8 @@
                                         <contract7NotPresent:Setter Target="LayoutRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
                                         <contract7Present:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
                                         <contract7NotPresent:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <contract7Present:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <contract7NotPresent:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <contract7Present:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <contract7NotPresent:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
                                         <contract7Present:Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -95,8 +95,8 @@
                                         <contract7NotPresent:Setter Target="LayoutRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
                                         <contract7Present:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
                                         <contract7NotPresent:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <contract7Present:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <contract7NotPresent:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <contract7Present:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <contract7NotPresent:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
                                         <contract7Present:Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -107,8 +107,8 @@
                                         <contract7NotPresent:Setter Target="LayoutRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
                                         <contract7Present:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
                                         <contract7NotPresent:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
-                                        <contract7Present:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <contract7NotPresent:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
+                                        <contract7Present:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <contract7NotPresent:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
                                         <contract7Present:Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -119,8 +119,8 @@
                                         <contract7NotPresent:Setter Target="LayoutRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
                                         <contract7Present:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
                                         <contract7NotPresent:Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
-                                        <contract7Present:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <contract7NotPresent:Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
+                                        <contract7Present:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <contract7NotPresent:Setter Target="OuterOverflowContentRootV2.CornerRadius" Value="{Binding Source={ThemeResource OverlayCornerRadius}}" />
                                         <contract7Present:Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -191,7 +191,7 @@
                                 </Grid>
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
                                     <Grid
-                                        x:Name="OuterOverflowContentRoot"
+                                        x:Name="OuterOverflowContentRootV2"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
@@ -242,213 +242,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
-    <!-- This is the same as the template in CommandBarFlyoutOS_themeresources.xaml, except its animations have been removed.
-         Any changes to the style in the above file should also be made here. -->
-    <contract13Present:Style TargetType="CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarOSStyle}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="CommandBarFlyoutCommandBar">
-                    <Grid x:Name="LayoutRoot"
-                         CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid.Resources>
-                            <Style TargetType="AppBarButton" BasedOn="{StaticResource CommandBarFlyoutAppBarButtonStyle}" />
-                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource CommandBarFlyoutAppBarToggleButtonStyle}" />
-                        </Grid.Resources>
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal" />
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="EllipsisIcon.Foreground" Value="{ThemeResource CommandBarEllipsisIconForegroundDisabled}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="DisplayModeStates">
-                                <VisualState x:Name="CompactClosed" />
-                                <VisualState x:Name="CompactOpenUp" />
-                                <VisualState x:Name="CompactOpenDown" />
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="ExpansionStates">
-                                <VisualState x:Name="Collapsed" />
-                                <VisualState x:Name="ExpandedUp">
-                                    <VisualState.Setters>
-                                        <Setter Target="MoreButtonTransform.X" Value="0" />
-                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpOverflowVerticalPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpAnimationEndPosition}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDown">
-                                    <VisualState.Setters>
-                                        <Setter Target="MoreButtonTransform.X" Value="0" />
-                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownAnimationEndPosition}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="AvailableCommandsStates">
-                                <VisualState x:Name="BothCommands" />
-                                <VisualState x:Name="PrimaryCommandsOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="OverflowContentRoot.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="SecondaryCommandsOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="PrimaryItemsRoot.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup>
-                                <VisualState x:Name="Default" />
-                                <VisualState x:Name="ExpandedUpWithPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDownWithPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedUpWithoutPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDownWithoutPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="OuterContentRoot"
-                            VerticalAlignment="Top"
-                            Margin="{TemplateBinding Padding}"
-                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
-                            Height="{TemplateBinding Height}"
-                            XYFocusKeyboardNavigation="Enabled">
-                            <Grid x:Name="ContentRoot"
-                                    Background="{TemplateBinding Background}">
-                                <Grid.Clip>
-                                    <RectangleGeometry x:Name="ContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ContentClipRect}">
-                                        <RectangleGeometry.Transform>
-                                            <!-- If you have a value set by a binding and then animate that value,
-                                                 the animation will clear the binding.  Because of that, we need to have
-                                                 two translate transforms - one that we bind to a property,
-                                                 and another that we can animate. -->
-                                            <TransformGroup>
-                                                <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
-                                                <TranslateTransform x:Name="ContentRootClipTransform" />
-                                            </TransformGroup>
-                                        </RectangleGeometry.Transform>
-                                    </RectangleGeometry>
-                                </Grid.Clip>
-                                <Grid x:Name="PrimaryItemsRoot"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding CornerRadius}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <ItemsControl x:Name="PrimaryItemsControl"
-                                        Height="40"
-                                        Margin="3,3,0,3"
-                                        Grid.Column="0"
-                                        IsTabStop="False"
-                                        HorizontalAlignment="Left">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                    </ItemsControl>
-                                    <Button x:Name="MoreButton"
-                                        Foreground="{TemplateBinding Foreground}"
-                                        Style="{StaticResource CommandBarFlyoutEllipsisButtonStyle}"
-                                        Grid.Column="1"
-                                        Control.IsTemplateKeyTipTarget="True"
-                                        IsAccessKeyScope="True"
-                                        IsTabStop="False"
-                                        CornerRadius="{TemplateBinding CornerRadius}"
-                                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.EffectiveOverflowButtonVisibility}">
-                                        <Button.RenderTransform>
-                                            <TranslateTransform x:Name="MoreButtonTransform" />
-                                        </Button.RenderTransform>
-                                        <FontIcon x:Name="EllipsisIcon"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                            FontSize="16"
-                                            Glyph="&#xE10C;" />
-                                    </Button>
-                                </Grid>
-                                <Popup x:Name="OverflowPopup">
-                                    <Grid
-                                        x:Name="OuterOverflowContentRoot"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
-                                        <Grid.RenderTransform>
-                                            <TranslateTransform
-                                                x:Name="OverflowContentRootTransform"
-                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
-                                        </Grid.RenderTransform>
-                                        <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition />
-                                                <RowDefinition Height="Auto" />
-                                            </Grid.RowDefinitions>
-                                            <Grid.Clip>
-                                                <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
-                                                    <RectangleGeometry.Transform>
-                                                        <!-- If you have a value set by a binding and then animate that value,
-                                                             the animation will clear the binding.  Because of that, we need to have
-                                                             two translate transforms - one that we bind to a property,
-                                                             and another that we can animate. -->
-                                                        <TransformGroup>
-                                                            <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
-                                                            <TranslateTransform x:Name="OverflowContentRootClipTransform" />
-                                                        </TransformGroup>
-                                                    </RectangleGeometry.Transform>
-                                                </RectangleGeometry>
-                                            </Grid.Clip>
-                                            <CommandBarOverflowPresenter
-                                                Grid.Row="1"
-                                                x:Name="SecondaryItemsControl"
-                                                Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
-                                                IsTabStop="False">
-                                            </CommandBarOverflowPresenter>
-                                        </Grid>
-                                    </Grid>
-                                </Popup>
-                            </Grid>
-                        </Grid>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </contract13Present:Style>
 </ResourceDictionary>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -242,4 +242,213 @@
             </Setter.Value>
         </Setter>
     </Style>
+    
+    <!-- This is the same as the template in CommandBarFlyoutOS_themeresources.xaml, except its animations have been removed.
+         Any changes to the style in the above file should also be made here. -->
+    <contract13Present:Style TargetType="CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarOSStyle}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CommandBarFlyoutCommandBar">
+                    <Grid x:Name="LayoutRoot"
+                         CornerRadius="{TemplateBinding CornerRadius}">
+                        <Grid.Resources>
+                            <Style TargetType="AppBarButton" BasedOn="{StaticResource CommandBarFlyoutAppBarButtonStyle}" />
+                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource CommandBarFlyoutAppBarToggleButtonStyle}" />
+                        </Grid.Resources>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="EllipsisIcon.Foreground" Value="{ThemeResource CommandBarEllipsisIconForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualState x:Name="CompactClosed" />
+                                <VisualState x:Name="CompactOpenUp" />
+                                <VisualState x:Name="CompactOpenDown" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ExpansionStates">
+                                <VisualState x:Name="Collapsed" />
+                                <VisualState x:Name="ExpandedUp">
+                                    <VisualState.Setters>
+                                        <Setter Target="MoreButtonTransform.X" Value="0" />
+                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpOverflowVerticalPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpAnimationEndPosition}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedDown">
+                                    <VisualState.Setters>
+                                        <Setter Target="MoreButtonTransform.X" Value="0" />
+                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownAnimationEndPosition}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="AvailableCommandsStates">
+                                <VisualState x:Name="BothCommands" />
+                                <VisualState x:Name="PrimaryCommandsOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="OverflowContentRoot.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="SecondaryCommandsOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="PrimaryItemsRoot.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Default" />
+                                <VisualState x:Name="ExpandedUpWithPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedDownWithPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedUpWithoutPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedDownWithoutPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid x:Name="OuterContentRoot"
+                            VerticalAlignment="Top"
+                            Margin="{TemplateBinding Padding}"
+                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
+                            Height="{TemplateBinding Height}"
+                            XYFocusKeyboardNavigation="Enabled">
+                            <Grid x:Name="ContentRoot"
+                                    Background="{TemplateBinding Background}">
+                                <Grid.Clip>
+                                    <RectangleGeometry x:Name="ContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ContentClipRect}">
+                                        <RectangleGeometry.Transform>
+                                            <!-- If you have a value set by a binding and then animate that value,
+                                                 the animation will clear the binding.  Because of that, we need to have
+                                                 two translate transforms - one that we bind to a property,
+                                                 and another that we can animate. -->
+                                            <TransformGroup>
+                                                <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
+                                                <TranslateTransform x:Name="ContentRootClipTransform" />
+                                            </TransformGroup>
+                                        </RectangleGeometry.Transform>
+                                    </RectangleGeometry>
+                                </Grid.Clip>
+                                <Grid x:Name="PrimaryItemsRoot"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ItemsControl x:Name="PrimaryItemsControl"
+                                        Height="40"
+                                        Margin="3,3,0,3"
+                                        Grid.Column="0"
+                                        IsTabStop="False"
+                                        HorizontalAlignment="Left">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                    </ItemsControl>
+                                    <Button x:Name="MoreButton"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Style="{StaticResource CommandBarFlyoutEllipsisButtonStyle}"
+                                        Grid.Column="1"
+                                        Control.IsTemplateKeyTipTarget="True"
+                                        IsAccessKeyScope="True"
+                                        IsTabStop="False"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.EffectiveOverflowButtonVisibility}">
+                                        <Button.RenderTransform>
+                                            <TranslateTransform x:Name="MoreButtonTransform" />
+                                        </Button.RenderTransform>
+                                        <FontIcon x:Name="EllipsisIcon"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                            FontSize="16"
+                                            Glyph="&#xE10C;" />
+                                    </Button>
+                                </Grid>
+                                <Popup x:Name="OverflowPopup">
+                                    <Grid
+                                        x:Name="OuterOverflowContentRoot"
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform
+                                                x:Name="OverflowContentRootTransform"
+                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
+                                        </Grid.RenderTransform>
+                                        <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <Grid.Clip>
+                                                <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
+                                                    <RectangleGeometry.Transform>
+                                                        <!-- If you have a value set by a binding and then animate that value,
+                                                             the animation will clear the binding.  Because of that, we need to have
+                                                             two translate transforms - one that we bind to a property,
+                                                             and another that we can animate. -->
+                                                        <TransformGroup>
+                                                            <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
+                                                            <TranslateTransform x:Name="OverflowContentRootClipTransform" />
+                                                        </TransformGroup>
+                                                    </RectangleGeometry.Transform>
+                                                </RectangleGeometry>
+                                            </Grid.Clip>
+                                            <CommandBarOverflowPresenter
+                                                Grid.Row="1"
+                                                x:Name="SecondaryItemsControl"
+                                                Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
+                                                IsTabStop="False">
+                                            </CommandBarOverflowPresenter>
+                                        </Grid>
+                                    </Grid>
+                                </Popup>
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </contract13Present:Style>
 </ResourceDictionary>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -155,7 +155,7 @@
                                     contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" MinWidth="3" />
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
                                         Height="40"
@@ -190,13 +190,231 @@
                                     </Button>
                                 </Grid>
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
+                                    <!-- The name OuterOverflowContentRoot is treated specially by the system and causes a shadow placed on this
+                                         an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
                                     <Grid
                                         x:Name="OuterOverflowContentRootV2"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
+                                        RequestedTheme="{TemplateBinding ActualTheme}"
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
+                                        contract7Present:Translation="0,0,32">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
                                                 contract14NotPresent:Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
+                                        </Grid.RenderTransform>
+                                        <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <Grid.Clip>
+                                                <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
+                                                    <RectangleGeometry.Transform>
+                                                        <!-- If you have a value set by a binding and then animate that value,
+                                                             the animation will clear the binding.  Because of that, we need to have
+                                                             two translate transforms - one that we bind to a property,
+                                                             and another that we can animate. -->
+                                                        <TransformGroup>
+                                                            <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
+                                                            <TranslateTransform x:Name="OverflowContentRootClipTransform" />
+                                                        </TransformGroup>
+                                                    </RectangleGeometry.Transform>
+                                                </RectangleGeometry>
+                                            </Grid.Clip>
+                                            <contract7NotPresent:Border
+                                                x:Name="OverflowPresenterBorder"
+                                                Grid.Row="1"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
+                                                CornerRadius="{ThemeResource OverlayCornerRadius}"/>
+                                            <CommandBarOverflowPresenter
+                                                Grid.Row="1"
+                                                x:Name="SecondaryItemsControl"
+                                                Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
+                                                IsTabStop="False">
+                                            </CommandBarOverflowPresenter>
+                                        </Grid>
+                                    </Grid>
+                                </Popup>
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!-- This is the same as the template in CommandBarFlyoutOS_themeresources.xaml, except its animations have been removed.
+         Any changes to the style in the above file should also be made here. -->
+    <contract13Present:Style TargetType="CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarOSStyle}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="CommandBarFlyoutCommandBar">
+                    <Grid x:Name="LayoutRoot"
+                         CornerRadius="{TemplateBinding CornerRadius}">
+                        <Grid.Resources>
+                            <Style TargetType="AppBarButton" BasedOn="{StaticResource CommandBarFlyoutAppBarButtonStyle}" />
+                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource CommandBarFlyoutAppBarToggleButtonStyle}" />
+                        </Grid.Resources>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Disabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="EllipsisIcon.Foreground" Value="{ThemeResource CommandBarEllipsisIconForegroundDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="DisplayModeStates">
+                                <VisualState x:Name="CompactClosed" />
+                                <VisualState x:Name="CompactOpenUp" />
+                                <VisualState x:Name="CompactOpenDown" />
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ExpansionStates">
+                                <VisualState x:Name="Collapsed" />
+                                <VisualState x:Name="ExpandedUp">
+                                    <VisualState.Setters>
+                                        <Setter Target="MoreButtonTransform.X" Value="0" />
+                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpOverflowVerticalPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpAnimationEndPosition}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedDown">
+                                    <VisualState.Setters>
+                                        <Setter Target="MoreButtonTransform.X" Value="0" />
+                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
+                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownAnimationEndPosition}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="AvailableCommandsStates">
+                                <VisualState x:Name="BothCommands" />
+                                <VisualState x:Name="PrimaryCommandsOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="OverflowContentRoot.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="SecondaryCommandsOnly">
+                                    <VisualState.Setters>
+                                        <Setter Target="PrimaryItemsRoot.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Default" />
+                                <VisualState x:Name="ExpandedUpWithPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedDownWithPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedUpWithoutPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="ExpandedDownWithoutPrimaryCommands">
+                                    <VisualState.Setters>
+                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
+                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid x:Name="OuterContentRoot"
+                            VerticalAlignment="Top"
+                            Margin="{TemplateBinding Padding}"
+                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
+                            Height="{TemplateBinding Height}"
+                            XYFocusKeyboardNavigation="Enabled">
+                            <Grid x:Name="ContentRoot"
+                                    Background="{TemplateBinding Background}">
+                                <Grid.Clip>
+                                    <RectangleGeometry x:Name="ContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ContentClipRect}">
+                                        <RectangleGeometry.Transform>
+                                            <!-- If you have a value set by a binding and then animate that value,
+                                                 the animation will clear the binding.  Because of that, we need to have
+                                                 two translate transforms - one that we bind to a property,
+                                                 and another that we can animate. -->
+                                            <TransformGroup>
+                                                <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
+                                                <TranslateTransform x:Name="ContentRootClipTransform" />
+                                            </TransformGroup>
+                                        </RectangleGeometry.Transform>
+                                    </RectangleGeometry>
+                                </Grid.Clip>
+                                <Grid x:Name="PrimaryItemsRoot"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{TemplateBinding CornerRadius}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ItemsControl x:Name="PrimaryItemsControl"
+                                        Height="40"
+                                        Margin="3,3,0,3"
+                                        Grid.Column="0"
+                                        IsTabStop="False"
+                                        HorizontalAlignment="Left">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                    </ItemsControl>
+                                    <Button x:Name="MoreButton"
+                                        Foreground="{TemplateBinding Foreground}"
+                                        Style="{StaticResource CommandBarFlyoutEllipsisButtonStyle}"
+                                        Grid.Column="1"
+                                        Control.IsTemplateKeyTipTarget="True"
+                                        IsAccessKeyScope="True"
+                                        IsTabStop="False"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.EffectiveOverflowButtonVisibility}">
+                                        <Button.RenderTransform>
+                                            <TranslateTransform x:Name="MoreButtonTransform" />
+                                        </Button.RenderTransform>
+                                        <FontIcon x:Name="EllipsisIcon"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                            FontSize="16"
+                                            Glyph="&#xE10C;" />
+                                    </Button>
+                                </Grid>
+                                <Popup x:Name="OverflowPopup">
+                                    <Grid
+                                        x:Name="OuterOverflowContentRoot"
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform
+                                                x:Name="OverflowContentRootTransform"
+                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
                                         </Grid.RenderTransform>
                                         <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
                                             <Grid.RowDefinitions>
@@ -225,12 +443,6 @@
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
                                                 IsTabStop="False">
-                                                <CommandBarOverflowPresenter.ItemContainerStyle>
-                                                    <Style TargetType="FrameworkElement">
-                                                        <Setter Property="HorizontalAlignment" Value="Stretch" />
-                                                        <Setter Property="Width" Value="NaN" />
-                                                    </Style>
-                                                </CommandBarOverflowPresenter.ItemContainerStyle>
                                             </CommandBarOverflowPresenter>
                                         </Grid>
                                     </Grid>
@@ -241,5 +453,5 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>
+    </contract13Present:Style>
 </ResourceDictionary>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
@@ -9,7 +9,7 @@
     xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
     xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
     xmlns:contract14NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,14)">
-    
+
     <!-- This is the same as the template in CommandBarFlyout_themeresources.xaml, except its animations have been removed.
          Any changes to the style in the above file should also be made here. -->
     <Style TargetType="primitives:CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarStyle}">
@@ -155,7 +155,7 @@
                                     contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" MinWidth="3" />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
                                         Height="40"
@@ -190,13 +190,9 @@
                                     </Button>
                                 </Grid>
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
-                                    <!-- The name OuterOverflowContentRoot is treated specially by the system and causes a shadow placed on this
-                                         an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
                                     <Grid
                                         x:Name="OuterOverflowContentRootV2"
-                                        RequestedTheme="{TemplateBinding ActualTheme}"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
-                                        contract7Present:Translation="0,0,32">
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
@@ -222,12 +218,6 @@
                                                     </RectangleGeometry.Transform>
                                                 </RectangleGeometry>
                                             </Grid.Clip>
-                                            <contract7NotPresent:Border
-                                                x:Name="OverflowPresenterBorder"
-                                                Grid.Row="1"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
-                                                CornerRadius="{ThemeResource OverlayCornerRadius}"/>
                                             <CommandBarOverflowPresenter
                                                 Grid.Row="1"
                                                 x:Name="SecondaryItemsControl"
@@ -235,6 +225,12 @@
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
                                                 IsTabStop="False">
+                                                <CommandBarOverflowPresenter.ItemContainerStyle>
+                                                    <Style TargetType="FrameworkElement">
+                                                        <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                                        <Setter Property="Width" Value="NaN" />
+                                                    </Style>
+                                                </CommandBarOverflowPresenter.ItemContainerStyle>
                                             </CommandBarOverflowPresenter>
                                         </Grid>
                                     </Grid>
@@ -246,212 +242,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <!-- This is the same as the template in CommandBarFlyoutOS_themeresources.xaml, except its animations have been removed.
-         Any changes to the style in the above file should also be made here. -->
-    <contract13Present:Style TargetType="CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarOSStyle}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="CommandBarFlyoutCommandBar">
-                    <Grid x:Name="LayoutRoot"
-                         CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid.Resources>
-                            <Style TargetType="AppBarButton" BasedOn="{StaticResource CommandBarFlyoutAppBarButtonStyle}" />
-                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource CommandBarFlyoutAppBarToggleButtonStyle}" />
-                        </Grid.Resources>
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal" />
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="EllipsisIcon.Foreground" Value="{ThemeResource CommandBarEllipsisIconForegroundDisabled}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="DisplayModeStates">
-                                <VisualState x:Name="CompactClosed" />
-                                <VisualState x:Name="CompactOpenUp" />
-                                <VisualState x:Name="CompactOpenDown" />
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="ExpansionStates">
-                                <VisualState x:Name="Collapsed" />
-                                <VisualState x:Name="ExpandedUp">
-                                    <VisualState.Setters>
-                                        <Setter Target="MoreButtonTransform.X" Value="0" />
-                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpOverflowVerticalPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpAnimationEndPosition}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDown">
-                                    <VisualState.Setters>
-                                        <Setter Target="MoreButtonTransform.X" Value="0" />
-                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownAnimationEndPosition}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="AvailableCommandsStates">
-                                <VisualState x:Name="BothCommands" />
-                                <VisualState x:Name="PrimaryCommandsOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="OverflowContentRoot.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="SecondaryCommandsOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="PrimaryItemsRoot.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup>
-                                <VisualState x:Name="Default" />
-                                <VisualState x:Name="ExpandedUpWithPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDownWithPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedUpWithoutPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDownWithoutPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="OuterContentRoot"
-                            VerticalAlignment="Top"
-                            Margin="{TemplateBinding Padding}"
-                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
-                            Height="{TemplateBinding Height}"
-                            XYFocusKeyboardNavigation="Enabled">
-                            <Grid x:Name="ContentRoot"
-                                    Background="{TemplateBinding Background}">
-                                <Grid.Clip>
-                                    <RectangleGeometry x:Name="ContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ContentClipRect}">
-                                        <RectangleGeometry.Transform>
-                                            <!-- If you have a value set by a binding and then animate that value,
-                                                 the animation will clear the binding.  Because of that, we need to have
-                                                 two translate transforms - one that we bind to a property,
-                                                 and another that we can animate. -->
-                                            <TransformGroup>
-                                                <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
-                                                <TranslateTransform x:Name="ContentRootClipTransform" />
-                                            </TransformGroup>
-                                        </RectangleGeometry.Transform>
-                                    </RectangleGeometry>
-                                </Grid.Clip>
-                                <Grid x:Name="PrimaryItemsRoot"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding CornerRadius}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <ItemsControl x:Name="PrimaryItemsControl"
-                                        Height="40"
-                                        Margin="3,3,0,3"
-                                        Grid.Column="0"
-                                        IsTabStop="False"
-                                        HorizontalAlignment="Left">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                    </ItemsControl>
-                                    <Button x:Name="MoreButton"
-                                        Foreground="{TemplateBinding Foreground}"
-                                        Style="{StaticResource CommandBarFlyoutEllipsisButtonStyle}"
-                                        Grid.Column="1"
-                                        Control.IsTemplateKeyTipTarget="True"
-                                        IsAccessKeyScope="True"
-                                        IsTabStop="False"
-                                        CornerRadius="{TemplateBinding CornerRadius}"
-                                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.EffectiveOverflowButtonVisibility}">
-                                        <Button.RenderTransform>
-                                            <TranslateTransform x:Name="MoreButtonTransform" />
-                                        </Button.RenderTransform>
-                                        <FontIcon x:Name="EllipsisIcon"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                            FontSize="16"
-                                            Glyph="&#xE10C;" />
-                                    </Button>
-                                </Grid>
-                                <Popup x:Name="OverflowPopup">
-                                    <Grid
-                                        x:Name="OuterOverflowContentRoot"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
-                                        <Grid.RenderTransform>
-                                            <TranslateTransform
-                                                x:Name="OverflowContentRootTransform"
-                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
-                                        </Grid.RenderTransform>
-                                        <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition />
-                                                <RowDefinition Height="Auto" />
-                                            </Grid.RowDefinitions>
-                                            <Grid.Clip>
-                                                <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
-                                                    <RectangleGeometry.Transform>
-                                                        <!-- If you have a value set by a binding and then animate that value,
-                                                             the animation will clear the binding.  Because of that, we need to have
-                                                             two translate transforms - one that we bind to a property,
-                                                             and another that we can animate. -->
-                                                        <TransformGroup>
-                                                            <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
-                                                            <TranslateTransform x:Name="OverflowContentRootClipTransform" />
-                                                        </TransformGroup>
-                                                    </RectangleGeometry.Transform>
-                                                </RectangleGeometry>
-                                            </Grid.Clip>
-                                            <CommandBarOverflowPresenter
-                                                Grid.Row="1"
-                                                x:Name="SecondaryItemsControl"
-                                                Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
-                                                IsTabStop="False">
-                                            </CommandBarOverflowPresenter>
-                                        </Grid>
-                                    </Grid>
-                                </Popup>
-                            </Grid>
-                        </Grid>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </contract13Present:Style>
 </ResourceDictionary>


### PR DESCRIPTION
CommandBar has code in it that records the last used input type and updates certain template setting values to increase the size of the app bar buttons when touch is used to open them. However the mechanism that is used to do this uses layout properties of the AppBarButton's container to specify the default size of the item. However CommandBarFlyout bypasses this logic by specifying a height in the style that is used for its AppBarButtons.  Removing this height allows the behavior to function as expected.