### PR TITLE
ColorPicker Doesn't Update HS values when Value == 0 Fix

### DIFF
--- a/dev/ColorPicker/ColorSpectrum.cpp
+++ b/dev/ColorPicker/ColorSpectrum.cpp
@@ -328,32 +328,26 @@ void ColorSpectrum::RaiseColorChanged()
 {
     const winrt::Color newColor = Color();
 
-    if (m_oldColor.A != newColor.A ||
-        m_oldColor.R != newColor.R ||
-        m_oldColor.G != newColor.G ||
-        m_oldColor.B != newColor.B)
+    auto colorChangedEventArgs = winrt::make_self<ColorChangedEventArgs>();
+
+    colorChangedEventArgs->OldColor(m_oldColor);
+    colorChangedEventArgs->NewColor(newColor);
+
+    m_colorChangedEventSource(*this, *colorChangedEventArgs);
+
+    if (DownlevelHelper::ToDisplayNameExists())
     {
-        auto colorChangedEventArgs = winrt::make_self<ColorChangedEventArgs>();
-
-        colorChangedEventArgs->OldColor(m_oldColor);
-        colorChangedEventArgs->NewColor(newColor);
-
-        m_colorChangedEventSource(*this, *colorChangedEventArgs);
-
-        if (DownlevelHelper::ToDisplayNameExists())
+        if (auto&& colorNameToolTip = m_colorNameToolTip.get())
         {
-            if (auto&& colorNameToolTip = m_colorNameToolTip.get())
-            {
-                colorNameToolTip.Content(box_value(winrt::ColorHelper::ToDisplayName(newColor)));
-            }
+            colorNameToolTip.Content(box_value(winrt::ColorHelper::ToDisplayName(newColor)));
         }
+    }
 
-        auto peer = winrt::FrameworkElementAutomationPeer::FromElement(*this);
-        if (peer)
-        {
-            winrt::ColorSpectrumAutomationPeer colorSpectrumPeer = peer.as<winrt::ColorSpectrumAutomationPeer>();
-            winrt::get_self<ColorSpectrumAutomationPeer>(colorSpectrumPeer)->RaisePropertyChangedEvent(m_oldColor, newColor, m_oldHsvColor, HsvColor());
-        }
+    auto peer = winrt::FrameworkElementAutomationPeer::FromElement(*this);
+    if (peer)
+    {
+        winrt::ColorSpectrumAutomationPeer colorSpectrumPeer = peer.as<winrt::ColorSpectrumAutomationPeer>();
+        winrt::get_self<ColorSpectrumAutomationPeer>(colorSpectrumPeer)->RaisePropertyChangedEvent(m_oldColor, newColor, m_oldHsvColor, HsvColor());
     }
 }
 

--- a/dev/ColorPicker/ColorSpectrum.cpp
+++ b/dev/ColorPicker/ColorSpectrum.cpp
@@ -327,27 +327,39 @@ void ColorSpectrum::SetColor()
 void ColorSpectrum::RaiseColorChanged()
 {
     const winrt::Color newColor = Color();
+    const auto colorChanged =
+        m_oldColor.A != newColor.A ||
+        m_oldColor.R != newColor.R ||
+        m_oldColor.G != newColor.G ||
+        m_oldColor.B != newColor.B;
+    const auto areBothColorsBlack =
+        (m_oldColor.R == newColor.R && newColor.R == 0) ||
+        (m_oldColor.G == newColor.G && newColor.G == 0) ||
+        (m_oldColor.B == newColor.B && newColor.B == 0);
 
-    auto colorChangedEventArgs = winrt::make_self<ColorChangedEventArgs>();
-
-    colorChangedEventArgs->OldColor(m_oldColor);
-    colorChangedEventArgs->NewColor(newColor);
-
-    m_colorChangedEventSource(*this, *colorChangedEventArgs);
-
-    if (DownlevelHelper::ToDisplayNameExists())
+    if (colorChanged || areBothColorsBlack)
     {
-        if (auto&& colorNameToolTip = m_colorNameToolTip.get())
+        auto colorChangedEventArgs = winrt::make_self<ColorChangedEventArgs>();
+
+        colorChangedEventArgs->OldColor(m_oldColor);
+        colorChangedEventArgs->NewColor(newColor);
+
+        m_colorChangedEventSource(*this, *colorChangedEventArgs);
+
+        if (DownlevelHelper::ToDisplayNameExists())
         {
-            colorNameToolTip.Content(box_value(winrt::ColorHelper::ToDisplayName(newColor)));
+            if (auto&& colorNameToolTip = m_colorNameToolTip.get())
+            {
+                colorNameToolTip.Content(box_value(winrt::ColorHelper::ToDisplayName(newColor)));
+            }
         }
-    }
 
-    auto peer = winrt::FrameworkElementAutomationPeer::FromElement(*this);
-    if (peer)
-    {
-        winrt::ColorSpectrumAutomationPeer colorSpectrumPeer = peer.as<winrt::ColorSpectrumAutomationPeer>();
-        winrt::get_self<ColorSpectrumAutomationPeer>(colorSpectrumPeer)->RaisePropertyChangedEvent(m_oldColor, newColor, m_oldHsvColor, HsvColor());
+        auto peer = winrt::FrameworkElementAutomationPeer::FromElement(*this);
+        if (peer)
+        {
+            winrt::ColorSpectrumAutomationPeer colorSpectrumPeer = peer.as<winrt::ColorSpectrumAutomationPeer>();
+            winrt::get_self<ColorSpectrumAutomationPeer>(colorSpectrumPeer)->RaisePropertyChangedEvent(m_oldColor, newColor, m_oldHsvColor, HsvColor());
+        }
     }
 }
 

