### PR TITLE
Fix usage of WinUI 2.7+ in xaml islands C++ apps

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -33,6 +33,7 @@
   <PropertyGroup>
     <XamlWinmdName>Microsoft.UI.Xaml.winmd</XamlWinmdName>
     <XamlCompactXbfName>Microsoft.UI.Xaml\DensityStyles\Compact.xbf</XamlCompactXbfName>
+    <WebView2UseWinRT Condition="'$(WebView2UseWinRT)' ==''">true</WebView2UseWinRT>
   </PropertyGroup>
   <Target Name="_FixWinmdCopyLocal" AfterTargets="ResolveNuGetPackageAssets">
     <ItemGroup>


### PR DESCRIPTION
Fixes consumption of webview2 nuget package so winui can be used in xaml islands apps
Fixes #5793

## Description
Set the new flag we added for WV2 to reference/copy the WV2 winmd file. 

## Motivation and Context
This is necessary in xaml islands apps since WV2 otherwise relies on the app type being UAP, and also because WinUI's winmd now references the WV2 winmd, so this is necessary even if the xaml islands app does not use webview2.

## How Has This Been Tested?
Locally validated adding the property to microsoft.ui.xaml.targets does the trick

