### PR TITLE
Fix yml pool name conditional

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -5,10 +5,10 @@ variables:
 jobs:
 - job: Build
   pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
-      name: WinDevPool-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:

--- a/build/MUX-PGOInstrument.yml
+++ b/build/MUX-PGOInstrument.yml
@@ -8,10 +8,7 @@ variables:
 jobs:
 - job: Build
   pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
-      name: WinDevPool-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
-      name: WinDevPoolOSS-L
+    name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -21,10 +21,10 @@ jobs:
       ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
     )
   pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
-      name: WinDevPool-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -16,10 +16,10 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'')
   pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
-      name: WinDevPool-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   strategy:

--- a/build/MUX-SimpleBuildAndTest.yml
+++ b/build/MUX-SimpleBuildAndTest.yml
@@ -11,10 +11,10 @@ jobs:
   condition:
     eq(variables['useBuildOutputFromBuildId'],'') 
   pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
-      name: WinDevPool-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft/') }}:
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
     demands: ImageOverride -equals WinDevVS16-9
   timeoutInMinutes: 120
   variables:


### PR DESCRIPTION
We use a yml condition to control the name of the pool depending on which Azure DevOps instance we are building in. However, the value of CollectionUri in the 'microsoft' instance is a bit unreliable since depending on how the build was triggered it could be 'dev.azure.com/microsoft' or 'microsoft.visualstudio.com'. 

So, we reverse the comparison and just look for 'dev.azure.com/ms'.