### PR TITLE
Add ExpanderToggleButton Children to Peer

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -597,6 +597,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Expander_TestUI", "dev\Expa
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Expander_InteractionTests", "dev\Expander\InteractionTests\Expander_InteractionTests.shproj", "{D6DF4AB9-FACC-4E51-8C57-6B1F96919365}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Expander_APITests", "dev\Expander\APITests\Expander_APITests.shproj", "{0589A608-FB9C-49BF-9EA3-06CA805F3A9D}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "InfoBar", "InfoBar", "{CEFD707F-6686-4CF4-8D4C-B5FECD50D739}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InfoBar", "dev\InfoBar\InfoBar.vcxitems", "{CCC102B7-F5EF-479D-94F1-008D189448B1}"
@@ -681,6 +683,7 @@ Global
 		dev\ParallaxView\TestUI\ParallaxView_TestUI.projitems*{00c52fd5-42fd-33b4-84a0-795c9b5a014d}*SharedItemsImports = 13
 		dev\lights\ApiTests\Lights_ApiTests\Lights_ApiTests.projitems*{02ed27be-97e4-4327-bb96-8b3fa6869c48}*SharedItemsImports = 13
 		dev\RadioButtons\APITests\RadioButtons_APITests.projitems*{0352711a-d79a-4d82-8255-916d29522ae0}*SharedItemsImports = 13
+		dev\Expander\APITests\Expander_APITests.projitems*{0589a608-fb9c-49bf-9ea3-06ca805f3a9d}*SharedItemsImports = 13
 		dev\Telemetry\Telemetry.vcxitems*{0db22ba9-6053-459b-baf5-e82ea1c78ab3}*SharedItemsImports = 9
 		dev\ScrollPresenter\TestUI\ScrollPresenter_TestUI.projitems*{0ec52fd5-42fe-3eb4-84e0-79ec9b5a014e}*SharedItemsImports = 13
 		dev\ProgressBar\ProgressBar.vcxitems*{0f61c8bd-d066-4812-a02b-e95ce18a985d}*SharedItemsImports = 9
@@ -913,6 +916,7 @@ Global
 		dev\CommonStyles\APITests\CommonStyles_ApiTests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\CommonStyles\TestUI\CommonStyles_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\DropDownButton\TestUI\DropDownButton_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
+		dev\Expander\APITests\Expander_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\Expander\TestUI\Expander_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\IconSource\APITests\IconSource_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\ImageIcon\APITests\ImageIcon_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
@@ -1014,6 +1018,7 @@ Global
 		dev\CommonStyles\APITests\CommonStyles_ApiTests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\CommonStyles\TestUI\CommonStyles_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\DropDownButton\TestUI\DropDownButton_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
+		dev\Expander\APITests\Expander_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\Expander\TestUI\Expander_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\IconSource\APITests\IconSource_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\ImageIcon\APITests\ImageIcon_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
@@ -1644,6 +1649,7 @@ Global
 		{EC3B6F65-32C6-4BC8-8902-EE0B397E2787} = {84BB4F12-73FD-4E4A-8724-C2C060DF5E82}
 		{50C1F1D3-20AA-49A8-9E4C-CF4E5811A1D8} = {84BB4F12-73FD-4E4A-8724-C2C060DF5E82}
 		{D6DF4AB9-FACC-4E51-8C57-6B1F96919365} = {84BB4F12-73FD-4E4A-8724-C2C060DF5E82}
+		{0589A608-FB9C-49BF-9EA3-06CA805F3A9D} = {84BB4F12-73FD-4E4A-8724-C2C060DF5E82}
 		{CEFD707F-6686-4CF4-8D4C-B5FECD50D739} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
 		{CCC102B7-F5EF-479D-94F1-008D189448B1} = {CEFD707F-6686-4CF4-8D4C-B5FECD50D739}
 		{32DFAF1E-C2EC-4C52-A4D8-B3A3946242B4} = {CEFD707F-6686-4CF4-8D4C-B5FECD50D739}

--- a/dev/Expander/APITests/ExpanderTests.cs
+++ b/dev/Expander/APITests/ExpanderTests.cs
@@ -12,6 +12,7 @@ using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Shapes;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Controls;
+
 #if USING_TAEF
 using WEX.TestExecution;
 using WEX.TestExecution.Markup;
