### PR TITLE
Fix for crash in BackdropMaterialState event callback

### DIFF
--- a/dev/Materials/Backdrop/BackdropMaterial.cpp
+++ b/dev/Materials/Backdrop/BackdropMaterial.cpp
@@ -91,10 +91,13 @@ BackdropMaterial::BackdropMaterialState::BackdropMaterialState(winrt::Control co
     {
         if (auto targetThemeChanged = target.try_as<winrt::IFrameworkElement6>())
         {
-            m_themeChangedRevoker = targetThemeChanged.ActualThemeChanged(winrt::auto_revoke, [this](auto&&, auto&&)
+            m_themeChangedRevoker = targetThemeChanged.ActualThemeChanged(winrt::auto_revoke, [weakThis = get_weak()](auto&&, auto&&)
+            {
+                if (auto instance = weakThis.get())
                 {
-                    UpdateFallbackBrush();
-                });
+                    instance->UpdateFallbackBrush();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
There's a crash we're seeing that's affecting Store where we are calling in to a BackdropMaterialState object that's already been deleted. 

Based on the code I don't see how this could happen unless the m_themeChangedRevoker failed to revoke (which we've seen happen for things like XamlRoot Changed event when XAML implemented the 'managed peer' incorrectly). Since we won't be able to fix that downlevel and we can't change the lambda capture to be strong (that would create a cycle), the only way I see to address this capture the back pointer using a weak ref.

It means that we are "leaking" this callback on the target but this would only present as a true leak if someone was changing the BackdropMaterial attached property frequently during runtime, which we do not expect to happen. It should be a "set it and forget it" kind of thing.

I'm only changing this one particular handler where we are seeing the problem -- this pattern in general is safe.