### PR TITLE
Change Informational info badge styles to use a Neutral brush.

### DIFF
--- a/dev/InfoBadge/InfoBadge_themeresources.xaml
+++ b/dev/InfoBadge/InfoBadge_themeresources.xaml
@@ -124,7 +124,7 @@
     </Style>
 
     <Style TargetType="local:InfoBadge" x:Key="InformationalDotInfoBadgeStyle" BasedOn="{StaticResource DefaultInfoBadgeStyle}">
-        <Setter Property="Background" Value="{ThemeResource SystemFillColorAttentionBrush}"/>
+        <Setter Property="Background" Value="{ThemeResource SystemFillColorSolidNeutralBrush}"/>
     </Style>
 
     <Style TargetType="local:InfoBadge" x:Key="InformationalValueInfoBadgeStyle" BasedOn="{StaticResource InformationalDotInfoBadgeStyle}"/>


### PR DESCRIPTION
The informational info badge styles were incorrectly using an attention brush.

![image](https://user-images.githubusercontent.com/7758786/132900292-55c8c647-9b6a-48f9-9c0b-6a90fe08c7e7.png)
