### PR TITLE
Deprecate some CornerRadius resources

### DIFF
--- a/dev/ComboBox/ComboBox_themeresources.xaml
+++ b/dev/ComboBox/ComboBox_themeresources.xaml
@@ -361,9 +361,6 @@
     <Thickness x:Key="ComboBoxPadding">12,5,0,7</Thickness>
     <Thickness x:Key="ComboBoxEditableTextPadding">11,5,38,6</Thickness>
 
-    <CornerRadius x:Key="ComboBoxHiglightBorderCornerRadius">7</CornerRadius>
-    <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
-    <CornerRadius x:Key="ComboBoxItemCornerRadius">3</CornerRadius>
     <CornerRadius x:Key="ComboBoxItemPillCornerRadius">1.5</CornerRadius>
     
     <FontWeight x:Key="ComboBoxHeaderThemeFontWeight">Normal</FontWeight>
@@ -640,7 +637,7 @@
                             Background="{ThemeResource ComboBoxBackgroundFocused}"
                             BorderBrush="{ThemeResource ComboBoxBackgroundBorderBrushFocused}"
                             BorderThickness="{StaticResource ComboBoxBackgroundBorderThicknessFocused}"
-                            contract7Present:CornerRadius="{StaticResource ComboBoxHiglightBorderCornerRadius}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                             contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                             Opacity="0" />
 
@@ -704,7 +701,7 @@
                             Background="Transparent"
                             Margin="4,4,4,4"
                             Visibility="Collapsed"
-                            contract7Present:CornerRadius="{StaticResource ComboBoxDropDownButtonBackgroundCornerRadius}"
+                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                             contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
                             Width="30"
                             HorizontalAlignment="Right"
@@ -783,7 +780,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="UseSystemFocusVisuals" Value="True" />
         <Setter Property="FocusVisualMargin" Value="-3"/>
-        <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ComboBoxItemCornerRadius}"/>
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ComboBoxItem">

--- a/dev/CommonStyles/Deprecated_themeresources.xaml
+++ b/dev/CommonStyles/Deprecated_themeresources.xaml
@@ -60,6 +60,10 @@
             <StaticResource x:Key="ExpanderDisabledBorderBrush" ResourceKey="ExpanderBorderBrush" />
             <Thickness x:Key="ExpanderBorderThickness">1</Thickness>
             
+            <CornerRadius x:Key="ListViewItemCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="ListViewItemCheckBoxCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key='GridViewItemCornerRadius'>4</CornerRadius>
+            <CornerRadius x:Key='GridViewItemCheckBoxCornerRadius'>4</CornerRadius>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="TopNavigationViewItemRevealBackgroundFocused" ResourceKey="SystemControlHighlightAccentBrush" />
@@ -114,6 +118,11 @@
             <StaticResource x:Key="ExpanderDisabledForeground" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="ExpanderDisabledBorderBrush" ResourceKey="ExpanderBorderBrush" />
             <Thickness x:Key="ExpanderBorderThickness">1</Thickness>
+
+            <CornerRadius x:Key="ListViewItemCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="ListViewItemCheckBoxCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key='GridViewItemCornerRadius'>4</CornerRadius>
+            <CornerRadius x:Key='GridViewItemCheckBoxCornerRadius'>4</CornerRadius>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <!-- System high contrast colors -->
@@ -179,6 +188,11 @@
             <StaticResource x:Key="ExpanderDisabledForeground" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="ExpanderDisabledBorderBrush" ResourceKey="TextFillColorDisabledBrush" />
             <Thickness x:Key="ExpanderBorderThickness">2</Thickness>
+
+            <CornerRadius x:Key="ListViewItemCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key="ListViewItemCheckBoxCornerRadius">4</CornerRadius>
+            <CornerRadius x:Key='GridViewItemCornerRadius'>4</CornerRadius>
+            <CornerRadius x:Key='GridViewItemCheckBoxCornerRadius'>4</CornerRadius>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -211,6 +225,10 @@
     <Thickness x:Key="ExpanderDropdownDownBorderThickness">1,0,1,1</Thickness>
     <Thickness x:Key="ExpanderDropdownUpBorderThickness">1,1,1,0</Thickness>
     
