### PR TITLE
Fix ARM build break from WebView2 changes

### DIFF
--- a/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
+++ b/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
@@ -147,6 +147,22 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- Targets to help compile against  the WebView2 nupkg even though they don't yet support Arm32 compilation -->
+  <Target Name="RemoveCopyLocal" BeforeTargets="_CopyFilesMarkedCopyLocal" Condition="'$(Platform)'=='ARM'">
+    <Message Text="***Removing ReferenceCopyLocalPaths*** PRE: @(ReferenceCopyLocalPaths)"/>
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"/>
+    </ItemGroup>
+    <Message Text="***Removing ReferenceCopyLocalPaths*** POST: @(ReferenceCopyLocalPaths)"/>
+  </Target>
+  <Target Name="RemoveWebView2Loaderdll" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectoryAlways" Condition="'$(Platform)'=='ARM'">
+    <Message Text="***Removing _SourceItemsToCopyToOutputDirectoryAlways*** PRE: @(_SourceItemsToCopyToOutputDirectoryAlways)"/>
+    <ItemGroup>
+      <_SourceItemsToCopyToOutputDirectoryAlways Remove="@(_SourceItemsToCopyToOutputDirectoryAlways)" Condition="'%(Filename)%(Extension)' == 'WebView2Loader.dll'"/>
+    </ItemGroup>
+    <Message Text="***Removing _SourceItemsToCopyToOutputDirectoryAlways*** POST: @(_SourceItemsToCopyToOutputDirectoryAlways)"/>
+  </Target>
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
+++ b/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
@@ -145,6 +145,8 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Platform)' != 'ARM'">
     <Import Project="..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
+++ b/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
@@ -95,6 +95,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <ModuleDefinitionFile>RuntimeComponentThatUsesMUX.def</ModuleDefinitionFile>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='ARM'">%(AdditionalLibraryDirectories);..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\x86</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
@@ -145,8 +146,6 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Platform)' != 'ARM'">
     <Import Project="..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -157,6 +156,21 @@
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.UI.Xaml.2.1.190606001\build\native\Microsoft.UI.Xaml.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Web.WebView2.1.0.955-prerelease\build\native\Microsoft.Web.WebView2.targets'))" />
+  </Target>
+  <!-- Targets to help compile against  the WebView2 nupkg even though they don't yet support Arm32 compilation -->
+  <Target Name="RemoveCopyLocal" BeforeTargets="_CopyFilesMarkedCopyLocal" Condition="'$(Platform)'=='ARM'">
+    <Message Text="***Removing ReferenceCopyLocalPaths*** PRE: @(ReferenceCopyLocalPaths)"/>
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"/>
+    </ItemGroup>
+    <Message Text="***Removing ReferenceCopyLocalPaths*** POST: @(ReferenceCopyLocalPaths)"/>
+  </Target>
+  <Target Name="RemoveWebView2Loaderdll" BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectoryAlways" Condition="'$(Platform)'=='ARM'">
+    <Message Text="***Removing _SourceItemsToCopyToOutputDirectoryAlways*** PRE: @(_SourceItemsToCopyToOutputDirectoryAlways)"/>
+    <ItemGroup>
+      <_SourceItemsToCopyToOutputDirectoryAlways Remove="@(_SourceItemsToCopyToOutputDirectoryAlways)" Condition="'%(Filename)%(Extension)' == 'WebView2Loader.dll'"/>
+    </ItemGroup>
+    <Message Text="***Removing _SourceItemsToCopyToOutputDirectoryAlways*** POST: @(_SourceItemsToCopyToOutputDirectoryAlways)"/>
   </Target>
   <Target Name="AfterBuild">
     <PropertyGroup>

--- a/test/TestAppCX/MainPage.xaml.cpp
+++ b/test/TestAppCX/MainPage.xaml.cpp
@@ -13,7 +13,9 @@
 #include "CornerRadiusTestPage.xaml.h"
 #include "TreeViewTestPage.xaml.h"
 #include "BackdropMaterialTestPage.xaml.h"
+#ifndef _ARM_
 #include "WebView2TestPage.xaml.h"
+#endif
 
 using namespace TestAppCX;
 
@@ -74,5 +76,7 @@ void TestAppCX::MainPage::GoToBackdropMaterialTestPage(Platform::Object^ sender,
 void TestAppCX::MainPage::GoToWebView2TestPage(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
     auto app = dynamic_cast<App^>(Application::Current);
+#ifndef _ARM_
     app->RootFrame->Navigate(TypeName(WebView2TestPage::typeid), nullptr);
+#endif
 }

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -203,7 +203,7 @@
     <ClInclude Include="TreeViewTestPage.xaml.h">
       <DependentUpon>TreeViewTestPage.xaml</DependentUpon>
     </ClInclude>
-    <ClInclude Include="WebView2TestPage.xaml.h">
+    <ClInclude Include="WebView2TestPage.xaml.h" Condition="'$(Platform)' != 'ARM'">
       <DependentUpon>WebView2TestPage.xaml</DependentUpon>
     </ClInclude>
   </ItemGroup>
@@ -229,7 +229,7 @@
     <Page Include="TreeViewTestPage.xaml">
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="WebView2TestPage.xaml">
+    <Page Include="WebView2TestPage.xaml" Condition="'$(Platform)' != 'ARM'">
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
@@ -281,7 +281,7 @@
     <ClCompile Include="TreeViewTestPage.xaml.cpp">
       <DependentUpon>TreeViewTestPage.xaml</DependentUpon>
     </ClCompile>
-    <ClCompile Include="WebView2TestPage.xaml.cpp">
+    <ClCompile Include="WebView2TestPage.xaml.cpp" Condition="'$(Platform)' != 'ARM'">
       <DependentUpon>WebView2TestPage.xaml</DependentUpon>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Looks like we don't compile ARM in PR builds so we didn't catch this sooner. Ifdef out the WebView2 usage in the CX test app.