### PR TITLE
Fix CommandBarFlyout crashing down level

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -1297,7 +1297,7 @@
                                         x:Name="OuterOverflowContentRootV2"
                                         RequestedTheme="{TemplateBinding ActualTheme}"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
-                                        contract7Present:Translation="0,0,32">
+                                        contract14NotPresent:Translation="0,0,32">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
@@ -1312,10 +1312,10 @@
                                             <Grid.Clip>
                                                 <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
                                                     <RectangleGeometry.Transform>
-                                                         <!-- If you have a value set by a binding and then animate that value,
+                                                        <!-- If you have a value set by a binding and then animate that value,
                                                              the animation will clear the binding.  Because of that, we need to have
                                                              two translate transforms - one that we bind to a property,
-                                                             and another that we can animate. --> 
+                                                             and another that we can animate. -->
                                                         <TransformGroup>
                                                             <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
                                                             <TranslateTransform x:Name="OverflowContentRootClipTransform" />

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -1293,7 +1293,7 @@
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
                                     <!-- The name OuterOverflowContentRoot is treated specially by the system and causes a shadow placed on this
                                          an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
-                                    <Grid
+                                    <contract7Present:Grid
                                         x:Name="OuterOverflowContentRootV2"
                                         RequestedTheme="{TemplateBinding ActualTheme}"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
@@ -1323,7 +1323,46 @@
                                                     </RectangleGeometry.Transform>
                                                 </RectangleGeometry>
                                             </Grid.Clip>
-                                            <contract7NotPresent:Border
+                                            <CommandBarOverflowPresenter
+                                                Grid.Row="1"
+                                                x:Name="SecondaryItemsControl"
+                                                Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
+                                                IsTabStop="False">
+                                            </CommandBarOverflowPresenter>
+                                        </Grid>
+                                    </contract7Present:Grid>
+                                    <contract7NotPresent:Grid
+                                        x:Name="OuterOverflowContentRootV2"
+                                        RequestedTheme="{TemplateBinding ActualTheme}"
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
+                                        <Grid.RenderTransform>
+                                            <TranslateTransform
+                                                x:Name="OverflowContentRootTransform"
+                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
+                                        </Grid.RenderTransform>
+                                        <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <Grid.Clip>
+                                                <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
+                                                    <RectangleGeometry.Transform>
+                                                        <!-- If you have a value set by a binding and then animate that value,
+                                                             the animation will clear the binding.  Because of that, we need to have
+                                                             two translate transforms - one that we bind to a property,
+                                                             and another that we can animate. -->
+                                                        <TransformGroup>
+                                                            <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
+                                                            <TranslateTransform x:Name="OverflowContentRootClipTransform" />
+                                                        </TransformGroup>
+                                                    </RectangleGeometry.Transform>
+                                                </RectangleGeometry>
+                                            </Grid.Clip>
+                                            <Border
                                                 x:Name="OverflowPresenterBorder"
                                                 Grid.Row="1"
                                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -1338,7 +1377,7 @@
                                                 IsTabStop="False">
                                             </CommandBarOverflowPresenter>
                                         </Grid>
-                                    </Grid>
+                                    </contract7NotPresent:Grid>
                                 </Popup>
                             </Grid>
                         </Grid>

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -11,7 +11,8 @@
     xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
     xmlns:contract9NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,9)"
     xmlns:contract12Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,12)"
-    xmlns:contract14NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,14)">
+    xmlns:contract14NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,14)"
+    xmlns:contract14Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,14)">
     
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
@@ -1291,11 +1292,14 @@
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
                                     <!-- The name OuterOverflowContentRoot is treated specially by the system and causes a shadow placed on this
                                          an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
+                                    <!-- The Translation and Render transform are mutually exclusive properties. We need
+                                         The translation property on contract 14+ for the drop shadow to work.  We need
+                                         The TranslationTransform is needed before-->
                                     <contract7Present:Grid
                                         x:Name="OuterOverflowContentRootV2"
                                         RequestedTheme="{TemplateBinding ActualTheme}"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
-                                        contract14NotPresent:Translation="0,0,32">
+                                        contract14Present:Translation="0,0,32">
                                         <contract14NotPresent:Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
@@ -1328,6 +1332,9 @@
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
                                                 IsTabStop="False">
