### PR TITLE
Update framework package versioning to avoid version number size constraints

### DIFF
--- a/build/FrameworkPackage/MakeFrameworkPackage.ps1
+++ b/build/FrameworkPackage/MakeFrameworkPackage.ps1
@@ -245,18 +245,11 @@ else
     $pstTime = [System.TimeZoneInfo]::ConvertTimeFromUtc((Get-Date).ToUniversalTime(), $pstZone)
     # Split version into yyMM.dd because appx versions can't be greater than 65535
     # Also store submission requires that the revision field stay 0, so our scheme is:
-    #    A.ByyMM.ddNNN
+    #    B.yyMM.ddNNN
     # compared to nuget version which is:
     #    A.B.yyMMddNN
     # We could consider dropping the B part out of the minor section if we need to because
-    # it's part of the package name, but we'll try to keep it in for now. We also omit the "B"
-    # part when it's 0 because the appx version doesn't allow the minor version to have a 0 prefix.
-    # Also note that we trim 0s off the beginning of the day because appx versions can't start with 0.
-    if ($versionMinor -eq 0)
-    {
-        $versionMinor = ""
-    }
-
+    # it's part of the package name, but we'll try to keep it in for now.
     if (-not $builddate_yymm)
     {
         $builddate_yymm = ($pstTime).ToString("yyMM")
@@ -269,7 +262,7 @@ else
     # Pad subversion up to 3 digits
     $subversionPadded = $subversion.ToString("000")
 
-    $version = "${versionMajor}.${versionMinor}" + $builddate_yymm + "." + $builddate_dd.TrimStart("0") + "$subversionPadded.0"
+    $version = "${versionMinor}." + $builddate_yymm + "." + $builddate_dd.TrimStart("0") + "$subversionPadded.0"
 
     Write-Verbose "Version = $version"
 }


### PR DESCRIPTION
Our current versioning system for the framework package is soon going to run into the fact that framework package version numbers aren't allowed to exceed 65535.  To avoid that, we'll move what was the minor version to be the major version of the framework package, which ensures that no portion of the version will be larger than that value.  Since the actual WinUI version is part of the framework package name, this shouldn't create confusion regarding what NuGet package corresponds with what framework package.  So, for example, the current framework package full name is this:

`Microsoft.UI.Xaml.2.6_2.62107.6002.0_x64__8wekyb3d8bbwe`

This change will instead make it look like this:

`Microsoft.UI.Xaml.2.6_6.2107.6002.0_x64__8wekyb3d8bbwe`