### PR TITLE
Pipeline Failure Workaround: Exclude WpfApp.Package.WapProj

### DIFF
--- a/test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln
+++ b/test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln
@@ -45,7 +45,7 @@ Temporarily_Excluded_Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "WpfApp
 	ProjectSection(ProjectDependencies) = postProject
 		{51654A14-2759-4DD0-96E2-DD05084BA720} = {51654A14-2759-4DD0-96E2-DD05084BA720}
 	EndProjectSection
-Temporarily_Excluded_EndProject
+EndTemporarily_Excluded_Project
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MUXTestInfra", "MUXTestInfra", "{8BC8219D-1669-4147-9941-1CA911D0A958}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MUXTestInfra.Shared", "..\testinfra\MUXTestInfra\MUXTestInfra.Shared.shproj", "{107794D7-4BE0-407E-A76C-EFA46D1E9F93}"
@@ -391,6 +391,8 @@ Global
 		{BBF64CD0-9E73-4669-B42B-EE6BD986877C}.Release|x64.Build.0 = Release|x64
 		{BBF64CD0-9E73-4669-B42B-EE6BD986877C}.Release|x86.ActiveCfg = Release|x86
 		{BBF64CD0-9E73-4669-B42B-EE6BD986877C}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	Temporarily_Excluded_GlobalSection_ProjectConfigurationPlatforms
 		{4454B583-39A0-4A91-881C-2078FA26C447}.Debug_test|ARM.ActiveCfg = Release|x86
 		{4454B583-39A0-4A91-881C-2078FA26C447}.Debug_test|arm64.ActiveCfg = Debug|x64
 		{4454B583-39A0-4A91-881C-2078FA26C447}.Debug_test|x64.ActiveCfg = Debug|x64
@@ -417,7 +419,7 @@ Global
 		{4454B583-39A0-4A91-881C-2078FA26C447}.Release|x86.ActiveCfg = Release|x86
 		{4454B583-39A0-4A91-881C-2078FA26C447}.Release|x86.Build.0 = Release|x86
 		{4454B583-39A0-4A91-881C-2078FA26C447}.Release|x86.Deploy.0 = Release|x86
-	EndGlobalSection
+	EndTemporarily_Excluded_GlobalSection_ProjectConfigurationPlatforms
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
@@ -432,9 +434,11 @@ Global
 		{94DF1545-C2FD-41DC-B68D-2C16D6BA3FD4} = {8BC8219D-1669-4147-9941-1CA911D0A958}
 		{51654A14-2759-4DD0-96E2-DD05084BA720} = {24B82701-D5C4-43BA-A35B-B20194CBF42D}
 		{BBF64CD0-9E73-4669-B42B-EE6BD986877C} = {24B82701-D5C4-43BA-A35B-B20194CBF42D}
-		{4454B583-39A0-4A91-881C-2078FA26C447} = {24B82701-D5C4-43BA-A35B-B20194CBF42D}
 		{107794D7-4BE0-407E-A76C-EFA46D1E9F93} = {8BC8219D-1669-4147-9941-1CA911D0A958}
 	EndGlobalSection
+	Temporarily_Excluded_GlobalSection_NestedProjects
+		{4454B583-39A0-4A91-881C-2078FA26C447} = {24B82701-D5C4-43BA-A35B-B20194CBF42D}
+	EndTemporarily_Excluded_GlobalSection_NestedProjects
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E45DFF44-1BEF-4538-9DC4-E0FC5B89B857}
 	EndGlobalSection

--- a/test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln
+++ b/test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln
@@ -41,11 +41,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UwpApp", "XamlIslandsTestAp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfApp", "XamlIslandsTestApp\WpfApp\WpfApp.csproj", "{BBF64CD0-9E73-4669-B42B-EE6BD986877C}"
 EndProject
-Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "WpfApp.Package", "XamlIslandsTestApp\WpfApp\WpfApp.Package.wapproj", "{4454B583-39A0-4A91-881C-2078FA26C447}"
+Temporarily_Excluded_Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "WpfApp.Package", "XamlIslandsTestApp\WpfApp\WpfApp.Package.wapproj", "{4454B583-39A0-4A91-881C-2078FA26C447}"
 	ProjectSection(ProjectDependencies) = postProject
 		{51654A14-2759-4DD0-96E2-DD05084BA720} = {51654A14-2759-4DD0-96E2-DD05084BA720}
 	EndProjectSection
-EndProject
+Temporarily_Excluded_EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MUXTestInfra", "MUXTestInfra", "{8BC8219D-1669-4147-9941-1CA911D0A958}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MUXTestInfra.Shared", "..\testinfra\MUXTestInfra\MUXTestInfra.Shared.shproj", "{107794D7-4BE0-407E-A76C-EFA46D1E9F93}"


### PR DESCRIPTION
Avoid PR pipeline failures by temporarily disabling the WpfApp.Package.WapProj in test/MUXControlsReleaseTest/MUXControlsReleaseTest.sln

Its test are already disabled anyways - so we don't lose much in disabling the build.

Reported error in recent PR pipelines:
```
2021-07-27T00:41:39.3879745Z   C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VisualStudio\v16.0\AppxPackage\Microsoft.AppXPackage.Targets(3387,5): error APPX1112: Payload contains two or more files with the same destination path 'WpfApp\AppTestAutomationHelpers.dll', but they have different content. Source files:  [D:\a\1\s\test\MUXControlsReleaseTest\XamlIslandsTestApp\WpfApp\WpfApp.Package.wapproj]
2021-07-27T00:41:39.3884698Z C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VisualStudio\v16.0\AppxPackage\Microsoft.AppXPackage.Targets(3387,5): error APPX1112: D:\a\1\s\test\MUXControlsReleaseTest\XamlIslandsTestApp\WpfApp\bin\win10-x64\publish\AppTestAutomationHelpers.dll [D:\a\1\s\test\MUXControlsReleaseTest\XamlIslandsTestApp\WpfApp\WpfApp.Package.wapproj]
2021-07-27T00:41:39.3888732Z C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VisualStudio\v16.0\AppxPackage\Microsoft.AppXPackage.Targets(3387,5): error APPX1112: D:\a\1\s\BuildOutput\Release\x64\UwpApp\ilc\AppTestAutomationHelpers.dll [D:\a\1\s\test\MUXControlsReleaseTest\XamlIslandsTestApp\WpfApp\WpfApp.Package.wapproj]
```

This recent regression was probably introduced by a Visual Studio upgrade on the build machines.

Visual Studio does not approve of # for comment lines in .sln files, but it does accept any tag name. So I made up  Temporarily_Excluded_Project to replace Project.
