### PR TITLE
Fix source indexing to enable source debugging for official builds.

### DIFF
--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -14,23 +14,23 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      Debug_x86:
-        buildPlatform: 'x86'
-        buildConfiguration: 'Debug'
+      # Debug_x86:
+      #   buildPlatform: 'x86'
+      #   buildConfiguration: 'Debug'
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'
         PGOBuildMode: 'Optimize'
-      Release_x64:
-        buildPlatform: 'x64'
-        buildConfiguration: 'Release'
-        PGOBuildMode: 'Optimize'
-      Release_Arm:
-        buildPlatform: 'arm'
-        buildConfiguration: 'Release'
-      Release_Arm64:
-        buildPlatform: 'arm64'
-        buildConfiguration: 'Release'
+      # Release_x64:
+      #   buildPlatform: 'x64'
+      #   buildConfiguration: 'Release'
+      #   PGOBuildMode: 'Optimize'
+      # Release_Arm:
+      #   buildPlatform: 'arm'
+      #   buildConfiguration: 'Release'
+      # Release_Arm64:
+      #   buildPlatform: 'arm64'
+      #   buildConfiguration: 'Release'
 
   variables:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
@@ -40,13 +40,13 @@ jobs:
   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-  parameters:
-    name: 'RunTestsInHelix'
-    dependsOn: Build
-    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-    testSuite: 'DevTestSuite'
-    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+# - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+#   parameters:
+#     name: 'RunTestsInHelix'
+#     dependsOn: Build
+#     condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+#     testSuite: 'DevTestSuite'
+#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
@@ -55,31 +55,31 @@ jobs:
     dependsOn: Build
     prereleaseVersionTag: ci
 
-# Build solution that depends on nuget package
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildNugetPkgTests'
-    buildArtifactName: 'NugetPkgTestsDrop'
-    runTestJobName: 'RunNugetPkgTestsInHelix'
-    helixType: 'test/nuget'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: false
+# # Build solution that depends on nuget package
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildNugetPkgTests'
+#     buildArtifactName: 'NugetPkgTestsDrop'
+#     runTestJobName: 'RunNugetPkgTestsInHelix'
+#     helixType: 'test/nuget'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: false
 
-# Framework package tests
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildFrameworkPkgTests'
-    buildArtifactName: 'FrameworkPkgTestsDrop'
-    runTestJobName: 'RunFrameworkPkgTestsInHelix'
-    helixType: 'test/frpkg'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: true
+# # Framework package tests
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildFrameworkPkgTests'
+#     buildArtifactName: 'FrameworkPkgTestsDrop'
+#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+#     helixType: 'test/frpkg'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: true
 
-- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-  parameters:
-    dependsOn:
-    - RunTestsInHelix
-    - RunNugetPkgTestsInHelix
-    - RunFrameworkPkgTestsInHelix
-    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+#   parameters:
+#     dependsOn:
+#     - RunTestsInHelix
+#     - RunNugetPkgTestsInHelix
+#     - RunFrameworkPkgTestsInHelix
+#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)

--- a/build/MUX-CI.yml
+++ b/build/MUX-CI.yml
@@ -14,23 +14,23 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      # Debug_x86:
-      #   buildPlatform: 'x86'
-      #   buildConfiguration: 'Debug'
+      Debug_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Debug'
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'
         PGOBuildMode: 'Optimize'
-      # Release_x64:
-      #   buildPlatform: 'x64'
-      #   buildConfiguration: 'Release'
-      #   PGOBuildMode: 'Optimize'
-      # Release_Arm:
-      #   buildPlatform: 'arm'
-      #   buildConfiguration: 'Release'
-      # Release_Arm64:
-      #   buildPlatform: 'arm64'
-      #   buildConfiguration: 'Release'
+      Release_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
+        PGOBuildMode: 'Optimize'
+      Release_Arm:
+        buildPlatform: 'arm'
+        buildConfiguration: 'Release'
+      Release_Arm64:
+        buildPlatform: 'arm64'
+        buildConfiguration: 'Release'
 
   variables:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
@@ -40,13 +40,13 @@ jobs:
   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-#   parameters:
-#     name: 'RunTestsInHelix'
-#     dependsOn: Build
-#     condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-#     testSuite: 'DevTestSuite'
-#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    dependsOn: Build
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+    testSuite: 'DevTestSuite'
+    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
@@ -55,31 +55,31 @@ jobs:
     dependsOn: Build
     prereleaseVersionTag: ci
 
-# # Build solution that depends on nuget package
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildNugetPkgTests'
-#     buildArtifactName: 'NugetPkgTestsDrop'
-#     runTestJobName: 'RunNugetPkgTestsInHelix'
-#     helixType: 'test/nuget'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: false
+# Build solution that depends on nuget package
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildNugetPkgTests'
+    buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: false
 
-# # Framework package tests
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildFrameworkPkgTests'
-#     buildArtifactName: 'FrameworkPkgTestsDrop'
-#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
-#     helixType: 'test/frpkg'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: true
+# Framework package tests
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildFrameworkPkgTests'
+    buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: true
 
-# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-#   parameters:
-#     dependsOn:
-#     - RunTestsInHelix
-#     - RunNugetPkgTestsInHelix
-#     - RunFrameworkPkgTestsInHelix
-#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunTestsInHelix
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)

