### PR TITLE
[ Breadcrumb Bar ] [ HC ] Style updates (remainder)

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBar_themeresources.xaml
+++ b/dev/Breadcrumb/BreadcrumbBar_themeresources.xaml
@@ -94,29 +94,29 @@
 
             <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
 
-            <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="SystemColorButtonTextColor" />
-            <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColor" />
-            <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="SystemColorHighlightColor" />
+            <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
 
-            <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="SystemColorButtonTextColor" />
-            <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColor" />
-            <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="SystemColorHighlightColor" />
+            <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
 
             <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush"  />
+            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SystemControlTransparentBrush"  />
+            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush"  />
+            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
 
-            <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="SystemColorWindowTextColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarBackgroundBrush" ResourceKey="SystemColorButtonFaceColor" />
-            <StaticResource x:Key="BreadcrumbBarBorderBrush" ResourceKey="SystemColorButtonFaceColor" />
+            <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="BreadcrumbBarBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
+            <StaticResource x:Key="BreadcrumbBarBorderBrush" ResourceKey="SystemControlTransparentBrush" />
 
             <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="SystemColorWindowColorBrush" />
             <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />


### PR DESCRIPTION
Updating rest/hover/pressed states for breadcrumb items and flyout.
Spec shows chevron change color on hover, but that won't be possible without a structural change to the control so if that's specifically requested by design later it would be a different task as it applies not only to HC but control style all up.

Spec:
![BreadcrumbBar](https://user-images.githubusercontent.com/29714167/138523342-b2f4bedf-796a-4e2f-aaa8-413ed30f2613.png)

Control with updates:


![breadcrumb-fixed](https://user-images.githubusercontent.com/29714167/138523356-677e0995-095c-4126-a5ff-fd6dbf089bc1.png)
![flyout-fixed](https://user-images.githubusercontent.com/29714167/138523358-233f81dd-e285-447f-8fb3-eb1ad068a68c.png)


