### PR TITLE
Fix CommandBar resource overridability.

### DIFF
--- a/dev/CommonStyles/CommandBar_themeresources.xaml
+++ b/dev/CommonStyles/CommandBar_themeresources.xaml
@@ -933,8 +933,8 @@
                                         <TranslateTransform x:Name="OverflowContentTransform" />
                                     </CommandBarOverflowPresenter.RenderTransform>
                                     <CommandBarOverflowPresenter.Resources>
-                                        <Style TargetType="AppBarButton" BasedOn="{StaticResource AppBarButtonOverflowStyle}" />
-                                        <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonOverflowStyle}" />
+                                        <Style TargetType="AppBarButton" BasedOn="{ThemeResource AppBarButtonOverflowStyle}" />
+                                        <Style TargetType="AppBarToggleButton" BasedOn="{ThemeResource AppBarToggleButtonOverflowStyle}" />
                                     </CommandBarOverflowPresenter.Resources>
                                 </contract12NotPresent:CommandBarOverflowPresenter>
                                 <!--For 21H1 and up, we'll need to wrap the clip and presenter in a Grid which will host the Drop Shadow.-->
@@ -957,8 +957,8 @@
                                             <TranslateTransform x:Name="OverflowContentTransform" />
                                         </CommandBarOverflowPresenter.RenderTransform>
                                         <CommandBarOverflowPresenter.Resources>
-                                            <Style TargetType="AppBarButton" BasedOn="{StaticResource AppBarButtonOverflowStyle}" />
-                                            <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonOverflowStyle}" />
+                                            <Style TargetType="AppBarButton" BasedOn="{ThemeResource AppBarButtonOverflowStyle}" />
+                                            <Style TargetType="AppBarToggleButton" BasedOn="{ThemeResource AppBarToggleButtonOverflowStyle}" />
                                         </CommandBarOverflowPresenter.Resources>
                                     </CommandBarOverflowPresenter>
                                 </contract12Present:Grid>


### PR DESCRIPTION
Change the AppBarButtonOverflowStyle and AppBarToggleButtonOverflowStyle resource look ups to be ThemeResource lookups so that they are overridable at the page level.  They still aren't overridable at the application level, but I don't think we can afford to triplicate and entire style by moving them to theme dictionaries, plus it would remove the ability to override the resources referenced by those styles in some cases.