### PR TITLE
Run build for MUXControlsReleaseTest on WinDevPool-S instead of windows-2019

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -55,19 +55,8 @@ jobs:
   # projects at the just-built nupkg. The MUXRelease projects use a specific nuget version so we need
   # to update nuget.config to include the drop location as well as update the version in the csproj and
   # packages.config for the projects.
-  # - task: DownloadBuildArtifacts@0
-  #   inputs:
-  #     artifactName: drop
-  #     downloadPath: $(artifactDownloadPath)
-  #     itemPattern: '**\*.nupkg'
-
-  - task: DownloadBuildArtifacts@0 
-    inputs: 
-      buildType: specific
-      buildVersionToDownload: specific
-      project: $(System.TeamProjectId)
-      pipeline: $(System.DefinitionId)
-      buildId: 210993
+  - task: DownloadBuildArtifacts@0
+    inputs:
       artifactName: drop
       downloadPath: $(artifactDownloadPath)
       itemPattern: '**\*.nupkg'

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -33,9 +33,9 @@ jobs:
 
   pool: 
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: WinDevPoolOSS-S
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: WinDevPool-S
     demands: ImageOverride -equals WinDevVS16-9
   strategy:
     maxParallel: 10

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -55,8 +55,19 @@ jobs:
   # projects at the just-built nupkg. The MUXRelease projects use a specific nuget version so we need
   # to update nuget.config to include the drop location as well as update the version in the csproj and
   # packages.config for the projects.
-  - task: DownloadBuildArtifacts@0
-    inputs:
+  # - task: DownloadBuildArtifacts@0
+  #   inputs:
+  #     artifactName: drop
+  #     downloadPath: $(artifactDownloadPath)
+  #     itemPattern: '**\*.nupkg'
+
+  - task: DownloadBuildArtifacts@0 
+    inputs: 
+      buildType: specific
+      buildVersionToDownload: specific
+      project: $(System.TeamProjectId)
+      pipeline: $(System.DefinitionId)
+      buildId: 212174
       artifactName: drop
       downloadPath: $(artifactDownloadPath)
       itemPattern: '**\*.nupkg'

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -67,7 +67,7 @@ jobs:
       buildVersionToDownload: specific
       project: $(System.TeamProjectId)
       pipeline: $(System.DefinitionId)
-      buildId: 212174
+      buildId: 210993
       artifactName: drop
       downloadPath: $(artifactDownloadPath)
       itemPattern: '**\*.nupkg'

--- a/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-NugetReleaseTest-Job.yml
@@ -31,8 +31,12 @@ jobs:
     - ${{if parameters.dependsOn }}:
       - ${{ parameters.dependsOn }}
 
-  pool:
-    vmImage: 'windows-2019'
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
+    demands: ImageOverride -equals WinDevVS16-9
   strategy:
     maxParallel: 10
     matrix: ${{ parameters.matrix }}

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -3,23 +3,23 @@ variables:
   minimumExpectedTestsExecutedCount: 3000  # Sanity check for minimum expected tests to be reported
   rerunPassesRequiredToAvoidFailure: 5
 jobs:
-- job: Setup
-  steps:
-    - task: powershell@2
-      name: checkPayload
-      displayName: 'Check if build is required for this PR'
-      inputs:
-        targetType: filePath
-        filePath: build\ShouldSkipPRBuild.ps1
+# - job: Setup
+#   steps:
+#     - task: powershell@2
+#       name: checkPayload
+#       displayName: 'Check if build is required for this PR'
+#       inputs:
+#         targetType: filePath
+#         filePath: build\ShouldSkipPRBuild.ps1
 
 - job: Build
-  dependsOn: Setup
-  condition: |
-    and
-    (
-      eq(variables['useBuildOutputFromBuildId'],''),
-      ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
-    )
+  # dependsOn: Setup
+  # condition: |
+  #   and
+  #   (
+  #     eq(variables['useBuildOutputFromBuildId'],''),
+  #     ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
+  #   )
   pool: 
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
       name: WinDevPoolOSS-L
