### PR TITLE
Fix CBS Vpack to handle WebView2

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -3,8 +3,8 @@ parameters:
 
 jobs:
 - job: CreateVPack
-  dependsOn:
-    - ${{ parameters.dependsOn }}
+  # dependsOn:
+  #   - ${{ parameters.dependsOn }}
   pool:
     name: WinDevPool-S
   variables:

--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -3,8 +3,8 @@ parameters:
 
 jobs:
 - job: CreateVPack
-  # dependsOn:
-  #   - ${{ parameters.dependsOn }}
+  dependsOn:
+    - ${{ parameters.dependsOn }}
   pool:
     name: WinDevPool-S
   variables:
@@ -12,17 +12,8 @@ jobs:
     internalSDKFeedUrl: https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json
 
   steps:
-  # - task: DownloadBuildArtifacts@0 
-  #   inputs: 
-  #     artifactName: drop
-  #     downloadPath: $(System.ArtifactsDirectory)
   - task: DownloadBuildArtifacts@0 
     inputs: 
-      buildType: specific
-      buildVersionToDownload: specific
-      project: $(System.TeamProjectId)
-      pipeline: 72016
-      buildId: 39843408
       artifactName: drop
       downloadPath: $(System.ArtifactsDirectory)
 

--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -12,8 +12,17 @@ jobs:
     internalSDKFeedUrl: https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json
 
   steps:
+  # - task: DownloadBuildArtifacts@0 
+  #   inputs: 
+  #     artifactName: drop
+  #     downloadPath: $(System.ArtifactsDirectory)
   - task: DownloadBuildArtifacts@0 
     inputs: 
+      buildType: specific
+      buildVersionToDownload: specific
+      project: $(System.TeamProjectId)
+      pipeline: 72016
+      buildId: 39843408
       artifactName: drop
       downloadPath: $(System.ArtifactsDirectory)
 
@@ -35,6 +44,7 @@ jobs:
   - script: |
       $(Build.SourcesDirectory)\build\CreateCBSVPack.cmd -releaseFolder $(System.ArtifactsDirectory)\drop\Release -publicsRoot $(Build.SourcesDirectory)\packages\Microsoft.Internal.WinUI.WindowsPublicsWinmd.$(windowsPublicsWinmdVersion)
     displayName: CreateCBSVPack.cmd
+    failOnStderr: true
     # Note: This task sets the 'vpackversion' variable that is used below.
 
   - task: PublishBuildArtifacts@1

--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -34,12 +34,12 @@ jobs:
       arguments: 'install Microsoft.Internal.WinUI.WindowsPublicsWinmd -NonInteractive -Version $(windowsPublicsWinmdVersion) -Source $(internalSDKFeedUrl) -OutputDirectory packages'
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: 'NuGet restore build/Helix/packages.config'
+    displayName: 'NuGet restore dev\dll\packages.config'
     inputs:
       restoreSolution: dev\dll\packages.config
       feedsToUse: config
       nugetConfigPath: nuget.config
-      restoreDirectory: packages
+      restoreDirectory: $(Build.SourcesDirectory)\packages
 
   - script: |
       $(Build.SourcesDirectory)\build\CreateCBSVPack.cmd -releaseFolder $(System.ArtifactsDirectory)\drop\Release -publicsRoot $(Build.SourcesDirectory)\packages\Microsoft.Internal.WinUI.WindowsPublicsWinmd.$(windowsPublicsWinmdVersion)

--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -36,7 +36,7 @@ jobs:
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore build/Helix/packages.config'
     inputs:
-      restoreSolution: build/Helix/packages.config
+      restoreSolution: dev\dll\packages.config
       feedsToUse: config
       nugetConfigPath: nuget.config
       restoreDirectory: packages

--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -24,6 +24,14 @@ jobs:
       command: custom
       arguments: 'install Microsoft.Internal.WinUI.WindowsPublicsWinmd -NonInteractive -Version $(windowsPublicsWinmdVersion) -Source $(internalSDKFeedUrl) -OutputDirectory packages'
 
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+    displayName: 'NuGet restore build/Helix/packages.config'
+    inputs:
+      restoreSolution: build/Helix/packages.config
+      feedsToUse: config
+      nugetConfigPath: nuget.config
+      restoreDirectory: packages
+
   - script: |
       $(Build.SourcesDirectory)\build\CreateCBSVPack.cmd -releaseFolder $(System.ArtifactsDirectory)\drop\Release -publicsRoot $(Build.SourcesDirectory)\packages\Microsoft.Internal.WinUI.WindowsPublicsWinmd.$(windowsPublicsWinmdVersion)
     displayName: CreateCBSVPack.cmd

