### PR TITLE
NavigationView TopNav: fix insertion bug and improve top nav performance/fix flyout positioning

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3117,7 +3117,6 @@ void NavigationView::TopNavigationViewItemContentChanged()
 {
     if (m_appliedTemplate)
     {
-        m_topDataProvider.InvalidWidthCache();
         InvalidateMeasure();
     }
 }

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3117,6 +3117,10 @@ void NavigationView::TopNavigationViewItemContentChanged()
 {
     if (m_appliedTemplate)
     {
+        if (!MenuItemsSource())
+        {
+            m_topDataProvider.InvalidWidthCache();
+        }
         InvalidateMeasure();
     }
 }

--- a/dev/NavigationView/SplitDataSourceBase.h
+++ b/dev/NavigationView/SplitDataSourceBase.h
@@ -59,7 +59,7 @@ public:
     {
         for (auto& v : m_indexesInOriginalVector)
         {
-            if (v > indexInOriginalVector)
+            if (v >= indexInOriginalVector)
             {
                 v++;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR corrects the update of index in original vector while inserting an element in custom data source and improves performance of topnav overflow flyout rendering.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
First, I've fixed the procedure of insertion of the element at already existing index in raw data source. Before, it was not incrementing the index at which the new element was inserted. It resulted in two elements referencing the same data in the original vector and it messed up the animations and correct ordering.

Second, I've removed width cache invalidation for custom data source when content of NavItem changes. That cache invalidation call was leading to our own "layout cycle" that resulted in poor performance and sometimes incorrect positioning of the overflow items flyout when overflow button was clicked. The reason why it could be removed without affecting behavior of TopNav is because when content of any of ithe items changes (so it can potentially properly resize and may move some items from OverflowItems due to some of them shrinking in size) is because when Custom data source changes, all the items will be moved to PrimaryList and all items sizes will be recalculated. We still need cache invalidation in case of non custom data source being used because changing content of NavItem in this case won't lead to cache invalidation - it will simply try to rearrange items with existing width values stored in the cache.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manually.