### PR TITLE
Fix TwoPaneView layout bug when touch keyboard is visible

### DIFF
--- a/dev/TwoPaneView/TwoPaneView.cpp
+++ b/dev/TwoPaneView/TwoPaneView.cpp
@@ -76,11 +76,6 @@ void TwoPaneView::SetScrollViewerProperties(std::wstring_view const& scrollViewe
             {
                 revoker = scrollViewer.Loaded(winrt::auto_revoke, { this, &TwoPaneView::OnScrollViewerLoaded });
             }
-
-            if (SharedHelpers::IsScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable())
-            {
-                scrollViewer.ReduceViewportForCoreInputViewOcclusions(true);
-            }
         }
     }
 }

--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -127,14 +127,6 @@ bool SharedHelpers::IsFlyoutShowOptionsAvailable()
     return s_isFlyoutShowOptionsAvailable;
 }
 
-bool SharedHelpers::IsScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable()
-{
-    static bool s_isScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable =
-        Is19H1OrHigher() ||
-        winrt::ApiInformation::IsPropertyPresent(L"Windows.UI.Xaml.Controls.ScrollViewer", L"ReduceViewportForCoreInputViewOcclusions");
-    return s_isScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable;
-}
-
 bool SharedHelpers::IsScrollContentPresenterSizesContentToTemplatedParentAvailable()
 {
     static bool s_isScrollContentPresenterSizesContentToTemplatedParentAvailable =

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -37,8 +37,6 @@ public:
 
     static bool IsFlyoutShowOptionsAvailable();
 
-    static bool IsScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable();
-
     static bool IsScrollContentPresenterSizesContentToTemplatedParentAvailable();
 
     static bool IsBringIntoViewOptionsVerticalAlignmentRatioAvailable();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the gap between TwoPaneView content and touch keyboard, that is caused by setting ScrollViewer.ReduceViewportForCoreInputViewOcclusions = true inside TwoPaneView.

## Description
<!--- Describe your changes in detail -->
ScrollViewer.ReduceViewportForCoreInputViewOcclusions property was intended for RootScrollViewer, and is NOT set on RootScrollViewer anymore (at least on Win10.0.19043) and RootScrollViewer does not show buggy layout. But this property is set for both scrollviewers within two pane view template - and TwoPaneView shows buggy layout. Removing this property fixes the issue on current Windows version, and should not cause troubles on old Windows versions as RootScrollViewer already takes care of avoiding occlusion by touch keyboard for all nested controls, including TwoPaneView instances.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #5657