+    <CornerRadius x:Key="ComboBoxHiglightBorderCornerRadius">8</CornerRadius>
+    <CornerRadius x:Key="ComboBoxDropDownButtonBackgroundCornerRadius">4</CornerRadius>
+    <CornerRadius x:Key="ComboBoxItemCornerRadius">4</CornerRadius>
+
     <Style TargetType="primitives:NavigationViewItemPresenter" x:Key="MUX_NavigationViewItemPresenterStyleWhenOnTopPaneWithRevealFocus">
         <Setter Property="Template">
             <Setter.Value>

--- a/dev/CommonStyles/GridViewItem_themeresources_21h1.xaml
+++ b/dev/CommonStyles/GridViewItem_themeresources_21h1.xaml
@@ -3,8 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
-            <CornerRadius x:Key='GridViewItemCornerRadius'>4</CornerRadius>
-            <CornerRadius x:Key='GridViewItemCheckBoxCornerRadius'>3</CornerRadius>
             <Thickness x:Key='GridViewItemSelectedBorderThickness'>2</Thickness>
             <StaticResource x:Key="GridViewItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="GridViewItemForeground" ResourceKey="TextFillColorPrimaryBrush" />
@@ -41,8 +39,6 @@
             <StaticResource x:Key="GridViewItemBackgroundSelectedDisabled" ResourceKey="SubtleFillColorSecondaryBrush" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
-            <CornerRadius x:Key='GridViewItemCornerRadius'>4</CornerRadius>
-            <CornerRadius x:Key='GridViewItemCheckBoxCornerRadius'>3</CornerRadius>
             <Thickness x:Key='GridViewItemSelectedBorderThickness'>2</Thickness>
             <SolidColorBrush x:Key="GridViewItemBackground" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="GridViewItemForeground" Color="{ThemeResource SystemColorWindowTextColor}" />
@@ -79,8 +75,6 @@
             <SolidColorBrush x:Key="GridViewItemBackgroundSelectedDisabled" Color="{ThemeResource SystemColorWindowColor}" />
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
-            <CornerRadius x:Key='GridViewItemCornerRadius'>4</CornerRadius>
-            <CornerRadius x:Key='GridViewItemCheckBoxCornerRadius'>3</CornerRadius>
             <Thickness x:Key='GridViewItemSelectedBorderThickness'>2</Thickness>
             <StaticResource x:Key="GridViewItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="GridViewItemForeground" ResourceKey="TextFillColorPrimaryBrush" />
@@ -174,8 +168,8 @@
                         CheckMode='{ThemeResource GridViewItemCheckMode}'
                         SelectedBorderThickness='{ThemeResource GridViewItemSelectedBorderThickness}'
                         SelectedPointerOverBorderBrush='{ThemeResource GridViewItemSelectedPointerOverBorderBrush}'
-                        CornerRadius='{ThemeResource GridViewItemCornerRadius}'
-                        CheckBoxCornerRadius='{ThemeResource GridViewItemCheckBoxCornerRadius}'
+                        CornerRadius='{ThemeResource ControlCornerRadius}'
+                        CheckBoxCornerRadius='{ThemeResource ControlCornerRadius}'
                         CheckPressedBrush='{ThemeResource GridViewItemCheckPressedBrush}'
                         CheckDisabledBrush='{ThemeResource GridViewItemCheckDisabledBrush}'
                         CheckBoxPointerOverBrush='{ThemeResource GridViewItemCheckBoxPointerOverBrush}'

--- a/dev/CommonStyles/InkToolbar_themeresources.xaml
+++ b/dev/CommonStyles/InkToolbar_themeresources.xaml
@@ -235,7 +235,7 @@
         <Setter Property="MinWidth" Value="0" />
         <Setter Property="MinHeight" Value="0" />
         <Setter Property="Margin" Value="2,4,2,4" />
-        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
     </Style>
 
     <Style x:Key="InkToolbarCommonButtonStyle" TargetType="ToggleButton">

--- a/dev/CommonStyles/ListViewItem_themeresources_21h1.xaml
+++ b/dev/CommonStyles/ListViewItem_themeresources_21h1.xaml
@@ -58,9 +58,7 @@
             <SolidColorBrush x:Key="ListViewItemSelectedForegroundThemeBrush" Color="#FFFFFFFF" />
             <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBackgroundThemeBrush" Color="#FF5F37BE" />
             <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBorderThemeBrush" Color="#FF5F37BE" />
