### PR TITLE
Make TabView have an actual border

### DIFF
--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -28,7 +28,10 @@
 
                         <Grid x:Name="TabContainerGrid"
                                 Background="{TemplateBinding Background}"
-                                XYFocusKeyboardNavigation="Enabled">
+                                XYFocusKeyboardNavigation="Enabled"
+                                BorderBrush="{ThemeResource TabViewBorderBrush}"
+                                BorderThickness="0,0,0,1"
+                                contract7Present:BackgroundSizing="OuterBorderEdge">
 
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" x:Name="LeftContentColumn"/>
@@ -36,8 +39,6 @@
                                 <ColumnDefinition Width="Auto" x:Name="AddButtonColumn"/>
                                 <ColumnDefinition Width="*" x:Name="RightContentColumn"/>
                             </Grid.ColumnDefinitions>
-
-                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="1" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
 
                             <ContentPresenter
                                 Grid.Column="0"
@@ -48,6 +49,7 @@
                             <primitives:TabViewListView
                                 Grid.Column="1"
                                 x:Name="TabListView"
+                                Margin="0,0,0,-1"
                                 Padding="{TemplateBinding Padding}"
                                 CanReorderItems="{TemplateBinding CanReorderTabs}"
                                 CanDragItems="{TemplateBinding CanDragTabs}"


### PR DESCRIPTION
## Description
The TabView container used to have a border added on top of it, but now the border is part of the container itself. The border actually works like one, and the content inside will be adjusted automatically depending on the border thickness (though it's not yet customizable). The tab strip is dragged 1px below, so that tabs will overlap with the border as they used to.

## Motivation and Context
If you added content inside the TabView container, you needed to take into account the bottom border and adjust that content 1px up.
 
This will probably be more useful in the future, if the tab container becomes more customizable. You could make the container have a border on all sides with a custom thickness, rounded corners etc.

## How Has This Been Tested?
Manually