### PR TITLE
Fixing SwipeControl mem leaks

### DIFF
--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 #include "common.h"
 #include "SwipeControl.h"
+#include "SwipeControlInteractionTrackerOwner.h"
 #include "SwipeItems.h"
 #include "Vector.h"
 #include "SwipeItem.h"
@@ -28,7 +29,7 @@ SwipeControl::SwipeControl()
 
 SwipeControl::~SwipeControl()
 {
-    DetachEventHandlers();
+    DetachEventHandlers(true /*useSafeGet*/);
 
     if (auto lastInteractedWithSwipeControl = s_lastInteractedWithSwipeControl.get())
     {
@@ -107,7 +108,7 @@ void SwipeControl::OnApplyTemplate()
 {
     ThrowIfHasVerticalAndHorizontalContent(/*setIsHorizontal*/ true);
 
-    DetachEventHandlers();
+    DetachEventHandlers(false /*useSafeGet*/);
     GetTemplateParts();
     EnsureClip();
     AttachEventHandlers();
@@ -157,9 +158,7 @@ winrt::Size SwipeControl::MeasureOverride(winrt::Size const& availableSize)
 }
 #pragma endregion
 
-#pragma region IInteractionTrackerOwner
 void SwipeControl::CustomAnimationStateEntered(
-    winrt::InteractionTracker const& /*sender*/,
     winrt::InteractionTrackerCustomAnimationStateEnteredArgs const& /*args*/)
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
@@ -177,14 +176,12 @@ void SwipeControl::CustomAnimationStateEntered(
 }
 
 void SwipeControl::RequestIgnored(
-    winrt::InteractionTracker const& /*sender*/,
     winrt::InteractionTrackerRequestIgnoredArgs const& /*args*/)
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
 }
 
 void SwipeControl::IdleStateEntered(
-    winrt::InteractionTracker const& /*sender*/,
     winrt::InteractionTrackerIdleStateEnteredArgs const& /*args*/)
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
@@ -230,7 +227,6 @@ void SwipeControl::IdleStateEntered(
 }
 
 void SwipeControl::InteractingStateEntered(
-    winrt::InteractionTracker const& /*sender*/,
     winrt::InteractionTrackerInteractingStateEnteredArgs const& /*args*/)
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
@@ -260,7 +256,6 @@ void SwipeControl::InteractingStateEntered(
 }
 
 void SwipeControl::InertiaStateEntered(
-    winrt::InteractionTracker const& /*sender*/,
     winrt::InteractionTrackerInertiaStateEnteredArgs const& args)
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
@@ -323,7 +318,6 @@ void SwipeControl::InertiaStateEntered(
 }
 
 void SwipeControl::ValuesChanged(
-    winrt::InteractionTracker const& /*sender*/,
     winrt::InteractionTrackerValuesChangedArgs const& args)
 {
     SWIPECONTROL_TRACE_VERBOSE(*this, TRACE_MSG_METH, METH_NAME, this);
@@ -371,7 +365,6 @@ void SwipeControl::ValuesChanged(
     }
     UpdateThresholdReached(value);
 }
-#pragma endregion
 
 #pragma region TestHookHelpers
 winrt::SwipeControl SwipeControl::GetLastInteractedWithSwipeControl()
@@ -550,7 +543,7 @@ void SwipeControl::AttachEventHandlers()
     m_inputEaterTappedToken = m_inputEater.get().Tapped({ this, &SwipeControl::InputEaterGridTapped });
 }
 
-void SwipeControl::DetachEventHandlers()
+void SwipeControl::DetachEventHandlers(bool useSafeGet)
 {
     SWIPECONTROL_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, this);
 
@@ -568,7 +561,10 @@ void SwipeControl::DetachEventHandlers()
 
     if (m_onSwipeContentStackPanelSizeChangedToken.value != 0)
     {
-        m_swipeContentStackPanel.get().SizeChanged(m_onSwipeContentStackPanelSizeChangedToken);
+        if (auto swipeContentStackPanel = useSafeGet ? m_swipeContentStackPanel.safe_get() : m_swipeContentStackPanel.get())
+        {
+            swipeContentStackPanel.SizeChanged(m_onSwipeContentStackPanelSizeChangedToken);
+        }
         m_onSwipeContentStackPanelSizeChangedToken.value = 0;
     }
 
