### PR TITLE
Fixed lost button foreground after pointer over

### DIFF
--- a/dev/CommonStyles/Button_themeresources.xaml
+++ b/dev/CommonStyles/Button_themeresources.xaml
@@ -156,6 +156,7 @@
                         x:Name="ContentPresenter"
                         Background="{TemplateBinding Background}"
                         contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                        Foreground="{TemplateBinding Foreground}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Content="{TemplateBinding Content}"

--- a/dev/CommonStyles/RepeatButton_themeresources.xaml
+++ b/dev/CommonStyles/RepeatButton_themeresources.xaml
@@ -106,6 +106,7 @@
                     <ContentPresenter x:Name="ContentPresenter"
                                       Background="{TemplateBinding Background}"
                                       contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                      Foreground="{TemplateBinding Foreground}"
                                       BorderBrush="{TemplateBinding BorderBrush}"
                                       BorderThickness="{TemplateBinding BorderThickness}"
                                       Content="{TemplateBinding Content}"

--- a/dev/CommonStyles/ToggleButton_themeresources.xaml
+++ b/dev/CommonStyles/ToggleButton_themeresources.xaml
@@ -208,6 +208,7 @@
                         x:Name="ContentPresenter"
                         Background="{TemplateBinding Background}"
                         contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                        Foreground="{TemplateBinding Foreground}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Content="{TemplateBinding Content}"


### PR DESCRIPTION
Fixes #5717

Button and RepeatButton foregrounds are lost after pointer over for buttons that use DefaultButtonStyle and DefaultRepeatButtonStyle, but not for the AccentButtonStyle.

```
    <StackPanel Spacing="8" HorizontalAlignment="Left">
        <Button Content="Btn1" Foreground="Red"/>
        <RepeatButton Content="Btn2" Foreground="Red"/>
        <Button Content="Btn3" Foreground="Red" Style="{StaticResource AccentButtonStyle}"/>
    </StackPanel>
```

![image](https://user-images.githubusercontent.com/34012295/137486826-3ec075c5-f636-41c7-aae4-dcc3aa8302ba.png)

Remarks related to the fix:
1) AccentButtonStyle has `ContentPresenter.Foreground = "{TemplateBinding Foreground}"` line of code and works properly - after resetting from PointerOver to Normal state property reverted from value set by visual state to local value.
2) DefaultButtonStyle and DefaultRepeatButtonStyle has no such `ContentPresenter.Foreground = "{TemplateBinding Foreground}"` line of code and seems to rely on Foreground property propagation, that is the reason buttons are initially red. But after returning from PointerOver to Normal state such property propagation does not occured. Bug could be fixed by adding aforementioned line of code, it is the current PR.
3) BUT ControlsResourcesVersion="Version1" does not exhibit the bug, despite missing `ContentPresenter.Foreground = "{TemplateBinding Foreground}"` line of code. I can not explain this behavior without sources for Button and VisualStateManager, it could be side effect of other differences between Version1 and Version2 versions of DefaultButtonStyle. Note, that WUX styles has no such line of code too.

P.S. 
DropDownButton is affected too, probably many more controls too - not in current PR
P.P.S
ToggleButton is affected, SplitButton and ToggleSplitButton are unaffected

@jevansaks @StephenLPeters @tashatitova  FYI

Win11 10.0.22000.258, WinUI 2.7