### PR TITLE
Fixes visual glitch near the inner arcs of selected TabViewItems when scale is 150%

### DIFF
--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -639,9 +639,9 @@
                             x:Load="False"
                             Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
                             VerticalAlignment="Bottom"
-                            Margin="-4,0,0,0"
                             Visibility="Collapsed"
-                            Data="M0 4H4V0C4 2.20914 2.20914 4 0 4Z" />
+                            Margin="-4,0,-4,0"
+                            Data="M0 4H8V0H4C4 2.20914 2.20914 4 0 4Z" />
 
                         <Path x:Name="RightRadiusRenderArc"
                             x:Load="False"
@@ -660,8 +660,8 @@
                             Visibility="Collapsed"
                             Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
                             VerticalAlignment="Bottom"
-                            Margin="0,0,-4,0"
-                            Data="M4 4H0V0C0 2.20914 1.79086 4 4 4Z"/>
+                            Margin="-4,0,-4,0"
+                            Data="M8 4H0V0H4C4 2.20914 5.79086 4 8 4Z"/>
 
                         <Border x:Name="TabSeparator"
                             HorizontalAlignment="Right"


### PR DESCRIPTION
## Description
Selected TabViewItems are drawn with borders, that are connected by inner arc with bottom border. When scale is 150% there are visual glitches, as shown here:
![image](https://user-images.githubusercontent.com/34012295/135506738-29f6d960-4ac3-4e3a-9d6d-225432e9e588.png)

The reason is that at 150% border line position is somewhat rounded, as well as the position of the triangle that should cover and hide bottom part of it. This fix extends the shape of small covering 4x4 triangle into trapezoid by additional 4x4 rect on the inner side of tab, so that when border line width became rounded up it would still be covered. 

Idea of the fix:
![image](https://user-images.githubusercontent.com/34012295/135510568-9612390e-89c2-469b-b025-c6bd34a4ecff.png)

Screenshot with the fix
![image](https://user-images.githubusercontent.com/34012295/135508641-040e8e37-826a-402c-990c-eeaada17c6e4.png)

It is not important that additional rect is "so big" as 4x4, as TabViewItem.TabContainer is drawn above it, and at the same time TabViewItem.TabContainer.Border below it - this was tested by filling those small rectangles (actually trapezoids now) with red color - it does not leak past the border to inner part of the TabViewItem.TabContainer