--- a/build/CreateCBSVPack.cmd
+++ b/build/CreateCBSVPack.cmd
@@ -4,3 +4,5 @@ call ..\DevCmd.cmd /PreserveContext
 pushd %~dp0
 echo "Calling CreateCBSVpack.ps1"
 powershell -ExecutionPolicy Unrestricted -NonInteractive -Command %~dpn0.ps1 %*
+popd
+popd

--- a/build/CreateCBSVPack.cmd
+++ b/build/CreateCBSVPack.cmd
@@ -3,6 +3,6 @@ echo "Calling DevCmd.cmd"
 call ..\DevCmd.cmd /PreserveContext
 pushd %~dp0
 echo "Calling CreateCBSVpack.ps1"
-powershell -ExecutionPolicy Unrestricted -NonInteractive -Command %~dpn0.ps1 %*
+powershell -ExecutionPolicy Unrestricted -NoProfile -NonInteractive -Command %~dpn0.ps1 %*
 popd
 popd

--- a/build/CreateCBSVPack.ps1
+++ b/build/CreateCBSVPack.ps1
@@ -92,11 +92,18 @@ New-Item -Path "$winmdFolder" -ItemType Directory | Out-Null
 New-Item -Path "$winmdReferencesDir" -ItemType Directory | Out-Null
 
 $osBuildMetadataDir = Join-Path $publicsRoot "onecoreuap\internal\buildmetadata"
-Copy-Item "$osBuildMetadataDir\*.winmd" "$winmdReferencesDir" -Force | Out-Null
+Copy-Item "$osBuildMetadataDir\*.winmd" "$winmdReferencesDir" -Force 
 
 $webView2Version = Get-WebView2PackageVersion
 $webView2WinMdPath = Join-Path $packagesDir "Microsoft.Web.WebView2.$($webView2Version)\lib\Microsoft.Web.WebView2.Core.winmd"
-Copy-Item "$webView2WinMdPath\*.winmd" "$winmdReferencesDir" -Force | Out-Null
+Copy-Item "$webView2WinMdPath\*.winmd" "$winmdReferencesDir" -Force 
+
+Write-Host 
+Write-Host 
+Write-Host dir "$winmdReferencesDir"
+dir "$winmdReferencesDir"
+Write-Host 
+Write-Host 
 
 
 $buildFlavours = @("X64", "X86", "ARM", "ARM64")

--- a/build/CreateCBSVPack.ps1
+++ b/build/CreateCBSVPack.ps1
@@ -91,11 +91,13 @@ New-Item -Path "$cbsFolder" -ItemType Directory | Out-Null
 New-Item -Path "$winmdFolder" -ItemType Directory | Out-Null
 New-Item -Path "$winmdReferencesDir" -ItemType Directory | Out-Null
 
+Write-Host "Copy OS publics to $winmdReferencesDir"
 $osBuildMetadataDir = Join-Path $publicsRoot "onecoreuap\internal\buildmetadata"
 Copy-Item "$osBuildMetadataDir\*.winmd" "$winmdReferencesDir" -Force 
 
+Write-Host "Copy WebView2 winmd to $winmdReferencesDir"
 $webView2Version = Get-WebView2PackageVersion
-$webView2WinMdPath = Join-Path $packagesDir "Microsoft.Web.WebView2.$($webView2Version)\lib\Microsoft.Web.WebView2.Core.winmd"
+$webView2WinMdPath = Join-Path $packagesDir "Microsoft.Web.WebView2.$($webView2Version)\lib"
 Copy-Item "$webView2WinMdPath\*.winmd" "$winmdReferencesDir" -Force 
 
 Write-Host 