--- a/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
+++ b/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
@@ -524,19 +524,22 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Wait.ForIdle();
 
                 VerifySelectedColorIsNear(0, 0, 0);
+
+                // Allowing +/-1 devation
+                const double errorMargin = 1;
                 
-                Verify.AreEqual("90", (new Edit(FindElement.ById(HueTextBoxAutomationId))).Value);
-                Verify.AreEqual("75", (new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value);
-                Verify.AreEqual("0", (new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value);
+                Verify.IsLessThanOrEqual(90 - Double.Parse((new Edit(FindElement.ById(HueTextBoxAutomationId))).Value), errorMargin);
+                Verify.IsLessThanOrEqual(75- Double.Parse((new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value), errorMargin);
+                Verify.IsLessThanOrEqual(0 - Double.Parse((new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value), errorMargin);
 
                 TapOnColorSpectrum(0.75, 0.75);
                 Wait.ForIdle();
 
                 VerifySelectedColorIsNear(0, 0, 0);
 
-                Verify.AreEqual("270", (new Edit(FindElement.ById(HueTextBoxAutomationId))).Value);
-                Verify.AreEqual("25", (new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value);
-                Verify.AreEqual("0", (new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value);
+                Verify.IsLessThanOrEqual(270 - Double.Parse((new Edit(FindElement.ById(HueTextBoxAutomationId))).Value), errorMargin);
+                Verify.IsLessThanOrEqual(25 - Double.Parse((new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value), errorMargin);
+                Verify.IsLessThanOrEqual(0 - Double.Parse((new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value), errorMargin);
             }
         }
 

--- a/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
+++ b/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
@@ -507,6 +507,27 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void VerifyHsvUpdatesOnSpectrumSelection()
+        {
+            using (var setup = SetupColorPickerTest())
+            {
+                setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.5, 0.5));
+                VerifySelectedColorIsNear(127, 255, 252);
+                VerifySelectionEllipseIsNear(127, 127);
+               
+                WriteInTextBox(ValueTextBoxAutomationId, "0");
+                VerifySelectedColorIsNear(0, 0, 0);
+
+                setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.25, 0.25));
+                VerifySelectedColorIsNear(0, 0, 0);
+
+                Verify.AreEqual("89", (new Edit(FindElement.ById(HueTextBoxAutomationId))).Value);
+                Verify.AreEqual("75", (new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value);
+                Verify.AreEqual("0", (new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value);
+            }
+        }
+
+        [TestMethod]
         public void CanSelectPreviousColor()
         {
             using (var setup = SetupColorPickerTest(TestOptions.DisableColorSpectrumLoadWait))

--- a/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
+++ b/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
@@ -528,9 +528,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Allowing +/-1 devation
                 const double errorMargin = 1;
                 
-                Verify.IsLessThanOrEqual(90 - Double.Parse((new Edit(FindElement.ById(HueTextBoxAutomationId))).Value), errorMargin);
-                Verify.IsLessThanOrEqual(75- Double.Parse((new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value), errorMargin);
-                Verify.IsLessThanOrEqual(0 - Double.Parse((new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value), errorMargin);
+                Verify.IsLessThanOrEqual(Math.Abs(90 - Double.Parse((new Edit(FindElement.ById(HueTextBoxAutomationId))).Value)), errorMargin);
+                Verify.IsLessThanOrEqual(Math.Abs(75 - Double.Parse((new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value)), errorMargin);
+                Verify.IsLessThanOrEqual(Math.Abs(0 - Double.Parse((new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value)), errorMargin);
 
                 TapOnColorSpectrum(0.75, 0.75);
                 Wait.ForIdle();

--- a/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
+++ b/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
@@ -489,19 +489,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             // We snap to the nearest HSV value and then derive the RGB value and ellipse position from that,
             // so we're bound to run into rounding errors along the way, which is what accounts for the slightly
             // different values we get in RTL where our x-axis is flipped.
-            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.5, 0.5));
+            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrumAndWaitForColorChange(0.5, 0.5));
             VerifySelectedColorIsNear(127, 255, 252);
             VerifySelectionEllipseIsNear(127, 127);
-            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.25, 0.25));
+            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrumAndWaitForColorChange(0.25, 0.25));
             VerifySelectedColorIsNear(163, isRTL ? 63 : 255, isRTL ? 255 : 63);
             VerifySelectionEllipseIsNear(isRTL ? 194 : 63, 63);
-            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.75, 0.25));
+            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrumAndWaitForColorChange(0.75, 0.25));
             VerifySelectedColorIsNear(151, isRTL ? 255 : 63, isRTL ? 63 : 255);
             VerifySelectionEllipseIsNear(isRTL ? 66 : 191, 63);