@@ -60,19 +61,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var toggleButtonGrid = VisualTreeHelper.GetChild(toggleButton, 0);
                 var contentPresenter = VisualTreeHelper.GetChild(toggleButtonGrid, 0);
                 var stackPanel = VisualTreeHelper.GetChild(contentPresenter, 0);
-                var textBlock1 = VisualTreeHelper.GetChild(stackPanel, 0) as TextBlock;
-                var textBlock2 = VisualTreeHelper.GetChild(stackPanel, 1) as TextBlock;
+                var textBlock1 = expander.FindVisualChildByName("This expander is expanded by default.") as TextBlock;
+                var textBlock2 = expander.FindVisualChildByName("This is the second line of text.") as TextBlock;
 
                 var border = VisualTreeHelper.GetChild(grid, 1);
                 var expanderContentBorder = VisualTreeHelper.GetChild(border, 0);
                 var expanderContentContentPresenter = VisualTreeHelper.GetChild(expanderContentBorder, 0);
-                var button = VisualTreeHelper.GetChild(expanderContentContentPresenter, 0) as Button;
+                var button = expander.FindVisualChildByName("Content") as Button;
 
                 Verify.AreEqual("ExpandedExpander", AutomationProperties.GetName(expander));
 
                 // Verify ExpandedExpander header content AutomationProperties.Name properties are set
-                Verify.AreEqual("This expander is expanded by default.", AutomationProperties.GetName(textBlock1));
-                Verify.AreEqual("This is the second line of text.", AutomationProperties.GetName(textBlock2));
+                Verify.IsNotNull(textBlock1);
+                Verify.IsNotNull(textBlock2);
 
                 // Verify ExpandedExpander content AutomationProperties.Name property is set
                 Verify.AreEqual("Content", AutomationProperties.GetName(button));

--- a/dev/Expander/APITests/ExpanderTests.cs
+++ b/dev/Expander/APITests/ExpanderTests.cs
@@ -61,19 +61,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var toggleButtonGrid = VisualTreeHelper.GetChild(toggleButton, 0);
                 var contentPresenter = VisualTreeHelper.GetChild(toggleButtonGrid, 0);
                 var stackPanel = VisualTreeHelper.GetChild(contentPresenter, 0);
-                var textBlock1 = expander.FindVisualChildByName("This expander is expanded by default.") as TextBlock;
-                var textBlock2 = expander.FindVisualChildByName("This is the second line of text.") as TextBlock;
+                var textBlock1 = VisualTreeHelper.GetChild(stackPanel, 0) as TextBlock;
+                var textBlock2 = VisualTreeHelper.GetChild(stackPanel, 1) as TextBlock;
 
                 var border = VisualTreeHelper.GetChild(grid, 1);
                 var expanderContentBorder = VisualTreeHelper.GetChild(border, 0);
                 var expanderContentContentPresenter = VisualTreeHelper.GetChild(expanderContentBorder, 0);
-                var button = expander.FindVisualChildByName("Content") as Button;
+                var button = VisualTreeHelper.GetChild(expanderContentContentPresenter, 0) as Button;
 
                 Verify.AreEqual("ExpandedExpander", AutomationProperties.GetName(expander));
 
                 // Verify ExpandedExpander header content AutomationProperties.Name properties are set
-                Verify.IsNotNull(textBlock1);
-                Verify.IsNotNull(textBlock2);
+                Verify.AreEqual("This expander is expanded by default.", AutomationProperties.GetName(textBlock1));
+                Verify.AreEqual("This is the second line of text.", AutomationProperties.GetName(textBlock2));
 
                 // Verify ExpandedExpander content AutomationProperties.Name property is set
                 Verify.AreEqual("Content", AutomationProperties.GetName(button));

--- a/dev/Expander/APITests/ExpanderTests.cs
+++ b/dev/Expander/APITests/ExpanderTests.cs
@@ -39,10 +39,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                              xmlns:controls='using:Microsoft.UI.Xaml.Controls'> 
                              <controls:Expander x:Name ='ExpandedExpander' AutomationProperties.Name='ExpandedExpander' IsExpanded='True' Margin='12' HorizontalAlignment='Left'>
                                 <controls:Expander.Header>