@@ -49,20 +49,20 @@ jobs:
   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-  parameters:
-    name: 'RunTestsInHelix'
-    dependsOn:
-    - Setup
-    - Build
-    condition: |
-      and
-      (
-        ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True'),
-        in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-      )
-    testSuite: 'DevTestSuite'
-    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+# - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+#   parameters:
+#     name: 'RunTestsInHelix'
+#     dependsOn:
+#     - Setup
+#     - Build
+#     condition: |
+#       and
+#       (
+#         ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True'),
+#         in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+#       )
+#     testSuite: 'DevTestSuite'
+#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
 # Create Nuget Package
 - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
@@ -85,9 +85,9 @@ jobs:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
 
-- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-  parameters:
-    dependsOn: RunTestsInHelix
-    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
-    checkJobAttempt: true
+# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+#   parameters:
+#     dependsOn: RunTestsInHelix
+#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+#     checkJobAttempt: true

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -12,42 +12,42 @@ jobs:
 #         targetType: filePath
 #         filePath: build\ShouldSkipPRBuild.ps1
 
-- job: Build
-  # dependsOn: Setup
-  # condition: |
-  #   and
-  #   (
-  #     eq(variables['useBuildOutputFromBuildId'],''),
-  #     ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
-  #   )
-  pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS16-9
-  timeoutInMinutes: 120
-  strategy:
-    maxParallel: 10
-    matrix:
-      Debug_x86:
-        buildPlatform: 'x86'
-        buildConfiguration: 'Debug'
-      Release_x86:
-        buildPlatform: 'x86'
-        buildConfiguration: 'Release'
-        PGOBuildMode: 'Optimize'
-      Release_x64:
-        buildPlatform: 'x64'
-        buildConfiguration: 'Release'
-        PGOBuildMode: 'Optimize'
-  variables:
-    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
-    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
-    publishDir : $(Build.ArtifactStagingDirectory)
-  steps:
-  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+# - job: Build
+#   # dependsOn: Setup
+#   # condition: |
+#   #   and
+#   #   (
+#   #     eq(variables['useBuildOutputFromBuildId'],''),
+#   #     ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
+#   #   )
+#   pool: 
+#     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+#       name: WinDevPoolOSS-L
+#     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+#       name: WinDevPool-L
+#     demands: ImageOverride -equals WinDevVS16-9
+#   timeoutInMinutes: 120
+#   strategy:
+#     maxParallel: 10
+#     matrix:
+#       Debug_x86:
+#         buildPlatform: 'x86'
+#         buildConfiguration: 'Debug'
+#       Release_x86:
+#         buildPlatform: 'x86'
+#         buildConfiguration: 'Release'
+#         PGOBuildMode: 'Optimize'
+#       Release_x64:
+#         buildPlatform: 'x64'
+#         buildConfiguration: 'Release'
+#         PGOBuildMode: 'Optimize'
+#   variables:
+#     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+#     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+#     publishDir : $(Build.ArtifactStagingDirectory)
+#   steps:
+#   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+#   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
 # - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
 #   parameters:
@@ -65,16 +65,16 @@ jobs:
 #     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
 # Create Nuget Package
-- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-  parameters:
-    jobName: CreateNugetPackage
-    dependsOn: Build
-    primaryBuildArch: x64
-    prereleaseVersionTag: pr
+# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+#   parameters:
+#     jobName: CreateNugetPackage
+#     dependsOn: Build
+#     primaryBuildArch: x64
+#     prereleaseVersionTag: pr
 
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
-    dependsOn: CreateNugetPackage
+    # dependsOn: CreateNugetPackage
     useFrameworkPkg: false
     runTests: 'false'
     matrix:

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -3,78 +3,78 @@ variables:
   minimumExpectedTestsExecutedCount: 3000  # Sanity check for minimum expected tests to be reported
   rerunPassesRequiredToAvoidFailure: 5
 jobs:
