### PR TITLE
[ TreeView ] [ HC ] Style updates

### DIFF
--- a/dev/TreeView/TreeViewItem.xaml
+++ b/dev/TreeView/TreeViewItem.xaml
@@ -30,25 +30,46 @@
                         contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
-                                <VisualState x:Name="Normal"/>
-                                <VisualState x:Name="PointerOver">
+                                <VisualState x:Name="Normal">
+                                    <VisualState.Setters>
+                                        <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackground}" />
+                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForeground}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForeground}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForeground}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForeground}" />
+                                        <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrush}" />
+                                        <Setter Target="SelectionIndicator.Opacity" Value="0" />
+                                    </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="PointerOver">
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundPointerOver}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundPointerOver}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForegroundPointerOver}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundPointerOver}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundPointerOver}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushPointerOver}" />
+                                         <Setter Target="SelectionIndicator.Opacity" Value="0" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundPressed}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundPressed}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForegroundPressed}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundPressed}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundPressed}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushPressed}" />
+                                        <Setter Target="SelectionIndicator.Opacity" Value="0" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Selected">
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundSelected}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundSelected}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForeground}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelected}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelected}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushSelected}" />
                                         <Setter Target="SelectionIndicator.Opacity" Value="1" />
                                     </VisualState.Setters>
@@ -57,6 +78,9 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundDisabled}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundDisabled}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForegroundDisabled}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundDisabled}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundDisabled}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushDisabled}" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -64,6 +88,9 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundSelectedPointerOver}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedPointerOver}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForegroundPointerOver}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedPointerOver}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedPointerOver}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushSelectedPointerOver}" />
                                         <Setter Target="SelectionIndicator.Opacity" Value="1" />
                                     </VisualState.Setters>
@@ -72,6 +99,9 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundSelectedPressed}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedPressed}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForegroundPressed}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedPressed}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedPressed}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushSelectedPressed}" />
                                         <Setter Target="SelectionIndicator.Opacity" Value="1" />
                                     </VisualState.Setters>
@@ -80,7 +110,11 @@
                                     <VisualState.Setters>
                                         <Setter Target="ContentPresenterGrid.Background" Value="{ThemeResource TreeViewItemBackgroundSelectedDisabled}" />
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedDisabled}" />
+                                        <Setter Target="SelectionIndicator.Fill" Value="{ThemeResource TreeViewItemSelectionIndicatorForegroundDisabled}" />
+                                        <Setter Target="CollapsedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedDisabled}" />
+                                        <Setter Target="ExpandedGlyph.Foreground" Value="{ThemeResource TreeViewItemForegroundSelectedDisabled}" />
                                         <Setter Target="ContentPresenterGrid.BorderBrush" Value="{ThemeResource TreeViewItemBorderBrushSelectedDisabled}" />
+                                        <Setter Target="SelectionIndicator.Opacity" Value="1" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="ReorderedPlaceholder">
@@ -175,7 +209,8 @@
                                 Width="Auto"
                                 Opacity="{TemplateBinding GlyphOpacity}"
                                 Background="Transparent">
-                                <TextBlock Foreground="{TemplateBinding GlyphBrush}"
+                                <TextBlock x:Name="CollapsedGlyph"
+                                    Foreground="{TemplateBinding GlyphBrush}"
                                     Width="12"
                                     Height="12"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.CollapsedGlyphVisibility}"
@@ -187,7 +222,8 @@
                                     AutomationProperties.AccessibilityView="Raw"
                                     IsTextScaleFactorEnabled="False"
                                     IsHitTestVisible="False"/>
-                                <TextBlock Foreground="{TemplateBinding GlyphBrush}"
+                                <TextBlock x:Name="ExpandedGlyph"
+                                    Foreground="{TemplateBinding GlyphBrush}"
                                     Width="12"
                                     Height="12"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.ExpandedGlyphVisibility}" 

--- a/dev/TreeView/TreeView_themeresources.xaml
+++ b/dev/TreeView/TreeView_themeresources.xaml
@@ -15,6 +15,7 @@
             <StaticResource x:Key="TreeViewItemBackgroundSelectedPointerOver" ResourceKey="SubtleFillColorTertiaryBrush" />
             <StaticResource x:Key="TreeViewItemBackgroundSelectedPressed" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemBackgroundSelectedDisabled" ResourceKey="SubtleFillColorDisabledBrush" />
+            
             <StaticResource x:Key="TreeViewItemForeground" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
@@ -23,6 +24,7 @@
             <StaticResource x:Key="TreeViewItemForegroundSelectedPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundSelectedPressed" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundSelectedDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            
             <StaticResource x:Key="TreeViewItemBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
@@ -31,10 +33,15 @@
             <StaticResource x:Key="TreeViewItemBorderBrushSelectedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushSelectedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushSelectedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+            
             <StaticResource x:Key="TreeViewItemCheckBoxBackgroundSelected" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemCheckBoxBorderSelected" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemCheckGlyphSelected" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemSelectionIndicatorForeground" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundPointerOver" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundPressed" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
             <Thickness x:Key="TreeViewItemBorderThemeThickness">0</Thickness>
             <Thickness x:Key="TreeViewItemPresenterMargin">4,2</Thickness>
             <Thickness x:Key="TreeViewItemPresenterPadding">0,3,0,5</Thickness>
@@ -42,6 +49,7 @@
             <x:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">28</x:Double>
             <x:Double x:Key="TreeViewItemContentHeight">20</x:Double>
         </ResourceDictionary>
