### PR TITLE
InkToolBar:  add missing visual states to CustomToggleButton

### DIFF
--- a/dev/CommonStyles/InkToolbar_themeresources.xaml
+++ b/dev/CommonStyles/InkToolbar_themeresources.xaml
@@ -23,6 +23,10 @@
             <StaticResource x:Key="InkToolbarFlyoutItemPressedSelectedBackgroundThemeBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemHoverSelectedBackgroundThemeBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemSelectedBackgroundThemeBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedPointerOver" ResourceKey="AccentFillColorSecondaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedPressed" ResourceKey="AccentFillColorTertiaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedDisabled" ResourceKey="AccentFillColorDisabledBrush"/>
             <!--Foreground-->
             <StaticResource x:Key="InkToolbarButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
@@ -39,6 +43,10 @@
             <StaticResource x:Key="InkToolbarFlyoutItemHoverForegroundThemeBrush" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemPressedForegroundThemeBrush" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemSelectedForegroundThemeBrush" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundChecked" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedDisabled" ResourceKey="TextOnAccentFillColorDisabledBrush"/>
             <!-- BorderBrush -->
             <Thickness x:Key="InkToolbarButtonBorderThemeThickness">0</Thickness>
             <StaticResource x:Key="InkToolbarButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
@@ -54,6 +62,10 @@
             <StaticResource x:Key="InkToolbarFlyoutItemBorderPressedThemeBrush" ResourceKey="InkToolbarFlyoutItemBorderSelectedThemeBrush" />
             <StaticResource x:Key="InkToolbarAccentColorForegroundThemeBrush" ResourceKey="AccentTextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarAccentHoverColorForegroundThemeBrush" ResourceKey="AccentTextFillColorSecondaryBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushChecked" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <!--Background-->
@@ -74,6 +86,10 @@
             <StaticResource x:Key="InkToolbarFlyoutItemPressedSelectedBackgroundThemeBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemHoverSelectedBackgroundThemeBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemSelectedBackgroundThemeBrush" ResourceKey="SubtleFillColorSecondaryBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedPointerOver" ResourceKey="AccentFillColorSecondaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedPressed" ResourceKey="AccentFillColorTertiaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedDisabled" ResourceKey="AccentFillColorDisabledBrush"/>
             <!--Foreground-->
             <StaticResource x:Key="InkToolbarButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
@@ -90,6 +106,10 @@
             <StaticResource x:Key="InkToolbarFlyoutItemHoverForegroundThemeBrush" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemPressedForegroundThemeBrush" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarFlyoutItemSelectedForegroundThemeBrush" ResourceKey="TextFillColorPrimaryBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundChecked" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedDisabled" ResourceKey="TextOnAccentFillColorDisabledBrush"/>
             <!-- BorderBrush -->
             <Thickness x:Key="InkToolbarButtonBorderThemeThickness">0</Thickness>
             <StaticResource x:Key="InkToolbarButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
@@ -105,6 +125,10 @@
             <StaticResource x:Key="InkToolbarFlyoutItemBorderPressedThemeBrush" ResourceKey="InkToolbarFlyoutItemBorderSelectedThemeBrush" />            
             <StaticResource x:Key="InkToolbarAccentColorForegroundThemeBrush" ResourceKey="AccentTextFillColorPrimaryBrush" />
             <StaticResource x:Key="InkToolbarAccentHoverColorForegroundThemeBrush" ResourceKey="AccentTextFillColorSecondaryBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushChecked" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <SolidColorBrush x:Key="InkToolbarFlyoutItemBackgroundThemeBrush" Color="{ThemeResource SystemColorWindowColor}" />
@@ -138,6 +162,10 @@
             <StaticResource x:Key="InkToolbarButtonSelectedBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="InkToolbarButtonSelectedBackgroundPressed" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="InkToolbarButtonSelectedBackgroundDisabled" ResourceKey="ControlFillColorDisabledBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundChecked" ResourceKey="AccentFillColorDefaultBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedPointerOver" ResourceKey="AccentFillColorSecondaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedPressed" ResourceKey="AccentFillColorTertiaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonBackgroundCheckedDisabled" ResourceKey="AccentFillColorDisabledBrush"/>
             <!-- Foreground -->
             <StaticResource x:Key="InkToolbarButtonForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
             <StaticResource x:Key="InkToolbarButtonForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
