### PR TITLE
Undoing CommandBarFlyout changes in release/2.8cbs branch because of crash regressions.

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyout.cpp
@@ -251,14 +251,11 @@ CommandBarFlyout::CommandBarFlyout()
                     args.Cancel(true);
 
                     commandBar->PlayCloseAnimation(
-                        [weakThis{ get_weak() }]()
+                        [this]()
                         {
-                            if (auto strongThis = weakThis.get())
-                            {
-                                strongThis->m_isClosingAfterCloseAnimation = true;
-                                strongThis->Hide();
-                                strongThis->m_isClosingAfterCloseAnimation = false;
-                            }
+                            m_isClosingAfterCloseAnimation = true;
+                            Hide();
+                            m_isClosingAfterCloseAnimation = false;
                         });
                 }
                 else


### PR DESCRIPTION
Same changes as last week's undo in the 'main' branch: undoing a recent CommandBarFlyout fix that caused crashes.