-                                    <StackPanel Margin='0,14,0,16'>
-                                        <TextBlock AutomationProperties.Name='test' Text='This expander is expanded by default.'  Margin='0,0,0,4' />
-                                        <TextBlock Text='This is the second line of text.' />
-                                    </StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition />
+                                            <ColumnDefinition Width='80'/>
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Margin='0,14,0,16'>
+                                            <TextBlock AutomationProperties.Name='test' Text='This expander is expanded by default.'  Margin='0,0,0,4' />
+                                            <TextBlock Text='This is the second line of text.' />
+                                        </StackPanel>
+                                        <ToggleSwitch Grid.Column='1'/>
+                                    </Grid>
                                 </controls:Expander.Header>
                                 <Button AutomationProperties.AutomationId = 'ExpandedExpanderContent'> Content </Button>
                              </controls:Expander>
@@ -60,9 +67,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 var toggleButton = VisualTreeHelper.GetChild(grid, 0);
                 var toggleButtonGrid = VisualTreeHelper.GetChild(toggleButton, 0);
                 var contentPresenter = VisualTreeHelper.GetChild(toggleButtonGrid, 0);
-                var stackPanel = VisualTreeHelper.GetChild(contentPresenter, 0);
+                var grid2 = VisualTreeHelper.GetChild(contentPresenter, 0);
+                var stackPanel = VisualTreeHelper.GetChild(grid2, 0);
                 var textBlock1 = VisualTreeHelper.GetChild(stackPanel, 0) as TextBlock;
                 var textBlock2 = VisualTreeHelper.GetChild(stackPanel, 1) as TextBlock;
+                var toggleSwitch = VisualTreeHelper.GetChild(grid2, 1) as ToggleSwitch;
 
                 var border = VisualTreeHelper.GetChild(grid, 1);
                 var expanderContentBorder = VisualTreeHelper.GetChild(border, 0);
@@ -74,6 +83,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 // Verify ExpandedExpander header content are included in the accessibility tree
                 Verify.AreEqual(AutomationProperties.GetAccessibilityView(textBlock1), AccessibilityView.Content);
                 Verify.AreEqual(AutomationProperties.GetAccessibilityView(textBlock2), AccessibilityView.Content);
+                Verify.AreEqual(AutomationProperties.GetAccessibilityView(toggleSwitch), AccessibilityView.Content);
 
                 // Verify ExpandedExpander content is included in the accessibility tree
                 Verify.AreEqual(AutomationProperties.GetAccessibilityView(button), AccessibilityView.Content);

--- a/dev/Expander/APITests/ExpanderTests.cs
+++ b/dev/Expander/APITests/ExpanderTests.cs
@@ -40,7 +40,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                              <controls:Expander x:Name ='ExpandedExpander' AutomationProperties.Name='ExpandedExpander' IsExpanded='True' Margin='12' HorizontalAlignment='Left'>
                                 <controls:Expander.Header>
                                     <StackPanel Margin='0,14,0,16'>
-                                        <TextBlock Text='This expander is expanded by default.'  Margin='0,0,0,4' />
+                                        <TextBlock AutomationProperties.Name='test' Text='This expander is expanded by default.'  Margin='0,0,0,4' />
                                         <TextBlock Text='This is the second line of text.' />
                                     </StackPanel>
                                 </controls:Expander.Header>
@@ -71,18 +71,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
                 Verify.AreEqual("ExpandedExpander", AutomationProperties.GetName(expander));
 
-                // Verify ExpandedExpander header content AutomationProperties.Name properties are set
-                Verify.AreEqual("This expander is expanded by default.", AutomationProperties.GetName(textBlock1));
-                Verify.AreEqual("This is the second line of text.", AutomationProperties.GetName(textBlock2));
+                // Verify ExpandedExpander header content are included in the accessibility tree
+                Verify.AreEqual(AutomationProperties.GetAccessibilityView(textBlock1), AccessibilityView.Content);
+                Verify.AreEqual(AutomationProperties.GetAccessibilityView(textBlock2), AccessibilityView.Content);
 
