### PR TITLE
CalendarView control: Allow longer week day labels without wrapping

### DIFF
--- a/dev/CommonStyles/CalendarView_themeresources_21h1.xaml
+++ b/dev/CommonStyles/CalendarView_themeresources_21h1.xaml
@@ -69,8 +69,8 @@
             <x:Double x:Key="CalendarViewHeaderNavigationButtonFontSize">14</x:Double>
             <x:Double x:Key="CalendarViewNavigationButtonFontSize">8</x:Double>
             <Thickness x:Key="CalendarViewDayItemMargin">0,3,0,0</Thickness>
-            <Thickness x:Key="CalendarViewWeekDayMargin">1</Thickness>
-            <Thickness x:Key="CalendarViewWeekDayPadding">12</Thickness>
+            <Thickness x:Key="CalendarViewWeekDayMargin">1,13,1,13</Thickness>
+            <Thickness x:Key="CalendarViewWeekDayPadding">0</Thickness>
             <Thickness x:Key="CalendarViewMonthYearItemMargin">0</Thickness>
             <Thickness x:Key="CalendarViewFirstOfMonthLabelMargin">0,2,0,0</Thickness>
             <Thickness x:Key="CalendarViewFirstOfYearDecadeLabelMargin">0,9,0,0</Thickness>
@@ -148,8 +148,8 @@
             <x:Double x:Key="CalendarViewHeaderNavigationButtonFontSize">14</x:Double>
             <x:Double x:Key="CalendarViewNavigationButtonFontSize">8</x:Double>
             <Thickness x:Key="CalendarViewDayItemMargin">0,3,0,0</Thickness>
-            <Thickness x:Key="CalendarViewWeekDayMargin">1</Thickness>
-            <Thickness x:Key="CalendarViewWeekDayPadding">12</Thickness>
+            <Thickness x:Key="CalendarViewWeekDayMargin">1,13,1,13</Thickness>
+            <Thickness x:Key="CalendarViewWeekDayPadding">0</Thickness>
             <Thickness x:Key="CalendarViewMonthYearItemMargin">0</Thickness>
             <Thickness x:Key="CalendarViewFirstOfMonthLabelMargin">0,2,0,0</Thickness>
             <Thickness x:Key="CalendarViewFirstOfYearDecadeLabelMargin">0,9,0,0</Thickness>
@@ -227,8 +227,8 @@
             <x:Double x:Key="CalendarViewHeaderNavigationButtonFontSize">14</x:Double>
             <x:Double x:Key="CalendarViewNavigationButtonFontSize">8</x:Double>
             <Thickness x:Key="CalendarViewDayItemMargin">0,3,0,0</Thickness>
-            <Thickness x:Key="CalendarViewWeekDayMargin">1</Thickness>
-            <Thickness x:Key="CalendarViewWeekDayPadding">12</Thickness>
+            <Thickness x:Key="CalendarViewWeekDayMargin">1,13,1,13</Thickness>
+            <Thickness x:Key="CalendarViewWeekDayPadding">0</Thickness>
             <Thickness x:Key="CalendarViewMonthYearItemMargin">0</Thickness>
             <Thickness x:Key="CalendarViewFirstOfMonthLabelMargin">0,2,0,0</Thickness>
             <Thickness x:Key="CalendarViewFirstOfYearDecadeLabelMargin">0,9,0,0</Thickness>

--- a/dev/CommonStyles/TestUI/CalendarViewPage.xaml
+++ b/dev/CommonStyles/TestUI/CalendarViewPage.xaml
@@ -47,10 +47,14 @@
             <ComboBox x:Name="calendarIdentifier" Margin="0,2,0,0" Header="CalendarIdentifier" Width="220" />
 
             <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
-                <TextBlock Text="Width:" VerticalAlignment="Center"/>
+                <TextBlock Text="Size:" VerticalAlignment="Center"/>
                 <TextBox x:Name="calendarWidth" Text="600" Margin="2" VerticalAlignment="Center" MinWidth="60"/>
-                <Button x:Name="getCalendarWidth" Content="Get" Margin="2" Click="GetCalendarWidth_Click" VerticalAlignment="Center"/>
-                <Button x:Name="setCalendarWidth" Content="Set" Margin="2" Click="SetCalendarWidth_Click" VerticalAlignment="Center"/>
+                <TextBox x:Name="calendarHeight" Text="600" Margin="2" VerticalAlignment="Center" MinWidth="60"/>
+                <TextBlock Text="ActualSize:" VerticalAlignment="Center"/>
+                <TextBlock x:Name="calendarActualWidth" Text="600" Margin="2" VerticalAlignment="Center" MinWidth="60"/>
+                <TextBlock x:Name="calendarActualHeight" Text="600" Margin="2" VerticalAlignment="Center" MinWidth="60"/>
+                <Button x:Name="getCalendarSize" Content="Get" Margin="2" Click="GetCalendarSize_Click" VerticalAlignment="Center"/>
+                <Button x:Name="setCalendarSize" Content="Set" Margin="2" Click="SetCalendarSize_Click" VerticalAlignment="Center"/>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" Margin="0,2,0,0">

--- a/dev/CommonStyles/TestUI/CalendarViewPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/CalendarViewPage.xaml.cs
@@ -134,14 +134,18 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void GetCalendarWidth_Click(object sender, RoutedEventArgs e)
+        private void GetCalendarSize_Click(object sender, RoutedEventArgs e)
         {
             calendarWidth.Text = PageCalendar2.Width.ToString();
+            calendarActualWidth.Text = PageCalendar2.ActualWidth.ToString();
+            calendarHeight.Text = PageCalendar2.Height.ToString();
+            calendarActualHeight.Text = PageCalendar2.ActualHeight.ToString();
         }
 
-        private void SetCalendarWidth_Click(object sender, RoutedEventArgs e)
+        private void SetCalendarSize_Click(object sender, RoutedEventArgs e)
         {
             PageCalendar2.Width = Double.Parse(calendarWidth.Text);
+            PageCalendar2.Height = Double.Parse(calendarHeight.Text);
         }
 
         private void SetDayItemMargin_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Some languages use 3-letter labels for the week days and they easily wrap when the CalendarView's width is constrained.

To repro, install for example the “Bahasa Indonesia” language pack in the Settings app. Then switch to it in the “Windows display language” option. Finally bring up the calendar in the Action Center on the bottom right corner of the desktop.

The solution here is to reduce the padding for the week day labels and adjust their margin so that the default natural CalendarView size remains at 300x352px. With the reduced horizontal padding, the labels have room to grow. 

I added some more size testing capabilities to the CalendarView test page and did ad-hoc testing with MuxControlsTestApp.