### PR TITLE
Fixing WinUI 2.6 store certification error

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -53,8 +53,7 @@
       <PackagingOutputs Include="@(XamlWinmd)" />
     </ItemGroup>
   </Target>
-  <!-- WinMD files should only go in the WinMetadata folder of the AppX if they're being supplied by a framework package. -->
-  <Target Name="_RemoveXamlWinmdFromWinMetadataFolder" Condition="'$(MicrosoftUIXamlAppxVersion)' == ''" AfterTargets="BuildNativePackage" BeforeTargets="_AddXamlWinmdToPackageLayoutRoot">
+  <Target Name="_RemoveXamlWinmdFromWinMetadataFolder" AfterTargets="BuildNativePackage" BeforeTargets="_AddXamlWinmdToPackageLayoutRoot">
     <ItemGroup>
       <XamlWinmdAppxPackagePayload Include="@(AppxPackagePayload)" Condition="'%(AppxPackagePayload.TargetPath)' == '$(WinMetadataDir)\$(XamlWinmdName)'" />
       <XamlWinmdAppxUploadPackagePayload Include="@(AppxUploadPackagePayload)" Condition="'%(AppxUploadPackagePayload.TargetPath)' == '$(WinMetadataDir)\$(XamlWinmdName)'" />


### PR DESCRIPTION
I had previously thought that the WinMetadata version of Microsoft.UI.Xaml.winmd was necessary for .NET Native compilation when that WinMD's implementation comes from a framework package, but it looks like it isn't.  Since its presence is causing store certification to fail, this change removes it from that location, leaving only the WinMD in the root.

I've tested building and uploading a package with this change to the store as well as building and running the app locally, and all seems well - the store certification passes, and the app runs fine.

Fixes #5298