### PR TITLE
Delay load NavigationView's heirarchical chevron

### DIFF
--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -59,10 +59,8 @@ void AnimatedIcon::OnApplyTemplate()
                 path.Visibility(winrt::Visibility::Collapsed);
             }
         }
-        if (auto const visual = m_animatedVisual.get())
-        {
-            winrt::ElementCompositionPreview::SetElementChildVisual(panel, visual.RootVisual());
-        }
+
+        winrt::ElementCompositionPreview::SetElementChildVisual(panel, visual);
 
         TrySetForegroundProperty();
     }

--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -31,7 +31,16 @@ void AnimatedIcon::OnApplyTemplate()
     __super::OnApplyTemplate();
     // Construct the visual from the Source property in on apply template so that it participates
     // in the initial measure for the object.
-    ConstructAndInsertVisual();
+    auto const visual = [animatedVisual = m_animatedVisual.get(), this]()
+    {
+        if (animatedVisual)
+        {
+            return animatedVisual.RootVisual();
+        }
+        return ConstructVisual();
+    }();
+    InsertVisual(visual);
+
     auto const panel = winrt::VisualTreeHelper::GetChild(*this, 0).as<winrt::Panel>();
     m_rootPanel.set(panel);
     m_currentState = GetState(*this);
@@ -464,7 +473,8 @@ void AnimatedIcon::PlaySegment(float from, float to, const std::function<void()>
 
 void AnimatedIcon::OnSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs&)
 {
-    if(!ConstructAndInsertVisual())
+    auto const visual = ConstructVisual();
+    if(!InsertVisual(visual))
     {
         SetRootPanelChildToFallbackIcon();
     }
@@ -497,26 +507,26 @@ void AnimatedIcon::OnMirroredWhenRightToLeftPropertyChanged(const winrt::Depende
     UpdateMirrorTransform();
 }
 
-bool AnimatedIcon::ConstructAndInsertVisual()
+winrt::Visual AnimatedIcon::ConstructVisual()
 {
-    auto const visual = [this]()
+    if (auto const source = Source())
     {
-        if (auto const source = Source())
-        {
-            TrySetForegroundProperty(source);
+        TrySetForegroundProperty(source);
 
-            winrt::IInspectable diagnostics{};
-            auto const visual = source.TryCreateAnimatedVisual(winrt::Window::Current().Compositor(), diagnostics);
-            m_animatedVisual.set(visual);
-            return visual ? visual.RootVisual() : nullptr;
-        }
-        else
-        {
-            m_animatedVisual.set(nullptr);
-            return static_cast<winrt::Visual>(nullptr);
-        }
-    }();
+        winrt::IInspectable diagnostics{};
+        auto const visual = source.TryCreateAnimatedVisual(winrt::Window::Current().Compositor(), diagnostics);
+        m_animatedVisual.set(visual);
+        return visual ? visual.RootVisual() : nullptr;
+    }
+    else
+    {
+        m_animatedVisual.set(nullptr);
+        return static_cast<winrt::Visual>(nullptr);
+    }
+}
 
