### PR TITLE
Fix toggle switch off pressed border color.

### DIFF
--- a/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -86,7 +86,7 @@
             <StaticResource x:Key="ToggleSwitchFillOffDisabled" ResourceKey="SystemColorButtonFaceColorBrush" />
             <StaticResource x:Key="ToggleSwitchStrokeOff" ResourceKey="SystemControlForegroundBaseMediumBrush" />
             <StaticResource x:Key="ToggleSwitchStrokeOffPointerOver" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="ToggleSwitchStrokeOffPressed" ResourceKey="SystemBaseHighColor" />
+            <StaticResource x:Key="ToggleSwitchStrokeOffPressed" ResourceKey="SystemColorHighlightColor" />
             <StaticResource x:Key="ToggleSwitchStrokeOffDisabled" ResourceKey="SystemBaseMediumLowColor" />
             <StaticResource x:Key="ToggleSwitchFillOn" ResourceKey="SystemControlHighlightAccentBrush" />
             <StaticResource x:Key="ToggleSwitchFillOnPointerOver" ResourceKey="SystemColorButtonFaceColorBrush" />


### PR DESCRIPTION
The ToggleSwitch's off, pressed border color was the same as the background. 
Previously looked like:
![image](https://user-images.githubusercontent.com/7758786/128759500-0a9f767b-cc13-478c-b73e-7511ebf511e6.png)


Fixed looks like:
![image](https://user-images.githubusercontent.com/7758786/128759414-45fc4249-26df-4071-b285-64b931705cdb.png)


Fixes #5647