--- a/build/SourceIndexing/IndexPdbs.ps1
+++ b/build/SourceIndexing/IndexPdbs.ps1
@@ -23,6 +23,7 @@ $mappedFiles = New-Object System.Collections.ArrayList
 
 foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 {
+    $mappedFiles = New-Object System.Collections.ArrayList
     Write-Verbose "Found $file"
 
     $ErrorActionPreference = "Continue" # Azure Pipelines defaults to "Stop", continue past errors in this script.
@@ -38,6 +39,7 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 
     for ($i = 0; $i -lt $allFiles.Length; $i++)
     {
+        #Write-Host $allFiles[$i]
         if ($allFiles[$i].StartsWith($SourceRoot, [StringComparison]::OrdinalIgnoreCase))
         {
             $relative = $allFiles[$i].Substring($SourceRoot.Length).TrimStart("\")
@@ -50,7 +52,7 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
             if ($relative)
             {
                 $mapping = $allFiles[$i] + "*$relative"
-                $mappedFiles.Add($mapping)
+                $ignore = $mappedFiles.Add($mapping)
 
                 Write-Verbose "Mapped path $($i): $mapping"
             }
@@ -78,7 +80,26 @@ $($mappedFiles -join "`r`n")
 SRCSRV: end ------------------------------------------------
 "@ | Set-Content $pdbstrFile
 
+    Write-Host
+    Write-Host
+    Write-Host (Get-Content $pdbstrFile)
+    Write-Host
+    Write-Host
+
+    Write-Host "$pdbstrExe -p:""$file"" -w -s:srcsrv -i:$pdbstrFile"
     & $pdbstrExe -p:"$file" -w -s:srcsrv -i:$pdbstrFile
+    Write-Host
+    Write-Host
+
+    Write-Host "$pdbstrExe -p:""$file"" -r -s:srcsrv"
+    & $pdbstrExe -p:"$file" -r -s:srcsrv
+    Write-Host
+    Write-Host
+
+    Write-Host "$srctoolExe $file"
+    & $srctoolExe "$file"
+    Write-Host
+    Write-Host
 }
 
 # Return with exit 0 to override any weird error code from other tools

--- a/build/SourceIndexing/IndexPdbs.ps1
+++ b/build/SourceIndexing/IndexPdbs.ps1
@@ -39,7 +39,6 @@ foreach ($file in (Get-ChildItem -r:$recursive "$SearchDir\*.pdb"))
 
     for ($i = 0; $i -lt $allFiles.Length; $i++)
     {
-        #Write-Host $allFiles[$i]
         if ($allFiles[$i].StartsWith($SourceRoot, [StringComparison]::OrdinalIgnoreCase))
         {
             $relative = $allFiles[$i].Substring($SourceRoot.Length).TrimStart("\")

--- a/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
+++ b/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
@@ -3,7 +3,7 @@ SETLOCAL
 set ERRORLEVEL=
 
 echo executing %~dp0..\..\packages\InternalWindowsSDK.1.0.7\winsdksetup.exe /quiet
-call %~dp0..\..\packages\InternalWindowsSDK.1.0.7\winsdksetup.exe /quiet
+call %~dp0..\..\packages\InternalWindowsSDK.1.0.7\winsdksetup.exe /features OptionId.UWPCpp OptionId.DesktopCPPx64 OptionId.DesktopCPPx86 OptionId.DesktopCPPARM64 OptionId.DesktopCPPARM /quiet
 
 :END
 exit /B %ERRORLEVEL%

--- a/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
+++ b/tools/InternalWindowsSDKNuget/SetUpInternalWindowsSDK.cmd
@@ -2,7 +2,7 @@
 SETLOCAL
 set ERRORLEVEL=
 
-echo executing %~dp0..\..\packages\InternalWindowsSDK.1.0.7\winsdksetup.exe /quiet
+echo executing %~dp0..\..\packages\InternalWindowsSDK.1.0.7\winsdksetup.exe /features OptionId.UWPCpp OptionId.DesktopCPPx64 OptionId.DesktopCPPx86 OptionId.DesktopCPPARM64 OptionId.DesktopCPPARM /quiet
 call %~dp0..\..\packages\InternalWindowsSDK.1.0.7\winsdksetup.exe /features OptionId.UWPCpp OptionId.DesktopCPPx64 OptionId.DesktopCPPx86 OptionId.DesktopCPPARM64 OptionId.DesktopCPPARM /quiet
 
 :END


### PR DESCRIPTION
Fixes #5577

There are two methods that can be used to enable pdbs to find matching source code: SourceLink and Source Server. WinUI supports both. For Microsoft.UI.Xaml 2.6 both of these were broken in different ways. 

SourceLink was generating invalid urls due to the build being run from an Azure DevOps fork of this repo instead of directly from GitHub. This should be resolved in the next release of 2.6.

For Source Server support we have a script, IndexPDBs.ps1, that writes the required file url mapping into the pdb using tools from the Windows Debugging Tools (pdbstr.exe, srctool.exe). However, this script stopped working when using the internal SDK which we use for official builds of WinUI. The internal SDK installs a more recent version of these tools, which fail silently when run in the Pipeline. I have not been able to reproduce the issue locally when using these tools. It only seems to happen when run in the Pipeline. So the solution is to not install the updated Windows Debugging Tools from this SDK and instead only install the specific SDK components that we need to build.

In addition to making this fix, I have updated IndexPDBs.ps1 with some extra logging to aid in debugging.