### PR TITLE
Add a MenuFlyoutItemTextTrimming Resource

### DIFF
--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -42,6 +42,7 @@
             <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
             <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
 
+            <TextTrimming x:Key="MenuFlyoutItemTextTrimming">Clip</TextTrimming>
             <Thickness x:Key="MenuFlyoutItemBorderThickness">0</Thickness>
             <Thickness x:Key="MenuFlyoutSubItemBorderThickness">0</Thickness>
 
@@ -128,6 +129,7 @@
             <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />
             <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">2</Thickness>
 
+            <TextTrimming x:Key="MenuFlyoutItemTextTrimming">Clip</TextTrimming>
             <Thickness x:Key="MenuFlyoutItemBorderThickness">0</Thickness>
             <Thickness x:Key="MenuFlyoutSubItemBorderThickness">0</Thickness>
 
@@ -214,6 +216,7 @@
             <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
             <Thickness x:Key="MenuFlyoutPresenterBorderThemeThickness">1</Thickness>
 
+            <TextTrimming x:Key="MenuFlyoutItemTextTrimming">Clip</TextTrimming>
             <Thickness x:Key="MenuFlyoutItemBorderThickness">0</Thickness>
             <Thickness x:Key="MenuFlyoutSubItemBorderThickness">0</Thickness>
 
@@ -432,7 +435,7 @@
                         </Viewbox>
                         <TextBlock x:Name="TextBlock"
                             Text="{TemplateBinding Text}"
-                            TextTrimming="Clip"
+                            TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                             Foreground="{TemplateBinding Foreground}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -574,7 +577,7 @@
                             x:Name="TextBlock"
                             Grid.Column="1"
                             Text="{TemplateBinding Text}"
-                            TextTrimming="Clip"
+                            TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                             Foreground="{TemplateBinding Foreground}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -710,7 +713,7 @@
                                 Grid.Column="0"
                                 Foreground="{TemplateBinding Foreground}"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             <FontIcon x:Name="SubItemChevron"
@@ -857,7 +860,7 @@
                         </Viewbox>
                         <TextBlock x:Name="TextBlock"
                             Text="{TemplateBinding Text}"
-                            TextTrimming="Clip"
+                            TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                             Foreground="{TemplateBinding Foreground}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1000,7 +1003,7 @@
                         <TextBlock x:Name="TextBlock"
                             Grid.Column="1"
                             Text="{TemplateBinding Text}"
-                            TextTrimming="Clip"
+                            TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                             Foreground="{TemplateBinding Foreground}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -1140,7 +1143,7 @@
                                 Grid.Column="0"
                                 Foreground="{TemplateBinding Foreground}"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             <FontIcon x:Name="SubItemChevron"

--- a/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
+++ b/dev/CommonStyles/TestUI/MenuFlyoutPage.xaml
@@ -122,6 +122,33 @@
                     </MenuFlyout>
                 </Button.Flyout>
             </Button>
+            <Button Content="NarrowWidthTextTrimming">
+                <Button.Flyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem Text="Share">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE72D;"/>
+                            </MenuFlyoutItem.Icon>
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator Key="S" Modifiers="Control"/>
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Text="Copy Super long so that we can see the TextClipping mode" Icon="Copy">
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator Key="C" Modifiers="Control"/>
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem Text="Delete" Icon="Delete">
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator Key="Delete" />
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutSeparator/>
+                        <MenuFlyoutItem Text="Rename"/>
+                        <MenuFlyoutItem Text="Select"/>
+                    </MenuFlyout>
+                </Button.Flyout>
+            </Button>
         </StackPanel>
 
         <Grid Grid.Column="1" Margin="20,0,0,0">

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs1_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs1_themeresources_v1.xaml
@@ -110,7 +110,7 @@
                             <TextBlock x:Name="TextBlock"
                                 Grid.Column="1"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 Foreground="{TemplateBinding Foreground}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs2_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs2_themeresources_v1.xaml
@@ -130,7 +130,7 @@
                             <TextBlock x:Name="TextBlock"
                                 Grid.Column="1"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 Foreground="{TemplateBinding Foreground}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
@@ -158,7 +158,7 @@
                             <TextBlock x:Name="TextBlock"
                                 Grid.Column="1"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 Foreground="{TemplateBinding Foreground}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
@@ -146,7 +146,7 @@
                             <TextBlock x:Name="TextBlock"
                                 Grid.Column="1"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 Foreground="{TemplateBinding Foreground}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
@@ -132,7 +132,7 @@
                             x:Name="TextBlock"
                             Grid.Column="1"
                             Text="{TemplateBinding Text}"
-                            TextTrimming="Clip"
+                            TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                             Foreground="{TemplateBinding Foreground}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
@@ -279,7 +279,7 @@
                                 Grid.Column="1"
                                 Foreground="{TemplateBinding Foreground}"
                                 Text="{TemplateBinding Text}"
-                                TextTrimming="Clip"
+                                TextTrimming="{ThemeResource MenuFlyoutItemTextTrimming}"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             <FontIcon x:Name="SubItemChevron"


### PR DESCRIPTION
To allow apps to override the text trimming behavior of MenuFlyoutItems. However, due to a bug in the platform with items in popups looking up resources, which we cannot fix means that the only place that this resource can be overwritten is within the XamlControlsResources.MergedDictionaries in your App.xaml:


                <controls:XamlControlsResources>
                    <controls:XamlControlsResources.MergedDictionaries>
                        <ResourceDictionary>
                            <TextTrimming x:Key="MenuFlyoutItemTextTrimming">CharacterEllipsis</TextTrimming>
                        </ResourceDictionary>
                    </controls:XamlControlsResources.MergedDictionaries>
                </controls:XamlControlsResources>
