### PR TITLE
BaseWindowHandler fix in Materials/Backdrop/SystemBackdropWindowHandler

### DIFF
--- a/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
+++ b/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
@@ -51,36 +51,46 @@ namespace SystemBackdropComponentInternal
         m_capabilities = winrt::Windows::UI::Composition::CompositionCapabilities::GetForCurrentView();
         m_capabilitiesEventRevoker = { m_capabilities, m_capabilities.Changed([&](auto&&, auto&&)
             {
-                m_dispatcherQueue.TryEnqueue([&]()
-                    {
-                        if (m_capabilities.AreEffectsFast())
-                        {
-                            m_policy->SetIncompatibleGraphicsDevice(false);
-                        }
-                        else
-                        {
-                            m_policy->SetIncompatibleGraphicsDevice(true);
-                        }
+                auto capabilitiesWeakRef = winrt::make_weak(m_capabilities);
 
-                        ActivateOrDeactivateController();
+                m_dispatcherQueue.TryEnqueue([capabilitiesWeakRef, this]()
+                    {
+                        if (auto capabilities = capabilitiesWeakRef.get())
+                        {
+                            if (capabilities.AreEffectsFast())
+                            {
+                                m_policy->SetIncompatibleGraphicsDevice(false);
+                            }
+                            else
+                            {
+                                m_policy->SetIncompatibleGraphicsDevice(true);
+                            }
+
+                            ActivateOrDeactivateController();
+                        }
                     });
             }) };
 
         m_uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
         m_uiSettingsEventRevoker = m_uiSettings.AdvancedEffectsEnabledChanged(winrt::auto_revoke, [&](auto&&, auto&&)
             {
-                m_dispatcherQueue.TryEnqueue([&]()
-                    {
-                        if (m_uiSettings.AdvancedEffectsEnabled())
-                        {
-                            m_policy->SetTransparencyDisabled(false);
-                        }
-                        else
-                        {
-                            m_policy->SetTransparencyDisabled(true);
-                        }
+                auto uiSettingsWeakRef = winrt::make_weak(m_uiSettings);
 
-                        ActivateOrDeactivateController();
+                m_dispatcherQueue.TryEnqueue([uiSettingsWeakRef, this]()
+                    {
+                        if (auto uiSettings = uiSettingsWeakRef.get())
+                        {
+                            if (uiSettings.AdvancedEffectsEnabled())
+                            {
+                                m_policy->SetTransparencyDisabled(false);
+                            }
+                            else
+                            {
+                                m_policy->SetTransparencyDisabled(true);
+                            }
+
+                            ActivateOrDeactivateController();
+                        }
                     });
             });
     }


### PR DESCRIPTION
Fix for internal bug 34425302 - NULL_CLASS_PTR_READ_c0000005_Microsoft.UI.Xaml.dll!winrt::impl::consume_Windows_UI_ViewManagement_IUISettings4_winrt::Windows::UI::ViewManagement::UISettings_::AdvancedEffectsEnabled


1. Switch to System in dark mode
2. Enable taskbar to show touch keyboard (Settings app -> Personalization -> Taskbar -> Taskbar corner icons -> Enable touch keyboard) 
![image](https://user-images.githubusercontent.com/36547063/134071425-10a565e4-d85f-45fb-9e67-c7cfc313f6c1.png)
3. Launch touch keyboard from system tray
4. Go to Settings' Personalization -> Colors -> Transparency effects
![image](https://user-images.githubusercontent.com/36547063/134071489-765feed4-6216-4492-9aee-5463591bef00.png)
5. Toggle transparency effects on and off

Result: TextInputHost.exe crashes and SIP dismisses.

This was caused by a race condition where the m_uiSettings was disposed between the m_dispatcherQueue.TryEnqueue([&]() ... call and the m_uiSettings.AdvancedEffectsEnabled() async execution.

The fix is to use a weak reference to m_uiSettings in the asynchronous handler. I applied the same pattern to the similar m_capabilities case.

I overwrote the C:\Windows\SystemApps\Microsoft.UI.Xaml.CBS_8wekyb3d8bbwe\microsoft.ui.xaml.dll on my touch-capable laptop and the crash no longer repro'd.

