### PR TITLE
Fix InfoBadge default high contrast background.

### DIFF
--- a/dev/InfoBadge/InfoBadge_themeresources.xaml
+++ b/dev/InfoBadge/InfoBadge_themeresources.xaml
@@ -40,7 +40,7 @@
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="InfoBadgeForeground" ResourceKey="SystemControlHighlightAltChromeWhiteBrush"/>
-            <StaticResource x:Key="InfoBadgeBackground" ResourceKey="AccentFillColorDefaultBrush"/>
+            <StaticResource x:Key="InfoBadgeBackground" ResourceKey="SystemControlHighlightAccentBrush"/>
 
             <x:Double x:Key="InfoBadgeMinHeight">4</x:Double>
             <x:Double x:Key="InfoBadgeMinWidth">4</x:Double>


### PR DESCRIPTION
PreviousValue was white on white. Updated value is appropriate.

![image](https://user-images.githubusercontent.com/7758786/133672206-2277f819-417b-4fe4-91f3-ddf13e9ae4ea.png)
