### PR TITLE
Fix issue where checkbox indeterminate icon would not be aligned vertically

### DIFF
--- a/dev/CommonStyles/CheckBox_themeresources.xaml
+++ b/dev/CommonStyles/CheckBox_themeresources.xaml
@@ -658,6 +658,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalIndeterminate"/>
+                                        <Setter Target="CheckGlyph.Margin" Value="0"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminatePointerOver">
@@ -691,6 +692,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PointerOverIndeterminate"/>
+                                        <Setter Target="CheckGlyph.Margin" Value="0"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminatePressed">
@@ -724,6 +726,7 @@
                                     </Storyboard>
                                     <VisualState.Setters>
                                         <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="PressedIndeterminate"/>
+                                        <Setter Target="CheckGlyph.Margin" Value="0"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="IndeterminateDisabled">
@@ -758,6 +761,7 @@
                                     <VisualState.Setters>
                                         <!-- DisabledVisual Should be handled by the control, not the animated icon. -->
                                         <Setter Target="CheckGlyph.(local:AnimatedIcon.State)" Value="NormalIndeterminate"/>
+                                        <Setter Target="CheckGlyph.Margin" Value="0"/>
                                     </VisualState.Setters>
                                 </VisualState>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add visual state setters in indeterminate states to change the margin from "0,1,0,-1" to "0". Having the negative margin will make the indeterminate icon off center.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes a very minor issue that has been bothering me, where the indeterminate CheckBox icon was off center vertically. 

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested visually in test app.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
Before:
![image](https://user-images.githubusercontent.com/59544401/131284682-950adb55-8ca4-4ea9-bd17-ece33678fcd7.png)
![image](https://user-images.githubusercontent.com/59544401/131284702-28b168ee-fb5b-4393-8c15-c18cd4e24774.png)

After:
![image](https://user-images.githubusercontent.com/59544401/131283847-643bee39-c086-41ea-9799-05c0c5f5f31e.png)
![image](https://user-images.githubusercontent.com/59544401/131284289-8af28c23-319d-41f4-894c-a2c98e209c1a.png)
