### PR TITLE
Fix NavigationView Flash in Compact Dark Theme

### DIFF
--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -90,6 +90,7 @@
             <Color x:Key="SolidBackgroundFillColorSecondary">#1C1C1C</Color>
             <Color x:Key="SolidBackgroundFillColorTertiary">#282828</Color>
             <Color x:Key="SolidBackgroundFillColorQuarternary">#2C2C2C</Color>
+            <Color x:Key="SolidBackgroundFillColorTransparent">#00202020</Color>
 
             <Color x:Key="SystemFillColorSuccess">#6CCB5F</Color>
             <Color x:Key="SystemFillColorCaution">#FCE100</Color>
@@ -334,6 +335,7 @@
             <Color x:Key="SolidBackgroundFillColorSecondary">#EEEEEE</Color>
             <Color x:Key="SolidBackgroundFillColorTertiary">#F9F9F9</Color>
             <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFFFF</Color>
+            <Color x:Key="SolidBackgroundFillColorTransparent">#00F3F3F3</Color>
 
             <Color x:Key="SystemFillColorSuccess">#0F7B0F</Color>
             <Color x:Key="SystemFillColorCaution">#9D5D00</Color>
@@ -668,6 +670,7 @@
             <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
+            <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
             <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
             <Color x:Key="SystemFillColorCaution">#FF0000</Color>
             <Color x:Key="SystemFillColorCritical">#FF0000</Color>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -14,7 +14,7 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Dark">
             <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
-            <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="ControlFillColorTransparentBrush" />
+            <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SolidBackgroundFillColorTransparent" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="ControlFillColorTransparentBrush" />
             <StaticResource x:Key="NavigationViewContentBackground" ResourceKey="LayerFillColorDefaultBrush" />
 
@@ -92,7 +92,7 @@
 
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="NavigationViewDefaultPaneBackground" ResourceKey="SolidBackgroundFillColorBaseBrush" />
-            <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="ControlFillColorTransparentBrush" />
+            <StaticResource x:Key="NavigationViewExpandedPaneBackground" ResourceKey="SolidBackgroundFillColorTransparent" />
             <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="ControlFillColorTransparentBrush" />
             <StaticResource x:Key="NavigationViewContentBackground" ResourceKey="LayerFillColorDefaultBrush" />
 

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-4.xml
@@ -657,7 +657,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-5.xml
@@ -657,7 +657,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-6.xml
@@ -657,7 +657,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-7.xml
@@ -597,7 +597,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-8.xml
@@ -597,7 +597,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-4.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-5.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-6.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-7.xml
@@ -549,7 +549,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-8.xml
@@ -549,7 +549,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-4.xml
@@ -616,7 +616,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-5.xml
@@ -616,7 +616,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-6.xml
@@ -616,7 +616,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-7.xml
@@ -596,7 +596,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-8.xml
@@ -597,7 +597,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-4.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-5.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-6.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-7.xml
@@ -549,7 +549,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-8.xml
@@ -549,7 +549,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-4.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-5.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-6.xml
@@ -600,7 +600,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-7.xml
@@ -549,7 +549,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-8.xml
@@ -549,7 +549,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTop-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTop-4.xml
@@ -1396,7 +1396,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTop-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTop-5.xml
@@ -1396,7 +1396,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTop-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTop-6.xml
@@ -1396,7 +1396,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTop-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTop-7.xml
@@ -1353,7 +1353,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTop-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTop-8.xml
@@ -1353,7 +1353,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=120
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-4.xml
@@ -1788,7 +1788,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-5.xml
@@ -1788,7 +1788,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-6.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-6.xml
@@ -1788,7 +1788,7 @@
               CornerRadius=0,0,0,0
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-7.xml
@@ -1770,7 +1770,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0

--- a/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewTopPaneContent-8.xml
@@ -1770,7 +1770,7 @@
               CornerRadius=8,8,8,8
               BorderThickness=1,1,1,1
               BorderBrush=#00FFFFFF
-              Background=#00FFFFFF
+              Background=#00F3F3F3
               Width=300
               Name=PaneRoot
               Margin=0,0,0,0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Color animations animate using RGB channels but not the Alpha channel, causing a flash of white animating between a dark colour and a transparent white colour.
- Added `SolidBackgroundFillColorTransparent` that is a transparent version of the base colour.