+                                                <!-- 19h1 has a bug in focus manager that causes a crash when an implicitly styled element
+                                                     has focus and its parent popup closes.  To work around this, on 19h1 we will explicitly
+                                                     Style the overflow elements. -->
                                                 <contract9NotPresent:CommandBarOverflowPresenter.ItemContainerStyle>
                                                     <Style TargetType="Control">
                                                         <Setter Property="Background" Value="{ThemeResource CommandBarFlyoutAppBarButtonBackground}" />

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -9,6 +9,7 @@
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+    xmlns:contract9NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,9)"
     xmlns:contract12Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,12)"
     xmlns:contract14NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,14)">
     
@@ -353,7 +354,6 @@
         <Setter Property="Width" Value="NaN" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
         <Setter Property="AllowFocusOnInteraction" Value="False" />
-        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="local:CommandBarFlyoutCommandBarAutomationProperties.ControlType" Value="MenuItem" />
         <Setter Property="Template">
             <Setter.Value>
@@ -1296,11 +1296,11 @@
                                         RequestedTheme="{TemplateBinding ActualTheme}"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
                                         contract14NotPresent:Translation="0,0,32">
-                                        <Grid.RenderTransform>
+                                        <contract14NotPresent:Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
-                                                contract14NotPresent:Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
-                                        </Grid.RenderTransform>
+                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
+                                        </contract14NotPresent:Grid.RenderTransform>
                                         <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto" />
@@ -1328,6 +1328,23 @@
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
                                                 IsTabStop="False">
+                                                <contract9NotPresent:CommandBarOverflowPresenter.ItemContainerStyle>
+                                                    <Style TargetType="Control">
+                                                        <Setter Property="Background" Value="{ThemeResource CommandBarFlyoutAppBarButtonBackground}" />
+                                                        <Setter Property="Foreground" Value="{ThemeResource CommandBarFlyoutAppBarButtonForeground}" />
+                                                        <Setter Property="BorderBrush" Value="{ThemeResource CommandBarFlyoutAppBarButtonBorderBrush}" />
+                                                        <Setter Property="BorderThickness" Value="0" />
+                                                        <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                                        <Setter Property="VerticalAlignment" Value="Stretch" />
+                                                        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                                                        <Setter Property="FontWeight" Value="Normal" />
+                                                        <Setter Property="Width" Value="NaN" />
+                                                        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                                                        <Setter Property="AllowFocusOnInteraction" Value="False" />
+                                                        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+                                                        <Setter Property="local:CommandBarFlyoutCommandBarAutomationProperties.ControlType" Value="MenuItem" />
+                                                    </Style>
+                                                </contract9NotPresent:CommandBarOverflowPresenter.ItemContainerStyle>
                                             </CommandBarOverflowPresenter>
                                         </Grid>
                                     </contract7Present:Grid>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -240,8 +240,6 @@
                                                         <Setter Property="Width" Value="NaN" />
                                                         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
                                                         <Setter Property="AllowFocusOnInteraction" Value="False" />
-                                                        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-                                                        <Setter Property="local:CommandBarFlyoutCommandBarAutomationProperties.ControlType" Value="MenuItem" />
                                                     </Style>
                                                 </CommandBarOverflowPresenter.ItemContainerStyle>
                                             </CommandBarOverflowPresenter>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -192,11 +192,10 @@
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
                                     <!-- The name OuterOverflowContentRoot is treated specially by the system and causes a shadow placed on this
                                          an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
-                                    <contract7Present:Grid
+                                    <Grid
                                         x:Name="OuterOverflowContentRootV2"
                                         RequestedTheme="{TemplateBinding ActualTheme}"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
-                                        contract14NotPresent:Translation="0,0,32">
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
@@ -231,52 +230,7 @@
                                                 IsTabStop="False">
                                             </CommandBarOverflowPresenter>
                                         </Grid>