-                // Verify ExpandedExpander content AutomationProperties.Name property is set
-                Verify.AreEqual("Content", AutomationProperties.GetName(button));
+                // Verify ExpandedExpander content is included in the accessibility tree
+                Verify.AreEqual(AutomationProperties.GetAccessibilityView(button), AccessibilityView.Content);
 
                 expander.IsExpanded = false;
                 Content.UpdateLayout();
 
-                // Verify ExpandedExpander content AutomationProperties.Name property is not visible once collapsed
-                Verify.AreNotEqual("Content", AutomationProperties.GetName(button));
+                // Verify ExpandedExpander content is not included in the accessibility tree and not readable once collapsed
+                Verify.AreNotEqual(AutomationProperties.GetAccessibilityView(button), AccessibilityView.Raw);
             });
         }
     }

--- a/dev/Expander/APITests/ExpanderTests.cs
+++ b/dev/Expander/APITests/ExpanderTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Common;
+using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp.Utilities;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Shapes;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Controls;
+#if USING_TAEF
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+using WEX.Logging.Interop;
+#else
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
+#endif
+
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
+{
+    [TestClass]
+    public class ExpanderTests : ApiTestBase
+    {
+        [TestMethod]
+        public void ExpanderAutomationPeerTest()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var root = (StackPanel)XamlReader.Load(
+    @"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' 
+                             xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                             xmlns:primitives='using:Microsoft.UI.Xaml.Controls.Primitives'
+                             xmlns:controls='using:Microsoft.UI.Xaml.Controls'> 
+                             <controls:Expander x:Name ='ExpandedExpander' AutomationProperties.Name='ExpandedExpander' IsExpanded='True' Margin='12' HorizontalAlignment='Left'>
+                                <controls:Expander.Header>
+                                    <StackPanel Margin='0,14,0,16'>
+                                        <TextBlock Text='This expander is expanded by default.'  Margin='0,0,0,4' />
+                                        <TextBlock Text='This is the second line of text.' />
+                                    </StackPanel>
+                                </controls:Expander.Header>
+                                <Button AutomationProperties.AutomationId = 'ExpandedExpanderContent'> Content </Button>
+                             </controls:Expander>
+                                    </StackPanel>");
+
+                Content = root;
+                Content.UpdateLayout();
+
+                var expander = VisualTreeHelper.GetChild(root, 0) as Expander;
+
+                expander.IsExpanded = true;
+                Content.UpdateLayout();
+
+                var grid = VisualTreeHelper.GetChild(expander, 0);
+                var toggleButton = VisualTreeHelper.GetChild(grid, 0);
+                var toggleButtonGrid = VisualTreeHelper.GetChild(toggleButton, 0);
+                var contentPresenter = VisualTreeHelper.GetChild(toggleButtonGrid, 0);
+                var stackPanel = VisualTreeHelper.GetChild(contentPresenter, 0);
+                var textBlock1 = VisualTreeHelper.GetChild(stackPanel, 0) as TextBlock;
+                var textBlock2 = VisualTreeHelper.GetChild(stackPanel, 1) as TextBlock;
+
+                var border = VisualTreeHelper.GetChild(grid, 1);
+                var expanderContentBorder = VisualTreeHelper.GetChild(border, 0);
+                var expanderContentContentPresenter = VisualTreeHelper.GetChild(expanderContentBorder, 0);
+                var button = VisualTreeHelper.GetChild(expanderContentContentPresenter, 0) as Button;
+
+                Verify.AreEqual("ExpandedExpander", AutomationProperties.GetName(expander));
+
+                // Verify ExpandedExpander header content AutomationProperties.Name properties are set
+                Verify.AreEqual("This expander is expanded by default.", AutomationProperties.GetName(textBlock1));
+                Verify.AreEqual("This is the second line of text.", AutomationProperties.GetName(textBlock2));
+
+                // Verify ExpandedExpander content AutomationProperties.Name property is set
+                Verify.AreEqual("Content", AutomationProperties.GetName(button));
+
+                expander.IsExpanded = false;
+                Content.UpdateLayout();
+
+                // Verify ExpandedExpander content AutomationProperties.Name property is not visible once collapsed
+                Verify.AreNotEqual("Content", AutomationProperties.GetName(button));
+            });
+        }
+    }
+}