--- a/build/CreateCBSVPack.ps1
+++ b/build/CreateCBSVPack.ps1
@@ -100,14 +100,6 @@ $webView2Version = Get-WebView2PackageVersion
 $webView2WinMdPath = Join-Path $packagesDir "Microsoft.Web.WebView2.$($webView2Version)\lib"
 Copy-Item "$webView2WinMdPath\*.winmd" "$winmdReferencesDir" -Force 
 
-Write-Host 
-Write-Host 
-Write-Host dir "$winmdReferencesDir"
-dir "$winmdReferencesDir"
-Write-Host 
-Write-Host 
-
-
 $buildFlavours = @("X64", "X86", "ARM", "ARM64")
 
 foreach ($flavour in $buildFlavours)

--- a/build/CreateCBSVPack.ps1
+++ b/build/CreateCBSVPack.ps1
@@ -13,6 +13,8 @@ Trap
     Exit 1
 };
 
+$repoRoot = $script:MyInvocation.MyCommand.Path | Split-Path -Parent | Split-Path -Parent
+
 function GetVersionFromManifest([string] $manifestPath)
 {
     return (Get-Content $manifestPath) | Select-String 'Version="(.+?)"' -caseSensitive | Foreach-Object {$_.Matches} | Foreach-Object {$_.Groups[1].Value} | Select-Object -First 1
@@ -42,6 +44,14 @@ function Get-ScriptDirectory {
     Split-Path -parent $PSCommandPath
 }
 
+function Get-WebView2PackageVersion {
+    $packagesConfig = Join-Path $repoRoot "dev\dll\packages.config"
+    [xml]$packages = Get-Content $packagesConfig
+    $webView2Version = $packages.SelectSingleNode("//packages/package[@id=`"Microsoft.Web.WebView2`"]").version
+
+    return $webView2Version
+}
+
 if (-not (Test-Path "$releaseFolder"))
 {
     Write-Error "Not found folder $releaseFolder"
@@ -62,6 +72,8 @@ if(!(Get-Command mdmerge -ErrorAction Ignore))
 
 $cbsFolder = "$releaseFolder\CBS"
 $winmdFolder = "$cbsFolder\winmd"
+$packagesDir = Join-Path $repoRoot "packages"
+$winmdReferencesDir = Join-Path $repoRoot "winmdreferences"
 
 if (Test-Path $cbsFolder)
 {
@@ -69,8 +81,23 @@ if (Test-Path $cbsFolder)
     Remove-Item -Path $cbsFolder -Force -Recurse| Out-Null
 }
 
+if (Test-Path $winmdReferencesDir)
+{
+    Write-Host "Deleting $winmdReferencesDir"
+    Remove-Item -Path $winmdReferencesDir -Force -Recurse| Out-Null
+}
+
 New-Item -Path "$cbsFolder" -ItemType Directory | Out-Null
 New-Item -Path "$winmdFolder" -ItemType Directory | Out-Null
+New-Item -Path "$winmdReferencesDir" -ItemType Directory | Out-Null
+
+$osBuildMetadataDir = Join-Path $publicsRoot "onecoreuap\internal\buildmetadata"
+Copy-Item "$osBuildMetadataDir\*.winmd" "$winmdReferencesDir" -Force | Out-Null
+
+$webView2Version = Get-WebView2PackageVersion
+$webView2WinMdPath = Join-Path $packagesDir "Microsoft.Web.WebView2.$($webView2Version)\lib\Microsoft.Web.WebView2.Core.winmd"
+Copy-Item "$webView2WinMdPath\*.winmd" "$winmdReferencesDir" -Force | Out-Null
+
 
 $buildFlavours = @("X64", "X86", "ARM", "ARM64")
 
@@ -102,10 +129,8 @@ foreach ($flavour in $buildFlavours)
     {
         Write-Host "re-merge Microsoft.UI.Xaml.winmd"
 
-        $osBuildMetadataDir = Join-Path $publicsRoot "onecoreuap\internal\buildmetadata"
-
         # We need to re-merge Microsoft.UI.Xaml.winmd against the OS internal metadata instead of against the metadata from the public sdk:
-        $mdMergeArgs = "-v -metadata_dir ""$osBuildMetadataDir"" -o ""$winmdFolder"" -i ""$targetFolder"" -partial -n:3 -createPublicMetadata -transformExperimental:transform"
+        $mdMergeArgs = "-v -metadata_dir ""$winmdReferencesDir"" -o ""$winmdFolder"" -i ""$targetFolder"" -partial -n:3 -createPublicMetadata -transformExperimental:transform"
         Write-Host "mdmerge $mdMergeArgs"
         Invoke-Expression "mdmerge $mdMergeArgs" | Out-Null
         if($LASTEXITCODE)

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -2,86 +2,86 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
 jobs:
-- job: ComponentDetection
-  pool:
-    vmImage: 'windows-2019'
+# - job: ComponentDetection
+#   pool:
+#     vmImage: 'windows-2019'
 
-  steps:
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
+#   steps:
+#   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+#     displayName: 'Component Detection'
 
-- job: Build
-  # Skip the build job if we are reusing the output of a previous build.
-  # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
-  condition:
-    eq(variables['useBuildOutputFromBuildId'],'')
-  pool: 
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
-    demands: ImageOverride -equals WinDevVS16-9
-  timeoutInMinutes: 120
-  strategy:
-    maxParallel: 10
-    matrix:
-      Release_x86:
-        buildPlatform: 'x86'
-        buildConfiguration: 'Release'
-        PGOBuildMode: 'Optimize'
-      Release_x64:
-        buildPlatform: 'x64'
-        buildConfiguration: 'Release'
-        PGOBuildMode: 'Optimize'
-      Release_Arm:
-        buildPlatform: 'arm'
-        buildConfiguration: 'Release'
-      Release_Arm64:
-        buildPlatform: 'arm64'
-        buildConfiguration: 'Release'
+# - job: Build
+#   # Skip the build job if we are reusing the output of a previous build.
+#   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
+#   condition:
+#     eq(variables['useBuildOutputFromBuildId'],'')
+#   pool: 
+#     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+#       name: WinDevPoolOSS-L
+#     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+#       name: WinDevPool-L
+#     demands: ImageOverride -equals WinDevVS16-9
+#   timeoutInMinutes: 120
+#   strategy:
+#     maxParallel: 10
+#     matrix:
+#       Release_x86:
+#         buildPlatform: 'x86'
+#         buildConfiguration: 'Release'
+#         PGOBuildMode: 'Optimize'
+#       Release_x64:
+#         buildPlatform: 'x64'
+#         buildConfiguration: 'Release'
+#         PGOBuildMode: 'Optimize'
+#       Release_Arm:
+#         buildPlatform: 'arm'
+#         buildConfiguration: 'Release'
+#       Release_Arm64:
+#         buildPlatform: 'arm64'
+#         buildConfiguration: 'Release'
 
-  variables:
-    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
-    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
-    publishDir : $(Build.ArtifactStagingDirectory)
-  steps:
+#   variables:
+#     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+#     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+#     publishDir : $(Build.ArtifactStagingDirectory)
+#   steps:
 
-  # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
-  - task: DownloadPackage@1
-    displayName: 'Download Microsoft.Telemetry.Inbox.Native'
-    inputs:
-      feed: '/3415933f-ac0d-4766-8c0a-3f4c247c25f5'                         # 0
-      view: 'ef61a1c1-003b-4a27-bde5-beec8301021b'                          # Release
-      definition: '2fe60c09-c66f-4275-ae2d-f015c7170c72'                    # Microsoft.Telemetry.Inbox.Native
-      version: '10.0.18362.1-190318-1202.19h1-release.amd64fre'             # latest version
-      downloadPath: '$(System.DefaultWorkingDirectory)'                     # download and extract to repo root
+#   # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
+#   - task: DownloadPackage@1
+#     displayName: 'Download Microsoft.Telemetry.Inbox.Native'
+#     inputs:
+#       feed: '/3415933f-ac0d-4766-8c0a-3f4c247c25f5'                         # 0
+#       view: 'ef61a1c1-003b-4a27-bde5-beec8301021b'                          # Release
+#       definition: '2fe60c09-c66f-4275-ae2d-f015c7170c72'                    # Microsoft.Telemetry.Inbox.Native
+#       version: '10.0.18362.1-190318-1202.19h1-release.amd64fre'             # latest version
+#       downloadPath: '$(System.DefaultWorkingDirectory)'                     # download and extract to repo root
 
-  # Replace the stubbed MicrosoftTelemetry.h with the real one
-  # Delete the existing stubbed MicrosoftTelemetry.h first, to ensure that if it is no longer at the expected path that the task, and build, fails
-  - script: |
-     del $(System.DefaultWorkingDirectory)\dev\telemetry\MicrosoftTelemetry.h
-     move /Y $(System.DefaultWorkingDirectory)\build\native\inc\MicrosoftTelemetry.h $(System.DefaultWorkingDirectory)\dev\telemetry\
-    failOnStderr: true
-    displayName: 'Replace existing stubbed MicrosoftTelemetry.h header with the real version from the nuget package'
+#   # Replace the stubbed MicrosoftTelemetry.h with the real one
+#   # Delete the existing stubbed MicrosoftTelemetry.h first, to ensure that if it is no longer at the expected path that the task, and build, fails
+#   - script: |
+#      del $(System.DefaultWorkingDirectory)\dev\telemetry\MicrosoftTelemetry.h
+#      move /Y $(System.DefaultWorkingDirectory)\build\native\inc\MicrosoftTelemetry.h $(System.DefaultWorkingDirectory)\dev\telemetry\
+#     failOnStderr: true
+#     displayName: 'Replace existing stubbed MicrosoftTelemetry.h header with the real version from the nuget package'
 
-  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-    parameters:
-      signOutput: true
+#   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+#     parameters:
+#       signOutput: true
 
-  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+#   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# Create Nuget Package
-- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-  parameters:
-    jobName: CreateNugetPackage
-    dependsOn: Build
-    signOutput: true
-    useReleaseTag: '$(MUXFinalRelease)'
-    prereleaseVersionTag: prerelease
+# # Create Nuget Package
+# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+#   parameters:
+#     jobName: CreateNugetPackage
+#     dependsOn: Build
+#     signOutput: true
+#     useReleaseTag: '$(MUXFinalRelease)'
+#     prereleaseVersionTag: prerelease
 
 - template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
-  parameters:
-    dependsOn: Build
+  # parameters:
+  #   dependsOn: Build
 
 # # Build solution that depends on nuget package
 # - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -2,125 +2,125 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
 jobs:
-# - job: ComponentDetection
-#   pool:
-#     vmImage: 'windows-2019'
+- job: ComponentDetection
+  pool:
+    vmImage: 'windows-2019'
 
-#   steps:
-#   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-#     displayName: 'Component Detection'
+  steps:
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
 
-# - job: Build
-#   # Skip the build job if we are reusing the output of a previous build.
-#   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
-#   condition:
-#     eq(variables['useBuildOutputFromBuildId'],'')
-#   pool: 
-#     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-#       name: WinDevPoolOSS-L
-#     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-#       name: WinDevPool-L
-#     demands: ImageOverride -equals WinDevVS16-9
-#   timeoutInMinutes: 120
-#   strategy:
-#     maxParallel: 10
-#     matrix:
-#       Release_x86:
-#         buildPlatform: 'x86'
-#         buildConfiguration: 'Release'
-#         PGOBuildMode: 'Optimize'
-#       Release_x64:
-#         buildPlatform: 'x64'
-#         buildConfiguration: 'Release'
-#         PGOBuildMode: 'Optimize'
-#       Release_Arm:
-#         buildPlatform: 'arm'
-#         buildConfiguration: 'Release'
-#       Release_Arm64:
-#         buildPlatform: 'arm64'
-#         buildConfiguration: 'Release'
+- job: Build
+  # Skip the build job if we are reusing the output of a previous build.
+  # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
+  condition:
+    eq(variables['useBuildOutputFromBuildId'],'')
+  pool: 
+    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPoolOSS-L
+    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+      name: WinDevPool-L
+    demands: ImageOverride -equals WinDevVS16-9
+  timeoutInMinutes: 120
+  strategy:
+    maxParallel: 10
+    matrix:
+      Release_x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Release'
+        PGOBuildMode: 'Optimize'
+      Release_x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
+        PGOBuildMode: 'Optimize'
+      Release_Arm:
+        buildPlatform: 'arm'
+        buildConfiguration: 'Release'
+      Release_Arm64:
+        buildPlatform: 'arm64'
+        buildConfiguration: 'Release'
 
-#   variables:
-#     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
-#     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
-#     publishDir : $(Build.ArtifactStagingDirectory)
-#   steps:
+  variables:
+    appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
+    buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
+    publishDir : $(Build.ArtifactStagingDirectory)
+  steps:
 
-#   # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
-#   - task: DownloadPackage@1
-#     displayName: 'Download Microsoft.Telemetry.Inbox.Native'
-#     inputs:
-#       feed: '/3415933f-ac0d-4766-8c0a-3f4c247c25f5'                         # 0
-#       view: 'ef61a1c1-003b-4a27-bde5-beec8301021b'                          # Release
-#       definition: '2fe60c09-c66f-4275-ae2d-f015c7170c72'                    # Microsoft.Telemetry.Inbox.Native
-#       version: '10.0.18362.1-190318-1202.19h1-release.amd64fre'             # latest version
-#       downloadPath: '$(System.DefaultWorkingDirectory)'                     # download and extract to repo root
+  # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
+  - task: DownloadPackage@1
+    displayName: 'Download Microsoft.Telemetry.Inbox.Native'
+    inputs:
+      feed: '/3415933f-ac0d-4766-8c0a-3f4c247c25f5'                         # 0
+      view: 'ef61a1c1-003b-4a27-bde5-beec8301021b'                          # Release
+      definition: '2fe60c09-c66f-4275-ae2d-f015c7170c72'                    # Microsoft.Telemetry.Inbox.Native
+      version: '10.0.18362.1-190318-1202.19h1-release.amd64fre'             # latest version
+      downloadPath: '$(System.DefaultWorkingDirectory)'                     # download and extract to repo root
 
-#   # Replace the stubbed MicrosoftTelemetry.h with the real one
-#   # Delete the existing stubbed MicrosoftTelemetry.h first, to ensure that if it is no longer at the expected path that the task, and build, fails
-#   - script: |
-#      del $(System.DefaultWorkingDirectory)\dev\telemetry\MicrosoftTelemetry.h
-#      move /Y $(System.DefaultWorkingDirectory)\build\native\inc\MicrosoftTelemetry.h $(System.DefaultWorkingDirectory)\dev\telemetry\
-#     failOnStderr: true
-#     displayName: 'Replace existing stubbed MicrosoftTelemetry.h header with the real version from the nuget package'
+  # Replace the stubbed MicrosoftTelemetry.h with the real one
+  # Delete the existing stubbed MicrosoftTelemetry.h first, to ensure that if it is no longer at the expected path that the task, and build, fails
+  - script: |
+     del $(System.DefaultWorkingDirectory)\dev\telemetry\MicrosoftTelemetry.h
+     move /Y $(System.DefaultWorkingDirectory)\build\native\inc\MicrosoftTelemetry.h $(System.DefaultWorkingDirectory)\dev\telemetry\
+    failOnStderr: true
+    displayName: 'Replace existing stubbed MicrosoftTelemetry.h header with the real version from the nuget package'
 
-#   - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-#     parameters:
-#       signOutput: true
+  - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+    parameters:
+      signOutput: true
 
-#   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+  - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# # Create Nuget Package
-# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-#   parameters:
-#     jobName: CreateNugetPackage
-#     dependsOn: Build
-#     signOutput: true
-#     useReleaseTag: '$(MUXFinalRelease)'
-#     prereleaseVersionTag: prerelease
+# Create Nuget Package
+- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+  parameters:
+    jobName: CreateNugetPackage
+    dependsOn: Build
+    signOutput: true
+    useReleaseTag: '$(MUXFinalRelease)'
+    prereleaseVersionTag: prerelease
 
 - template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
-  # parameters:
-  #   dependsOn: Build
+  parameters:
+    dependsOn: Build
 
-# # Build solution that depends on nuget package
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildNugetPkgTests'
-#     buildArtifactName: 'NugetPkgTestsDrop'
-#     runTestJobName: 'RunNugetPkgTestsInHelix'
-#     helixType: 'test/nuget'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: false
+# Build solution that depends on nuget package
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildNugetPkgTests'
+    buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: false
 
-# # Framework package tests
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildFrameworkPkgTests'
-#     buildArtifactName: 'FrameworkPkgTestsDrop'
-#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
-#     helixType: 'test/frpkg'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: true
+# Framework package tests
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildFrameworkPkgTests'
+    buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: true
 
-# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-#   parameters:
-#     dependsOn:
-#     - RunNugetPkgTestsInHelix
-#     - RunFrameworkPkgTestsInHelix
-#     rerunPassesRequiredToAvoidFailure: 5
-#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
-# # NuGet package WACK tests
-# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-#   parameters:
-#     name: 'NugetPkgWACKTests'
-#     dependsOn: BuildNugetPkgTests
-#     artifactName: 'NugetPkgTestsDrop'
+# NuGet package WACK tests
+- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+  parameters:
+    name: 'NugetPkgWACKTests'
+    dependsOn: BuildNugetPkgTests
+    artifactName: 'NugetPkgTestsDrop'
 
-# # Framework package WACK tests
-# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-#   parameters:
-#     name: 'FrameworkPkgWACKTests'
-#     dependsOn: BuildFrameworkPkgTests
-#     artifactName: 'FrameworkPkgTestsDrop'
+# Framework package WACK tests
+- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+  parameters:
+    name: 'FrameworkPkgWACKTests'
+    dependsOn: BuildFrameworkPkgTests
+    artifactName: 'FrameworkPkgTestsDrop'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -83,44 +83,44 @@ jobs:
   parameters:
     dependsOn: Build
 
-# Build solution that depends on nuget package
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildNugetPkgTests'
-    buildArtifactName: 'NugetPkgTestsDrop'
-    runTestJobName: 'RunNugetPkgTestsInHelix'
-    helixType: 'test/nuget'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: false
+# # Build solution that depends on nuget package
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildNugetPkgTests'
+#     buildArtifactName: 'NugetPkgTestsDrop'
+#     runTestJobName: 'RunNugetPkgTestsInHelix'
+#     helixType: 'test/nuget'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: false
 
-# Framework package tests
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildFrameworkPkgTests'
-    buildArtifactName: 'FrameworkPkgTestsDrop'
-    runTestJobName: 'RunFrameworkPkgTestsInHelix'
-    helixType: 'test/frpkg'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: true
+# # Framework package tests
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildFrameworkPkgTests'
+#     buildArtifactName: 'FrameworkPkgTestsDrop'
+#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+#     helixType: 'test/frpkg'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: true
 
-- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-  parameters:
-    dependsOn:
-    - RunNugetPkgTestsInHelix
-    - RunFrameworkPkgTestsInHelix
-    rerunPassesRequiredToAvoidFailure: 5
-    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+#   parameters:
+#     dependsOn:
+#     - RunNugetPkgTestsInHelix
+#     - RunFrameworkPkgTestsInHelix
+#     rerunPassesRequiredToAvoidFailure: 5
+#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
-# NuGet package WACK tests
-- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-  parameters:
-    name: 'NugetPkgWACKTests'
-    dependsOn: BuildNugetPkgTests
-    artifactName: 'NugetPkgTestsDrop'
+# # NuGet package WACK tests
+# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+#   parameters:
+#     name: 'NugetPkgWACKTests'
+#     dependsOn: BuildNugetPkgTests
+#     artifactName: 'NugetPkgTestsDrop'
 
-# Framework package WACK tests
-- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-  parameters:
-    name: 'FrameworkPkgWACKTests'
-    dependsOn: BuildFrameworkPkgTests
-    artifactName: 'FrameworkPkgTestsDrop'
+# # Framework package WACK tests
+# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+#   parameters:
+#     name: 'FrameworkPkgWACKTests'
+#     dependsOn: BuildFrameworkPkgTests
+#     artifactName: 'FrameworkPkgTestsDrop'


### PR DESCRIPTION
MUX.winmd now references CoreWebView2 types. For the nuget package, this is handled by having the MUX nuget package having a dependency on the WebView2 nuget package.

However, this broke the CBS Vpack which needs to remerge the winmd against OS publics so that it can be consumed by razzle components. To fix this, we need to include the WebView2 winmd as part of the reference winmds when we do the remerge.