-                                    </contract7Present:Grid>
-                                    <contract7NotPresent:Grid
-                                        x:Name="OuterOverflowContentRootV2"
-                                        RequestedTheme="{TemplateBinding ActualTheme}"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
-                                        <Grid.RenderTransform>
-                                            <TranslateTransform
-                                                x:Name="OverflowContentRootTransform"
-                                                Y="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownOverflowVerticalPosition}" />
-                                        </Grid.RenderTransform>
-                                        <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition />
-                                                <RowDefinition Height="Auto" />
-                                            </Grid.RowDefinitions>
-                                            <Grid.Clip>
-                                                <RectangleGeometry x:Name="OverflowContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.OverflowContentClipRect}">
-                                                    <RectangleGeometry.Transform>
-                                                        <!-- If you have a value set by a binding and then animate that value,
-                                                             the animation will clear the binding.  Because of that, we need to have
-                                                             two translate transforms - one that we bind to a property,
-                                                             and another that we can animate. -->
-                                                        <TransformGroup>
-                                                            <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
-                                                            <TranslateTransform x:Name="OverflowContentRootClipTransform" />
-                                                        </TransformGroup>
-                                                    </RectangleGeometry.Transform>
-                                                </RectangleGeometry>
-                                            </Grid.Clip>
-                                            <Border
-                                                x:Name="OverflowPresenterBorder"
-                                                Grid.Row="1"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
-                                                CornerRadius="{ThemeResource OverlayCornerRadius}"/>
-                                            <CommandBarOverflowPresenter
-                                                Grid.Row="1"
-                                                x:Name="SecondaryItemsControl"
-                                                Style="{TemplateBinding CommandBarOverflowPresenterStyle}"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
-                                                IsTabStop="False">
-                                            </CommandBarOverflowPresenter>
-                                        </Grid>
-                                    </contract7NotPresent:Grid>
+                                    </Grid>
                                 </Popup>
                             </Grid>
                         </Grid>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -155,7 +155,7 @@
                                     contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" MinWidth="3" />
+                                        <ColumnDefinition Width="Auto" MinWidth="3"/>
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
                                         Height="40"
@@ -194,7 +194,6 @@
                                          an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
                                     <Grid
                                         x:Name="OuterOverflowContentRootV2"
-                                        RequestedTheme="{TemplateBinding ActualTheme}"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
@@ -228,6 +227,23 @@
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
                                                 IsTabStop="False">
+                                                <CommandBarOverflowPresenter.ItemContainerStyle>
+                                                    <Style TargetType="Control">
+                                                        <Setter Property="Background" Value="{ThemeResource CommandBarFlyoutAppBarButtonBackground}" />
+                                                        <Setter Property="Foreground" Value="{ThemeResource CommandBarFlyoutAppBarButtonForeground}" />
+                                                        <Setter Property="BorderBrush" Value="{ThemeResource CommandBarFlyoutAppBarButtonBorderBrush}" />
+                                                        <Setter Property="BorderThickness" Value="0" />
+                                                        <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                                        <Setter Property="VerticalAlignment" Value="Stretch" />
+                                                        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                                                        <Setter Property="FontWeight" Value="Normal" />
+                                                        <Setter Property="Width" Value="NaN" />
+                                                        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                                                        <Setter Property="AllowFocusOnInteraction" Value="False" />
+                                                        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+                                                        <Setter Property="local:CommandBarFlyoutCommandBarAutomationProperties.ControlType" Value="MenuItem" />
+                                                    </Style>
+                                                </CommandBarOverflowPresenter.ItemContainerStyle>
                                             </CommandBarOverflowPresenter>
                                         </Grid>
                                     </Grid>

--- a/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
+++ b/test/MUXControlsTestApp/Themes/DisableAnimationsStylesOutsideStore_rs2.xaml
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<ResourceDictionary 
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
@@ -9,7 +9,7 @@
     xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
     xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
     xmlns:contract14NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,14)">
-    
+
     <!-- This is the same as the template in CommandBarFlyout_themeresources.xaml, except its animations have been removed.
          Any changes to the style in the above file should also be made here. -->
     <Style TargetType="primitives:CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarStyle}">
@@ -127,11 +127,11 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Grid x:Name="OuterContentRoot"
-                            VerticalAlignment="Top"
-                            Margin="{TemplateBinding Padding}"
-                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
-                            Height="{TemplateBinding Height}"
-                            contract4Present:XYFocusKeyboardNavigation="Enabled">
+                           VerticalAlignment="Top"
+                           Margin="{TemplateBinding Padding}"
+                           MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
+                           Height="{TemplateBinding Height}"
+                           contract4Present:XYFocusKeyboardNavigation="Enabled">
                             <Grid x:Name="ContentRoot"
                                     Background="{TemplateBinding Background}">
                                 <Grid.Clip>