@@ -147,6 +175,10 @@
             <StaticResource x:Key="InkToolbarButtonSelectedForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
             <StaticResource x:Key="InkToolbarButtonSelectedForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
             <StaticResource x:Key="InkToolbarButtonSelectedForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundChecked" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush"/>
+            <StaticResource x:Key="InkToolBarToggleButtonForegroundCheckedDisabled" ResourceKey="TextOnAccentFillColorDisabledBrush"/>
             <!-- BorderBrush -->
             <Thickness x:Key="InkToolbarButtonBorderThemeThickness">1</Thickness>
             <StaticResource x:Key="InkToolbarButtonBorderBrush" ResourceKey="SystemControlBackgroundTransparentRevealBorderBrush" />
@@ -157,6 +189,10 @@
             <StaticResource x:Key="InkToolbarButtonSelectedBorderBrushPointerOver" ResourceKey="SystemControlTransparentRevealListLowBorderBrush" />
             <StaticResource x:Key="InkToolbarButtonSelectedBorderBrushPressed" ResourceKey="SystemControlTransparentRevealListLowBorderBrush" />
             <StaticResource x:Key="InkToolbarButtonSelectedBorderBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushChecked" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="InkToolBarToggleButtonBorderBrushCheckedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -1776,6 +1812,37 @@
                                     </VisualState.Setters>
                                 </VisualState>
 
+                                <VisualState x:Name="Checked">
+                                    <VisualState.Setters>
+                                        <Setter Target="RootElement.Background" Value="{ThemeResource InkToolBarToggleButtonBackgroundChecked}" />
+                                        <Setter Target="Border.BorderBrush" Value="{ThemeResource InkToolBarToggleButtonBorderBrushChecked}" />
+                                        <Setter Target="Content.Foreground" Value="{ThemeResource InkToolBarToggleButtonForegroundChecked}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CheckedPointerOver">
+                                    <VisualState.Setters>
+                                        <Setter Target="RootElement.Background" Value="{ThemeResource InkToolBarToggleButtonBackgroundCheckedPointerOver}" />
+                                        <Setter Target="Border.BorderBrush" Value="{ThemeResource InkToolBarToggleButtonBorderBrushCheckedPointerOver}" />
+                                        <Setter Target="Content.Foreground" Value="{ThemeResource InkToolBarToggleButtonForegroundCheckedPointerOver}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CheckedPressed">
+                                    <VisualState.Setters>
+                                        <Setter Target="RootElement.Background" Value="{ThemeResource InkToolBarToggleButtonBackgroundCheckedPressed}" />
+                                        <Setter Target="Border.BorderBrush" Value="{ThemeResource InkToolBarToggleButtonBorderBrushCheckedPressed}" />
+                                        <Setter Target="Content.Foreground" Value="{ThemeResource InkToolBarToggleButtonForegroundCheckedPressed}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+
+                                <VisualState x:Name="CheckedDisabled">
+                                    <VisualState.Setters>
+                                        <Setter Target="RootElement.Background" Value="{ThemeResource InkToolBarToggleButtonBackgroundCheckedDisabled}" />
+                                        <Setter Target="Border.BorderBrush" Value="{ThemeResource InkToolBarToggleButtonBorderBrushCheckedDisabled}" />
+                                        <Setter Target="Content.Foreground" Value="{ThemeResource InkToolBarToggleButtonForegroundCheckedDisabled}" />
+                                    </VisualState.Setters>
+                                </VisualState>
                             </VisualStateGroup>
 
                             <VisualStateGroup x:Name="FlowDirectionStates">
@@ -1783,7 +1850,6 @@
                                 <VisualState x:Name="RightToLeft" />
 
                             </VisualStateGroup>
-
                         </VisualStateManager.VisualStateGroups>
                         <Rectangle x:Name="ContentBackground" Fill="Transparent" />
                         <ContentPresenter x:Name="Content"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds missing visual states to CustomToggleButton to fix #5296 (problem that's stated in that issue is related to the old styles) that will appear when using latest styles.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
`InkToolbarCustomToggleButton` style was missing `Checked` visual states - this PR fixes this issue.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.