-            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.25, 0.75));
+            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrumAndWaitForColorChange(0.25, 0.75));
             VerifySelectedColorIsNear(224, isRTL ? 191 : 255, isRTL ? 255 : 191);
             VerifySelectionEllipseIsNear(isRTL ? 194 : 63, 192);
-            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.75, 0.75));
+            setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrumAndWaitForColorChange(0.75, 0.75));
             VerifySelectedColorIsNear(220, isRTL ? 255 : 191, isRTL ? 191 : 255);
             VerifySelectionEllipseIsNear(isRTL ? 66 : 191, 192);
         }
@@ -511,18 +511,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             using (var setup = SetupColorPickerTest())
             {
-                setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.5, 0.5));
+                TapOnColorSpectrumAndWaitForColorChange(0.5, 0.5);
                 VerifySelectedColorIsNear(127, 255, 252);
                 VerifySelectionEllipseIsNear(127, 127);
                
                 WriteInTextBox(ValueTextBoxAutomationId, "0");
                 VerifySelectedColorIsNear(0, 0, 0);
 
-                setup.ExecuteAndWaitForColorChange(() => TapOnColorSpectrum(0.25, 0.25));
+                // Since Value is 0, the RGB value stays black and does not trigger the colorChangedEvent,
+                // so this helper function is used instead.
+                TapOnColorSpectrum(0.25, 0.25);
+                Wait.ForIdle();
+
+                VerifySelectedColorIsNear(0, 0, 0);
+                
+                Verify.AreEqual("90", (new Edit(FindElement.ById(HueTextBoxAutomationId))).Value);
+                Verify.AreEqual("75", (new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value);
+                Verify.AreEqual("0", (new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value);
+
+                TapOnColorSpectrum(0.75, 0.75);
+                Wait.ForIdle();
+
                 VerifySelectedColorIsNear(0, 0, 0);
 
-                Verify.AreEqual("89", (new Edit(FindElement.ById(HueTextBoxAutomationId))).Value);
-                Verify.AreEqual("75", (new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value);
+                Verify.AreEqual("270", (new Edit(FindElement.ById(HueTextBoxAutomationId))).Value);
+                Verify.AreEqual("25", (new Edit(FindElement.ById(SaturationTextBoxAutomationId))).Value);
                 Verify.AreEqual("0", (new Edit(FindElement.ById(ValueTextBoxAutomationId))).Value);
             }
         }
@@ -990,7 +1003,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             using (var setup = SetupColorPickerTest())
             {
-                TapOnColorSpectrum(0.5, 0.5);
+                TapOnColorSpectrumAndWaitForColorChange(0.5, 0.5);
                 VerifyElementIsFocused(ColorSpectrumAutomationId);
             }
         }
@@ -1362,6 +1375,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         private void TapOnColorSpectrum(double xPercent, double yPercent)
+        {
+            ColorSpectrum colorSpectrum = new ColorSpectrum(FindElement.ById(ColorSpectrumAutomationId));
+
+            int colorSpectrumWidth = colorSpectrum.BoundingRectangle.Width;
+            int colorSpectrumHeight = colorSpectrum.BoundingRectangle.Height;
+
+            double xPosition = xPercent * (colorSpectrumWidth - 1);
+            double yPosition = yPercent * (colorSpectrumHeight - 1);
+
+            InputHelper.Tap(colorSpectrum, xPosition, yPosition);
+        }
+
+        private void TapOnColorSpectrumAndWaitForColorChange(double xPercent, double yPercent)
         {
             ColorSpectrum colorSpectrum = new ColorSpectrum(FindElement.ById(ColorSpectrumAutomationId));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
HSV values are converted to RGB in `HSVtoRGB()` in `ColorConversion.cpp`. When Value is set to 0, the outputted RGB values are of course 0 (Black), and since it's just black, it does not raise ColorPicker's `OnColorChanged` event even when the user clicks around the colour wheel. As such, the HS values are not updated, and with no feedback, it seems like it's broken. 

**Solution**
In the above scenario, even when `HSVColor()` is updated, it does not call the color changed events in ColorPicker since 
the check in `ColorSpectrum::RaiseColorChanged` only checks if the `Color()` values in ARGB has changed. With the ARGB check removed, it will trigger `ColorPicker::OnColorSpectrumColorChanged` which will update the HS values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes internal bug 34154213

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manual verification