@@ -578,9 +574,12 @@ void SwipeControl::DetachEventHandlers()
         m_onPointerPressedEventHandler.set(nullptr);
     }
 
-    if (m_inputEater.safe_get() && m_inputEaterTappedToken.value != 0)
+    if (m_inputEaterTappedToken.value != 0)
     {
-        m_inputEater.safe_get().Tapped(m_inputEaterTappedToken);
+        if (auto inputEater = useSafeGet ? m_inputEater.safe_get() : m_inputEater.get())
+        {
+            inputEater.Tapped(m_inputEaterTappedToken);
+        }
         m_inputEaterTappedToken.value = 0;
     }
 
@@ -827,7 +826,10 @@ void SwipeControl::InitializeInteractionTracker()
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
 
-    winrt::IInteractionTrackerOwner interactionTrackerOwner = *this;
+    if (!m_interactionTrackerOwner)
+    {
+        m_interactionTrackerOwner = winrt::make_self<SwipeControlInteractionTrackerOwner>(*this).try_as<winrt::IInteractionTrackerOwner>();
+    }
 
     if (!m_compositor)
     {
@@ -849,7 +851,7 @@ void SwipeControl::InitializeInteractionTracker()
         m_visualInteractionSource.get().PositionYChainingMode(winrt::InteractionChainingMode::Never);
     }
 
-    m_interactionTracker.set(winrt::InteractionTracker::CreateWithOwner(m_compositor.get(), interactionTrackerOwner));
+    m_interactionTracker.set(winrt::InteractionTracker::CreateWithOwner(m_compositor.get(), m_interactionTrackerOwner));
     m_interactionTracker.get().InteractionSources().Add(m_visualInteractionSource.get());
     m_interactionTracker.get().Properties().InsertBoolean(s_isFarOpenPropertyName, false);
     m_interactionTracker.get().Properties().InsertBoolean(s_isNearOpenPropertyName, false);
@@ -1046,7 +1048,7 @@ void SwipeControl::CloseWithoutAnimation()
     m_interactionTracker.get().TryUpdatePosition({ 0.0f, 0.0f, 0.0f });
     if (wasIdle)
     {
-        IdleStateEntered(nullptr, nullptr);
+        IdleStateEntered(nullptr);
     }
 }
 

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -11,7 +11,7 @@
 enum class CreatedContent { Left, Top, Bottom, Right, None };
 
 class SwipeControl :