+bool AnimatedIcon::InsertVisual(winrt::Visual visual)
+{
     if (auto const rootPanel = m_rootPanel.get())
     {
         winrt::ElementCompositionPreview::SetElementChildVisual(rootPanel, visual);

--- a/dev/AnimatedIcon/AnimatedIcon.h
+++ b/dev/AnimatedIcon/AnimatedIcon.h
@@ -50,7 +50,8 @@ public:
     winrt::hstring GetLastAnimationSegmentStart();
     winrt::hstring GetLastAnimationSegmentEnd();
 private:
-    bool ConstructAndInsertVisual();
+    winrt::Visual ConstructVisual();
+    bool InsertVisual(winrt::Visual visual);
     void TransitionAndUpdateStates(const winrt::hstring& fromState, const winrt::hstring& toState, float playbackMultiplier = 1.0f);
     void TransitionStates(const winrt::hstring& fromState, const winrt::hstring& toState, const std::function<void()>& cleanupAction, float playtbackMultiplier = 1.0f);
     void PlaySegment(float from, float to, const std::function<void()>& cleanupAction = nullptr, float playbackMultiplier = 1.0f);

--- a/dev/Materials/Backdrop/MicaController.cpp
+++ b/dev/Materials/Backdrop/MicaController.cpp
@@ -17,7 +17,7 @@ MicaController::~MicaController()
                 // Workaround for null ref exception in Window::get_SystemBackdrop when the Window is shutting down.
                 // GenerateRawElementProviderRuntimeId will trigger an exception caught below and thus prevent the 
                 // crashing target.SystemBackdrop() call.
-                auto runtimeId = winrt::Automation::Peers::AutomationPeer::GenerateRawElementProviderRuntimeId();
+                auto const runtimeId = winrt::Automation::Peers::AutomationPeer::GenerateRawElementProviderRuntimeId();
             }
 
             // If we are going away and we own the backdrop, clear it.

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -654,12 +654,14 @@
                                 <VisualState x:Name="ChevronVisibleOpen">
                                     <VisualState.Setters>
                                         <Setter Target="ExpandCollapseChevron.Visibility" Value="Visible" />
+                                        <Setter Target="ExpandCollapseChevronIcon.Visibility" Value="Visible" />
                                         <contract7NotPresent:Setter Target="ExpandCollapseChevronRotateTransform.Angle" Value="180"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="ChevronVisibleClosed">
                                     <VisualState.Setters>
                                         <Setter Target="ExpandCollapseChevron.Visibility" Value="Visible" />
+                                        <Setter Target="ExpandCollapseChevronIcon.Visibility" Value="Visible" />
                                         <contract7NotPresent:Setter Target="ExpandCollapseChevronRotateTransform.Angle" Value="0"/>
                                     </VisualState.Setters>
                                 </VisualState>
@@ -668,42 +670,42 @@
                                 <VisualState x:Name="NormalChevronHidden"/>
                                 <VisualState x:Name="NormalChevronVisibleOpen">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="NormalOn"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="NormalOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="NormalChevronVisibleClosed">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="NormalOff"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="NormalOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="PointerOverChevronHidden">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="PointerOverOff"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="PointerOverOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="PointerOverChevronVisibleOpen">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="PointerOverOn"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="PointerOverOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="PointerOverChevronVisibleClosed">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="PointerOverOff"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="PointerOverOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="PressedChevronHidden">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="PressedOff"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="PressedOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="PressedChevronVisibleOpen">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="PressedOn"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="PressedOn"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="PressedChevronVisibleClosed">
                                     <VisualState.Setters>
-                                        <Setter Target="ExpandCollapseChevronIcon.(local:AnimatedIcon.State)" Value="PressedOff"/>
+                                        <Setter Target="ExpandCollapseChevron.(local:AnimatedIcon.State)" Value="PressedOff"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -787,7 +789,8 @@
                                     HorizontalAlignment="Right"
                                     Width="40"
                                     Margin="{ThemeResource NavigationViewItemExpandChevronMargin}"
-                                    Background="Transparent">
+                                    Background="Transparent"
+                                    local:AnimatedIcon.State="NormalOff">
                                     <local:AnimatedIcon
                                         Width="12"
                                         Height="12"
@@ -795,8 +798,9 @@
                                         x:Name="ExpandCollapseChevronIcon"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
+                                        Visibility="Collapsed"
                                         AutomationProperties.AccessibilityView="Raw"
-                                        local:AnimatedIcon.State="NormalOff">
+                                        x:DeferLoadStrategy="Lazy">
                                         <animatedvisuals:AnimatedChevronUpDownSmallVisualSource/>
                                         <local:AnimatedIcon.FallbackIconSource>
                                             <local:FontIconSource

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-4.xml
@@ -1090,18 +1090,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1362,18 +1350,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1868,18 +1844,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-7.xml
@@ -1046,18 +1046,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1320,18 +1308,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1801,18 +1777,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewAuto-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewAuto-8.xml
@@ -1046,18 +1046,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1320,18 +1308,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1801,18 +1777,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-4.xml
@@ -1091,18 +1091,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1363,18 +1351,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1869,18 +1845,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-5.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-5.xml
@@ -1091,18 +1091,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1363,18 +1351,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1869,18 +1845,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-7.xml
@@ -1047,18 +1047,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1321,18 +1309,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1802,18 +1778,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftCompact-8.xml
@@ -1047,18 +1047,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1321,18 +1309,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1802,18 +1778,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-4.xml
@@ -1049,18 +1049,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1321,18 +1309,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1804,18 +1780,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-7.xml
@@ -1045,18 +1045,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1319,18 +1307,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1800,18 +1776,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftMinimal-8.xml
@@ -1046,18 +1046,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1320,18 +1308,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1801,18 +1777,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-4.xml
@@ -1444,18 +1444,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1716,18 +1704,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2260,18 +2236,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-7.xml
@@ -1424,18 +1424,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1698,18 +1686,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2218,18 +2194,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewLeftPaneContent-8.xml
@@ -1424,18 +1424,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1698,18 +1686,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2218,18 +2194,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-4.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-4.xml
@@ -1090,18 +1090,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1362,18 +1350,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1687,18 +1663,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1959,18 +1923,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2269,18 +2221,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2541,18 +2481,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2813,18 +2741,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3085,18 +3001,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3410,18 +3314,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3682,18 +3574,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3992,18 +3872,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -4935,18 +4803,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-7.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-7.xml
@@ -1046,18 +1046,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1320,18 +1308,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1648,18 +1624,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1922,18 +1886,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2235,18 +2187,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2509,18 +2449,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2783,18 +2711,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3057,18 +2973,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3385,18 +3289,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3659,18 +3551,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3972,18 +3852,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -4900,18 +4768,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]

--- a/test/MUXControlsTestApp/verification/NavigationViewScrolling-8.xml
+++ b/test/MUXControlsTestApp/verification/NavigationViewScrolling-8.xml
@@ -1046,18 +1046,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1320,18 +1308,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1648,18 +1624,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -1922,18 +1886,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2235,18 +2187,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2509,18 +2449,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -2783,18 +2711,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3057,18 +2973,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3385,18 +3289,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3659,18 +3551,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -3972,18 +3852,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]
@@ -4900,18 +4768,6 @@
                                               RenderSize=0,0
                                               Visibility=Collapsed
                                               Width=40
-                                            [Microsoft.UI.Xaml.Controls.AnimatedIcon]
-                                                FocusVisualPrimaryBrush=#E4000000
-                                                FocusVisualPrimaryThickness=2,2,2,2
-                                                FocusVisualSecondaryBrush=#B3FFFFFF
-                                                FocusVisualSecondaryThickness=1,1,1,1
-                                                Foreground=#E4000000
-                                                Height=12
-                                                Margin=0,0,0,0
-                                                Name=ExpandCollapseChevronIcon
-                                                RenderSize=0,0
-                                                Visibility=Visible
-                                                Width=12
                                           [Windows.UI.Xaml.Controls.ContentPresenter]
                                               Background=[NULL]
                                               BorderBrush=[NULL]


### PR DESCRIPTION
The Chevron isn't needed for the majority of navigation view items but was being created regardless. This change makes it so the AnimatedIcon isn't loaded until it is actually needed.

Also fixes an issue in AnimatedIcon where the AnimatedVisual was being created twice.