@@ -155,7 +155,7 @@
                                     contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" MinWidth="3" />
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
                                         Height="40"
@@ -190,9 +190,13 @@
                                     </Button>
                                 </Grid>
                                 <Popup x:Name="OverflowPopup" contract8Present:ShouldConstrainToRootBounds="False">
-                                    <Grid
-                                        x:Name="OuterOverflowContentRoot"
-                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
+                                    <!-- The name OuterOverflowContentRoot is treated specially by the system and causes a shadow placed on this
+                                         an element with this name to fade in. We don't want this for this style, so we need a different template part name -->
+                                    <contract7Present:Grid
+                                        x:Name="OuterOverflowContentRootV2"
+                                        RequestedTheme="{TemplateBinding ActualTheme}"
+                                        Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}"
+                                        contract14NotPresent:Translation="0,0,32">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
                                                 x:Name="OverflowContentRootTransform"
@@ -225,188 +229,12 @@
                                                 BorderBrush="{TemplateBinding BorderBrush}"
                                                 BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
                                                 IsTabStop="False">
-                                                <CommandBarOverflowPresenter.ItemContainerStyle>
-                                                    <Style TargetType="FrameworkElement">
-                                                        <Setter Property="HorizontalAlignment" Value="Stretch" />
-                                                        <Setter Property="Width" Value="NaN" />
-                                                    </Style>
-                                                </CommandBarOverflowPresenter.ItemContainerStyle>
                                             </CommandBarOverflowPresenter>
                                         </Grid>
