### PR TITLE
Remove copying GUID-to-guid conversions

### DIFF
--- a/dev/Repeater/ElementFactory.h
+++ b/dev/Repeater/ElementFactory.h
@@ -20,7 +20,7 @@ public:
 #pragma endregion
 
     // TODO: Bug 14901501: Figure out a better way to have reference tracking for types doing in-component derivation (e.g. RecyclingElementFactory : ElementFactory)
-    virtual HRESULT __stdcall NonDelegatingQueryInterface(const GUID& id, void** object)
+    virtual int32_t __stdcall NonDelegatingQueryInterface(const winrt::guid& id, void** object)
     {
         return __super::NonDelegatingQueryInterface(id, object);
     }

--- a/dev/inc/RuntimeClassHelpers.h
+++ b/dev/inc/RuntimeClassHelpers.h
@@ -79,7 +79,7 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
         return this->m_inner;
     }
 
-    HRESULT __stdcall NonDelegatingQueryInterface(GUID const& riid, void** value) noexcept
+    int32_t __stdcall NonDelegatingQueryInterface(winrt::guid const& riid, void** value) noexcept
     {
         // In order for the reference tracking mechanism to work, we actually need to hand out XAML's
         // implementation of IWeakReferenceSource. However there are some bugs on RS2 where XAML calls
@@ -113,8 +113,9 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
 
     // TEMP-BEGIN
 
-    HRESULT __stdcall QueryInterface(GUID const& id, void** object) noexcept
+    HRESULT __stdcall QueryInterface(GUID const& id_abi, void** object) noexcept
     {
+        auto& id = reinterpret_cast<winrt::guid const&>(id_abi);
         if (this->outer())
         {
             return this->outer()->QueryInterface(id, object);


### PR DESCRIPTION
## Description
`winrt::guid const` has a non-copying conversion to `GUID const&`, but the only conversion from `GUID const` to `winrt::guid const` is a copying constructor.

That's because conversion operators must be members of the converted-from type, but we cannot inject methods into the system-provided `struct GUID`, so we cannot provide a non-copying conversion from `GUID&` to `winrt::guid&`.

Our custom `NonDelegatingQueryInterface`s accepted `GUID const&` by mistake when they should have accepted `winrt::guid const&`. The conversion from `winrt::guid const&` to `GUID const&` is free, but the reverse conversion (which occurs when we try to forward the `id` parameter to other methods) is expensive.

Note that the changes to `NonDelegatingQueryInterface` have to be made in sync so that they can override each other.

Fix this by changing the signature of `NonDelegatingQueryInterface` to match what C++/WinRT uses. The places where the `winrt::guid const&` is used as a `GUID` can be handled by the non-copying conversion.

Our implementation of `QueryInterface` must accept a `GUID const&` in order to match the ABI. However, we immediately convert it (non-copying) to a `winrt::guid const&` and operate on the `winrt::guid const&` from then on.

## Motivation and Context

This removes four GUID copies from every instance of ReferenceTracker (there are over 200 of them). For some reason, MSVC copies a GUID very slowly:

```
418b02          mov     eax,dword ptr [r10]
8945f0          mov     dword ptr [rbp-10h],eax
410fb74204      movzx   eax,word ptr [r10+4]
668945f4        mov     word ptr [rbp-0Ch],ax
410fb74206      movzx   eax,word ptr [r10+6]
668945f6        mov     word ptr [rbp-0Ah],ax
418a4208        mov     al,byte ptr [r10+8]
8845f8          mov     byte ptr [rbp-8],al
418a4209        mov     al,byte ptr [r10+9]
8845f9          mov     byte ptr [rbp-7],al
418a420a        mov     al,byte ptr [r10+0Ah]
8845fa          mov     byte ptr [rbp-6],al
418a420b        mov     al,byte ptr [r10+0Bh]
8845fb          mov     byte ptr [rbp-5],al
418a420c        mov     al,byte ptr [r10+0Ch]
8845fc          mov     byte ptr [rbp-4],al
418a420d        mov     al,byte ptr [r10+0Dh]
8845fd          mov     byte ptr [rbp-3],al
418a420e        mov     al,byte ptr [r10+0Eh]
8845fe          mov     byte ptr [rbp-2],al
418a420f        mov     al,byte ptr [r10+0Fh]
8845ff          mov     byte ptr [rbp-1],al
```
80 bytes times 4 times 200 = nearly 64KB of pointless GUID copying.

## How Has This Been Tested?

Verified vtable construction. Light interactive testing to make sure nothing exploded.