### PR TITLE
Move to 1ES Build Pool

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -5,7 +5,8 @@ variables:
 jobs:
 - job: Build
   pool:
-    name: 'windevbuildagents'
+    name: WinDevPool-XL
+    demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -4,8 +4,11 @@ variables:
   rerunPassesRequiredToAvoidFailure: 5
 jobs:
 - job: Build
-  pool:
-    name: WinDevPool-XL
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPool-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPoolOSS-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:
@@ -34,49 +37,53 @@ jobs:
     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
     publishDir : $(Build.ArtifactStagingDirectory)
   steps:
-  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-  parameters:
-    name: 'RunTestsInHelix'
-    dependsOn: Build
-    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-    testSuite: 'DevTestSuite'
-    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+  - script: set
+    displayName: 'Display current environment variables'
 
-# Create Nuget Package
-- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-  parameters:
-    jobName: CreateNugetPackage
-    dependsOn: Build
-    prereleaseVersionTag: ci
+#   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+#   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# Build solution that depends on nuget package
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildNugetPkgTests'
-    buildArtifactName: 'NugetPkgTestsDrop'
-    runTestJobName: 'RunNugetPkgTestsInHelix'
-    helixType: 'test/nuget'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: false
+# - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+#   parameters:
+#     name: 'RunTestsInHelix'
+#     dependsOn: Build
+#     condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+#     testSuite: 'DevTestSuite'
+#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
-# Framework package tests
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildFrameworkPkgTests'
-    buildArtifactName: 'FrameworkPkgTestsDrop'
-    runTestJobName: 'RunFrameworkPkgTestsInHelix'
-    helixType: 'test/frpkg'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: true
+# # Create Nuget Package
+# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+#   parameters:
+#     jobName: CreateNugetPackage
+#     dependsOn: Build
+#     prereleaseVersionTag: ci
 
-- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-  parameters:
-    dependsOn:
-    - RunTestsInHelix
-    - RunNugetPkgTestsInHelix
-    - RunFrameworkPkgTestsInHelix
-    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+# # Build solution that depends on nuget package
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildNugetPkgTests'
+#     buildArtifactName: 'NugetPkgTestsDrop'
+#     runTestJobName: 'RunNugetPkgTestsInHelix'
+#     helixType: 'test/nuget'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: false
+
+# # Framework package tests
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildFrameworkPkgTests'
+#     buildArtifactName: 'FrameworkPkgTestsDrop'
+#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+#     helixType: 'test/frpkg'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: true
+
+# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+#   parameters:
+#     dependsOn:
+#     - RunTestsInHelix
+#     - RunNugetPkgTestsInHelix
+#     - RunFrameworkPkgTestsInHelix
+#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -37,53 +37,49 @@ jobs:
     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
     publishDir : $(Build.ArtifactStagingDirectory)
   steps:
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-  - script: set
-    displayName: 'Display current environment variables'
+- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    dependsOn: Build
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    testSuite: 'DevTestSuite'
+    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
-#   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-#   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+# Create Nuget Package
+- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+  parameters:
+    jobName: CreateNugetPackage
+    dependsOn: Build
+    prereleaseVersionTag: ci
 
-# - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-#   parameters:
-#     name: 'RunTestsInHelix'
-#     dependsOn: Build
-#     condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-#     testSuite: 'DevTestSuite'
-#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+# Build solution that depends on nuget package
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildNugetPkgTests'
+    buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: false
 
-# # Create Nuget Package
-# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-#   parameters:
-#     jobName: CreateNugetPackage
-#     dependsOn: Build
-#     prereleaseVersionTag: ci
+# Framework package tests
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildFrameworkPkgTests'
+    buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: true
 
-# # Build solution that depends on nuget package
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildNugetPkgTests'
-#     buildArtifactName: 'NugetPkgTestsDrop'
-#     runTestJobName: 'RunNugetPkgTestsInHelix'
-#     helixType: 'test/nuget'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: false
-
-# # Framework package tests
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildFrameworkPkgTests'
-#     buildArtifactName: 'FrameworkPkgTestsDrop'
-#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
-#     helixType: 'test/frpkg'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: true
-
-# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-#   parameters:
-#     dependsOn:
-#     - RunTestsInHelix
-#     - RunNugetPkgTestsInHelix
-#     - RunFrameworkPkgTestsInHelix
-#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunTestsInHelix
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -21,7 +21,8 @@ jobs:
       ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
     )
   pool:
-    name: 'windevbuildagents'
+    name: WinDevPool-XL
+    demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -20,8 +20,11 @@ jobs:
       eq(variables['useBuildOutputFromBuildId'],''),
       ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
     )
-  pool:
-    name: WinDevPool-XL
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPool-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPoolOSS-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -15,8 +15,11 @@ jobs:
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
   condition:
     eq(variables['useBuildOutputFromBuildId'],'')
-  pool:
-    name: WinDevPool-XL
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPool-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPoolOSS-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -16,7 +16,8 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'')
   pool:
-    name: 'windevbuildagents'
+    name: WinDevPool-XL
+    demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -11,7 +11,8 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'') 
   pool:
-    name: 'windevbuildagents'
+    name: WinDevPool-XL
+    demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   variables:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -10,8 +10,11 @@ jobs:
 - job: Build
   condition:
     eq(variables['useBuildOutputFromBuildId'],'') 
-  pool:
-    name: WinDevPool-XL
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPool-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+      name: WinDevPoolOSS-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   variables:


### PR DESCRIPTION
The Self-Hosted windevbuildagents pool is being decommissioned and is being replaced with a 1ES Hosted agent pool. 

This PR switches over our Pipelines to point to the new pool.

Previously, we used the same pool name when we were building in dev.azure.com/ms and dev.azure.com/microsoft. However we cannot have two 1ES Pools with the same name, even if they are in different orgs. So we have to use conditional yml to choose the correct pool name based on the org we are running in.