-            
-            <CornerRadius x:Key="ListViewItemCornerRadius">4</CornerRadius>
-            <CornerRadius x:Key="ListViewItemCheckBoxCornerRadius">3</CornerRadius>
+
             <CornerRadius x:Key="ListViewItemSelectionIndicatorCornerRadius">1.5</CornerRadius>
             <StaticResource x:Key="ListViewItemCheckPressedBrush" ResourceKey="TextOnAccentFillColorSecondaryBrush" />
             <StaticResource x:Key="ListViewItemCheckDisabledBrush" ResourceKey="TextOnAccentFillColorDisabledBrush" />
@@ -137,8 +135,6 @@
             <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBackgroundThemeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
             <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBorderThemeBrush" Color="{ThemeResource SystemColorHighlightColor}" />
 
-            <CornerRadius x:Key="ListViewItemCornerRadius">4</CornerRadius>
-            <CornerRadius x:Key="ListViewItemCheckBoxCornerRadius">3</CornerRadius>
             <CornerRadius x:Key="ListViewItemSelectionIndicatorCornerRadius">1.5</CornerRadius>
             <SolidColorBrush x:Key="ListViewItemCheckPressedBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
             <SolidColorBrush x:Key="ListViewItemCheckDisabledBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
@@ -214,8 +210,6 @@
             <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBackgroundThemeBrush" Color="#FF5F37BE" />
             <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBorderThemeBrush" Color="#FF5F37BE" />
 
-            <CornerRadius x:Key="ListViewItemCornerRadius">4</CornerRadius>
-            <CornerRadius x:Key="ListViewItemCheckBoxCornerRadius">3</CornerRadius>
             <CornerRadius x:Key="ListViewItemSelectionIndicatorCornerRadius">1.5</CornerRadius>
             <StaticResource x:Key="ListViewItemCheckPressedBrush" ResourceKey="TextOnAccentFillColorSecondaryBrush" />
             <StaticResource x:Key="ListViewItemCheckDisabledBrush" ResourceKey="TextOnAccentFillColorDisabledBrush" />
@@ -295,7 +289,7 @@
                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                         ContentMargin="{TemplateBinding Padding}"
                         CheckMode="{ThemeResource ListViewItemCheckMode}"
-                        CornerRadius='{ThemeResource ListViewItemCornerRadius}'
+                        CornerRadius='{ThemeResource ControlCornerRadius}'
                         CheckPressedBrush='{ThemeResource ListViewItemCheckPressedBrush}'
                         CheckDisabledBrush='{ThemeResource ListViewItemCheckDisabledBrush}'
                         CheckBoxPointerOverBrush='{ThemeResource ListViewItemCheckBoxPointerOverBrush}'
@@ -309,7 +303,7 @@
                         CheckBoxPointerOverBorderBrush='{ThemeResource ListViewItemCheckBoxPointerOverBorderBrush}'
                         CheckBoxPressedBorderBrush='{ThemeResource ListViewItemCheckBoxPressedBorderBrush}'
                         CheckBoxDisabledBorderBrush='{ThemeResource ListViewItemCheckBoxDisabledBorderBrush}'
-                        CheckBoxCornerRadius='{ThemeResource ListViewItemCheckBoxCornerRadius}'
+                        CheckBoxCornerRadius='{ThemeResource ControlCornerRadius}'
                         SelectionIndicatorCornerRadius='{ThemeResource ListViewItemSelectionIndicatorCornerRadius}'
                         SelectionIndicatorVisualEnabled='{ThemeResource ListViewItemSelectionIndicatorVisualEnabled}'
                         SelectionIndicatorBrush='{ThemeResource ListViewItemSelectionIndicatorBrush}'

--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -126,8 +126,8 @@
                             Opacity="0"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
-                            contract7Present:RadiusX="2"
-                            contract7Present:RadiusY="2"/>
+                            contract7Present:RadiusX="1.5"
+                            contract7Present:RadiusY="1.5"/>
 
 
                         <Grid x:Name="MultiSelectGrid" Padding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.Indentation}">


### PR DESCRIPTION
Deprecated CornerRadius resources specific to ComboBox, ListViewItem and GridViewItem, which could instead be done with OverlayCornerRadius or ControlsCornerRadius. All the other controls use those, rather than having their own resources.

Other fixes:
* TreeViewItem selection indicator now uses a 1.5px corner radius (like the other indicators)
* InkToolbar flyouts now use OverlayCornerRadius