+        
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="TreeViewItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
@@ -51,6 +59,7 @@
             <StaticResource x:Key="TreeViewItemBackgroundSelectedPointerOver" ResourceKey="SubtleFillColorTertiaryBrush" />
             <StaticResource x:Key="TreeViewItemBackgroundSelectedPressed" ResourceKey="SubtleFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemBackgroundSelectedDisabled" ResourceKey="SubtleFillColorDisabledBrush" />
+            
             <StaticResource x:Key="TreeViewItemForeground" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
@@ -59,6 +68,7 @@
             <StaticResource x:Key="TreeViewItemForegroundSelectedPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundSelectedPressed" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemForegroundSelectedDisabled" ResourceKey="TextFillColorDisabledBrush" />
+            
             <StaticResource x:Key="TreeViewItemBorderBrush" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushPressed" ResourceKey="SubtleFillColorTransparentBrush" />
@@ -67,10 +77,15 @@
             <StaticResource x:Key="TreeViewItemBorderBrushSelectedPointerOver" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushSelectedPressed" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemBorderBrushSelectedDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+
             <StaticResource x:Key="TreeViewItemCheckBoxBackgroundSelected" ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TreeViewItemCheckBoxBorderSelected" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemCheckGlyphSelected" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TreeViewItemSelectionIndicatorForeground" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundPointerOver" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundPressed" ResourceKey="AccentFillColorDefaultBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+
             <Thickness x:Key="TreeViewItemBorderThemeThickness">0</Thickness>
             <Thickness x:Key="TreeViewItemPresenterMargin">4,2</Thickness>
             <Thickness x:Key="TreeViewItemPresenterPadding">0,3,0,5</Thickness>
@@ -78,36 +93,44 @@
             <x:Double x:Key="TreeViewItemMultiSelectCheckBoxMinHeight">28</x:Double>
             <x:Double x:Key="TreeViewItemContentHeight">20</x:Double>
         </ResourceDictionary>
+        
         <ResourceDictionary x:Key="HighContrast">
-            <StaticResource x:Key="TreeViewItemBackground" ResourceKey="SystemControlTransparentRevealBackgroundBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowRevealBackgroundBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumRevealBackgroundBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundSelected" ResourceKey="SystemControlHighlightAccent3RevealBackgroundBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightAccent2RevealBackgroundBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListMediumRevealBackgroundBrush" />
-            <StaticResource x:Key="TreeViewItemBackgroundSelectedDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <StaticResource x:Key="TreeViewItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundSelected" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundSelectedPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundSelectedPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="TreeViewItemForegroundSelectedDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrush" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushPointerOver" ResourceKey="SystemControlHighlightAltTransparentRevealBorderBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushPressed" ResourceKey="SystemControlHighlightAltTransparentRevealBorderBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushSelected" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushSelectedPointerOver" ResourceKey="SystemControlBackgroundTransparentRevealBorderBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushSelectedPressed" ResourceKey="SystemControlBackgroundTransparentRevealBorderBrush" />
-            <StaticResource x:Key="TreeViewItemBorderBrushSelectedDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <SolidColorBrush x:Key="TreeViewItemCheckBoxBackgroundSelected" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="TreeViewItemCheckBoxBorderSelected" Color="{ThemeResource SystemColorButtonTextColor}" />
-            <SolidColorBrush x:Key="TreeViewItemCheckGlyphSelected" Color="{ThemeResource SystemColorWindowTextColor}" />
-            <StaticResource x:Key="TreeViewItemSelectionIndicatorForeground" ResourceKey="SystemColorHighlightTextColor" />
-            <Thickness x:Key="TreeViewItemBorderThemeThickness">0</Thickness>
+            <StaticResource x:Key="TreeViewItemBackground" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundPressed" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundDisabled" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundSelected" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundSelectedPointerOver" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundSelectedPressed" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TreeViewItemBackgroundSelectedDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+
+            <StaticResource x:Key="TreeViewItemForeground" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundPointerOver" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundSelected" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundSelectedPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundSelectedPressed" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemForegroundSelectedDisabled" ResourceKey="SystemColorWindowColorBrush" />
+
+            <StaticResource x:Key="TreeViewItemBorderBrush" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushPressed" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushDisabled" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushSelected" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushSelectedPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushSelectedPressed" ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TreeViewItemBorderBrushSelectedDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+            
+            <StaticResource x:Key="TreeViewItemCheckBoxBackgroundSelected" ResourceKey="SystemColorWindowColor}" />
+            <StaticResource x:Key="TreeViewItemCheckBoxBorderSelected" ResourceKey="SystemColorButtonTextColor}" />
+            <StaticResource x:Key="TreeViewItemCheckGlyphSelected" ResourceKey="SystemColorWindowTextColor}" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForeground" ResourceKey="SystemColorHighlightColor" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundPointerOver" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundPressed" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TreeViewItemSelectionIndicatorForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+
+            <Thickness x:Key="TreeViewItemBorderThemeThickness">1</Thickness>
             <Thickness x:Key="TreeViewItemPresenterMargin">4,2</Thickness>
             <Thickness x:Key="TreeViewItemPresenterPadding">0,3,0,5</Thickness>
             <x:Double x:Key="TreeViewItemMinHeight">28</x:Double>


### PR DESCRIPTION
Fixing a bug where the indicator pill and the chevron both didnt change color on HC interactive states.
Adding states and brushes for indicator and chevron as appropriate.
Update the all up tree view item HC styles.
![TreeView](https://user-images.githubusercontent.com/29714167/135701031-45b015be-a12d-40b7-a587-b5e5f1a7882d.png)

https://user-images.githubusercontent.com/29714167/135701042-9f574805-0e12-4d17-aa19-e776c8d3e9d8.mp4



