### PR TITLE
Add 8px Padding to Left and Right Caret

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -719,9 +719,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 CloseTabAndVerifyWidth("Tab 3", 500, "False;False;");
 
-                CloseTabAndVerifyWidth("Tab 5", 410, "False;False;");
+                CloseTabAndVerifyWidth("Tab 5", 420, "False;False;");
 
-                CloseTabAndVerifyWidth("Tab 4", 410, "False;False;");
+                CloseTabAndVerifyWidth("Tab 4", 450, "False;False;");
 
                 Log.Comment("Leaving the pointer exited area");
                 var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
@@ -750,6 +750,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 var tabviewWidth = new TextBlock(FindElement.ByName("TabViewWidth"));
 
+                Log.Comment("TabView width:" + tabviewWidth.GetText());
                 return Double.Parse(tabviewWidth.GetText());
             }
         }

--- a/dev/TabView/TabView_themeresources.xaml
+++ b/dev/TabView/TabView_themeresources.xaml
@@ -228,8 +228,8 @@
     <x:Double x:Key="TabViewItemScrollButtonHeight">24</x:Double>
     <x:Double x:Key="TabViewItemScrollButonFontSize">8</x:Double>
     <Thickness x:Key="TabViewItemScrollButtonPadding">7,3,7,3</Thickness>
-    <Thickness x:Key="TabViewItemLeftScrollButtonContainerPadding">0,0,3,3</Thickness>
-    <Thickness x:Key="TabViewItemRightScrollButtonContainerPadding">3,0,0,3</Thickness>
+    <Thickness x:Key="TabViewItemLeftScrollButtonContainerPadding">8,0,3,3</Thickness>
+    <Thickness x:Key="TabViewItemRightScrollButtonContainerPadding">3,0,8,3</Thickness>
 
     <x:Double x:Key="TabViewItemAddButtonWidth">32</x:Double>
     <x:Double x:Key="TabViewItemAddButtonHeight">24</x:Double>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add 8px left padding to left caret, and 8px right padding to right caret for TabView.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fix internal bug 33581335

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![image](https://user-images.githubusercontent.com/7976322/128436559-73e4a4b9-860f-43d5-8e27-d1d7988fcc56.png)