-# - job: Setup
-#   steps:
-#     - task: powershell@2
-#       name: checkPayload
-#       displayName: 'Check if build is required for this PR'
-#       inputs:
-#         targetType: filePath
-#         filePath: build\ShouldSkipPRBuild.ps1
+- job: Setup
+  steps:
+    - task: powershell@2
+      name: checkPayload
+      displayName: 'Check if build is required for this PR'
+      inputs:
+        targetType: filePath
+        filePath: build\ShouldSkipPRBuild.ps1
 
-# - job: Build
-#   # dependsOn: Setup
-#   # condition: |
-#   #   and
-#   #   (
-#   #     eq(variables['useBuildOutputFromBuildId'],''),
-#   #     ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
-#   #   )
-#   pool: 
-#     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-#       name: WinDevPoolOSS-L
-#     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-#       name: WinDevPool-L
-#     demands: ImageOverride -equals WinDevVS16-9
-#   timeoutInMinutes: 120
-#   strategy:
-#     maxParallel: 10
-#     matrix:
-#       Debug_x86:
-#         buildPlatform: 'x86'
-#         buildConfiguration: 'Debug'
-#       Release_x86:
-#         buildPlatform: 'x86'
-#         buildConfiguration: 'Release'
-#         PGOBuildMode: 'Optimize'
-#       Release_x64:
-#         buildPlatform: 'x64'
-#         buildConfiguration: 'Release'
-#         PGOBuildMode: 'Optimize'
-#   variables:
-#     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
-#     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
-#     publishDir : $(Build.ArtifactStagingDirectory)
-#   steps:
-#   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-#   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+- job: Build
+  dependsOn: Setup
+  condition: |
+    and
+    (
+      eq(variables['useBuildOutputFromBuildId'],''),
+      ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
+    )
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
+    demands: ImageOverride -equals WinDevVS16-9
+  timeoutInMinutes: 120
+  strategy:
+    maxParallel: 10
+    matrix:
+      Debug_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Debug'
+      Release_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Release'
+        PGOBuildMode: 'Optimize'
+      Release_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
+        PGOBuildMode: 'Optimize'
+  variables:
+    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+    publishDir : $(Build.ArtifactStagingDirectory)
+  steps:
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-#   parameters:
-#     name: 'RunTestsInHelix'
-#     dependsOn:
-#     - Setup
-#     - Build
-#     condition: |
-#       and
-#       (
-#         ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True'),
-#         in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
-#       )
-#     testSuite: 'DevTestSuite'
-#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+- template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+  parameters:
+    name: 'RunTestsInHelix'
+    dependsOn:
+    - Setup
+    - Build
+    condition: |
+      and
+      (
+        ne(dependencies.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True'),
+        in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
+      )
+    testSuite: 'DevTestSuite'
+    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
 # Create Nuget Package
-# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-#   parameters:
-#     jobName: CreateNugetPackage
-#     dependsOn: Build
-#     primaryBuildArch: x64
-#     prereleaseVersionTag: pr
+- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+  parameters:
+    jobName: CreateNugetPackage
+    dependsOn: Build
+    primaryBuildArch: x64
+    prereleaseVersionTag: pr
 
 - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
   parameters:
-    # dependsOn: CreateNugetPackage
+    dependsOn: CreateNugetPackage
     useFrameworkPkg: false
     runTests: 'false'
     matrix:
@@ -85,9 +85,9 @@ jobs:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
 
-# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-#   parameters:
-#     dependsOn: RunTestsInHelix
-#     rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
-#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
-#     checkJobAttempt: true
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn: RunTestsInHelix
+    rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+    checkJobAttempt: true


### PR DESCRIPTION
We were using the 'windows-2019' pool to build MUXControlsReleaseTest.sln. This pool is the public pool that is provided by Azure Pipelines. It gets updated with new dependencies on a regular basis. However we are regularly running into issues where these updates cause out Pipelines to get broken.

So we switch over these Jobs to run on a pool using the same images that we use for running the main product build Job. I created WinDevPool-S and WinDevPoolOSS-S for this purpose. These are identical to WinDevPool-L and WinDevPoolOSS-L except they have lower machine specs (2 cores vs 8 cores).

This should make our build Pipelines more reliable.