### PR TITLE
Revert "CommandBarFlyout fix for internal bug 35782367 (#5937)"

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyout.cpp
@@ -251,14 +251,11 @@ CommandBarFlyout::CommandBarFlyout()
                     args.Cancel(true);
 
                     commandBar->PlayCloseAnimation(
-                        [weakThis{ get_weak() }]()
+                        [this]()
                         {
-                            if (auto strongThis = weakThis.get())
-                            {
-                                strongThis->m_isClosingAfterCloseAnimation = true;
-                                strongThis->Hide();
-                                strongThis->m_isClosingAfterCloseAnimation = false;
-                            }
+                            m_isClosingAfterCloseAnimation = true;
+                            Hide();
+                            m_isClosingAfterCloseAnimation = false;
                         });
                 }
                 else


### PR DESCRIPTION
This reverts commit 03a091b8c69d76f010f7f772a078db55b3710488.

Undoing CommandBarFlyout changes because of crash regressions.