-    public ReferenceTracker<SwipeControl, winrt::implementation::SwipeControlT, winrt::cloaked<winrt::IInteractionTrackerOwner>>,
+    public ReferenceTracker<SwipeControl, winrt::implementation::SwipeControlT>,
     public SwipeControlProperties
 {
 public:
@@ -19,7 +19,6 @@ public:
     virtual ~SwipeControl();
 
 #pragma region ISwipeControl
-
 
     void Close();
 
@@ -32,31 +31,23 @@ public:
     winrt::Size MeasureOverride(winrt::Size const& availableSize);
 #pragma endregion
 
-#pragma region IInteractionTrackerOwner
     void CustomAnimationStateEntered(
-        winrt::InteractionTracker const& sender,
         winrt::InteractionTrackerCustomAnimationStateEnteredArgs const& args);
 
     void RequestIgnored(
-        winrt::InteractionTracker const& sender,
         winrt::InteractionTrackerRequestIgnoredArgs const& args);
 
     void IdleStateEntered(
-        winrt::InteractionTracker const& sender,
         winrt::InteractionTrackerIdleStateEnteredArgs const& args);
 
     void InteractingStateEntered(
-        winrt::InteractionTracker const& sender,
         winrt::InteractionTrackerInteractingStateEnteredArgs const& args);
 
     void InertiaStateEntered(
-        winrt::InteractionTracker const& sender,
         winrt::InteractionTrackerInertiaStateEnteredArgs const& args);
 
     void ValuesChanged(
-        winrt::InteractionTracker const& sender,
         winrt::InteractionTrackerValuesChangedArgs const& args);
-#pragma endregion
 
     winrt::SwipeItems GetCurrentItems() { return m_currentItems.get(); }
 
@@ -74,7 +65,7 @@ private:
     void OnLoaded(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/);
 
     void AttachEventHandlers();
-    void DetachEventHandlers();
+    void DetachEventHandlers(bool useSafeGet);
     void OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
     void OnSwipeContentStackPanelSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args);
     void OnPointerPressedEvent(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
@@ -87,7 +78,6 @@ private:
     // Used on platforms where we have XamlRoot.
     void CurrentXamlRootChanged(const winrt::XamlRoot & sender, const winrt::XamlRootChangedEventArgs & args);
     
-
     // Used on platforms where we don't have XamlRoot.
     void DismissSwipeOnCoreWindowKeyDown(const winrt::CoreWindow & sender, const winrt::KeyEventArgs & args);
     void CurrentWindowSizeChanged(const winrt::IInspectable & sender, const winrt::WindowSizeChangedEventArgs& args);
@@ -140,6 +130,8 @@ private:
 
     winrt::SwipeControl GetThis();
 
+    winrt::IInteractionTrackerOwner m_interactionTrackerOwner{ nullptr };
+
     tracker_ref<winrt::Grid> m_rootGrid{ this };
     tracker_ref<winrt::Grid> m_content{ this };
     tracker_ref<winrt::Grid> m_inputEater{ this };
@@ -180,7 +172,6 @@ private:
     RoutedEventHandler_revoker m_xamlRootPointerPressedEventRevoker{};
     RoutedEventHandler_revoker m_xamlRootKeyDownEventRevoker{};
     winrt::IXamlRoot::Changed_revoker m_xamlRootChangedRevoker{};
-
 
     // Used on platforms where we don't have XamlRoot.
     winrt::ICoreWindow::PointerPressed_revoker m_coreWindowPointerPressedRevoker;

--- a/dev/SwipeControl/SwipeControl.vcxitems
+++ b/dev/SwipeControl/SwipeControl.vcxitems
@@ -19,6 +19,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\SwipeItem.properties.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\SwipeItems.properties.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SwipeControl.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)SwipeControlInteractionTrackerOwner.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SwipeItems.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SwipeItem.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SwipeItemInvokedEventArgs.cpp" />
@@ -28,6 +29,7 @@
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)SwipeControlTrace.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)SwipeControl.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)SwipeControlInteractionTrackerOwner.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)SwipeItems.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)SwipeItem.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)SwipeItemInvokedEventArgs.h" />

