### PR TITLE
Slider: give focus rect rounded corners

### DIFF
--- a/dev/CommonStyles/Slider_themeresources.xaml
+++ b/dev/CommonStyles/Slider_themeresources.xaml
@@ -174,14 +174,15 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
+    <Thickness x:Key="SliderContainerMargin">2</Thickness>
     <Thickness x:Key="SliderTopHeaderMargin">0,0,0,4</Thickness>
     <CornerRadius x:Key="SliderTrackCornerRadius">2</CornerRadius>
     <CornerRadius x:Key="SliderThumbCornerRadius">10</CornerRadius>
-    <x:Double x:Key="SliderPreContentMargin">15</x:Double>
-    <x:Double x:Key="SliderPostContentMargin">15</x:Double>
+    <x:Double x:Key="SliderPreContentMargin">13</x:Double>
+    <x:Double x:Key="SliderPostContentMargin">13</x:Double>
     <x:Double x:Key="SliderInnerThumbHeight">12</x:Double>
-    <x:Double x:Key="SliderHorizontalHeight">32</x:Double>
-    <x:Double x:Key="SliderVerticalWidth">32</x:Double>   
+    <x:Double x:Key="SliderHorizontalHeight">30</x:Double>
+    <x:Double x:Key="SliderVerticalWidth">30</x:Double>   
     <x:Double x:Key="SliderHorizontalThumbWidth">18</x:Double>
     <x:Double x:Key="SliderHorizontalThumbHeight">18</x:Double>
     <x:Double x:Key="SliderVerticalThumbWidth">18</x:Double>
@@ -206,7 +207,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Slider">
-                    <Grid Margin="{TemplateBinding Padding}">
+                    <Grid Margin="{TemplateBinding Padding}" CornerRadius="{ThemeResource ControlCornerRadius}">
                         <Grid.Resources>
                             <Style TargetType="Thumb" x:Key="SliderThumbStyle">
                                 <Setter Property="BorderThickness" Value="1" />
@@ -439,7 +440,7 @@
                         <Grid x:Name="SliderContainer"
                             Grid.Row="1"
                             Background="{ThemeResource SliderContainerBackground}"
-                            Control.IsTemplateFocusTarget="True">
+                            Margin="{ThemeResource SliderContainerMargin}">
                             <Grid x:Name="HorizontalTemplate" MinHeight="{ThemeResource SliderHorizontalHeight}">
 
                                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes regression introduced in #5353 and fixes #5396.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
 In #5353 we fixed cut off thumb however it was done through removing rounded corners from the main grid. It introduced a regression and removed rounded corners from the focus rect.
To fix that regression I've put the corner radius back as well as added a margin to the main slider container.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.