### PR TITLE
[XAMLControlsResources] Remove old preview API versions property

### DIFF
--- a/dev/Generated/XamlControlsResources.properties.cpp
+++ b/dev/Generated/XamlControlsResources.properties.cpp
@@ -15,7 +15,6 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 
 GlobalDependencyProperty XamlControlsResourcesProperties::s_ControlsResourcesVersionProperty{ nullptr };
 GlobalDependencyProperty XamlControlsResourcesProperties::s_UseCompactResourcesProperty{ nullptr };
-GlobalDependencyProperty XamlControlsResourcesProperties::s_VersionProperty{ nullptr };
 
 XamlControlsResourcesProperties::XamlControlsResourcesProperties()
 {
@@ -46,24 +45,12 @@ void XamlControlsResourcesProperties::EnsureProperties()
                 ValueHelper<bool>::BoxValueIfNecessary(false),
                 winrt::PropertyChangedCallback(&OnUseCompactResourcesPropertyChanged));
     }
-    if (!s_VersionProperty)
-    {
-        s_VersionProperty =
-            InitializeDependencyProperty(
-                L"Version",
-                winrt::name_of<winrt::StylesVersion>(),
-                winrt::name_of<winrt::XamlControlsResources>(),
-                false /* isAttached */,
-                ValueHelper<winrt::StylesVersion>::BoxValueIfNecessary(winrt::StylesVersion::Latest),
-                winrt::PropertyChangedCallback(&OnVersionPropertyChanged));
-    }
 }
 
 void XamlControlsResourcesProperties::ClearProperties()
 {
     s_ControlsResourcesVersionProperty = nullptr;
     s_UseCompactResourcesProperty = nullptr;
-    s_VersionProperty = nullptr;
 }
 
 void XamlControlsResourcesProperties::OnControlsResourcesVersionPropertyChanged(
@@ -75,14 +62,6 @@ void XamlControlsResourcesProperties::OnControlsResourcesVersionPropertyChanged(
 }
 
 void XamlControlsResourcesProperties::OnUseCompactResourcesPropertyChanged(
-    winrt::DependencyObject const& sender,
-    winrt::DependencyPropertyChangedEventArgs const& args)
-{
-    auto owner = sender.as<winrt::XamlControlsResources>();
-    winrt::get_self<XamlControlsResources>(owner)->OnPropertyChanged(args);
-}
-
-void XamlControlsResourcesProperties::OnVersionPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
@@ -114,17 +93,4 @@ void XamlControlsResourcesProperties::UseCompactResources(bool value)
 bool XamlControlsResourcesProperties::UseCompactResources()
 {
     return ValueHelper<bool>::CastOrUnbox(static_cast<XamlControlsResources*>(this)->GetValue(s_UseCompactResourcesProperty));
-}
-
-void XamlControlsResourcesProperties::Version(winrt::StylesVersion const& value)
-{
-    [[gsl::suppress(con)]]
-    {
-    static_cast<XamlControlsResources*>(this)->SetValue(s_VersionProperty, ValueHelper<winrt::StylesVersion>::BoxValueIfNecessary(value));
-    }
-}
-
-winrt::StylesVersion XamlControlsResourcesProperties::Version()
-{
-    return ValueHelper<winrt::StylesVersion>::CastOrUnbox(static_cast<XamlControlsResources*>(this)->GetValue(s_VersionProperty));
 }

--- a/dev/Generated/XamlControlsResources.properties.h
+++ b/dev/Generated/XamlControlsResources.properties.h
@@ -15,16 +15,11 @@ public:
     void UseCompactResources(bool value);
     bool UseCompactResources();
 
-    void Version(winrt::StylesVersion const& value);
-    winrt::StylesVersion Version();
-
     static winrt::DependencyProperty ControlsResourcesVersionProperty() { return s_ControlsResourcesVersionProperty; }
     static winrt::DependencyProperty UseCompactResourcesProperty() { return s_UseCompactResourcesProperty; }
-    static winrt::DependencyProperty VersionProperty() { return s_VersionProperty; }
 
     static GlobalDependencyProperty s_ControlsResourcesVersionProperty;
     static GlobalDependencyProperty s_UseCompactResourcesProperty;
-    static GlobalDependencyProperty s_VersionProperty;
 
     static void EnsureProperties();
     static void ClearProperties();
@@ -34,10 +29,6 @@ public:
         winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnUseCompactResourcesPropertyChanged(
-        winrt::DependencyObject const& sender,
-        winrt::DependencyPropertyChangedEventArgs const& args);
-
-    static void OnVersionPropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 };

--- a/dev/dll/XamlControlsResources.cpp
+++ b/dev/dll/XamlControlsResources.cpp
@@ -45,13 +45,6 @@ void XamlControlsResources::OnPropertyChanged(const winrt::DependencyPropertyCha
         // Source link depends on ControlsResourcesVersion and UseCompactResources flag, we need to update it when either property changed
         UpdateSource();
     }
-
-    // To be deleted
-    // Version is going to be replaced with ControlsResourcesVersion
-    else if (property == s_VersionProperty)
-    {
-        ControlsResourcesVersion(Version() == winrt::StylesVersion::Latest ? winrt::ControlsResourcesVersion::Version2 : winrt::ControlsResourcesVersion::Version1);
-    }
 }
 
 void XamlControlsResources::UpdateSource()

--- a/idl/Microsoft.UI.Xaml.idl
+++ b/idl/Microsoft.UI.Xaml.idl
@@ -184,15 +184,6 @@ namespace MU_XC_NAMESPACE
         Version2 = 2,
     };
 
-    // To be removed
-    [MUX_PREVIEW]
-    [webhosthidden]
-    enum StylesVersion
-    {
-        Latest = 0,
-        WinUI_2dot5 = 1,
-    };
-
     [MUX_PUBLIC]
     [webhosthidden]
     [default_interface]
@@ -217,15 +208,6 @@ namespace MU_XC_NAMESPACE
             ControlsResourcesVersion ControlsResourcesVersion{ get; set; };
 
             static Windows.UI.Xaml.DependencyProperty ControlsResourcesVersionProperty{ get; };
-        }
-
-        // To be removed
-        [MUX_PREVIEW]
-        {
-            [MUX_DEFAULT_VALUE("winrt::StylesVersion::Latest")]
-            StylesVersion Version{ get; set; };
-
-            static Windows.UI.Xaml.DependencyProperty VersionProperty{ get; };
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The old Version property has been commented "To be removed" and as preview for over 3 months now. This PR is removing it now.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Clean up code.
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested by building project and running MUXControlsTestApp

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->