--- a/dev/SwipeControl/SwipeControlInteractionTrackerOwner.cpp
+++ b/dev/SwipeControl/SwipeControlInteractionTrackerOwner.cpp
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "SwipeControlInteractionTrackerOwner.h"
+#include "SwipeControl.h"
+
+SwipeControlInteractionTrackerOwner::SwipeControlInteractionTrackerOwner(const winrt::SwipeControl& swipeControl)
+{
+    SWIPECONTROL_TRACE_VERBOSE(swipeControl, TRACE_MSG_METH_PTR, METH_NAME, this, swipeControl);
+
+    m_owner = swipeControl;
+}
+
+SwipeControlInteractionTrackerOwner::~SwipeControlInteractionTrackerOwner()
+{
+    SWIPECONTROL_TRACE_VERBOSE(nullptr, TRACE_MSG_METH, METH_NAME, this);
+
+    m_owner = nullptr;
+}
+
+#pragma region IInteractionTrackerOwner
+void SwipeControlInteractionTrackerOwner::ValuesChanged(
+    const winrt::InteractionTracker& /*sender*/, const winrt::InteractionTrackerValuesChangedArgs& args)
+{
+    if (!m_owner)
+    {
+        return;
+    }
+
+    if (auto rawOwner = m_owner.get())
+    {
+        auto swipeControl = winrt::get_self<SwipeControl>(rawOwner);
+        if (swipeControl)
+        {
+            swipeControl->ValuesChanged(args);
+        }
+    }
+}
+
+void SwipeControlInteractionTrackerOwner::RequestIgnored(
+    const winrt::InteractionTracker& /*sender*/, const winrt::InteractionTrackerRequestIgnoredArgs& args)
+{
+    if (!m_owner)
+    {
+        return;
+    }
+
+    if (auto rawOwner = m_owner.get())
+    {
+        auto swipeControl = winrt::get_self<SwipeControl>(rawOwner);
+        if (swipeControl)
+        {
+            swipeControl->RequestIgnored(args);
+        }
+    }
+}
+
+void SwipeControlInteractionTrackerOwner::InteractingStateEntered(
+    const winrt::InteractionTracker& /*sender*/, const winrt::InteractionTrackerInteractingStateEnteredArgs& args)
+{
+    if (!m_owner)
+    {
+        return;
+    }
+
+    if (auto rawOwner = m_owner.get())
+    {
+        auto swipeControl = winrt::get_self<SwipeControl>(rawOwner);
+        if (swipeControl)
+        {
+            swipeControl->InteractingStateEntered(args);
+        }
+    }
+}
+
+void SwipeControlInteractionTrackerOwner::InertiaStateEntered(
+    const winrt::InteractionTracker& /*sender*/, const winrt::InteractionTrackerInertiaStateEnteredArgs& args)
+{
+    if (!m_owner)
+    {
+        return;
+    }
+
+    if (auto rawOwner = m_owner.get())
+    {
+        auto swipeControl = winrt::get_self<SwipeControl>(rawOwner);
+        if (swipeControl)
+        {
+            swipeControl->InertiaStateEntered(args);
+        }
+    }
+}
+
+void SwipeControlInteractionTrackerOwner::IdleStateEntered(
+    const winrt::InteractionTracker& /*sender*/, const winrt::InteractionTrackerIdleStateEnteredArgs& args)
+{
+    if (!m_owner)
+    {
+        return;
+    }
+
+    if (auto rawOwner = m_owner.get())
+    {
+        auto swipeControl = winrt::get_self<SwipeControl>(rawOwner);
+        if (swipeControl)
+        {
+            swipeControl->IdleStateEntered(args);
+        }
+    }
+}
+
+void SwipeControlInteractionTrackerOwner::CustomAnimationStateEntered(
+    const winrt::InteractionTracker& /*sender*/, const winrt::InteractionTrackerCustomAnimationStateEnteredArgs& args)
+{
+    if (!m_owner)
+    {
+        return;
+    }
+
+    if (auto rawOwner = m_owner.get())
+    {
+        auto swipeControl = winrt::get_self<SwipeControl>(rawOwner);
+        if (swipeControl)
+        {
+            swipeControl->CustomAnimationStateEntered(args);
+        }
+    }
+}
+#pragma endregion

--- a/dev/SwipeControl/SwipeControlInteractionTrackerOwner.h
+++ b/dev/SwipeControl/SwipeControlInteractionTrackerOwner.h
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "common.h"
+
+// Class that handles the InteractionTracker callbacks. Has a weak reference back to the ScrollPresenter so it can be garbage-collected, 
+// since the InteractionTracker keeps a strong reference to this object.
+class SwipeControlInteractionTrackerOwner
+    : public winrt::implements<SwipeControlInteractionTrackerOwner, winrt::IInteractionTrackerOwner>
+{
+public:
+    SwipeControlInteractionTrackerOwner(const winrt::SwipeControl& swipeControl);
+    ~SwipeControlInteractionTrackerOwner();
+
+#pragma region IInteractionTrackerOwner
+    void ValuesChanged(const winrt::InteractionTracker& sender, const winrt::InteractionTrackerValuesChangedArgs& args);
+    void RequestIgnored(const winrt::InteractionTracker& sender, const winrt::InteractionTrackerRequestIgnoredArgs& args);
+    void InteractingStateEntered(const winrt::InteractionTracker& sender, const winrt::InteractionTrackerInteractingStateEnteredArgs& args);
+    void InertiaStateEntered(const winrt::InteractionTracker& sender, const winrt::InteractionTrackerInertiaStateEnteredArgs& args);
+    void IdleStateEntered(const winrt::InteractionTracker& sender, const winrt::InteractionTrackerIdleStateEnteredArgs& args);
+    void CustomAnimationStateEntered(const winrt::InteractionTracker& sender, const winrt::InteractionTrackerCustomAnimationStateEnteredArgs& args);
+#pragma endregion
+
+private:
+    weak_ref<winrt::SwipeControl> m_owner{ nullptr };
+};

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml
@@ -139,7 +139,8 @@
                         </ListViewItem>
 
                         <!-- Testing the same items can be reused in both sides just fine.-->