--- a/dev/Expander/APITests/Expander_APITests.projitems
+++ b/dev/Expander/APITests/Expander_APITests.projitems
@@ -1,0 +1,8 @@
+﻿using System;
+
+public class Class1
+{
+	public Class1()
+	{
+	}
+}

--- a/dev/Expander/APITests/Expander_APITests.projitems
+++ b/dev/Expander/APITests/Expander_APITests.projitems
@@ -1,8 +1,14 @@
-﻿using System;
-
-public class Class1
-{
-	public Class1()
-	{
-	}
-}
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>0589A608-FB9C-49BF-9EA3-06CA805F3A9D</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Expander_APITests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ExpanderTests.cs" />
+  </ItemGroup>
+</Project>

--- a/dev/Expander/APITests/Expander_APITests.shproj
+++ b/dev/Expander/APITests/Expander_APITests.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>0589A608-FB9C-49BF-9EA3-06CA805F3A9D</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Expander_APITests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/dev/Expander/APITests/Expander_APITests.testsettings
+++ b/dev/Expander/APITests/Expander_APITests.testsettings
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TestSettings
+  id="b924e60c-07ac-4b08-bf83-82852801b90b"
+  name="Expander_APITests"
+  enableDefaultDataCollectors="false"
+  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Description><!--_locID_text="Description1"-->These are default test settings for a local test run.</Description>
+  <Deployment enabled="false" />
+</TestSettings>

--- a/dev/Expander/ExpanderAutomationPeer.cpp
+++ b/dev/Expander/ExpanderAutomationPeer.cpp
@@ -107,9 +107,9 @@ winrt::IVector<winrt::AutomationPeer> ExpanderAutomationPeer::GetChildrenCore()
         {
             // If it is ExpanderToggleButton, we want to exclude it but add its children into the peer 
             auto expanderToggleButtonChildrenPeers = peer.GetChildrenCore();
-            for (auto peer : expanderToggleButtonChildrenPeers)
+            for (auto expanderHeaderPeer : expanderToggleButtonChildrenPeers)
             {
-                peers.Append(peer);
+                peers.Append(expanderHeaderPeer);
             }
         }
     }

--- a/dev/Expander/ExpanderAutomationPeer.cpp
+++ b/dev/Expander/ExpanderAutomationPeer.cpp
@@ -103,6 +103,15 @@ winrt::IVector<winrt::AutomationPeer> ExpanderAutomationPeer::GetChildrenCore()
         {
             peers.Append(peer);
         }
+        else
+        {
+            // If it is ExpanderToggleButton, we want to exclude it but add its children into the peer 
+            auto expanderToggleButtonChildrenPeers = peer.GetChildrenCore();
+            for (auto peer : expanderToggleButtonChildrenPeers)
+            {
+                peers.Append(peer);
+            }
+        }
     }
 
     return peers;

--- a/dev/Expander/Expander_themeresources.xaml
+++ b/dev/Expander/Expander_themeresources.xaml
@@ -348,8 +348,7 @@
                             ContentTransitions="{TemplateBinding ContentTransitions}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Foreground="{TemplateBinding Foreground}"
-                            AutomationProperties.AccessibilityView="Raw">
+                            Foreground="{TemplateBinding Foreground}">
                         </ContentPresenter>
 
                         <Border
@@ -620,8 +619,7 @@
                             ContentTransitions="{TemplateBinding ContentTransitions}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Foreground="{TemplateBinding Foreground}"
-                            AutomationProperties.AccessibilityView="Raw">
+                            Foreground="{TemplateBinding Foreground}">
                         </ContentPresenter>
 
                         <Border

--- a/dev/Expander/InteractionTests/ExpanderTests.cs
+++ b/dev/Expander/InteractionTests/ExpanderTests.cs
@@ -160,5 +160,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(expander.ExpandCollapseState, ExpandCollapseState.Expanded);
             }
         }
