### PR TITLE
Change Pivot.SelectedPipe color and thickness the same way as was changed NavigationViewItem...WhenOnTop

### DIFF
--- a/dev/CommonStyles/Pivot_themeresources.xaml
+++ b/dev/CommonStyles/Pivot_themeresources.xaml
@@ -57,7 +57,7 @@
             <StaticResource x:Key="PivotHeaderItemForegroundSelectedPressed" ResourceKey="SystemControlHighlightAltBaseMediumHighBrush" />
             <StaticResource x:Key="PivotHeaderItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="PivotHeaderItemFocusPipeFill" ResourceKey="SystemControlHighlightAltAccentBrush" />
-            <StaticResource x:Key="PivotHeaderItemSelectedPipeFill" ResourceKey="SystemControlHighlightAltAccentBrush" />
+            <StaticResource x:Key="PivotHeaderItemSelectedPipeFill" ResourceKey="AccentFillColorDefaultBrush" />
             <SolidColorBrush x:Key="PivotForegroundThemeBrush" Color="#FFFFFFFF" />
             <SolidColorBrush x:Key="PivotHeaderBackgroundSelectedBrush" Color="Transparent" />
             <SolidColorBrush x:Key="PivotHeaderBackgroundUnselectedBrush" Color="Transparent" />
@@ -191,7 +191,7 @@
             <StaticResource x:Key="PivotHeaderItemForegroundSelectedPressed" ResourceKey="SystemControlHighlightAltBaseMediumHighBrush" />
             <StaticResource x:Key="PivotHeaderItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <StaticResource x:Key="PivotHeaderItemFocusPipeFill" ResourceKey="SystemControlHighlightAltAccentBrush" />
-            <StaticResource x:Key="PivotHeaderItemSelectedPipeFill" ResourceKey="SystemControlHighlightAltAccentBrush" />
+            <StaticResource x:Key="PivotHeaderItemSelectedPipeFill" ResourceKey="AccentFillColorDefaultBrush" />
             <SolidColorBrush x:Key="PivotForegroundThemeBrush" Color="#FF000000" />
             <SolidColorBrush x:Key="PivotHeaderBackgroundSelectedBrush" Color="Transparent" />
             <SolidColorBrush x:Key="PivotHeaderBackgroundUnselectedBrush" Color="Transparent" />
@@ -208,6 +208,8 @@
             <SolidColorBrush x:Key="PivotNavButtonPressedForegroundThemeBrush" Color="#FFFFFFFF" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
+
+    <CornerRadius x:Key="PivotHeaderItemSelectedPipeCornerRadius">1.5</CornerRadius>
 
     <Style TargetType="Pivot" BasedOn="{StaticResource DefaultPivotStyle}" />
 
@@ -510,7 +512,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="UseSystemFocusVisuals" Value="False" />
-        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource PivotHeaderItemSelectedPipeCornerRadius}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="PivotHeaderItem">
@@ -624,11 +626,11 @@
                         </Grid.RenderTransform>
 
                         <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" FontWeight="{TemplateBinding FontWeight}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" OpticalMarginAlignment="TrimSideBearings" />
-                        <Rectangle x:Name="SelectedPipe" Fill="{ThemeResource PivotHeaderItemSelectedPipeFill}" Height="2" VerticalAlignment="Bottom" HorizontalAlignment="Stretch" Margin="0,0,0,2"
+                        <Rectangle x:Name="SelectedPipe" Fill="{ThemeResource PivotHeaderItemSelectedPipeFill}" Height="3" VerticalAlignment="Bottom" HorizontalAlignment="Stretch" Margin="0,0,0,2"
                                    contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                    contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
-                                   contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                   contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
+                                   contract7NotPresent:RadiusX="{Binding Source={ThemeResource PivotHeaderItemSelectedPipeCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                   contract7NotPresent:RadiusY="{Binding Source={ThemeResource PivotHeaderItemSelectedPipeCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
 
                     </Grid>
                 </ControlTemplate>


### PR DESCRIPTION
Pivot styles were not updated for Version2, and now selection pipe in it significantly differs by color and thickness from all other controls with selection pipes, like NavigationView, ListView, ComboBox, etc. This fix adjusts "selection pipe" of the Pivot control the same way as "selection pipe" of the MUX_NavigationViewItemPresenterStyleWhenOnTopPane was adjusted for Version2.

![image](https://user-images.githubusercontent.com/34012295/136843699-93253234-642d-45c3-b0c0-977078c20abe.png)
