### PR TITLE
[NumberBox] fix for initially collapsed NumberBox losing spin buttons

### DIFF
--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -211,6 +211,7 @@ void NumberBox::OnApplyTemplate()
     // .NET rounds to 12 significant digits when displaying doubles, so we will do the same.
     m_displayRounder.SignificantDigits(12);
 
+    UpdateSpinButtonPlacement();
     UpdateSpinButtonEnabled();
 
     UpdateVisualStateForIsEnabledChange();


### PR DESCRIPTION
Fixes #6052

### Describe the bug

NumberBox that was created in Collapsed state and then made Visible - will never show spin buttons. For example, for Page that adapts to window size it could be useful to create two NumberBox, visible and invisible, bound to the same property, and do something like this:
```
<VisualState.StateTriggers>
    <AdaptiveTrigger MinWindowWidth="{StaticResource MinWindowSnapPoint}" />
</VisualState.StateTriggers>
<VisualState.Setters>
    <Setter Target="RightPane.Visibility" Value="Collapsed"/>
    <Setter Target="BottomPane.Visibility" Value="Visible"/>
</VisualState.Setters>
```
it's enough to provoke bug.

### Steps to reproduce the bug

1. New C++ Blank project, add to MainPage.xaml such code:
```
    <StackPanel Spacing="8">
        <CheckBox x:Name="checkBox" Content="Show NumberBox" IsChecked="True"/>
        <muxc:NumberBox SpinButtonPlacementMode="Inline" Value="123" Header="This NumberBox was Visible initial part of lifetime, buttons are here" Visibility="{Binding IsChecked, ElementName=checkBox}"/>
        <muxc:NumberBox SpinButtonPlacementMode="Inline" Value="456" Header="This NumberBox was Collapsed initial part of lifetime, buttons are lost" Visibility="{Binding IsChecked, ElementName=checkBox, FallbackValue=Collapsed}"/>
    </StackPanel>
```
2. Run

### Expected behavior

Both NumberBox-es should have spin buttons

### Screenshots

![image](https://user-images.githubusercontent.com/34012295/136304011-8964d5b4-ccc5-45fe-99b9-5a60903f4d6c.png)


The reason is obvious - NumberBox::UpdateSpinButtonPlacement() is not called in NumberBox::OnApplyTemplate(), and for initially collapsed NumberBox template is applied very late, only when NumberBox became visible.

commit to blame for the bug https://github.com/microsoft/microsoft-ui-xaml/pull/5331/commits/c4f78f82775eef9f76dcf8cb4ce8cf102767d4c4

See also https://github.com/microsoft/microsoft-ui-xaml/pull/5985 

