### PR TITLE
[SplitButton] Fix jumping chevron on touch hovering/pressing…

### DIFF
--- a/dev/SplitButton/SplitButton_themeresources.xaml
+++ b/dev/SplitButton/SplitButton_themeresources.xaml
@@ -381,7 +381,7 @@
                             VerticalContentAlignment="Stretch"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
-                            Padding="2,0,7,0"
+                            Padding="2,0,8,0"
                             IsTabStop="False"
                             AutomationProperties.AccessibilityView="Raw">
                             <Button.Content>
@@ -391,7 +391,7 @@
                                     Text="&#xE972;"
                                     VerticalAlignment="Center"
                                     Padding="2,1,2,0"
-                                    HorizontalAlignment="Left"
+                                    HorizontalAlignment="Right"
                                     IsTextScaleFactorEnabled="False"
                                     AutomationProperties.AccessibilityView="Raw"/>
                             </Button.Content>


### PR DESCRIPTION
SplitButton extends secondary button to the whole control area for the touch, but chevron should be still aligned to the right side 

![image](https://user-images.githubusercontent.com/34012295/136980968-de202102-7217-4e59-817b-bd5541d9ba0a.png)

@teaP @StephenLPeters FYI