### PR TITLE
[NuGet] Ensure the buildTransitive folder is in sync with the build folder.

### DIFF
--- a/build/NuSpecs/MUXControls.nuspec
+++ b/build/NuSpecs/MUXControls.nuspec
@@ -34,5 +34,6 @@
 
     <!-- This is here for C++ based projects, see http://nugetdocsbeta.azurewebsites.net/ndocs/guides/create-uwp-packages -->
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-Native.targets"/>
+    <file target="buildTransitive\native\$ID$.targets" src="MUXControls-Nuget-Native.targets"/>
   </files>
 </package>


### PR DESCRIPTION
NuGet packages shipping both a build and a buildTransitive folder should by convention make sure the content of both folders are in sync.

- build/: Included for compatibility with packages.config projects. This is the default for native projects but can also be used for other project types.
- buildTransitive/: Used by PackageReference. If this folder is present Nuget will ignore the build/ folder.

## Description
This PR makes sure both build/ and buildTransitive/ contain the same files. 

## Motivation and Context
This makes the MUXC package better compatible with native projects that enable PackageReference through the built-in project system support as described in https://github.com/dotnet/project-system/issues/2491

## How Has This Been Tested?
Manually tested by including the target.

## Screenshots (if appropriate):
N/A