### PR TITLE
Stop using Package ES pools

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -6,7 +6,7 @@ jobs:
   dependsOn:
     - ${{ parameters.dependsOn }}
   pool:
-    name: Package ES Lab E
+    name: WinDevPool-S
   variables:
     windowsPublicsWinmdVersion: 0.0.2
     internalSDKFeedUrl: https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json
@@ -37,35 +37,35 @@ jobs:
     # This artifact is not consumed by anyone, but it is useful for debugging purposes.
 
   # Push the VPacks:
-  - task: PkgESVPack@10
+  - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_x64'
     inputs:
       sourceDirectory: '$(System.ArtifactsDirectory)\drop\Release\CBS\x64'
       description: 'MicrosoftUIXamlInbox_x64'
       pushPkgName: 'MicrosoftUIXamlInbox_x64'
       version: $(vpackversion)
-  - task: PkgESVPack@10
+  - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_x86'
     inputs:
       sourceDirectory: '$(System.ArtifactsDirectory)\drop\Release\CBS\x86'
       description: 'MicrosoftUIXamlInbox_x86'
       pushPkgName: 'MicrosoftUIXamlInbox_x86'
       version: $(vpackversion)
-  - task: PkgESVPack@10
+  - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_arm'
     inputs:
       sourceDirectory: '$(System.ArtifactsDirectory)\drop\Release\CBS\arm'
       description: 'MicrosoftUIXamlInbox_arm'
       pushPkgName: 'MicrosoftUIXamlInbox_arm'
       version: $(vpackversion)
-  - task: PkgESVPack@10
+  - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_arm64'
     inputs:
       sourceDirectory: '$(System.ArtifactsDirectory)\drop\Release\CBS\arm64'
       description: 'MicrosoftUIXamlInbox_arm64'
       pushPkgName: 'MicrosoftUIXamlInbox_arm64'
       version: $(vpackversion)
-  - task: PkgESVPack@10
+  - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInboxWinmd'
     inputs:
       sourceDirectory: '$(System.ArtifactsDirectory)\drop\Release\CBS\winmd'

--- a/build/MUX-LocalizationHandoff.yml
+++ b/build/MUX-LocalizationHandoff.yml
@@ -6,20 +6,12 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: LocalizationHandoff
   pool:
-    name: Package ES Standard Build
+    vmImage: 'windows-2019'
   variables:
     resourceStagingDirectory: '$(Build.ArtifactStagingDirectory)\LocStaging'
     resourceOutputDirectory: '$(Build.ArtifactStagingDirectory)\LocOutput'
 
   steps:
