### PR TITLE
Avoid heap corruption issue by setting the property via the DP instead of the property setter

### DIFF
--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -43,6 +43,11 @@ bool SharedHelpers::Is21H1OrHigher()
     return IsAPIContractV14Available();
 }
 
+bool SharedHelpers::Is20H1OrHigher()
+{
+    return IsAPIContractV10Available();
+}
+
 bool SharedHelpers::IsVanadiumOrHigher()
 {
     return IsAPIContractV9Available();
@@ -237,6 +242,11 @@ template <uint16_t APIVersion> bool SharedHelpers::IsAPIContractVxAvailable()
 bool SharedHelpers::IsAPIContractV14Available()
 {
     return IsAPIContractVxAvailable<14>();
+}
+
+bool SharedHelpers::IsAPIContractV10Available()
+{
+    return IsAPIContractVxAvailable<10>();
 }
 
 bool SharedHelpers::IsAPIContractV9Available()

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -255,7 +255,7 @@ void XamlControlsResources::UpdateTintLuminosityOpacity(winrt::Windows::UI::Xaml
     {
         // On 19h1 and 19h2 there is a heap corruption bug that occurs when setting the TintLuminosityOpacity via the property,
         // So we'll set it by the DP instead.
-        //brush.SetValue(winrt::Windows::UI::Xaml::Media::AcrylicBrush::TintLuminosityOpacityProperty(), box_value(luminosityValue));
+        brush.SetValue(winrt::Windows::UI::Xaml::Media::AcrylicBrush::TintLuminosityOpacityProperty(), box_value(luminosityValue));
     }
 }
 

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -158,43 +158,43 @@ void XamlControlsResources::UpdateAcrylicBrushesLightTheme(const winrt::IInspect
     const auto dictionary = themeDictionary.try_as<winrt::ResourceDictionary>();
     if (const auto acrylicBackgroundFillColorDefaultBrush = dictionary.Lookup(box_value(c_AcrylicBackgroundFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        acrylicBackgroundFillColorDefaultBrush.TintLuminosityOpacity(0.85);
+        UpdateTintLuminosityOpacity(acrylicBackgroundFillColorDefaultBrush, 0.85);
     }
     if (const auto acrylicInAppFillColorDefaultBrush = dictionary.Lookup(box_value(c_AcrylicInAppFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        acrylicInAppFillColorDefaultBrush.TintLuminosityOpacity(0.85);
+        UpdateTintLuminosityOpacity(acrylicInAppFillColorDefaultBrush, 0.85);
     }
     if (const auto acrylicBackgroundFillColorDefaultInverseBrush = dictionary.Lookup(box_value(c_AcrylicBackgroundFillColorDefaultInverseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        acrylicBackgroundFillColorDefaultInverseBrush.TintLuminosityOpacity(0.96);
+        UpdateTintLuminosityOpacity(acrylicBackgroundFillColorDefaultInverseBrush, 0.96);
     }
     if (const auto acrylicInAppFillColorDefaultInverseBrush = dictionary.Lookup(box_value(c_AcrylicInAppFillColorDefaultInverseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        acrylicInAppFillColorDefaultInverseBrush.TintLuminosityOpacity(0.96);
+        UpdateTintLuminosityOpacity(acrylicInAppFillColorDefaultInverseBrush, 0.96);
     }
     if (const auto acrylicBackgroundFillColorBaseBrush = dictionary.Lookup(box_value(c_AcrylicBackgroundFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        acrylicBackgroundFillColorBaseBrush.TintLuminosityOpacity(0.9);
+        UpdateTintLuminosityOpacity(acrylicBackgroundFillColorBaseBrush, 0.9);
     }
     if (const auto acrylicInAppFillColorBaseBrush = dictionary.Lookup(box_value(c_AcrylicInAppFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        acrylicInAppFillColorBaseBrush.TintLuminosityOpacity(0.9);
+        UpdateTintLuminosityOpacity(acrylicInAppFillColorBaseBrush, 0.9);
     }
     if (const auto accentAcrylicBackgroundFillColorDefaultBrush = dictionary.Lookup(box_value(c_AccentAcrylicBackgroundFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        accentAcrylicBackgroundFillColorDefaultBrush.TintLuminosityOpacity(0.9);
+        UpdateTintLuminosityOpacity(accentAcrylicBackgroundFillColorDefaultBrush, 0.9);
     }
     if (const auto accentAcrylicInAppFillColorDefaultBrush = dictionary.Lookup(box_value(c_AccentAcrylicInAppFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        accentAcrylicInAppFillColorDefaultBrush.TintLuminosityOpacity(0.9);
+        UpdateTintLuminosityOpacity(accentAcrylicInAppFillColorDefaultBrush, 0.9);
     }
     if (const auto accentAcrylicBackgroundFillColorBaseBrush = dictionary.Lookup(box_value(c_AccentAcrylicBackgroundFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        accentAcrylicBackgroundFillColorBaseBrush.TintLuminosityOpacity(0.9);
+        UpdateTintLuminosityOpacity(accentAcrylicBackgroundFillColorBaseBrush, 0.9);
     }
     if (const auto accentAcrylicInAppFillColorBaseBrush = dictionary.Lookup(box_value(c_AccentAcrylicInAppFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
     {
-        accentAcrylicInAppFillColorBaseBrush.TintLuminosityOpacity(0.9);
+        UpdateTintLuminosityOpacity(accentAcrylicInAppFillColorBaseBrush, 0.9);
     }
 }
 
@@ -204,44 +204,58 @@ void XamlControlsResources::UpdateAcrylicBrushesDarkTheme(const winrt::IInspecta
     {
         if (const auto acrylicBackgroundFillColorDefaultBrush = dictionary.Lookup(box_value(c_AcrylicBackgroundFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            acrylicBackgroundFillColorDefaultBrush.TintLuminosityOpacity(0.96);
+            UpdateTintLuminosityOpacity(acrylicBackgroundFillColorDefaultBrush, 0.96);
         }
         if (const auto acrylicInAppFillColorDefaultBrush = dictionary.Lookup(box_value(c_AcrylicInAppFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            acrylicInAppFillColorDefaultBrush.TintLuminosityOpacity(0.96);
+            UpdateTintLuminosityOpacity(acrylicInAppFillColorDefaultBrush, 0.96);
         }
         if (const auto acrylicBackgroundFillColorDefaultInverseBrush = dictionary.Lookup(box_value(c_AcrylicBackgroundFillColorDefaultInverseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            acrylicBackgroundFillColorDefaultInverseBrush.TintLuminosityOpacity(0.85);
+            UpdateTintLuminosityOpacity(acrylicBackgroundFillColorDefaultInverseBrush, 0.85);
         }
         if (const auto acrylicInAppFillColorDefaultInverseBrush = dictionary.Lookup(box_value(c_AcrylicInAppFillColorDefaultInverseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            acrylicInAppFillColorDefaultInverseBrush.TintLuminosityOpacity(0.85);
+            UpdateTintLuminosityOpacity(acrylicInAppFillColorDefaultInverseBrush, 0.85);
         }
         if (const auto acrylicBackgroundFillColorBaseBrush = dictionary.Lookup(box_value(c_AcrylicBackgroundFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            acrylicBackgroundFillColorBaseBrush.TintLuminosityOpacity(0.96);
+            UpdateTintLuminosityOpacity(acrylicBackgroundFillColorBaseBrush, 0.96);
         }
         if (const auto acrylicInAppFillColorBaseBrush = dictionary.Lookup(box_value(c_AcrylicInAppFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            acrylicInAppFillColorBaseBrush.TintLuminosityOpacity(0.96);
+            UpdateTintLuminosityOpacity(acrylicInAppFillColorBaseBrush, 0.96);
         }
         if (const auto accentAcrylicBackgroundFillColorDefaultBrush = dictionary.Lookup(box_value(c_AccentAcrylicBackgroundFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            accentAcrylicBackgroundFillColorDefaultBrush.TintLuminosityOpacity(0.8);
+            UpdateTintLuminosityOpacity(accentAcrylicBackgroundFillColorDefaultBrush, 0.8);
         }
         if (const auto accentAcrylicInAppFillColorDefaultBrush = dictionary.Lookup(box_value(c_AccentAcrylicInAppFillColorDefaultBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            accentAcrylicInAppFillColorDefaultBrush.TintLuminosityOpacity(0.8);
+            UpdateTintLuminosityOpacity(accentAcrylicInAppFillColorDefaultBrush, 0.8);
         }
         if (const auto accentAcrylicBackgroundFillColorBaseBrush = dictionary.Lookup(box_value(c_AccentAcrylicBackgroundFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            accentAcrylicBackgroundFillColorBaseBrush.TintLuminosityOpacity(0.8);
+            UpdateTintLuminosityOpacity(accentAcrylicBackgroundFillColorBaseBrush, 0.8);
         }
         if (const auto accentAcrylicInAppFillColorBaseBrush = dictionary.Lookup(box_value(c_AccentAcrylicInAppFillColorBaseBrush)).as<winrt::Windows::UI::Xaml::Media::AcrylicBrush>())
         {
-            accentAcrylicInAppFillColorBaseBrush.TintLuminosityOpacity(0.8);
+            UpdateTintLuminosityOpacity(accentAcrylicInAppFillColorBaseBrush, 0.8);
         }
+    }
+}
+
+void XamlControlsResources::UpdateTintLuminosityOpacity(winrt::Windows::UI::Xaml::Media::AcrylicBrush brush, double luminosityValue)
+{
+    if (SharedHelpers::Is20H1OrHigher())
+    {
+        brush.TintLuminosityOpacity(luminosityValue);
+    }
+    else
+    {
+        // On 19h1 and 19h2 there is a heap corruption bug that occurs when setting the TintLuminosityOpacity via the property,
+        // So we'll set it by the DP instead.
+        brush.SetValue(winrt::Windows::UI::Xaml::Media::AcrylicBrush::TintLuminosityOpacityProperty(), box_value(luminosityValue));
     }
 }
 

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -255,7 +255,7 @@ void XamlControlsResources::UpdateTintLuminosityOpacity(winrt::Windows::UI::Xaml
     {
         // On 19h1 and 19h2 there is a heap corruption bug that occurs when setting the TintLuminosityOpacity via the property,
         // So we'll set it by the DP instead.
-        brush.SetValue(winrt::Windows::UI::Xaml::Media::AcrylicBrush::TintLuminosityOpacityProperty(), box_value(luminosityValue));
+        //brush.SetValue(winrt::Windows::UI::Xaml::Media::AcrylicBrush::TintLuminosityOpacityProperty(), box_value(luminosityValue));
     }
 }
 

--- a/dev/dll/XamlControlsResources.h
+++ b/dev/dll/XamlControlsResources.h
@@ -21,4 +21,5 @@ public:
 private:
     void UpdateSource();
     bool IsControlsResourcesVersion2();
+    void UpdateTintLuminosityOpacity(winrt::Windows::UI::Xaml::Media::AcrylicBrush brush, double luminosityValue);
 };

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -17,6 +17,7 @@ public:
 
     // Logical OS version checks
     static bool Is21H1OrHigher();
+    static bool Is20H1OrHigher();
     static bool IsVanadiumOrHigher();
     static bool Is19H1OrHigher();
     static bool IsRS5OrHigher();
@@ -63,6 +64,7 @@ public:
 
     // Actual OS version checks
     static bool IsAPIContractV14Available(); // 21H1
+    static bool IsAPIContractV10Available();  // 20H1
     static bool IsAPIContractV9Available();  // 19H2
     static bool IsAPIContractV8Available();  // 19H1
     static bool IsAPIContractV7Available();  // RS5


### PR DESCRIPTION
An OS bug was fixed in 20h1 that resolved the heap corruption bug our code is hitting on 19h1 and 19h2. Fixes https://github.com/microsoft/microsoft-ui-xaml/issues/5435