### PR TITLE
CommandBarFlyout crash fix

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyout.cpp
@@ -251,11 +251,14 @@ CommandBarFlyout::CommandBarFlyout()
                     args.Cancel(true);
 
                     commandBar->PlayCloseAnimation(
-                        [this]()
+                        [weakThis{ get_weak() }]()
                         {
-                            m_isClosingAfterCloseAnimation = true;
-                            Hide();
-                            m_isClosingAfterCloseAnimation = false;
+                            if (auto strongThis = weakThis.get())
+                            {
+                                strongThis->m_isClosingAfterCloseAnimation = true;
+                                strongThis->Hide();
+                                strongThis->m_isClosingAfterCloseAnimation = false;
+                            }
                         });
                 }
                 else


### PR DESCRIPTION
CommandBarFlyout fix for internal bug 35782367.

Crash dumps indicated that the Hide() call was causing a null ref exception. The call occurs when the closing animation completes. 
My assumption is that in rare cases the 'this' pointer is no longer valid by the time the closing animation completed and using a weak reference to the CommandBarFlyout instead solves the issue.  I have not been able to repro the crash though after trying to get the CommandBarFlyout to be garbage-collected before the Hide call. So I was not able to confirm my assumption.