### PR TITLE
Update/clean up WebView2 WinRT error strings

### DIFF
--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -24,6 +24,10 @@
 #include <uiautomationclient.h>
 #include <WebView2Interop.h>
 
+static constexpr wstring_view s_error_wv2_closed{ L"Cannot create CoreWebView2 for Closed WebView2 element."sv };
+static constexpr wstring_view s_error_cwv2_not_present{ L"Failed because a valid CoreWebView2 is not present. Make sure one was created, for example by calling EnsureCoreWebView2Async() API."sv };
+static constexpr wstring_view s_error_cwv2_not_present_closed{ L"Failed because a valid CoreWebView2 is not present. One existed, but has been closed."sv };
+
 WebView2::WebView2()
 {
     if (auto user32module = GetModuleHandleW(L"user32.dll"))
@@ -168,7 +172,7 @@ void WebView2::OnPropertyChanged(winrt::DependencyPropertyChangedEventArgs const
             }
             else
             {
-                throw winrt::hresult_error(RO_E_CLOSED, L"Cannot create CoreWebView2 (via Source) for Closed WebView2 element.");
+                throw winrt::hresult_error(RO_E_CLOSED, s_error_wv2_closed);
             }
         }
     }
@@ -466,7 +470,7 @@ winrt::IAsyncAction WebView2::OnSourceChanged(winrt::Uri providedUri)
         // Try to apply latest source (could have changed during the co_await's above)
         if (m_isClosed)
         {
-            throw winrt::hresult_error(RO_E_CLOSED, L"Cannot create CoreWebView2 (via Source) for Closed WebView2 element.");
+            throw winrt::hresult_error(RO_E_CLOSED, s_error_wv2_closed);
         }
         const auto updatedUri = this->Source();
         if (!updatedUri.Equals(providedUri) && ShouldNavigate(updatedUri))
@@ -662,7 +666,7 @@ winrt::IAsyncAction WebView2::CreateCoreObjects()
 
     if (m_isClosed)
     {
-        throw winrt::hresult_error(RO_E_CLOSED, L"Cannot create CoreWebView2 (via Source) for Closed WebView2 element.");
+        throw winrt::hresult_error(RO_E_CLOSED, s_error_wv2_closed);
     }
     else
     {
@@ -1537,7 +1541,7 @@ winrt::IAsyncOperation<winrt::hstring> WebView2::ExecuteScriptAsync(winrt::hstri
     }
     else
     {
-        throw winrt::hresult_illegal_method_call(L"ExecuteScriptAsync() failed because a valid CoreWebView2 is not present.");
+        throw winrt::hresult_illegal_method_call(std::wstring(L"ExecuteScriptAsync(): ").append(s_error_cwv2_not_present));
     }
 
     co_return returnedValue;
@@ -1630,11 +1634,11 @@ void WebView2::Reload()
     {
         if (m_everHadCoreWebView)
         {
-            throw winrt::hresult_illegal_method_call(L"Reload() failed because a valid CoreWebView2 is not present. (and never had a CoreWebView)");
+            throw winrt::hresult_illegal_method_call(std::wstring(L"Reload(): ").append(s_error_cwv2_not_present_closed));
         }
         else
         {
-            throw winrt::hresult_illegal_method_call(L"Reload() failed because a valid CoreWebView2 is not present. (unloaded core webview)");
+            throw winrt::hresult_illegal_method_call(std::wstring(L"Reload(): ").append(s_error_cwv2_not_present));
         }
     }
 }
@@ -1647,7 +1651,7 @@ void WebView2::NavigateToString(winrt::hstring htmlContent)
     }
     else
     {
-        throw winrt::hresult_illegal_method_call(L"NavigateToString() failed because a valid CoreWebView2 is not present.");
+        throw winrt::hresult_illegal_method_call(std::wstring(L"NavigateToString(): ").append(s_error_cwv2_not_present));
     }
 }
 


### PR DESCRIPTION
Updating the error strings included with the WinRT Originate Error that is thrown by WebView2 when a non-trigger API is called and there is no backing CoreWebView2 object. The new message gives more insight and suggests fix action.
Replace duplicated string literals with shared string_view constants as appropriate.
Fix swapped values when there was/wasn't a CoreWebView2 at some point.