+
+        [TestMethod]
+        public void AutomationPeerTest()
+        {
+            using (var setup = new TestSetupHelper("Expander Tests"))
+            {
+                Expander expander = FindElement.ByName<Expander>("ExpanderWithToggleSwitch");
+                expander.SetFocus();
+                Wait.ForIdle();
+
+                // Verify ExpandedExpander header content AutomationProperties.Name properties are set
+                VerifyElement.Found("This expander with ToggleSwitch is expanded by default.", FindBy.Name);
+                VerifyElement.Found("This is the second line of text.", FindBy.Name);
+                VerifyElement.Found("SettingsToggleSwitch", FindBy.Name);
+
+                // Verify ExpandedExpander content AutomationProperties.Name property is set
+                VerifyElement.Found("ExpanderWithToggleSwitch Content", FindBy.Name);
+
+                Log.Comment("Collapse using keyboard space key.");
+                KeyboardHelper.PressKey(Key.Space);
+                Verify.AreEqual(expander.ExpandCollapseState, ExpandCollapseState.Collapsed);
+
+                // Verify ExpandedExpander content AutomationProperties.Name property is not visible once collapsed
+                VerifyElement.NotFound("ExpanderWithToggleSwitch Content", FindBy.Name);
+            }
+        }
     }
 }

--- a/dev/Expander/InteractionTests/ExpanderTests.cs
+++ b/dev/Expander/InteractionTests/ExpanderTests.cs
@@ -160,30 +160,5 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(expander.ExpandCollapseState, ExpandCollapseState.Expanded);
             }
         }
-
-        [TestMethod]
-        public void AutomationPeerTest()
-        {
-            using (var setup = new TestSetupHelper("Expander Tests"))
-            {
-                Expander expander = FindElement.ByName<Expander>("ExpandedExpander");
-                expander.SetFocus();
-                Wait.ForIdle();
-
-                // Verify ExpandedExpander header content AutomationProperties.Name properties are set
-                VerifyElement.Found("This expander is expanded by default.", FindBy.Name);
-                VerifyElement.Found("This is the second line of text.", FindBy.Name);
-
-                // Verify ExpandedExpander content AutomationProperties.Name property is set
-                VerifyElement.Found("Content", FindBy.Name);
-
-                Log.Comment("Collapse using keyboard space key.");
-                KeyboardHelper.PressKey(Key.Space);
-                Verify.AreEqual(expander.ExpandCollapseState, ExpandCollapseState.Collapsed);
-
-                // Verify ExpandedExpander content AutomationProperties.Name property is not visible once collapsed
-                VerifyElement.NotFound("Content", FindBy.Name);
-            }
-        }
     }
 }

--- a/dev/Expander/InteractionTests/ExpanderTests.cs
+++ b/dev/Expander/InteractionTests/ExpanderTests.cs
@@ -160,5 +160,30 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.AreEqual(expander.ExpandCollapseState, ExpandCollapseState.Expanded);
             }
         }
+
+        [TestMethod]
+        public void AutomationPeerTest()
+        {
+            using (var setup = new TestSetupHelper("Expander Tests"))
+            {
+                Expander expander = FindElement.ByName<Expander>("ExpandedExpander");
+                expander.SetFocus();
+                Wait.ForIdle();
+
+                // Verify ExpandedExpander header content AutomationProperties.Name properties are set
+                VerifyElement.Found("This expander is expanded by default.", FindBy.Name);
+                VerifyElement.Found("This is the second line of text.", FindBy.Name);
+
+                // Verify ExpandedExpander content AutomationProperties.Name property is set
+                VerifyElement.Found("Content", FindBy.Name);
+
+                Log.Comment("Collapse using keyboard space key.");
+                KeyboardHelper.PressKey(Key.Space);
+                Verify.AreEqual(expander.ExpandCollapseState, ExpandCollapseState.Collapsed);
+
+                // Verify ExpandedExpander content AutomationProperties.Name property is not visible once collapsed
+                VerifyElement.NotFound("Content", FindBy.Name);
+            }
+        }
     }
 }