-                        <ListViewItem AutomationProperties.Name="SwipeControl4"  x:Name="SwipeControl4" Loaded="TestSwipeControl_Loaded" Height="40" ContextFlyout="{StaticResource MyContextFlyout}" >
+                        <ListViewItem AutomationProperties.Name="SwipeControl4"  x:Name="SwipeControl4" Loaded="TestSwipeControl_Loaded" Unloaded="TestSwipeControl_Unloaded"
+                            Height="40" ContextFlyout="{StaticResource MyContextFlyout}" >
                             <muxc:SwipeControl x:Name="sc4" LeftItems="{StaticResource TwoRevealItems}" RightItems="{StaticResource TwoRevealItems}" >
                                 <TextBlock Text="Swipe Control 4" VerticalAlignment="Center"/>
                             </muxc:SwipeControl>

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml.cs
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml.cs
@@ -36,6 +36,7 @@ namespace MUXControlsTestApp
         SwipeItem pastSender;
         UIElement animatedSwipe;
         DispatcherTimer _dt;
+
         public SwipeControlPage()
         {
             // create command, and bind it to this object before initializing the components
@@ -132,11 +133,13 @@ namespace MUXControlsTestApp
             MaterialHelperTestApi.IgnoreAreEffectsFast = true;
             MaterialHelperTestApi.SimulateDisabledByPolicy = false;
         }
+
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             // Unset all override flags to avoid impacting subsequent tests
             MaterialHelperTestApi.IgnoreAreEffectsFast = false;
             MaterialHelperTestApi.SimulateDisabledByPolicy = false;
+            SwipeTestHooks.LastInteractedWithSwipeControlChanged -= SwipeTestHooks_LastInteractedWithSwipeControlChanged;
             base.OnNavigatedFrom(e);
         }
 
@@ -247,6 +250,12 @@ namespace MUXControlsTestApp
             SpyAnimatedValues();
             SwipeTestHooks.OpenedStatusChanged += SwipeTestHooks_OpenedStatusChanged;
             SwipeTestHooks.IdleStatusChanged += SwipeTestHooks_IdleStatusChanged;
+        }
+
+        private void TestSwipeControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            SwipeTestHooks.OpenedStatusChanged -= SwipeTestHooks_OpenedStatusChanged;
+            SwipeTestHooks.IdleStatusChanged -= SwipeTestHooks_IdleStatusChanged;
         }
 
         private void SwipeTestHooks_IdleStatusChanged(SwipeControl sender, object args)


### PR DESCRIPTION
The SwipeControl often would not be discarded because its InteractionTracker would hold a strong reference to it.

Check out this comment from the ScrollPresenter's internal InteractionTrackerOwner class:
"Class that handles the InteractionTracker callbacks. Has a weak reference back to the ScrollPresenter so it can be garbage-collected, since the InteractionTracker keeps a strong reference to this object."

It says it all. The ScrollPresenter is using an IInteractionTrackerOwner implementation with a weak pointer back to the ScrollPresenter. The SwipeControl was not - thus it would not be released.

I applied the pattern used by the ScrollPresenter to the SwipeControl and the leaks were gone. During the investigation, I also ran into two additional problems:

. SwipeControl::DetachEventHandlers would trigger errors when called from SwipeControl::~SwipeControl because safe_get() wasn't used. 

. The SwipeControlPage.xaml test page was not unhooking its SwipeTestHooks test handlers causing SwipeControl leaks too.

All is good now. 