-  - task: PkgESSetupBuild@10
-    displayName: 'XESSetupBuild'
-    inputs:
-      productName: dep.controls
-      branchVersion: true
-      nugetVer: true
-      useDfs: false
-
   - powershell: |
       & "$env:Build_SourcesDirectory\build\Localization\PrepLocFilesForUpload.ps1" `
         -DestinationFilePath '${{ variables.resourceStagingDirectory }}'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -70,57 +70,57 @@ jobs:
 
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# Create Nuget Package
-- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-  parameters:
-    jobName: CreateNugetPackage
-    dependsOn: Build
-    signOutput: true
-    useReleaseTag: '$(MUXFinalRelease)'
-    prereleaseVersionTag: prerelease
+# # Create Nuget Package
+# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+#   parameters:
+#     jobName: CreateNugetPackage
+#     dependsOn: Build
+#     signOutput: true
+#     useReleaseTag: '$(MUXFinalRelease)'
+#     prereleaseVersionTag: prerelease
 
 - template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
   parameters:
     dependsOn: Build
 
-# Build solution that depends on nuget package
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildNugetPkgTests'
-    buildArtifactName: 'NugetPkgTestsDrop'
-    runTestJobName: 'RunNugetPkgTestsInHelix'
-    helixType: 'test/nuget'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: false
+# # Build solution that depends on nuget package
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildNugetPkgTests'
+#     buildArtifactName: 'NugetPkgTestsDrop'
+#     runTestJobName: 'RunNugetPkgTestsInHelix'
+#     helixType: 'test/nuget'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: false
 
-# Framework package tests
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildFrameworkPkgTests'
-    buildArtifactName: 'FrameworkPkgTestsDrop'
-    runTestJobName: 'RunFrameworkPkgTestsInHelix'
-    helixType: 'test/frpkg'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: true
+# # Framework package tests
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildFrameworkPkgTests'
+#     buildArtifactName: 'FrameworkPkgTestsDrop'
+#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+#     helixType: 'test/frpkg'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: true
 
-- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-  parameters:
-    dependsOn:
-    - RunNugetPkgTestsInHelix
-    - RunFrameworkPkgTestsInHelix
-    rerunPassesRequiredToAvoidFailure: 5
-    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+#   parameters:
+#     dependsOn:
+#     - RunNugetPkgTestsInHelix
+#     - RunFrameworkPkgTestsInHelix
+#     rerunPassesRequiredToAvoidFailure: 5
+#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
-# NuGet package WACK tests
-- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-  parameters:
-    name: 'NugetPkgWACKTests'
-    dependsOn: BuildNugetPkgTests
-    artifactName: 'NugetPkgTestsDrop'
+# # NuGet package WACK tests
+# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+#   parameters:
+#     name: 'NugetPkgWACKTests'
+#     dependsOn: BuildNugetPkgTests
+#     artifactName: 'NugetPkgTestsDrop'
 
-# Framework package WACK tests
-- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-  parameters:
-    name: 'FrameworkPkgWACKTests'
-    dependsOn: BuildFrameworkPkgTests
-    artifactName: 'FrameworkPkgTestsDrop'
+# # Framework package WACK tests
+# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+#   parameters:
+#     name: 'FrameworkPkgWACKTests'
+#     dependsOn: BuildFrameworkPkgTests
+#     artifactName: 'FrameworkPkgTestsDrop'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -70,57 +70,57 @@ jobs:
 
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# # Create Nuget Package
-# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-#   parameters:
-#     jobName: CreateNugetPackage
-#     dependsOn: Build
-#     signOutput: true
-#     useReleaseTag: '$(MUXFinalRelease)'
-#     prereleaseVersionTag: prerelease
+# Create Nuget Package
+- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+  parameters:
+    jobName: CreateNugetPackage
+    dependsOn: Build
+    signOutput: true
+    useReleaseTag: '$(MUXFinalRelease)'
+    prereleaseVersionTag: prerelease
 
 - template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
   parameters:
     dependsOn: Build
 
-# # Build solution that depends on nuget package
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildNugetPkgTests'
-#     buildArtifactName: 'NugetPkgTestsDrop'
-#     runTestJobName: 'RunNugetPkgTestsInHelix'
-#     helixType: 'test/nuget'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: false
+# Build solution that depends on nuget package
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildNugetPkgTests'
+    buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: false
 
-# # Framework package tests
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildFrameworkPkgTests'
-#     buildArtifactName: 'FrameworkPkgTestsDrop'
-#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
-#     helixType: 'test/frpkg'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: true
+# Framework package tests
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildFrameworkPkgTests'
+    buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: true
 
-# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-#   parameters:
-#     dependsOn:
-#     - RunNugetPkgTestsInHelix
-#     - RunFrameworkPkgTestsInHelix
-#     rerunPassesRequiredToAvoidFailure: 5
-#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
-# # NuGet package WACK tests
-# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-#   parameters:
-#     name: 'NugetPkgWACKTests'
-#     dependsOn: BuildNugetPkgTests
-#     artifactName: 'NugetPkgTestsDrop'
+# NuGet package WACK tests
+- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+  parameters:
+    name: 'NugetPkgWACKTests'
+    dependsOn: BuildNugetPkgTests
+    artifactName: 'NugetPkgTestsDrop'
 
-# # Framework package WACK tests
-# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-#   parameters:
-#     name: 'FrameworkPkgWACKTests'
-#     dependsOn: BuildFrameworkPkgTests
-#     artifactName: 'FrameworkPkgTestsDrop'
+# Framework package WACK tests
+- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+  parameters:
+    name: 'FrameworkPkgWACKTests'
+    dependsOn: BuildFrameworkPkgTests
+    artifactName: 'FrameworkPkgTestsDrop'


### PR DESCRIPTION
Package ES agent pools are being disabled, so we need to move all of our Pipeline jobs onto other agents.