### PR TITLE
NumberBox to Announce Min/Max Values

### DIFF
--- a/dev/NumberBox/APITests/NumberBoxTests.cs
+++ b/dev/NumberBox/APITests/NumberBoxTests.cs
@@ -162,6 +162,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 VerifyUIAName("Some UIA name Minimum0 Maximum10");
+                numberBox.Minimum = 50;
+                numberBox.Maximum = 100;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                VerifyUIAName("Some UIA name Minimum50 Maximum100");
             });
 
             void VerifyUIAName(string value)

--- a/dev/NumberBox/APITests/NumberBoxTests.cs
+++ b/dev/NumberBox/APITests/NumberBoxTests.cs
@@ -161,7 +161,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                VerifyUIAName("Some UIA nameMinimum0Maximum10");
+                VerifyUIAName("Some UIA name Minimum0 Maximum10");
             });
 
             void VerifyUIAName(string value)

--- a/dev/NumberBox/APITests/NumberBoxTests.cs
+++ b/dev/NumberBox/APITests/NumberBoxTests.cs
@@ -153,6 +153,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             RunOnUIThread.Execute(() =>
             {
                 VerifyUIAName("Some UIA name");
+                numberBox.Minimum = 0;
+                numberBox.Maximum = 10;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                VerifyUIAName("Some UIA nameMinimum0Maximum10");
             });
 
             void VerifyUIAName(string value)

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -276,6 +276,7 @@ void NumberBox::OnMinimumPropertyChanged(const winrt::DependencyPropertyChangedE
     CoerceValue();
 
     UpdateSpinButtonEnabled();
+    ReevaluateForwardedUIAName();
 }
 
 void NumberBox::OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -284,6 +285,7 @@ void NumberBox::OnMaximumPropertyChanged(const winrt::DependencyPropertyChangedE
     CoerceValue();
 
     UpdateSpinButtonEnabled();
+    ReevaluateForwardedUIAName();
 }
 
 void NumberBox::OnSmallChangePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -362,19 +364,25 @@ void NumberBox::OnAutomationPropertiesNamePropertyChanged(const winrt::Dependenc
 void NumberBox::ReevaluateForwardedUIAName()
 {
     if (const auto textBox = m_textBox.get())
-    {
+    {    
         const auto name = winrt::AutomationProperties::GetName(*this);
+        const auto minimum = Minimum() == -std::numeric_limits<double>::max() ?
+            winrt::hstring{} :
+            winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMinimumValueStatus) + winrt::to_hstring(Minimum()) };
+        const auto maximum = Maximum() == std::numeric_limits<double>::max() ?
+            winrt::hstring{} :
+            winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMaximumValueStatus) + winrt::to_hstring(Maximum()) };      
         if (!name.empty())
-        {
+        {            
             // AutomationProperties.Name is a non empty string, we will use that value.
-            winrt::AutomationProperties::SetName(textBox, name);
+            winrt::AutomationProperties::SetName(textBox, name + minimum + maximum );
         }
         else
         {
             if (const auto headerAsString = Header().try_as<winrt::IReference<winrt::hstring>>())
             {
                 // Header is a string, we can use that as our UIA name.
-                winrt::AutomationProperties::SetName(textBox, headerAsString.Value());
+                winrt::AutomationProperties::SetName(textBox, headerAsString.Value() + minimum + maximum );
             }
         }
     }

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -364,16 +364,16 @@ void NumberBox::OnAutomationPropertiesNamePropertyChanged(const winrt::Dependenc
 void NumberBox::ReevaluateForwardedUIAName()
 {
     if (const auto textBox = m_textBox.get())
-    {    
+    {
         const auto name = winrt::AutomationProperties::GetName(*this);
         const auto minimum = Minimum() == -std::numeric_limits<double>::max() ?
             winrt::hstring{} :
-            winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMinimumValueStatus) + winrt::to_hstring(Minimum()) };
+            winrt::hstring{ L" " + ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMinimumValueStatus) + winrt::to_hstring(Minimum()) };
         const auto maximum = Maximum() == std::numeric_limits<double>::max() ?
             winrt::hstring{} :
-            winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMaximumValueStatus) + winrt::to_hstring(Maximum()) };      
+            winrt::hstring{ L" " + ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMaximumValueStatus) + winrt::to_hstring(Maximum()) };      
         if (!name.empty())
-        {            
+        {
             // AutomationProperties.Name is a non empty string, we will use that value.
             winrt::AutomationProperties::SetName(textBox, name + minimum + maximum );
         }

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -371,7 +371,8 @@ void NumberBox::ReevaluateForwardedUIAName()
             winrt::hstring{ L" " + ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMinimumValueStatus) + winrt::to_hstring(Minimum()) };
         const auto maximum = Maximum() == std::numeric_limits<double>::max() ?
             winrt::hstring{} :
-            winrt::hstring{ L" " + ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMaximumValueStatus) + winrt::to_hstring(Maximum()) };      
+            winrt::hstring{ L" " + ResourceAccessor::GetLocalizedStringResource(SR_NumberBoxMaximumValueStatus) + winrt::to_hstring(Maximum()) };
+
         if (!name.empty())
         {
             // AutomationProperties.Name is a non empty string, we will use that value.

--- a/dev/NumberBox/Strings/en-US/Resources.resw
+++ b/dev/NumberBox/Strings/en-US/Resources.resw
@@ -125,4 +125,12 @@
     <value>Increase</value>
     <comment>Automation name for the up button</comment>
   </data>
+  <data name="NumberBoxMaximumValueStatus" xml:space="preserve">
+    <value>Maximum</value>
+    <comment>Maximum value declaration</comment>
+  </data>
+  <data name="NumberBoxMinimumValueStatus" xml:space="preserve">
+    <value>Minimum</value>
+    <comment>Minimum value declaration</comment>
+  </data>
 </root>

--- a/dev/ResourceHelper/ResourceAccessor.h
+++ b/dev/ResourceHelper/ResourceAccessor.h
@@ -175,6 +175,8 @@ public:
 #define SR_TabViewScrollIncreaseButtonTooltip L"TabViewScrollIncreaseButtonTooltip"
 #define SR_NumberBoxUpSpinButtonName L"NumberBoxUpSpinButtonName"
 #define SR_NumberBoxDownSpinButtonName L"NumberBoxDownSpinButtonName"
+#define SR_NumberBoxMaximumValueStatus L"NumberBoxMaximumValueStatus"
+#define SR_NumberBoxMinimumValueStatus L"NumberBoxMinimumValueStatus"
 #define SR_ExpanderDefaultControlName L"ExpanderDefaultControlName"
 
 #define SR_InfoBarCloseButtonName L"InfoBarCloseButtonName"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NumberBox was not announcing min / max values with narrator. Tab focus goes to textbox within NumberBox by design, and there is no way to set its PatternInterface / AutomationControlType to be Rangebase / Spinner. 

**Solution**: The min / max values are forwarded to the textbox `AutomationProperties.Name` property in `ReevaluateForwardedUIAName()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #2951

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Appended test case to `VerifyUIANameBehavior()`

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->