--- a/dev/Expander/TestUI/ExpanderPage.xaml
+++ b/dev/Expander/TestUI/ExpanderPage.xaml
@@ -91,6 +91,25 @@
                     <TextBlock TextWrapping="Wrap">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id lacinia tellus. Integer eu mollis leo, ornare ultricies neque. Sed diam lectus, varius sed justo vel, malesuada condimentum lorem. Proin porttitor quis enim a facilisis. Suspendisse vehicula imperdiet egestas. Suspendisse imperdiet, ipsum in commodo cursus, mi nisl volutpat nulla, in interdum mi nulla a nulla. Cras feugiat odio ac eros ullamcorper suscipit. Praesent ultricies ligula eget efficitur tristique. Donec imperdiet ultrices dolor sollicitudin bibendum. In hac habitasse platea dictumst. Fusce vel lacinia purus. Sed tempor est sed suscipit luctus. Aenean laoreet tellus vitae efficitur scelerisque. Sed suscipit risus ac nisl rhoncus hendrerit.</TextBlock>
                 </ScrollViewer>
             </controls:Expander>
+
+            <controls:Expander x:Name ="ExpanderWithToggleSwitch" AutomationProperties.Name="ExpanderWithToggleSwitch" IsExpanded="True" Margin="12" HorizontalAlignment="Left">
+                <controls:Expander.Header>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="80"/>
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Margin="0,14,24,16">
+                            <TextBlock Text="This expander is expanded by default."  Margin="0,0,0,4"/>
+                            <TextBlock Text="This is the second line of text." Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        </StackPanel>
+                        <ToggleSwitch Grid.Column="1"/>
+                    </Grid>
+                    
+                </controls:Expander.Header>
+                <Button AutomationProperties.AutomationId="ExpandedExpanderContent">Content</Button>
+            </controls:Expander>
             
         </StackPanel>
 

--- a/dev/Expander/TestUI/ExpanderPage.xaml
+++ b/dev/Expander/TestUI/ExpanderPage.xaml
@@ -101,14 +101,14 @@
                         </Grid.ColumnDefinitions>
 
                         <StackPanel Margin="0,14,24,16">
-                            <TextBlock Text="This expander is expanded by default."  Margin="0,0,0,4"/>
+                            <TextBlock Text="This expander with ToggleSwitch is expanded by default."  Margin="0,0,0,4"/>
                             <TextBlock Text="This is the second line of text." Style="{StaticResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                         </StackPanel>
-                        <ToggleSwitch Grid.Column="1"/>
+                        <ToggleSwitch AutomationProperties.Name="SettingsToggleSwitch" Grid.Column="1"/>
                     </Grid>
                     
                 </controls:Expander.Header>
-                <Button AutomationProperties.AutomationId="ExpandedExpanderContent">Content</Button>
+                <Button AutomationProperties.AutomationId="ExpandedExpanderContent">ExpanderWithToggleSwitch Content</Button>
             </controls:Expander>
             
         </StackPanel>

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.targets
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.targets
@@ -75,6 +75,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\RadialGradientBrush\TestUI\RadialGradientBrush_TestUI.projitems" Label="Shared" Condition="$(FeatureRadialGradientBrushEnabled) == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\InfoBar\TestUI\InfoBar_TestUI.projitems" Label="Shared" Condition="$(FeatureInfoBarEnabled) == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\Expander\TestUI\Expander_TestUI.projitems" Label="Shared" Condition="$(FeatureExpanderEnabled) == 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\Expander\APITests\Expander_APITests.projitems" Label="Shared" Condition="$(FeatureExpanderEnabled) == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\PagerControl\TestUI\PagerControl_TestUI.projitems" Label="Shared" Condition="$(FeaturePagerControlEnabled) == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\PagerControl\APITests\PagerControl_APITests.projitems" Label="Shared" Condition="$(FeaturePagerControlEnabled) == 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\dev\Breadcrumb\TestUI\Breadcrumb_TestUI.projitems" Label="Shared" Condition="$(FeatureBreadcrumbEnabled) == 'true'" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Expander header content was unreadable by the navigator. 

Its children is now added to the peer so it shows up in the accessibility tree and can be read.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #5820 and internal bug: 35347574, and 35448193

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
![image](https://user-images.githubusercontent.com/7976322/135932691-d30cf514-27b1-47ab-9c3a-68d4f063fe2e.png)