-                                    </Grid>
-                                </Popup>
-                            </Grid>
-                        </Grid>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <!-- This is the same as the template in CommandBarFlyoutOS_themeresources.xaml, except its animations have been removed.
-         Any changes to the style in the above file should also be made here. -->
-    <contract13Present:Style TargetType="CommandBarFlyoutCommandBar" BasedOn="{StaticResource DefaultCommandBarFlyoutCommandBarOSStyle}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="CommandBarFlyoutCommandBar">
-                    <Grid x:Name="LayoutRoot"
-                         CornerRadius="{TemplateBinding CornerRadius}">
-                        <Grid.Resources>
-                            <Style TargetType="AppBarButton" BasedOn="{StaticResource CommandBarFlyoutAppBarButtonStyle}" />
-                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource CommandBarFlyoutAppBarToggleButtonStyle}" />
-                        </Grid.Resources>
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal" />
-                                <VisualState x:Name="Disabled">
-                                    <VisualState.Setters>
-                                        <Setter Target="EllipsisIcon.Foreground" Value="{ThemeResource CommandBarEllipsisIconForegroundDisabled}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="DisplayModeStates">
-                                <VisualState x:Name="CompactClosed" />
-                                <VisualState x:Name="CompactOpenUp" />
-                                <VisualState x:Name="CompactOpenDown" />
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="ExpansionStates">
-                                <VisualState x:Name="Collapsed" />
-                                <VisualState x:Name="ExpandedUp">
-                                    <VisualState.Setters>
-                                        <Setter Target="MoreButtonTransform.X" Value="0" />
-                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpOverflowVerticalPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandUpAnimationEndPosition}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDown">
-                                    <VisualState.Setters>
-                                        <Setter Target="MoreButtonTransform.X" Value="0" />
-                                        <Setter Target="ContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.X" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionAnimationEndPosition}" />
-                                        <Setter Target="OverflowContentRootClipTransform.Y" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandDownAnimationEndPosition}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="AvailableCommandsStates">
-                                <VisualState x:Name="BothCommands" />
-                                <VisualState x:Name="PrimaryCommandsOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="OverflowContentRoot.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="SecondaryCommandsOnly">
-                                    <VisualState.Setters>
-                                        <Setter Target="PrimaryItemsRoot.Visibility" Value="Collapsed" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup>
-                                <VisualState x:Name="Default" />
-                                <VisualState x:Name="ExpandedUpWithPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDownWithPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopCornerRadiusFilterConverter}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomCornerRadiusFilterConverter}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedUpWithoutPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedDownWithoutPrimaryCommands">
-                                    <VisualState.Setters>
-                                        <Setter Target="SecondaryItemsControl.BorderThickness" Value="{ThemeResource CommandBarFlyoutBorderThemeThickness}" />
-                                        <Setter Target="LayoutRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="PrimaryItemsRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="OuterOverflowContentRoot.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                        <Setter Target="SecondaryItemsControl.CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}" />
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-                        <Grid x:Name="OuterContentRoot"
-                            VerticalAlignment="Top"
-                            Margin="{TemplateBinding Padding}"
-                            MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.CurrentWidth}"
-                            Height="{TemplateBinding Height}"
-                            XYFocusKeyboardNavigation="Enabled">
-                            <Grid x:Name="ContentRoot"
-                                    Background="{TemplateBinding Background}">
-                                <Grid.Clip>
-                                    <RectangleGeometry x:Name="ContentRootClip" Rect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ContentClipRect}">
-                                        <RectangleGeometry.Transform>
-                                            <!-- If you have a value set by a binding and then animate that value,
-                                                 the animation will clear the binding.  Because of that, we need to have
-                                                 two translate transforms - one that we bind to a property,
-                                                 and another that we can animate. -->
-                                            <TransformGroup>
-                                                <TranslateTransform X="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.WidthExpansionDelta}" />
-                                                <TranslateTransform x:Name="ContentRootClipTransform" />
-                                            </TransformGroup>
-                                        </RectangleGeometry.Transform>
-                                    </RectangleGeometry>
-                                </Grid.Clip>
-                                <Grid x:Name="PrimaryItemsRoot"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding CornerRadius}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <ItemsControl x:Name="PrimaryItemsControl"
-                                        Height="40"
-                                        Margin="3,3,0,3"
-                                        Grid.Column="0"
-                                        IsTabStop="False"
-                                        HorizontalAlignment="Left">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                    </ItemsControl>
-                                    <Button x:Name="MoreButton"
-                                        Foreground="{TemplateBinding Foreground}"
-                                        Style="{StaticResource CommandBarFlyoutEllipsisButtonStyle}"
-                                        Grid.Column="1"
-                                        Control.IsTemplateKeyTipTarget="True"
-                                        IsAccessKeyScope="True"
-                                        IsTabStop="False"
-                                        CornerRadius="{TemplateBinding CornerRadius}"
-                                        Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CommandBarTemplateSettings.EffectiveOverflowButtonVisibility}">
-                                        <Button.RenderTransform>
-                                            <TranslateTransform x:Name="MoreButtonTransform" />
-                                        </Button.RenderTransform>
-                                        <FontIcon x:Name="EllipsisIcon"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                            FontSize="16"
-                                            Glyph="&#xE10C;" />
-                                    </Button>
-                                </Grid>
-                                <Popup x:Name="OverflowPopup">
-                                    <Grid
-                                        x:Name="OuterOverflowContentRoot"
+                                    </contract7Present:Grid>
+                                    <contract7NotPresent:Grid
+                                        x:Name="OuterOverflowContentRootV2"
+                                        RequestedTheme="{TemplateBinding ActualTheme}"
                                         Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}">
                                         <Grid.RenderTransform>
                                             <TranslateTransform
@@ -433,6 +261,12 @@
                                                     </RectangleGeometry.Transform>
                                                 </RectangleGeometry>
                                             </Grid.Clip>
+                                            <Border
+                                                x:Name="OverflowPresenterBorder"
+                                                Grid.Row="1"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{ThemeResource CommandBarFlyoutBorderThemeThickness}"
+                                                CornerRadius="{ThemeResource OverlayCornerRadius}"/>
                                             <CommandBarOverflowPresenter
                                                 Grid.Row="1"
                                                 x:Name="SecondaryItemsControl"
@@ -442,7 +276,7 @@
                                                 IsTabStop="False">
                                             </CommandBarOverflowPresenter>
                                         </Grid>
-                                    </Grid>
+                                    </contract7NotPresent:Grid>
                                 </Popup>
                             </Grid>
                         </Grid>
@@ -450,5 +284,5 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </contract13Present:Style>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
We have an issue where CommandBarFlyout is crashing down level because we are attempting to set the elements translation and its render transform properties, which are mutually exclusive. However, we don't actually need to set the translation property before contract 14 because it isn't needed for projected shadows, but is needed for drop shadows.  So we can just set the translation property uplevel.  We missed this because the test app uses a different style for CommandBarFlyout to help with testing consistency (it removes some animations that are difficult to work with). I've also updated the test app with new style bits.