### PR TITLE
Added IAnimatedVisual2 interface and Freeze/Unfreeze AVP methods

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -934,6 +934,22 @@ void AnimatedVisualPlayer::UpdateContent()
     }
 }
 
+void AnimatedVisualPlayer::Freeze() {
+    if (auto animatedVisual2 = m_animatedVisual.try_as<winrt::IAnimatedVisual2>()) {
+        animatedVisual2.DestroyAnimations();
+    }
+}
+
+void AnimatedVisualPlayer::Unfreeze() {
+    if (auto animatedVisual2 = m_animatedVisual.try_as<winrt::IAnimatedVisual2>()) {
+        animatedVisual2.InstantiateAnimations();
+    }
+}
+
+bool AnimatedVisualPlayer::CanFreeze() {
+    return m_animatedVisual.try_as<winrt::IAnimatedVisual2>() != nullptr;
+}
+
 void AnimatedVisualPlayer::LoadFallbackContent()
 {
     MUX_ASSERT(m_isFallenBack);

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -27,6 +27,17 @@ struct AnimatedVisualPlayer:
     void SetProgress(double progress);
     void Stop();
 
+    // Destroys all composition animation that were created for this visual.
+    // It will effectively freeze the visual so that it consumes less CPU while idle.
+    void Freeze();
+
+    // Re-instantiates all composition animations to prepare animated visual
+    // before playing new animation.
+    void Unfreeze();
+
+    // Indicates if current animated visual supports freezing.
+    bool CanFreeze();
+
     // FrameworkElement overrides
     winrt::Size MeasureOverride(winrt::Size const& availableSize);
     winrt::Size ArrangeOverride(winrt::Size const& finalSize);

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -27,17 +27,6 @@ struct AnimatedVisualPlayer:
     void SetProgress(double progress);
     void Stop();
 
-    // Destroys all composition animation that were created for this visual.
-    // It will effectively freeze the visual so that it consumes less CPU while idle.
-    void Freeze();
-
-    // Re-instantiates all composition animations to prepare animated visual
-    // before playing new animation.
-    void Unfreeze();
-
-    // Indicates if current animated visual supports freezing.
-    bool CanFreeze();
-
     // FrameworkElement overrides
     winrt::Size MeasureOverride(winrt::Size const& availableSize);
     winrt::Size ArrangeOverride(winrt::Size const& finalSize);
@@ -93,6 +82,8 @@ private:
     };
 
     void OnAutoPlayPropertyChanged(winrt::DependencyPropertyChangedEventArgs const& args);
+
+    void OnActivePropertyChanged(winrt::DependencyPropertyChangedEventArgs const& args);
 
     void OnFallbackContentPropertyChanged(winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -129,7 +129,7 @@ private:
     winrt::float2 m_animatedVisualSize;
     winrt::Composition::Visual m_animatedVisualRoot{ nullptr };
     int m_playAsyncVersion{ 0 };
-    double m_currentPlayFromProgress{ 0 };
+    double m_lastPlayProgress{ 0 };
     // The play that will be stopped when Stop() is called.
     std::shared_ptr<AnimationPlay> m_nowPlaying{ nullptr };
     winrt::IDynamicAnimatedVisualSource::AnimatedVisualInvalidated_revoker  m_dynamicAnimatedVisualInvalidatedRevoker{};

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
@@ -36,6 +36,16 @@ interface IDynamicAnimatedVisualSource
     event Windows.Foundation.TypedEventHandler<IDynamicAnimatedVisualSource, Object> AnimatedVisualInvalidated;
 };
 
+[MUX_PREVIEW]
+[webhosthidden]
+interface IAnimatedVisualSource3
+{
+    IAnimatedVisual2 TryCreateAnimatedVisual(
+        Windows.UI.Composition.Compositor compositor,
+        Boolean instantiateAnimations,
+        out Object diagnostics);
+};
+
 [MUX_INTERNAL]
 [webhosthidden]
 interface ISelfPlayingAnimatedVisual
@@ -70,6 +80,9 @@ unsealed runtimeclass AnimatedVisualPlayer
     [MUX_DEFAULT_VALUE("true")]
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     Boolean AutoPlay;
+    [MUX_DEFAULT_VALUE("true")]
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
+    Boolean Active;
     Boolean IsAnimatedVisualLoaded{ get; };
     Boolean IsPlaying{ get; };
     [MUX_DEFAULT_VALUE("1")]
@@ -90,6 +103,7 @@ unsealed runtimeclass AnimatedVisualPlayer
 
     // Dependency properties
     static Windows.UI.Xaml.DependencyProperty AutoPlayProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty ActiveProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty DiagnosticsProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty DurationProperty{ get; };
     static Windows.UI.Xaml.DependencyProperty FallbackContentProperty{ get; };

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
@@ -15,7 +15,7 @@ interface IAnimatedVisual
 [webhosthidden]
 interface IAnimatedVisual2 requires IAnimatedVisual
 {
-    void InstantiateAnimations();
+    void InstantiateAnimations(Double progressHint);
     void DestroyAnimations();
 };
 

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
@@ -11,7 +11,7 @@ interface IAnimatedVisual
     Windows.Foundation.TimeSpan Duration{ get; };
 };
 
-[MUX_PUBLIC]
+[MUX_PREVIEW]
 [webhosthidden]
 interface IAnimatedVisual2 requires IAnimatedVisual
 {

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.idl
@@ -13,6 +13,14 @@ interface IAnimatedVisual
 
 [MUX_PUBLIC]
 [webhosthidden]
+interface IAnimatedVisual2 requires IAnimatedVisual
+{
+    void InstantiateAnimations();
+    void DestroyAnimations();
+};
+
+[MUX_PUBLIC]
+[webhosthidden]
 interface IAnimatedVisualSource
 {
     IAnimatedVisual TryCreateAnimatedVisual(

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml
@@ -45,9 +45,12 @@
                 </StackPanel.Resources>
                 <TextBlock Text="Actions" Style="{ThemeResource StandardGroupHeader}"/>
                 <Button x:Name="PlayButton" Click="PlayButton_Click">Play forwards from 0 to 1</Button>
+                <Button x:Name="PlayHalfButton" Click="PlayHalfButton_Click">Play forwards from 0.0 to 0.5</Button>
                 <Button x:Name="ToZeroKeyframeAnimationPlayButton" Click="ToZeroKeyframeAnimationPlayButton_Click">Play forwards from 0.35 to 0</Button>
                 <Button x:Name="AroundTheEndAnimationPlayButton" Click="AroundTheEndAnimationPlayButton_Click">Play forwards from 0.35 to 0.3</Button>
                 <Button x:Name="FromOneKeyframeAnimationPlayButton" Click="FromOneKeyframeAnimationPlayButton_Click">Play forwards from 1 to 0.35</Button>
+                <Button x:Name="SwitchActiveButton" Click="SwitchActiveButton_Click">Deactivate</Button>
+                <Button x:Name="StopButton" Click="StopButton_Click">Stop</Button>
                 <Button x:Name="ReverseNegativePlaybackRateAnimationPlayButton" Click="ReverseNegativePlaybackRateAnimationPlayButton_Click">Play backwards from 1 to 0.5 then forwards from 0.5 to 1</Button>
                 <Button x:Name="ReversePositivePlaybackRateAnimationPlayButton" Click="ReversePositivePlaybackRateAnimationPlayButton_Click">Play forwards from 0 to 0.5 then backwards from 0.5 to 0</Button>
                 <Button x:Name="FallenBackButton" Click="FallenBackButton_ClickAsync">Fall back</Button>

--- a/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/AnimatedVisualPlayerPage.xaml.cs
@@ -78,7 +78,7 @@ namespace MUXControlsTestApp
             IsPlayingTextBoxBeforePlaying.Text = Player.IsPlaying.ToString();
 
             // Start playing and concurrently get the IsPlaying state.
-            Task task1 = Player.PlayAsync(0, 1, false).AsTask();
+            Task task1 = Player.PlayAsync(from, to, false).AsTask();
             Task task2 = GetIsPlayingAsync();
 
             // Wait for playing to finish.
@@ -99,6 +99,13 @@ namespace MUXControlsTestApp
             PlayForward(0, 1, ProgressTextBox);
         }
 
+        // Play from 0 to 1.
+        void PlayHalfButton_Click(object sender, RoutedEventArgs e)
+        {
+            IsPlayingTextBoxBeforePlaying.Text = Player.IsPlaying.ToString();
+            PlayForward(0, 0.5, ProgressTextBox);
+        }
+
         // Play forwards from 0.35 to 0.
         void ToZeroKeyframeAnimationPlayButton_Click(object sender, RoutedEventArgs e)
         {
@@ -115,6 +122,17 @@ namespace MUXControlsTestApp
         void FromOneKeyframeAnimationPlayButton_Click(object sender, RoutedEventArgs e)
         {
             PlayForward(1, 0.35, FromOneKeyframeAnimationProgressTextBox);
+        }
+
+        void SwitchActiveButton_Click(object sender, RoutedEventArgs e)
+        {
+            Player.Active = !Player.Active;
+            SwitchActiveButton.Content = Player.Active ? "Deactivate" : "Activate";
+        }
+
+        void StopButton_Click(object sender, RoutedEventArgs e)
+        {
+            Player.Stop();
         }
 
         // Play backwards from 1 to 0.5 then forwards from 0.5 to 1.

--- a/dev/AnimatedVisualPlayer/TestUI/LottieLogo.cs
+++ b/dev/AnimatedVisualPlayer/TestUI/LottieLogo.cs
@@ -1,94 +1,911 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.UI.Xaml.Controls;
+using Microsoft.Graphics.Canvas.Geometry;
 using System;
+using System.Collections.Generic;
 using System.Numerics;
-using System.Runtime.InteropServices;
 using Windows.Graphics;
 using Windows.UI;
 using Windows.UI.Composition;
 
 namespace AnimatedVisuals
 {
-    sealed class LottieLogo : IAnimatedVisualSource
+    sealed class LottieLogo
+        : Microsoft.UI.Xaml.Controls.IAnimatedVisualSource
+        , Microsoft.UI.Xaml.Controls.IAnimatedVisualSource2
     {
-        public IAnimatedVisual TryCreateAnimatedVisual(Compositor compositor, out object diagnostics)
+        // Animation duration: 5.967 seconds.
+        internal const long c_durationTicks = 59666666;
+
+        public Microsoft.UI.Xaml.Controls.IAnimatedVisual TryCreateAnimatedVisual(Compositor compositor)
+        {
+            object ignored = null;
+            return TryCreateAnimatedVisual(compositor, out ignored);
+        }
+
+        public Microsoft.UI.Xaml.Controls.IAnimatedVisual TryCreateAnimatedVisual(Compositor compositor, out object diagnostics)
         {
             diagnostics = null;
-            if (!IsRuntimeCompatible())
+
+            if (LottieLogo_AnimatedVisual.IsRuntimeCompatible())
             {
-                return null;
+                var v =
+                    new LottieLogo_AnimatedVisual(
+                        compositor
+                        );
+                v.InstantiateAnimations(0.0);
+                return v;
             }
-            return new AnimatedVisual(compositor);
+
+            return null;
         }
 
-        static bool IsRuntimeCompatible()
+        /// <summary>
+        /// Gets the number of frames in the animation.
+        /// </summary>
+        public double FrameCount => 179d;
+
+        /// <summary>
+        /// Gets the frame rate of the animation.
+        /// </summary>
+        public double Framerate => 30d;
+
+        /// <summary>
+        /// Gets the duration of the animation.
+        /// </summary>
+        public TimeSpan Duration => TimeSpan.FromTicks(c_durationTicks);
+
+        /// <summary>
+        /// Converts a zero-based frame number to the corresponding progress value denoting the
+        /// start of the frame.
+        /// </summary>
+        public double FrameToProgress(double frameNumber)
         {
-            if (!Windows.Foundation.Metadata.ApiInformation.IsTypePresent("Windows.UI.Composition.CompositionGeometricClip"))
-            {
-                return false;
-            }
-            return true;
+            return frameNumber / 179d;
         }
 
-        sealed class AnimatedVisual : IAnimatedVisual
+        /// <summary>
+        /// Returns a map from marker names to corresponding progress values.
+        /// </summary>
+        public IReadOnlyDictionary<string, double> Markers =>
+            new Dictionary<string, double>
+            {
+            };
+
+        /// <summary>
+        /// Sets the color property with the given name, or does nothing if no such property
+        /// exists.
+        /// </summary>
+        public void SetColorProperty(string propertyName, Color value)
         {
-            readonly ID2D1Factory _d2d;
-            const long c_durationTicks = 59670000;
+        }
+
+        /// <summary>
+        /// Sets the scalar property with the given name, or does nothing if no such property
+        /// exists.
+        /// </summary>
+        public void SetScalarProperty(string propertyName, double value)
+        {
+        }
+
+        sealed class LottieLogo_AnimatedVisual : Microsoft.UI.Xaml.Controls.IAnimatedVisual2
+        {
+            const long c_durationTicks = 59666666;
             readonly Compositor _c;
             readonly ExpressionAnimation _reusableExpressionAnimation;
             CompositionColorBrush _colorBrush_AlmostTeal_FF007A87;
             CompositionColorBrush _colorBrush_White;
-            CompositionPath _compositionPath_00;
-            CompositionPath _compositionPath_01;
-            CompositionPath _compositionPath_02;
-            CompositionPath _compositionPath_03;
-            CompositionPath _compositionPath_04;
-            CompositionPath _compositionPath_05;
-            CompositionPath _compositionPath_06;
-            CompositionPath _compositionPath_07;
-            CompositionPath _compositionPath_08;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_02;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_03;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_04;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_05;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_07;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_08;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_10;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_11;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_14;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_15;
-            CubicBezierEasingFunction _cubicBezierEasingFunction_22;
+            CompositionContainerShape _containerShape_00;
+            CompositionContainerShape _containerShape_01;
+            CompositionContainerShape _containerShape_02;
+            CompositionContainerShape _containerShape_03;
+            CompositionContainerShape _containerShape_04;
+            CompositionContainerShape _containerShape_05;
+            CompositionContainerShape _containerShape_06;
+            CompositionContainerShape _containerShape_07;
+            CompositionContainerShape _containerShape_08;
+            CompositionContainerShape _containerShape_09;
+            CompositionContainerShape _containerShape_10;
+            CompositionContainerShape _containerShape_11;
+            CompositionContainerShape _containerShape_12;
+            CompositionContainerShape _containerShape_13;
+            CompositionContainerShape _containerShape_14;
+            CompositionContainerShape _containerShape_15;
+            CompositionContainerShape _containerShape_16;
+            CompositionContainerShape _containerShape_17;
+            CompositionContainerShape _containerShape_18;
+            CompositionContainerShape _containerShape_19;
+            CompositionContainerShape _containerShape_20;
+            CompositionContainerShape _containerShape_21;
+            CompositionContainerShape _containerShape_22;
+            CompositionEllipseGeometry _ellipse_0_0;
+            CompositionEllipseGeometry _ellipse_0_1;
             CompositionEllipseGeometry _ellipse_4p7;
-            StepEasingFunction _holdThenStepEasingFunction;
-            Vector2KeyFrameAnimation _positionVector2Animation_02;
-            Vector2KeyFrameAnimation _positionVector2Animation_03;
-            Vector2KeyFrameAnimation _positionVector2Animation_04;
-            Vector2KeyFrameAnimation _positionVector2Animation_05;
-            Vector2KeyFrameAnimation _positionVector2Animation_06;
-            Vector2KeyFrameAnimation _radiusVector2Animation;
+            CompositionPath _path_0;
+            CompositionPath _path_1;
+            CompositionPath _path_2;
+            CompositionPath _path_3;
+            CompositionPath _path_4;
+            CompositionPath _path_5;
+            CompositionPath _path_6;
+            CompositionPath _path_7;
+            CompositionPath _path_8;
+            CompositionPathGeometry _pathGeometry_00;
+            CompositionPathGeometry _pathGeometry_01;
+            CompositionPathGeometry _pathGeometry_02;
+            CompositionPathGeometry _pathGeometry_03;
+            CompositionPathGeometry _pathGeometry_04;
+            CompositionPathGeometry _pathGeometry_05;
+            CompositionPathGeometry _pathGeometry_06;
+            CompositionPathGeometry _pathGeometry_07;
+            CompositionPathGeometry _pathGeometry_08;
+            CompositionPathGeometry _pathGeometry_09;
+            CompositionPathGeometry _pathGeometry_10;
+            CompositionPathGeometry _pathGeometry_11;
+            CompositionPathGeometry _pathGeometry_12;
+            CompositionPathGeometry _pathGeometry_13;
+            CompositionPathGeometry _pathGeometry_14;
+            CompositionPathGeometry _pathGeometry_15;
+            CompositionPathGeometry _pathGeometry_16;
+            CompositionPathGeometry _pathGeometry_17;
+            CompositionPathGeometry _pathGeometry_18;
+            CompositionPathGeometry _pathGeometry_19;
+            CompositionPathGeometry _pathGeometry_20;
+            CompositionPathGeometry _pathGeometry_21;
+            CompositionPathGeometry _pathGeometry_22;
+            CompositionPathGeometry _pathGeometry_23;
+            CompositionPathGeometry _pathGeometry_24;
+            CompositionPathGeometry _pathGeometry_25;
+            CompositionPathGeometry _pathGeometry_26;
+            CompositionPathGeometry _pathGeometry_27;
+            CompositionPathGeometry _pathGeometry_28;
+            CompositionPathGeometry _pathGeometry_29;
+            CompositionPathGeometry _pathGeometry_30;
+            CompositionPathGeometry _pathGeometry_31;
+            CompositionPathGeometry _pathGeometry_32;
+            CompositionPathGeometry _pathGeometry_33;
+            CompositionPathGeometry _pathGeometry_34;
+            CompositionPathGeometry _pathGeometry_35;
+            CompositionPathGeometry _pathGeometry_36;
+            CompositionPathGeometry _pathGeometry_37;
+            CompositionPathGeometry _pathGeometry_38;
+            CompositionSpriteShape _spriteShape_11;
+            CompositionSpriteShape _spriteShape_12;
+            CompositionSpriteShape _spriteShape_13;
+            CompositionSpriteShape _spriteShape_14;
+            CompositionSpriteShape _spriteShape_15;
+            CompositionSpriteShape _spriteShape_19;
+            CompositionSpriteShape _spriteShape_22;
+            CompositionSpriteShape _spriteShape_23;
+            CompositionSpriteShape _spriteShape_36;
+            CompositionSpriteShape _spriteShape_37;
+            CompositionSpriteShape _spriteShape_38;
             ContainerVisual _root;
-            ScalarKeyFrameAnimation _scalarAnimation_0_to_1;
-            ExpressionAnimation _scalarExpressionAnimation;
-            StepEasingFunction _stepThenHoldEasingFunction;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_0;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_1;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_2;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_3;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_4;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_5;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_6;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_7;
+            CubicBezierEasingFunction _cubicBezierEasingFunction_8;
+            ExpressionAnimation _rootProgress;
             ScalarKeyFrameAnimation _tEndScalarAnimation_1_to_0_02;
             ScalarKeyFrameAnimation _tEndScalarAnimation_1_to_0_03;
             ScalarKeyFrameAnimation _tEndScalarAnimation_1_to_0_06;
             ScalarKeyFrameAnimation _tEndScalarAnimation_1_to_0_11;
             ScalarKeyFrameAnimation _tEndScalarAnimation_1_to_0_13;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_1_to_0_09;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_1_to_0_10;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_1_to_0_11;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_1_to_0_12;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_1_to_0_16;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_1_to_0_17;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_to_1_02;
-            ScalarKeyFrameAnimation _transformMatrix_11ScalarAnimation_to_1_06;
             ScalarKeyFrameAnimation _tStartScalarAnimation_0_to_0p249;
             ScalarKeyFrameAnimation _tStartScalarAnimation_0p87_to_0_02;
+            StepEasingFunction _holdThenStepEasingFunction;
+            StepEasingFunction _stepThenHoldEasingFunction;
+            Vector2KeyFrameAnimation _offsetVector2Animation_02;
+            Vector2KeyFrameAnimation _offsetVector2Animation_03;
+            Vector2KeyFrameAnimation _offsetVector2Animation_04;
+            Vector2KeyFrameAnimation _offsetVector2Animation_05;
+            Vector2KeyFrameAnimation _offsetVector2Animation_06;
+            Vector2KeyFrameAnimation _radiusVector2Animation;
+            Vector2KeyFrameAnimation _shapeVisibilityAnimation_04;
 
-            // Rectangle Path 1
+            public void InstantiateAnimations(double progressHint)
+            {
+                float currentProgress = (float)progressHint;
+                StartProgressBoundAnimation(_containerShape_00, "Offset", OffsetVector2Animation_01(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_00, "Scale", ShapeVisibilityAnimation_00(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_01, "Offset", OffsetVector2Animation_00(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_02, "Offset", OffsetVector2Animation_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_02, "Scale", ShapeVisibilityAnimation_01(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_03, "Offset", OffsetVector2Animation_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_03, "Scale", ShapeVisibilityAnimation_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_04, "Offset", OffsetVector2Animation_03(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_04, "Scale", ShapeVisibilityAnimation_03(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_05, "Offset", OffsetVector2Animation_03(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_05, "Scale", ShapeVisibilityAnimation_04(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_06, "Offset", OffsetVector2Animation_04(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_06, "Scale", ShapeVisibilityAnimation_05(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_07, "Offset", OffsetVector2Animation_04(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_07, "Scale", ShapeVisibilityAnimation_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_08, "Offset", OffsetVector2Animation_05(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_08, "Scale", ShapeVisibilityAnimation_07(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_09, "Offset", OffsetVector2Animation_05(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_09, "Scale", ShapeVisibilityAnimation_08(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_10, "Offset", OffsetVector2Animation_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_10, "Scale", ShapeVisibilityAnimation_09(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_11, "Offset", OffsetVector2Animation_07(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_11, "Scale", ShapeVisibilityAnimation_14(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_12, "Offset", OffsetVector2Animation_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_12, "Scale", ShapeVisibilityAnimation_15(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_13, "Offset", OffsetVector2Animation_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_13, "Scale", ShapeVisibilityAnimation_17(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_14, "Offset", OffsetVector2Animation_09(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_14, "Scale", ShapeVisibilityAnimation_18(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_15, "Offset", OffsetVector2Animation_08(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_16, "Scale", ShapeVisibilityAnimation_21(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_17, "Scale", ShapeVisibilityAnimation_22(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_18, "Scale", ShapeVisibilityAnimation_23(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_19, "Scale", ShapeVisibilityAnimation_24(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_20, "Scale", ShapeVisibilityAnimation_25(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_21, "Scale", ShapeVisibilityAnimation_29(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_containerShape_22, "Scale", ShapeVisibilityAnimation_30(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_ellipse_0_0, "Radius", RadiusVector2Animation(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_ellipse_0_1, "Radius", RadiusVector2Animation(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_ellipse_0_1, "TrimStart", TrimStartScalarAnimation_0_to_0p399(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_ellipse_0_1, "TrimEnd", TrimEndScalarAnimation_1_to_0p88(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_00, "TrimEnd", TrimEndScalarAnimation_0_to_0p316_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_01, "TrimEnd", TrimEndScalarAnimation_0_to_0p316_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_02, "TrimEnd", TrimEndScalarAnimation_0_to_0p457_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_03, "TrimEnd", TrimEndScalarAnimation_0_to_0p457_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_04, "TrimEnd", TrimEndScalarAnimation_0_to_0p43_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_05, "TrimEnd", TrimEndScalarAnimation_0_to_0p43_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_06, "TrimEnd", TrimEndScalarAnimation_0_to_0p375_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_07, "TrimEnd", TrimEndScalarAnimation_0_to_0p375_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_08, "TStart", TStartScalarAnimation_0_to_0p249(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_08, "TEnd", TEndScalarAnimation_0_to_1_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_09, "TrimStart", TrimStartScalarAnimation_0p29_to_0_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_09, "TrimEnd", TrimEndScalarAnimation_0p411_to_0p665_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_10, "TrimStart", TrimStartScalarAnimation_0p5_to_0_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_10, "TrimEnd", TrimEndScalarAnimation_0p5_to_1_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_11, "TrimStart", TrimStartScalarAnimation_0p29_to_0_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_11, "TrimEnd", TrimEndScalarAnimation_0p411_to_0p665_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_12, "TrimEnd", TrimEndScalarAnimation_0p117_to_1_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_13, "TrimEnd", TrimEndScalarAnimation_0p117_to_1_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_14, "TStart", TStartScalarAnimation_0_to_0p249(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_14, "TEnd", TEndScalarAnimation_0_to_1_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_15, "TrimStart", TrimStartScalarAnimation_0p5_to_0_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_15, "TrimEnd", TrimEndScalarAnimation_0p5_to_1_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_16, "TrimEnd", TrimEndScalarAnimation_0p249_to_0p891(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_17, "TStart", TStartScalarAnimation_0p8_to_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_17, "TEnd", TEndScalarAnimation_0p81_to_0p734_0(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_18, "TStart", TStartScalarAnimation_0p8_to_0p3(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_18, "TEnd", TEndScalarAnimation_0p81_to_0p734_1(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_19, "TStart", TStartScalarAnimation_0p87_to_0_00(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_19, "TEnd", TEndScalarAnimation_1_to_0_00(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_20, "TStart", TStartScalarAnimation_0p87_to_0_01(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_20, "TEnd", TEndScalarAnimation_1_to_0_01(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_21, "TStart", TStartScalarAnimation_0p87_to_0_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_21, "TEnd", TEndScalarAnimation_1_to_0_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_22, "TStart", TStartScalarAnimation_0p87_to_0_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_22, "TEnd", TEndScalarAnimation_1_to_0_02(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_23, "TStart", TStartScalarAnimation_0p87_to_0_03(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_23, "TEnd", TEndScalarAnimation_1_to_0_03(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_24, "TStart", TStartScalarAnimation_0p87_to_0_04(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_24, "TEnd", TEndScalarAnimation_1_to_0_03(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_25, "TStart", TStartScalarAnimation_0p87_to_0_05(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_25, "TEnd", TEndScalarAnimation_1_to_0_04(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_26, "TStart", TStartScalarAnimation_0p87_to_0_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_26, "TEnd", TEndScalarAnimation_1_to_0_05(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_27, "TStart", TStartScalarAnimation_0p87_to_0_07(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_27, "TEnd", TEndScalarAnimation_1_to_0_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_28, "TStart", TStartScalarAnimation_0p87_to_0_08(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_28, "TEnd", TEndScalarAnimation_1_to_0_06(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_29, "TStart", TStartScalarAnimation_0p87_to_0_09(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_29, "TEnd", TEndScalarAnimation_1_to_0_07(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_30, "TStart", TStartScalarAnimation_0p87_to_0_10(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_30, "TEnd", TEndScalarAnimation_1_to_0_08(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_31, "TStart", TStartScalarAnimation_0p87_to_0_11(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_31, "TEnd", TEndScalarAnimation_1_to_0_09(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_32, "TStart", TStartScalarAnimation_0p87_to_0_12(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_32, "TEnd", TEndScalarAnimation_1_to_0_10(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_33, "TStart", TStartScalarAnimation_0p87_to_0_13(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_33, "TEnd", TEndScalarAnimation_1_to_0_11(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_34, "TStart", TStartScalarAnimation_0p87_to_0_14(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_34, "TEnd", TEndScalarAnimation_1_to_0_11(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_35, "TStart", TStartScalarAnimation_0p87_to_0_15(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_35, "TEnd", TEndScalarAnimation_1_to_0_12(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_36, "TStart", TStartScalarAnimation_0p87_to_0_16(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_36, "TEnd", TEndScalarAnimation_1_to_0_13(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_37, "TStart", TStartScalarAnimation_0p87_to_0_17(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_37, "TEnd", TEndScalarAnimation_1_to_0_13(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_38, "TStart", TStartScalarAnimation_0p87_to_0_18(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_pathGeometry_38, "TEnd", TEndScalarAnimation_1_to_0_14(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_11, "Scale", ShapeVisibilityAnimation_10(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_12, "Scale", ShapeVisibilityAnimation_11(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_13, "Scale", ShapeVisibilityAnimation_12(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_14, "Scale", ShapeVisibilityAnimation_13(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_15, "Scale", ShapeVisibilityAnimation_04(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_19, "Scale", ShapeVisibilityAnimation_16(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_22, "Scale", ShapeVisibilityAnimation_19(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_23, "Scale", ShapeVisibilityAnimation_20(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_36, "Scale", ShapeVisibilityAnimation_26(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_37, "Scale", ShapeVisibilityAnimation_27(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_spriteShape_38, "Scale", ShapeVisibilityAnimation_28(), RootProgress(),currentProgress);
+                StartProgressBoundAnimation(_root.Properties, "t0", t0ScalarAnimation_0_to_1(), RootProgress(),currentProgress);
+            }
+            public void DestroyAnimations()
+            {
+                _containerShape_00.StopAnimation("Offset");
+                _containerShape_00.StopAnimation("Scale");
+                _containerShape_01.StopAnimation("Offset");
+                _containerShape_02.StopAnimation("Offset");
+                _containerShape_02.StopAnimation("Scale");
+                _containerShape_03.StopAnimation("Offset");
+                _containerShape_03.StopAnimation("Scale");
+                _containerShape_04.StopAnimation("Offset");
+                _containerShape_04.StopAnimation("Scale");
+                _containerShape_05.StopAnimation("Offset");
+                _containerShape_05.StopAnimation("Scale");
+                _containerShape_06.StopAnimation("Offset");
+                _containerShape_06.StopAnimation("Scale");
+                _containerShape_07.StopAnimation("Offset");
+                _containerShape_07.StopAnimation("Scale");
+                _containerShape_08.StopAnimation("Offset");
+                _containerShape_08.StopAnimation("Scale");
+                _containerShape_09.StopAnimation("Offset");
+                _containerShape_09.StopAnimation("Scale");
+                _containerShape_10.StopAnimation("Offset");
+                _containerShape_10.StopAnimation("Scale");
+                _containerShape_11.StopAnimation("Offset");
+                _containerShape_11.StopAnimation("Scale");
+                _containerShape_12.StopAnimation("Offset");
+                _containerShape_12.StopAnimation("Scale");
+                _containerShape_13.StopAnimation("Offset");
+                _containerShape_13.StopAnimation("Scale");
+                _containerShape_14.StopAnimation("Offset");
+                _containerShape_14.StopAnimation("Scale");
+                _containerShape_15.StopAnimation("Offset");
+                _containerShape_16.StopAnimation("Scale");
+                _containerShape_17.StopAnimation("Scale");
+                _containerShape_18.StopAnimation("Scale");
+                _containerShape_19.StopAnimation("Scale");
+                _containerShape_20.StopAnimation("Scale");
+                _containerShape_21.StopAnimation("Scale");
+                _containerShape_22.StopAnimation("Scale");
+                _ellipse_0_0.StopAnimation("Radius");
+                _ellipse_0_1.StopAnimation("Radius");
+                _ellipse_0_1.StopAnimation("TrimStart");
+                _ellipse_0_1.StopAnimation("TrimEnd");
+                _pathGeometry_00.StopAnimation("TrimEnd");
+                _pathGeometry_01.StopAnimation("TrimEnd");
+                _pathGeometry_02.StopAnimation("TrimEnd");
+                _pathGeometry_03.StopAnimation("TrimEnd");
+                _pathGeometry_04.StopAnimation("TrimEnd");
+                _pathGeometry_05.StopAnimation("TrimEnd");
+                _pathGeometry_06.StopAnimation("TrimEnd");
+                _pathGeometry_07.StopAnimation("TrimEnd");
+                _pathGeometry_08.StopAnimation("TStart");
+                _pathGeometry_08.StopAnimation("TEnd");
+                _pathGeometry_09.StopAnimation("TrimStart");
+                _pathGeometry_09.StopAnimation("TrimEnd");
+                _pathGeometry_10.StopAnimation("TrimStart");
+                _pathGeometry_10.StopAnimation("TrimEnd");
+                _pathGeometry_11.StopAnimation("TrimStart");
+                _pathGeometry_11.StopAnimation("TrimEnd");
+                _pathGeometry_12.StopAnimation("TrimEnd");
+                _pathGeometry_13.StopAnimation("TrimEnd");
+                _pathGeometry_14.StopAnimation("TStart");
+                _pathGeometry_14.StopAnimation("TEnd");
+                _pathGeometry_15.StopAnimation("TrimStart");
+                _pathGeometry_15.StopAnimation("TrimEnd");
+                _pathGeometry_16.StopAnimation("TrimEnd");
+                _pathGeometry_17.StopAnimation("TStart");
+                _pathGeometry_17.StopAnimation("TEnd");
+                _pathGeometry_18.StopAnimation("TStart");
+                _pathGeometry_18.StopAnimation("TEnd");
+                _pathGeometry_19.StopAnimation("TStart");
+                _pathGeometry_19.StopAnimation("TEnd");
+                _pathGeometry_20.StopAnimation("TStart");
+                _pathGeometry_20.StopAnimation("TEnd");
+                _pathGeometry_21.StopAnimation("TStart");
+                _pathGeometry_21.StopAnimation("TEnd");
+                _pathGeometry_22.StopAnimation("TStart");
+                _pathGeometry_22.StopAnimation("TEnd");
+                _pathGeometry_23.StopAnimation("TStart");
+                _pathGeometry_23.StopAnimation("TEnd");
+                _pathGeometry_24.StopAnimation("TStart");
+                _pathGeometry_24.StopAnimation("TEnd");
+                _pathGeometry_25.StopAnimation("TStart");
+                _pathGeometry_25.StopAnimation("TEnd");
+                _pathGeometry_26.StopAnimation("TStart");
+                _pathGeometry_26.StopAnimation("TEnd");
+                _pathGeometry_27.StopAnimation("TStart");
+                _pathGeometry_27.StopAnimation("TEnd");
+                _pathGeometry_28.StopAnimation("TStart");
+                _pathGeometry_28.StopAnimation("TEnd");
+                _pathGeometry_29.StopAnimation("TStart");
+                _pathGeometry_29.StopAnimation("TEnd");
+                _pathGeometry_30.StopAnimation("TStart");
+                _pathGeometry_30.StopAnimation("TEnd");
+                _pathGeometry_31.StopAnimation("TStart");
+                _pathGeometry_31.StopAnimation("TEnd");
+                _pathGeometry_32.StopAnimation("TStart");
+                _pathGeometry_32.StopAnimation("TEnd");
+                _pathGeometry_33.StopAnimation("TStart");
+                _pathGeometry_33.StopAnimation("TEnd");
+                _pathGeometry_34.StopAnimation("TStart");
+                _pathGeometry_34.StopAnimation("TEnd");
+                _pathGeometry_35.StopAnimation("TStart");
+                _pathGeometry_35.StopAnimation("TEnd");
+                _pathGeometry_36.StopAnimation("TStart");
+                _pathGeometry_36.StopAnimation("TEnd");
+                _pathGeometry_37.StopAnimation("TStart");
+                _pathGeometry_37.StopAnimation("TEnd");
+                _pathGeometry_38.StopAnimation("TStart");
+                _pathGeometry_38.StopAnimation("TEnd");
+                _spriteShape_11.StopAnimation("Scale");
+                _spriteShape_12.StopAnimation("Scale");
+                _spriteShape_13.StopAnimation("Scale");
+                _spriteShape_14.StopAnimation("Scale");
+                _spriteShape_15.StopAnimation("Scale");
+                _spriteShape_19.StopAnimation("Scale");
+                _spriteShape_22.StopAnimation("Scale");
+                _spriteShape_23.StopAnimation("Scale");
+                _spriteShape_36.StopAnimation("Scale");
+                _spriteShape_37.StopAnimation("Scale");
+                _spriteShape_38.StopAnimation("Scale");
+                _root.Properties.StopAnimation("t0");
+            }
+            static void StartProgressBoundAnimation(
+                CompositionObject target,
+                string animatedPropertyName,
+                CompositionAnimation animation,
+                ExpressionAnimation controllerProgressExpression, float currentProgress)
+            {
+                target.StartAnimation(animatedPropertyName, animation);
+                var controller = target.TryGetAnimationController(animatedPropertyName);
+                controller.Progress = currentProgress;
+                controller.Pause();
+                controller.StartAnimation("Progress", controllerProgressExpression);
+            }
+
+            void BindProperty(
+                CompositionObject target,
+                string animatedPropertyName,
+                string expression,
+                string referenceParameterName,
+                CompositionObject referencedObject)
+            {
+                _reusableExpressionAnimation.ClearAllParameters();
+                _reusableExpressionAnimation.Expression = expression;
+                _reusableExpressionAnimation.SetReferenceParameter(referenceParameterName, referencedObject);
+                target.StartAnimation(animatedPropertyName, _reusableExpressionAnimation);
+            }
+
+            ScalarKeyFrameAnimation CreateScalarKeyFrameAnimation(float initialProgress, float initialValue, CompositionEasingFunction initialEasingFunction)
+            {
+                var result = _c.CreateScalarKeyFrameAnimation();
+                result.Duration = TimeSpan.FromTicks(c_durationTicks);
+                result.InsertKeyFrame(initialProgress, initialValue, initialEasingFunction);
+                return result;
+            }
+
+            Vector2KeyFrameAnimation CreateVector2KeyFrameAnimation(float initialProgress, Vector2 initialValue, CompositionEasingFunction initialEasingFunction)
+            {
+                var result = _c.CreateVector2KeyFrameAnimation();
+                result.Duration = TimeSpan.FromTicks(c_durationTicks);
+                result.InsertKeyFrame(initialProgress, initialValue, initialEasingFunction);
+                return result;
+            }
+
+            CompositionSpriteShape CreateSpriteShape(CompositionGeometry geometry, Matrix3x2 transformMatrix)
+            {
+                var result = _c.CreateSpriteShape(geometry);
+                result.TransformMatrix = transformMatrix;
+                return result;
+            }
+
+            CompositionSpriteShape CreateSpriteShape(CompositionGeometry geometry, Matrix3x2 transformMatrix, CompositionBrush fillBrush)
+            {
+                var result = _c.CreateSpriteShape(geometry);
+                result.TransformMatrix = transformMatrix;
+                result.FillBrush = fillBrush;
+                return result;
+            }
+
+            CanvasGeometry Geometry_00()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-13.6639996F, -0.144999996F));
+                    builder.AddLine(new Vector2(75.663002F, 0.289999992F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_01()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(0.859000027F, -21.1429996F));
+                    builder.AddLine(new Vector2(-4.35900021F, 70.3919983F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_02()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-26.6700001F, -0.282999992F));
+                    builder.AddLine(new Vector2(99.1709976F, 0.0659999996F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_03()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-13.6639996F, -0.144999996F));
+                    builder.AddLine(new Vector2(62.1629982F, 0.289999992F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_04()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-30.7199993F, 63.7610016F));
+                    builder.AddCubicBezier(new Vector2(-30.6889992F, 63.1669998F), new Vector2(-30.7889996F, 50.8470001F), new Vector2(-30.7409992F, 45.1920013F));
+                    builder.AddCubicBezier(new Vector2(-30.6650009F, 36.2140007F), new Vector2(-37.3429985F, 27.0739994F), new Vector2(-37.3969994F, 27.0139999F));
+                    builder.AddCubicBezier(new Vector2(-38.5579987F, 25.7140007F), new Vector2(-39.7519989F, 24.1469994F), new Vector2(-40.6980019F, 22.6609993F));
+                    builder.AddCubicBezier(new Vector2(-46.637001F, 13.3339996F), new Vector2(-47.8400002F, 0.933000028F), new Vector2(-37.8730011F, -7.1170001F));
+                    builder.AddCubicBezier(new Vector2(-13.1960001F, -27.0459995F), new Vector2(8.96000004F, 11.559F), new Vector2(49.5060005F, 11.559F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_05()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(246.649994F, 213.813995F));
+                    builder.AddLine(new Vector2(340.955994F, 213.628006F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_06()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(1.68099999F, -29.9920006F));
+                    builder.AddLine(new Vector2(-1.68099999F, 29.9920006F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_07()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(1.76800001F, -25.9659996F));
+                    builder.AddLine(new Vector2(-1.76800001F, 25.9659996F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_08()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-8.83699989F, -58.2290001F));
+                    builder.AddCubicBezier(new Vector2(-8.83699989F, -58.2290001F), new Vector2(-10.1630001F, 29.4950008F), new Vector2(-35.8339996F, 33.6619987F));
+                    builder.AddCubicBezier(new Vector2(-44.0579987F, 34.9970016F), new Vector2(-50.2319984F, 30.0499992F), new Vector2(-51.6879997F, 23.1480007F));
+                    builder.AddCubicBezier(new Vector2(-53.144001F, 16.2450008F), new Vector2(-49.6549988F, 9.15600014F), new Vector2(-41.1739998F, 7.29300022F));
+                    builder.AddCubicBezier(new Vector2(-17.3570004F, 2.05999994F), new Vector2(4.23500013F, 57.1879997F), new Vector2(51.7970009F, 44.1780014F));
+                    builder.AddCubicBezier(new Vector2(51.9570007F, 44.1339989F), new Vector2(52.6870003F, 43.8740005F), new Vector2(53.1879997F, 43.7410011F));
+                    builder.AddCubicBezier(new Vector2(53.6889992F, 43.6080017F), new Vector2(68.9710007F, 41.3569984F), new Vector2(140.393997F, 43.6720009F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_09()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-67.125F, -112F));
+                    builder.AddCubicBezier(new Vector2(-67.125F, -112F), new Vector2(-73.5579987F, -100.719002F), new Vector2(-75.4580002F, -89.9509964F));
+                    builder.AddCubicBezier(new Vector2(-78.625F, -72F), new Vector2(-79.375F, -58.25F), new Vector2(-80.375F, -39.25F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_10()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-67.25F, -105.5F));
+                    builder.AddCubicBezier(new Vector2(-67.25F, -105.5F), new Vector2(-70.4329987F, -94.9690018F), new Vector2(-72.3330002F, -84.2009964F));
+                    builder.AddCubicBezier(new Vector2(-75.5F, -66.25F), new Vector2(-75.5F, -56.75F), new Vector2(-76.5F, -37.75F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_11()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(34.5F, -13.0500002F));
+                    builder.AddCubicBezier(new Vector2(7.5F, -14.5F), new Vector2(-4F, -37F), new Vector2(-35.0460014F, -35.5789986F));
+                    builder.AddCubicBezier(new Vector2(-61.4720001F, -34.3689995F), new Vector2(-62.25F, -5.75F), new Vector2(-62.25F, -5.75F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_12()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-3F, 35.9500008F));
+                    builder.AddCubicBezier(new Vector2(-3F, 35.9500008F), new Vector2(-1.5F, 7.5F), new Vector2(-1.352F, -6.75600004F));
+                    builder.AddCubicBezier(new Vector2(-9.90299988F, -15.0190001F), new Vector2(-21.5699997F, -20.5790005F), new Vector2(-32.0460014F, -20.5790005F));
+                    builder.AddCubicBezier(new Vector2(-53.5F, -20.5790005F), new Vector2(-42.25F, 4.25F), new Vector2(-42.25F, 4.25F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_13()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(16.2310009F, 39.0730019F));
+                    builder.AddLine(new Vector2(-32.769001F, 57.3650017F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_14()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(7.44999981F, 21.9500008F));
+                    builder.AddLine(new Vector2(-32.75F, 55.75F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_15()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-94.5F, 37.0730019F));
+                    builder.AddLine(new Vector2(-48.769001F, 55.3650017F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_16()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(-87.5F, 20.9500008F));
+                    builder.AddLine(new Vector2(-48.75F, 54.75F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_17()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(166.731003F, -7.92700005F));
+                    builder.AddLine(new Vector2(136.731003F, 7.11499977F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_18()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(156.449997F, -23.0499992F));
+                    builder.AddLine(new Vector2(132F, 2.75F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_19()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(169.5F, 18.073F));
+                    builder.AddLine(new Vector2(137.481003F, 11.3649998F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_20()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(119.5F, -45.0499992F));
+                    builder.AddLine(new Vector2(82.75F, -44.75F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_21()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(119.25F, -20.0499992F));
+                    builder.AddLine(new Vector2(63.5F, -20.5F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_22()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(128F, 3.6500001F));
+                    builder.AddLine(new Vector2(78.25F, 3.5F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_23()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(149.623993F, 8.24400043F));
+                    builder.AddLine(new Vector2(136.647995F, 10.1560001F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_24()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(144.429001F, -5.39699984F));
+                    builder.AddLine(new Vector2(132.274994F, 4.73099995F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_25()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(145.677002F, 22.2199993F));
+                    builder.AddLine(new Vector2(134.921997F, 14.7489996F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_26()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(147.699005F, 13.0249996F));
+                    builder.AddLine(new Vector2(133.195007F, 13.21F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_27()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(142.182999F, -5.11199999F));
+                    builder.AddLine(new Vector2(130.029007F, 5.01599979F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            CanvasGeometry Geometry_28()
+            {
+                CanvasGeometry result;
+                using (var builder = new CanvasPathBuilder(null))
+                {
+                    builder.BeginFigure(new Vector2(142.037994F, 29.2779999F));
+                    builder.AddLine(new Vector2(131.281998F, 21.8069992F));
+                    builder.EndFigure(CanvasFigureLoop.Open);
+                    result = CanvasGeometry.CreatePath(builder);
+                }
+                return result;
+            }
+
+            // - Layer aggregator
+            // Offset:<187.5, 333.5>
             CompositionColorBrush ColorBrush_AlmostDarkTurquoise_FF00D1C1()
             {
                 return _c.CreateColorBrush(Color.FromArgb(0xFF, 0x00, 0xD1, 0xC1));
@@ -104,1560 +921,356 @@ namespace AnimatedVisuals
                 return _colorBrush_White = _c.CreateColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF));
             }
 
-            CompositionPath CompositionPath_00()
-            {
-                var result = _compositionPath_00 = new CompositionPath(Geometry_00());
-                return result;
-            }
-
-            CompositionPath CompositionPath_01()
-            {
-                var result = _compositionPath_01 = new CompositionPath(Geometry_01());
-                return result;
-            }
-
-            CompositionPath CompositionPath_02()
-            {
-                var result = _compositionPath_02 = new CompositionPath(Geometry_02());
-                return result;
-            }
-
-            CompositionPath CompositionPath_03()
-            {
-                var result = _compositionPath_03 = new CompositionPath(Geometry_03());
-                return result;
-            }
-
-            CompositionPath CompositionPath_04()
-            {
-                var result = _compositionPath_04 = new CompositionPath(Geometry_04());
-                return result;
-            }
-
-            CompositionPath CompositionPath_05()
-            {
-                var result = _compositionPath_05 = new CompositionPath(Geometry_05());
-                return result;
-            }
-
-            CompositionPath CompositionPath_06()
-            {
-                var result = _compositionPath_06 = new CompositionPath(Geometry_06());
-                return result;
-            }
-
-            CompositionPath CompositionPath_07()
-            {
-                var result = _compositionPath_07 = new CompositionPath(Geometry_07());
-                return result;
-            }
-
-            CompositionPath CompositionPath_08()
-            {
-                var result = _compositionPath_08 = new CompositionPath(Geometry_08());
-                return result;
-            }
-
-            // Layer (Shape): Dot-Y
+            // Layer aggregator
+            // Transforms for Bncr
             CompositionContainerShape ContainerShape_00()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_01());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_00());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                if (_containerShape_00 != null) return _containerShape_00;
+                var result = _containerShape_00 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: Dot-Y
+                result.Shapes.Add(ContainerShape_01());
                 return result;
             }
 
-            // Layer (Shape): Dot-Y
+            // - Layer aggregator
+            // Layer: Dot-Y
+            // Transforms for Dot-Y
             CompositionContainerShape ContainerShape_01()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_02());
+                if (_containerShape_01 != null) return _containerShape_01;
+                var result = _containerShape_01 = _c.CreateContainerShape();
+                // ShapeGroup: Ellipse 1 Offset:<196, 267>
+                result.Shapes.Add(SpriteShape_01());
                 return result;
             }
 
-            // Transforms for Bncr
+            // Layer aggregator
+            // Transforms for E3-Y
             CompositionContainerShape ContainerShape_02()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(164.781998F, 57.4729996F));
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_03());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 60),(my.Position.Y - 60))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_01());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_containerShape_02 != null) return _containerShape_02;
+                var result = _containerShape_02 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Group 1 Offset:<344.674, 261.877>
+                result.Shapes.Add(SpriteShape_02());
                 return result;
             }
 
-            // Transforms for Dot-Y
+            // Layer aggregator
+            // Transforms for E3-Y
             CompositionContainerShape ContainerShape_03()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(43.2630005F, 59.75F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_01());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 196.791),(my.Position.Y - 266.504))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_00());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", ScalarExpressionAnimation());
+                if (_containerShape_03 != null) return _containerShape_03;
+                var result = _containerShape_03 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: E3-B Offset:<0.06500244, 0>
+                result.Shapes.Add(SpriteShape_03());
                 return result;
             }
 
-            // Layer (Shape): E3-Y
+            // Layer aggregator
+            // Transforms for I-Y
             CompositionContainerShape ContainerShape_04()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_05());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_00());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                if (_containerShape_04 != null) return _containerShape_04;
+                var result = _containerShape_04 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Group 6 Offset:<304.135, 282.409>
+                result.Shapes.Add(SpriteShape_04());
                 return result;
             }
 
-            // Layer (Shape): E3-Y
+            // Layer aggregator
+            // Transforms for I-Y
             CompositionContainerShape ContainerShape_05()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_06());
+                if (_containerShape_05 != null) return _containerShape_05;
+                var result = _containerShape_05 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: I-B
+                result.Shapes.Add(SpriteShape_05());
                 return result;
             }
 
-            // Transforms for E3-Y
+            // Layer aggregator
+            // Transforms for E2-Y
             CompositionContainerShape ContainerShape_06()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(119.167F, 57.4790001F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_02());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 345.124),(my.Position.Y - 261.801))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_02());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_containerShape_06 != null) return _containerShape_06;
+                var result = _containerShape_06 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Group 3 Offset:<331.664, 238.14>
+                result.Shapes.Add(SpriteShape_06());
                 return result;
             }
 
-            // Layer (Shape): E3-B
+            // Layer aggregator
+            // Transforms for E2-Y
             CompositionContainerShape ContainerShape_07()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_08());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_01());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                if (_containerShape_07 != null) return _containerShape_07;
+                var result = _containerShape_07 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: E2-B
+                result.Shapes.Add(SpriteShape_07());
                 return result;
             }
 
-            // Layer (Shape): E3-B
+            // Layer aggregator
+            // Transforms for E1-Y
             CompositionContainerShape ContainerShape_08()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_09());
+                if (_containerShape_08 != null) return _containerShape_08;
+                var result = _containerShape_08 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Group 2 Offset:<344.672, 214.842>
+                result.Shapes.Add(SpriteShape_08());
                 return result;
             }
 
-            // Transforms for E3-Y
+            // Layer aggregator
+            // Transforms for E1-Y
             CompositionContainerShape ContainerShape_09()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(119.167F, 57.4790001F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_03());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 345.124),(my.Position.Y - 261.801))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", _positionVector2Animation_02);
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_containerShape_09 != null) return _containerShape_09;
+                var result = _containerShape_09 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: E1-B
+                result.Shapes.Add(SpriteShape_09());
                 return result;
             }
 
-            // Layer (Shape): I-Y
+            // Layer aggregator
+            // Transforms for T1a-Y
             CompositionContainerShape ContainerShape_10()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_11());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_01());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                if (_containerShape_10 != null) return _containerShape_10;
+                var result = _containerShape_10 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Group 9 Offset:<227.677, 234.375>
+                result.Shapes.Add(SpriteShape_10());
                 return result;
             }
 
-            // Layer (Shape): I-Y
+            // Layer aggregator
+            // Transforms for O-Y
             CompositionContainerShape ContainerShape_11()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
+                if (_containerShape_11 != null) return _containerShape_11;
+                var result = _containerShape_11 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
                 var shapes = result.Shapes;
-                shapes.Add(ContainerShape_12());
+                // ShapeGroup: Ellipse 1 Offset:<196, 267>
+                shapes.Add(SpriteShape_16());
+                // ShapeGroup: Ellipse 1 Offset:<196, 267>
+                shapes.Add(SpriteShape_17());
                 return result;
             }
 
-            // Transforms for I-Y
+            // Layer aggregator
+            // Transforms for T1a-Y 2
             CompositionContainerShape ContainerShape_12()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(93.5940018F, 62.8610001F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_04());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 303.802),(my.Position.Y - 282.182))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_03());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_containerShape_12 != null) return _containerShape_12;
+                var result = _containerShape_12 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Group 9 Offset:<227.677, 234.375>
+                result.Shapes.Add(SpriteShape_18());
                 return result;
             }
 
-            // Layer (Shape): I-B
+            // Layer aggregator
+            // Transforms for T1a-Y
             CompositionContainerShape ContainerShape_13()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_14());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_02());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                if (_containerShape_13 != null) return _containerShape_13;
+                var result = _containerShape_13 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: T1a-B
+                result.Shapes.Add(SpriteShape_20());
                 return result;
             }
 
-            // Layer (Shape): I-B
+            // Layer aggregator
+            // Transforms for N
             CompositionContainerShape ContainerShape_14()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_15());
+                if (_containerShape_14 != null) return _containerShape_14;
+                var result = _containerShape_14 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // Transforms: Dot-Y
+                result.Shapes.Add(ContainerShape_15());
                 return result;
             }
 
-            // Transforms for I-Y
+            // - Layer aggregator
+            // Layer: Dot-Y
+            // Transforms for Dot-Y
             CompositionContainerShape ContainerShape_15()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(93.5940018F, 62.8610001F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_05());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 303.802),(my.Position.Y - 282.182))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", _positionVector2Animation_03);
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_containerShape_15 != null) return _containerShape_15;
+                var result = _containerShape_15 = _c.CreateContainerShape();
+                // ShapeGroup: Ellipse 1 Offset:<196, 267>
+                result.Shapes.Add(SpriteShape_21());
                 return result;
             }
 
-            // Layer (Shape): E2-Y
+            // Layer aggregator
+            // Transforms for Dot1
             CompositionContainerShape ContainerShape_16()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_17());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_02());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
+                if (_containerShape_16 != null) return _containerShape_16;
+                var result = _containerShape_16 = _c.CreateContainerShape();
+                // Offset:<154.457, 287.822>
+                result.TransformMatrix = new Matrix3x2(1F, 0F, 0F, 1F, 154.457001F, 287.821991F);
+                // ShapeGroup: Ellipse 1 Offset:<196, 267>
+                result.Shapes.Add(SpriteShape_24());
+                _containerShape_16.StartAnimation("Offset", OffsetVector2Animation_10());
+                var controller = _containerShape_16.TryGetAnimationController("Offset");
                 controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                BindProperty(controller, "Progress", "_.Progress*0.9835165+0.01648352", "_", _root);
                 return result;
             }
 
-            // Layer (Shape): E2-Y
+            // Layer aggregator
+            // Layer: S1-Y
             CompositionContainerShape ContainerShape_17()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
+                if (_containerShape_17 != null) return _containerShape_17;
+                var result = _containerShape_17 = _c.CreateContainerShape();
                 var shapes = result.Shapes;
-                shapes.Add(ContainerShape_18());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_25());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_26());
                 return result;
             }
 
-            // Transforms for E2-Y
+            // Layer aggregator
+            // Layer: S7
             CompositionContainerShape ContainerShape_18()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(109.092003F, 33.6100006F));
+                if (_containerShape_18 != null) return _containerShape_18;
+                var result = _containerShape_18 = _c.CreateContainerShape();
                 var shapes = result.Shapes;
-                shapes.Add(SpriteShape_06());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 332.05),(my.Position.Y - 237.932))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_04());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_27());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_28());
                 return result;
             }
 
-            // Layer (Shape): E2-B
+            // Layer aggregator
+            // Layer: S3-Y
             CompositionContainerShape ContainerShape_19()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
+                if (_containerShape_19 != null) return _containerShape_19;
+                var result = _containerShape_19 = _c.CreateContainerShape();
                 var shapes = result.Shapes;
-                shapes.Add(ContainerShape_20());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_03());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_29());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_30());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_31());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_32());
                 return result;
             }
 
-            // Layer (Shape): E2-B
+            // Layer aggregator
+            // Layer: S3-Y 2
             CompositionContainerShape ContainerShape_20()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
+                if (_containerShape_20 != null) return _containerShape_20;
+                var result = _containerShape_20 = _c.CreateContainerShape();
                 var shapes = result.Shapes;
-                shapes.Add(ContainerShape_21());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_33());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_34());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_35());
                 return result;
             }
 
-            // Transforms for E2-Y
+            // Layer aggregator
+            // Layer: S3-Y 3
             CompositionContainerShape ContainerShape_21()
             {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(109.092003F, 33.6100006F));
+                if (_containerShape_21 != null) return _containerShape_21;
+                var result = _containerShape_21 = _c.CreateContainerShape();
                 var shapes = result.Shapes;
-                shapes.Add(SpriteShape_07());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 332.05),(my.Position.Y - 237.932))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", _positionVector2Animation_04);
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_39());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_40());
+                // Offset:<154.457, 287.822>
+                shapes.Add(SpriteShape_41());
                 return result;
             }
 
-            // Layer (Shape): E1-Y
+            // Layer aggregator
+            // Layer: S3-Y 4
             CompositionContainerShape ContainerShape_22()
             {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
+                if (_containerShape_22 != null) return _containerShape_22;
+                var result = _containerShape_22 = _c.CreateContainerShape();
                 var shapes = result.Shapes;
-                shapes.Add(ContainerShape_23());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_03());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): E1-Y
-            CompositionContainerShape ContainerShape_23()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_24());
-                return result;
-            }
-
-            // Transforms for E1-Y
-            CompositionContainerShape ContainerShape_24()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(113.714996F, 9.14599991F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_08());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 344.672),(my.Position.Y - 214.842))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_05());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): E1-B
-            CompositionContainerShape ContainerShape_25()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_26());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_04());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): E1-B
-            CompositionContainerShape ContainerShape_26()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_27());
-                return result;
-            }
-
-            // Transforms for E1-Y
-            CompositionContainerShape ContainerShape_27()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(113.714996F, 9.14599991F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_09());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 344.672),(my.Position.Y - 214.842))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", _positionVector2Animation_05);
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1a-Y
-            CompositionContainerShape ContainerShape_28()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_29());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_04());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1a-Y
-            CompositionContainerShape ContainerShape_29()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_30());
-                return result;
-            }
-
-            // Transforms for T1a-Y
-            CompositionContainerShape ContainerShape_30()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(39.0429993F, 48.6780014F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_10());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 250),(my.Position.Y - 250))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_06());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T2b-Y
-            CompositionContainerShape ContainerShape_31()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_11());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_05());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T2a-Y
-            CompositionContainerShape ContainerShape_32()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_12());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_06());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T2b-B
-            CompositionContainerShape ContainerShape_33()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_13());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_05());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1b-Y
-            CompositionContainerShape ContainerShape_34()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_14());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_07());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1b-B
-            CompositionContainerShape ContainerShape_35()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_15());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_to_1_02);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): O-Y
-            CompositionContainerShape ContainerShape_36()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_37());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_06());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): O-Y
-            CompositionContainerShape ContainerShape_37()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_38());
-                return result;
-            }
-
-            // Transforms for O-Y
-            CompositionContainerShape ContainerShape_38()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(-62.7919998F, 73.0569992F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_16());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 196.791),(my.Position.Y - 266.504))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_07());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): O-B
-            CompositionContainerShape ContainerShape_39()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_40());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_to_1_06);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): O-B
-            CompositionContainerShape ContainerShape_40()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_41());
-                return result;
-            }
-
-            // Transforms for O-B
-            CompositionContainerShape ContainerShape_41()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(-62.7919998F, 73.0569992F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_17());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 196.791),(my.Position.Y - 266.504))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_08());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1a-Y 2
-            CompositionContainerShape ContainerShape_42()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_43());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_07());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1a-Y 2
-            CompositionContainerShape ContainerShape_43()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_44());
-                return result;
-            }
-
-            // Transforms for T1a-Y 2
-            CompositionContainerShape ContainerShape_44()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(39.0429993F, 48.6780014F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_18());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 250),(my.Position.Y - 250))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", _positionVector2Animation_06);
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T2a-B
-            CompositionContainerShape ContainerShape_45()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_19());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_08());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1a-B
-            CompositionContainerShape ContainerShape_46()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_47());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_09());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): T1a-B
-            CompositionContainerShape ContainerShape_47()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_48());
-                return result;
-            }
-
-            // Transforms for T1a-Y
-            CompositionContainerShape ContainerShape_48()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(39.0429993F, 48.6780014F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_20());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 250),(my.Position.Y - 250))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", _positionVector2Animation_06);
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): Dot-Y
-            CompositionContainerShape ContainerShape_49()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_50());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_08());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): Dot-Y
-            CompositionContainerShape ContainerShape_50()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_51());
-                return result;
-            }
-
-            // Transforms for N
-            CompositionContainerShape ContainerShape_51()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(-33.6669998F, 8.18200016F));
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_52());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 60),(my.Position.Y - 60))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_10());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Transforms for Dot-Y
-            CompositionContainerShape ContainerShape_52()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(39.875F, 60));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_21());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 196.791),(my.Position.Y - 266.504))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_09());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): L-Y
-            CompositionContainerShape ContainerShape_53()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_22());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_10());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): L-B
-            CompositionContainerShape ContainerShape_54()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_23());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_1_11());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): Dot1
-            CompositionContainerShape ContainerShape_55()
-            {
-                var result = _c.CreateContainerShape();
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_56());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_to_0());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): Dot1
-            CompositionContainerShape ContainerShape_56()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 154.457001F, 287.821991F);
-                var shapes = result.Shapes;
-                shapes.Add(ContainerShape_57());
-                return result;
-            }
-
-            // Transforms for Dot1
-            CompositionContainerShape ContainerShape_57()
-            {
-                var result = _c.CreateContainerShape();
-                var propertySet = result.Properties;
-                propertySet.InsertVector2("Position", new Vector2(295.770996F, 108.994003F));
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_24());
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Vector2((my.Position.X - 196.791),(my.Position.Y - 266.504))";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("Offset", _reusableExpressionAnimation);
-                result.StartAnimation("Position", PositionVector2Animation_11());
-                var controller = result.TryGetAnimationController("Position");
-                controller.Pause();
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "(_.Progress * 0.9835165) + 0.01648352";
-                _reusableExpressionAnimation.SetReferenceParameter("_", _root);
-                controller.StartAnimation("Progress", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S1-Y
-            CompositionContainerShape ContainerShape_58()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_25());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_09());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S2-Y
-            CompositionContainerShape ContainerShape_59()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_26());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_09);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S7
-            CompositionContainerShape ContainerShape_60()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_27());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_10());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S8
-            CompositionContainerShape ContainerShape_61()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_28());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_10);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S3-Y
-            CompositionContainerShape ContainerShape_62()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_29());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_11());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S4-Y
-            CompositionContainerShape ContainerShape_63()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_30());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_11);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S5-Y
-            CompositionContainerShape ContainerShape_64()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_31());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_11);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S6-Y
-            CompositionContainerShape ContainerShape_65()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_32());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_11);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S3-Y 2
-            CompositionContainerShape ContainerShape_66()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_33());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_12());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S4-Y 2
-            CompositionContainerShape ContainerShape_67()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_34());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_12);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S5-Y 2
-            CompositionContainerShape ContainerShape_68()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_35());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_12);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S11
-            CompositionContainerShape ContainerShape_69()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_36());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_13());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S12
-            CompositionContainerShape ContainerShape_70()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_37());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_14());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S13
-            CompositionContainerShape ContainerShape_71()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_38());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_15());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S3-Y 3
-            CompositionContainerShape ContainerShape_72()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_39());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_16());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S4-Y 3
-            CompositionContainerShape ContainerShape_73()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_40());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_16);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S5-Y 3
-            CompositionContainerShape ContainerShape_74()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
-                shapes.Add(SpriteShape_41());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_16);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S3-Y 4
-            CompositionContainerShape ContainerShape_75()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
+                // Offset:<154.457, 287.822>
                 shapes.Add(SpriteShape_42());
-                result.StartAnimation("TransformMatrix._11", TransformMatrix_11ScalarAnimation_1_to_0_17());
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S4-Y 4
-            CompositionContainerShape ContainerShape_76()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
+                // Offset:<154.457, 287.822>
                 shapes.Add(SpriteShape_43());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_17);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
-                return result;
-            }
-
-            // Layer (Shape): S5-Y 4
-            CompositionContainerShape ContainerShape_77()
-            {
-                var result = _c.CreateContainerShape();
-                result.TransformMatrix = new Matrix3x2(0, 0, 0, 0, 0, 0);
-                var shapes = result.Shapes;
+                // Offset:<154.457, 287.822>
                 shapes.Add(SpriteShape_44());
-                result.StartAnimation("TransformMatrix._11", _transformMatrix_11ScalarAnimation_1_to_0_17);
-                var controller = result.TryGetAnimationController("TransformMatrix._11");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "my.TransformMatrix._11";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TransformMatrix._22", _reusableExpressionAnimation);
                 return result;
             }
 
-            // Position
-            CubicBezierEasingFunction CubicBezierEasingFunction_00()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0, 0), new Vector2(0, 0.811999977F));
-            }
-
-            // Position
-            CubicBezierEasingFunction CubicBezierEasingFunction_01()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.389999986F, 0.707000017F), new Vector2(0.708000004F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_02()
-            {
-                return _cubicBezierEasingFunction_02 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.180000007F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_03()
-            {
-                return _cubicBezierEasingFunction_03 = _c.CreateCubicBezierEasingFunction(new Vector2(0.819999993F, 0), new Vector2(0.833000004F, 0.833000004F));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_04()
-            {
-                return _cubicBezierEasingFunction_04 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.833000004F, 0.833000004F));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_05()
-            {
-                return _cubicBezierEasingFunction_05 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.666999996F, 1));
-            }
-
-            // Position
-            CubicBezierEasingFunction CubicBezierEasingFunction_06()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0), new Vector2(0.666999996F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_07()
-            {
-                return _cubicBezierEasingFunction_07 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.119999997F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_08()
-            {
-                return _cubicBezierEasingFunction_08 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0), new Vector2(0.119999997F, 1));
-            }
-
-            // TStart
-            CubicBezierEasingFunction CubicBezierEasingFunction_09()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.300999999F, 0), new Vector2(0.833000004F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_10()
-            {
-                return _cubicBezierEasingFunction_10 = _c.CreateCubicBezierEasingFunction(new Vector2(0.300999999F, 0), new Vector2(0.666999996F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_11()
-            {
-                return _cubicBezierEasingFunction_11 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.0599999987F, 1));
-            }
-
-            // Layer (Shape): T1b-B
-            //   Path 1
-            //     Path 1.PathGeometry
-            //       TrimEnd
-            CubicBezierEasingFunction CubicBezierEasingFunction_12()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.209999993F, 1));
-            }
-
-            // Radius
-            CubicBezierEasingFunction CubicBezierEasingFunction_13()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.333000004F, 0), new Vector2(0.666999996F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_14()
-            {
-                return _cubicBezierEasingFunction_14 = _c.CreateCubicBezierEasingFunction(new Vector2(0.180000007F, 0), new Vector2(0.34799999F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_15()
-            {
-                return _cubicBezierEasingFunction_15 = _c.CreateCubicBezierEasingFunction(new Vector2(0.693000019F, 0), new Vector2(0.270000011F, 1));
-            }
-
-            // Transforms: O-B
-            //   Ellipse Path 1
-            //     Ellipse Path 1.EllipseGeometry
-            //       TrimStart
-            CubicBezierEasingFunction CubicBezierEasingFunction_16()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 1), new Vector2(0.432000011F, 1));
-            }
-
-            // Transforms: T1a-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            //       TrimEnd
-            CubicBezierEasingFunction CubicBezierEasingFunction_17()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.672999978F, 1));
-            }
-
-            // Position
-            CubicBezierEasingFunction CubicBezierEasingFunction_18()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.25999999F, 1));
-            }
-
-            // Position
-            CubicBezierEasingFunction CubicBezierEasingFunction_19()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.74000001F, 0), new Vector2(0.833000004F, 0.833000004F));
-            }
-
-            // TStart
-            CubicBezierEasingFunction CubicBezierEasingFunction_20()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.703000009F, 0.856999993F));
-            }
-
-            // TStart
-            CubicBezierEasingFunction CubicBezierEasingFunction_21()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.333000004F, 0.202000007F), new Vector2(0.938000023F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_22()
-            {
-                return _cubicBezierEasingFunction_22 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.337000012F, 1));
-            }
-
-            // TStart
-            CubicBezierEasingFunction CubicBezierEasingFunction_23()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.703000009F, 0.82099998F));
-            }
-
-            // TStart
-            CubicBezierEasingFunction CubicBezierEasingFunction_24()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.0370000005F, 0.167999998F), new Vector2(0.263000011F, 1));
-            }
-
-            // Position
-            CubicBezierEasingFunction CubicBezierEasingFunction_25()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.823000014F, 0), new Vector2(0.833000004F, 0.833000004F));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_26()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.197999999F), new Vector2(0.638000011F, 1));
-            }
-
-            CubicBezierEasingFunction CubicBezierEasingFunction_27()
-            {
-                return _c.CreateCubicBezierEasingFunction(new Vector2(0.523000002F, 0), new Vector2(0.795000017F, 1));
-            }
-
-            // Transforms: O-Y
-            //   Ellipse Path 1
+            // - - Layer aggregator
+            // - Layer: O-Y
+            // ShapeGroup: Ellipse 1 Offset:<196, 267>
             // Ellipse Path 1.EllipseGeometry
             CompositionEllipseGeometry Ellipse_0_0()
             {
-                var result = _c.CreateEllipseGeometry();
+                if (_ellipse_0_0 != null) return _ellipse_0_0;
+                var result = _ellipse_0_0 = _c.CreateEllipseGeometry();
                 result.Center = new Vector2(0.800000012F, -0.5F);
-                result.Radius = new Vector2(0, 0);
-                result.StartAnimation("Radius", RadiusVector2Animation());
-                var controller = result.TryGetAnimationController("Radius");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                result.Radius = new Vector2(0F, 0F);
                 return result;
             }
 
-            // Transforms: O-B
-            //   Ellipse Path 1
+            // - - Layer aggregator
+            // - Layer: O-Y
+            // ShapeGroup: Ellipse 1 Offset:<196, 267>
             // Ellipse Path 1.EllipseGeometry
             CompositionEllipseGeometry Ellipse_0_1()
             {
-                var result = _c.CreateEllipseGeometry();
+                if (_ellipse_0_1 != null) return _ellipse_0_1;
+                var result = _ellipse_0_1 = _c.CreateEllipseGeometry();
                 result.Center = new Vector2(0.800000012F, -0.5F);
-                result.Radius = new Vector2(0, 0);
-                result.StartAnimation("Radius", _radiusVector2Animation);
-                var controller = result.TryGetAnimationController("Radius");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TrimStart", TrimStartScalarAnimation_0_to_0p399());
-                controller = result.TryGetAnimationController("TrimStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_1_to_0p88());
-                controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                result.Radius = new Vector2(0F, 0F);
                 return result;
             }
 
-            // Transforms: Dot-Y
-            //   Ellipse Path 1
+            // - - - Layer aggregator
+            // - - Layer: Dot-Y
+            // - Transforms: Dot-Y
+            // ShapeGroup: Ellipse 1 Offset:<196, 267>
             // Ellipse Path 1.EllipseGeometry
             CompositionEllipseGeometry Ellipse_4p6()
             {
@@ -1670,3572 +1283,2854 @@ namespace AnimatedVisuals
             // Ellipse Path 1.EllipseGeometry
             CompositionEllipseGeometry Ellipse_4p7()
             {
+                if (_ellipse_4p7 != null) return _ellipse_4p7;
                 var result = _ellipse_4p7 = _c.CreateEllipseGeometry();
                 result.Center = new Vector2(0.800000012F, -0.5F);
                 result.Radius = new Vector2(4.69999981F, 4.69999981F);
                 return result;
             }
 
-            IGeometrySource2D Geometry_00()
+            CompositionPath Path_0()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-13.6639996F, -0.144999996F), 0);
-                {
-                    var line = new Vector2(75.663002F, 0.289999992F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_0 != null) return _path_0;
+                var result = _path_0 = new CompositionPath(Geometry_00());
                 return result;
             }
 
-            IGeometrySource2D Geometry_01()
+            CompositionPath Path_1()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(0.859000027F, -21.1429996F), 0);
-                {
-                    var line = new Vector2(-4.35900021F, 70.3919983F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_1 != null) return _path_1;
+                var result = _path_1 = new CompositionPath(Geometry_01());
                 return result;
             }
 
-            IGeometrySource2D Geometry_02()
+            CompositionPath Path_2()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-26.6700001F, -0.282999992F), 0);
-                {
-                    var line = new Vector2(99.1709976F, 0.0659999996F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_2 != null) return _path_2;
+                var result = _path_2 = new CompositionPath(Geometry_02());
                 return result;
             }
 
-            IGeometrySource2D Geometry_03()
+            CompositionPath Path_3()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-13.6639996F, -0.144999996F), 0);
-                {
-                    var line = new Vector2(62.1629982F, 0.289999992F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_3 != null) return _path_3;
+                var result = _path_3 = new CompositionPath(Geometry_03());
                 return result;
             }
 
-            IGeometrySource2D Geometry_04()
+            CompositionPath Path_4()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-30.7199993F, 63.7610016F), 0);
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-30.6889992F, 63.1669998F), Point2 = new Vector2(-30.7889996F, 50.8470001F), Point3 = new Vector2(-30.7409992F, 45.1920013F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-30.6650009F, 36.2140007F), Point2 = new Vector2(-37.3429985F, 27.0739994F), Point3 = new Vector2(-37.3969994F, 27.0139999F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-38.5579987F, 25.7140007F), Point2 = new Vector2(-39.7519989F, 24.1469994F), Point3 = new Vector2(-40.6980019F, 22.6609993F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-46.637001F, 13.3339996F), Point2 = new Vector2(-47.8400002F, 0.933000028F), Point3 = new Vector2(-37.8730011F, -7.1170001F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-13.1960001F, -27.0459995F), Point2 = new Vector2(8.96000004F, 11.559F), Point3 = new Vector2(49.5060005F, 11.559F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_4 != null) return _path_4;
+                var result = _path_4 = new CompositionPath(Geometry_04());
                 return result;
             }
 
-            IGeometrySource2D Geometry_05()
+            CompositionPath Path_5()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(246.649994F, 213.813995F), 0);
-                {
-                    var line = new Vector2(340.955994F, 213.628006F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_5 != null) return _path_5;
+                var result = _path_5 = new CompositionPath(Geometry_05());
                 return result;
             }
 
-            IGeometrySource2D Geometry_06()
+            CompositionPath Path_6()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(1.68099999F, -29.9920006F), 0);
-                {
-                    var line = new Vector2(-1.68099999F, 29.9920006F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_6 != null) return _path_6;
+                var result = _path_6 = new CompositionPath(Geometry_06());
                 return result;
             }
 
-            IGeometrySource2D Geometry_07()
+            CompositionPath Path_7()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(1.76800001F, -25.9659996F), 0);
-                {
-                    var line = new Vector2(-1.76800001F, 25.9659996F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_7 != null) return _path_7;
+                var result = _path_7 = new CompositionPath(Geometry_07());
                 return result;
             }
 
-            IGeometrySource2D Geometry_08()
+            CompositionPath Path_8()
             {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-8.83699989F, -58.2290001F), 0);
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-8.83699989F, -58.2290001F), Point2 = new Vector2(-10.1630001F, 29.4950008F), Point3 = new Vector2(-35.8339996F, 33.6619987F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-44.0579987F, 34.9970016F), Point2 = new Vector2(-50.2319984F, 30.0499992F), Point3 = new Vector2(-51.6879997F, 23.1480007F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-53.144001F, 16.2450008F), Point2 = new Vector2(-49.6549988F, 9.15600014F), Point3 = new Vector2(-41.1739998F, 7.29300022F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-17.3570004F, 2.05999994F), Point2 = new Vector2(4.23500013F, 57.1879997F), Point3 = new Vector2(51.7970009F, 44.1780014F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(51.9570007F, 44.1339989F), Point2 = new Vector2(52.6870003F, 43.8740005F), Point3 = new Vector2(53.1879997F, 43.7410011F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(53.6889992F, 43.6080017F), Point2 = new Vector2(68.9710007F, 41.3569984F), Point3 = new Vector2(140.393997F, 43.6720009F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
+                if (_path_8 != null) return _path_8;
+                var result = _path_8 = new CompositionPath(Geometry_08());
                 return result;
             }
 
-            IGeometrySource2D Geometry_09()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-67.125F, -112), 0);
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-67.125F, -112), Point2 = new Vector2(-73.5579987F, -100.719002F), Point3 = new Vector2(-75.4580002F, -89.9509964F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-78.625F, -72), Point2 = new Vector2(-79.375F, -58.25F), Point3 = new Vector2(-80.375F, -39.25F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_10()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-67.25F, -105.5F), 0);
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-67.25F, -105.5F), Point2 = new Vector2(-70.4329987F, -94.9690018F), Point3 = new Vector2(-72.3330002F, -84.2009964F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-75.5F, -66.25F), Point2 = new Vector2(-75.5F, -56.75F), Point3 = new Vector2(-76.5F, -37.75F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_11()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(34.5F, -13.0500002F), 0);
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(7.5F, -14.5F), Point2 = new Vector2(-4, -37), Point3 = new Vector2(-35.0460014F, -35.5789986F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-61.4720001F, -34.3689995F), Point2 = new Vector2(-62.25F, -5.75F), Point3 = new Vector2(-62.25F, -5.75F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_12()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-3, 35.9500008F), 0);
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-3, 35.9500008F), Point2 = new Vector2(-1.5F, 7.5F), Point3 = new Vector2(-1.352F, -6.75600004F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-9.90299988F, -15.0190001F), Point2 = new Vector2(-21.5699997F, -20.5790005F), Point3 = new Vector2(-32.0460014F, -20.5790005F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                {
-                    var bezier = new D2D1_BEZIER_SEGMENT { Point1 = new Vector2(-53.5F, -20.5790005F), Point2 = new Vector2(-42.25F, 4.25F), Point3 = new Vector2(-42.25F, 4.25F) };
-                    sink.AddBeziers(in bezier, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_13()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(16.2310009F, 39.0730019F), 0);
-                {
-                    var line = new Vector2(-32.769001F, 57.3650017F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_14()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(7.44999981F, 21.9500008F), 0);
-                {
-                    var line = new Vector2(-32.75F, 55.75F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_15()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-94.5F, 37.0730019F), 0);
-                {
-                    var line = new Vector2(-48.769001F, 55.3650017F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_16()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(-87.5F, 20.9500008F), 0);
-                {
-                    var line = new Vector2(-48.75F, 54.75F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_17()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(166.731003F, -7.92700005F), 0);
-                {
-                    var line = new Vector2(136.731003F, 7.11499977F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_18()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(156.449997F, -23.0499992F), 0);
-                {
-                    var line = new Vector2(132, 2.75F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_19()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(169.5F, 18.073F), 0);
-                {
-                    var line = new Vector2(137.481003F, 11.3649998F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_20()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(119.5F, -45.0499992F), 0);
-                {
-                    var line = new Vector2(82.75F, -44.75F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_21()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(119.25F, -20.0499992F), 0);
-                {
-                    var line = new Vector2(63.5F, -20.5F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_22()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(128, 3.6500001F), 0);
-                {
-                    var line = new Vector2(78.25F, 3.5F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_23()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(149.623993F, 8.24400043F), 0);
-                {
-                    var line = new Vector2(136.647995F, 10.1560001F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_24()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(144.429001F, -5.39699984F), 0);
-                {
-                    var line = new Vector2(132.274994F, 4.73099995F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_25()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(145.677002F, 22.2199993F), 0);
-                {
-                    var line = new Vector2(134.921997F, 14.7489996F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_26()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(147.699005F, 13.0249996F), 0);
-                {
-                    var line = new Vector2(133.195007F, 13.21F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_27()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(142.182999F, -5.11199999F), 0);
-                {
-                    var line = new Vector2(130.029007F, 5.01599979F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            IGeometrySource2D Geometry_28()
-            {
-                var path = _d2d.CreatePathGeometry();
-                var sink = path.Open();
-                sink.BeginFigure(new Vector2(142.037994F, 29.2779999F), 0);
-                {
-                    var line = new Vector2(131.281998F, 21.8069992F);
-                    sink.AddLines(in line, 1);
-                }
-                sink.EndFigure(0);
-                sink.Close();
-                Marshal.ReleaseComObject(sink);
-                var result = new GeometrySource2D(path);
-                return result;
-            }
-
-            StepEasingFunction HoldThenStepEasingFunction()
-            {
-                var result = _holdThenStepEasingFunction = _c.CreateStepEasingFunction();
-                result.IsFinalStepSingleFrame = true;
-                return result;
-            }
-
-            // Transforms: E3-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: E3-Y
+            // ShapeGroup: Group 1 Offset:<344.674, 261.877>
             CompositionPathGeometry PathGeometry_00()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_00());
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p316_0());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_00 != null) return _pathGeometry_00;
+                var result = _pathGeometry_00 = _c.CreatePathGeometry(Path_0());
                 return result;
             }
 
-            // Transforms: E3-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: E3-B
+            // Transforms: E3-B Offset:<0.06500244, 0>
             CompositionPathGeometry PathGeometry_01()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_00);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p316_1());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_01 != null) return _pathGeometry_01;
+                var result = _pathGeometry_01 = _c.CreatePathGeometry(Path_0());
                 return result;
             }
 
-            // Transforms: I-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: I-Y
+            // ShapeGroup: Group 6 Offset:<304.135, 282.409>
             CompositionPathGeometry PathGeometry_02()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_01());
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p457_0());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_02 != null) return _pathGeometry_02;
+                var result = _pathGeometry_02 = _c.CreatePathGeometry(Path_1());
                 return result;
             }
 
-            // Transforms: I-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: I-B
+            // Transforms: I-B
             CompositionPathGeometry PathGeometry_03()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_01);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p457_1());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_03 != null) return _pathGeometry_03;
+                var result = _pathGeometry_03 = _c.CreatePathGeometry(Path_1());
                 return result;
             }
 
-            // Transforms: E2-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: E2-Y
+            // ShapeGroup: Group 3 Offset:<331.664, 238.14>
             CompositionPathGeometry PathGeometry_04()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_02());
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p43_0());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_04 != null) return _pathGeometry_04;
+                var result = _pathGeometry_04 = _c.CreatePathGeometry(Path_2());
                 return result;
             }
 
-            // Transforms: E2-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: E2-B
+            // Transforms: E2-B
             CompositionPathGeometry PathGeometry_05()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_02);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p43_1());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_05 != null) return _pathGeometry_05;
+                var result = _pathGeometry_05 = _c.CreatePathGeometry(Path_2());
                 return result;
             }
 
-            // Transforms: E1-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: E1-Y
+            // ShapeGroup: Group 2 Offset:<344.672, 214.842>
             CompositionPathGeometry PathGeometry_06()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_03());
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p375_0());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_06 != null) return _pathGeometry_06;
+                var result = _pathGeometry_06 = _c.CreatePathGeometry(Path_3());
                 return result;
             }
 
-            // Transforms: E1-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: E1-B
+            // Transforms: E1-B
             CompositionPathGeometry PathGeometry_07()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_03);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0_to_0p375_1());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_07 != null) return _pathGeometry_07;
+                var result = _pathGeometry_07 = _c.CreatePathGeometry(Path_3());
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_08()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_04());
+                if (_pathGeometry_08 != null) return _pathGeometry_08;
+                var result = _pathGeometry_08 = _c.CreatePathGeometry(Path_4());
                 var propertySet = result.Properties;
-                propertySet.InsertScalar("TStart", 0);
-                propertySet.InsertScalar("TEnd", 0);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0_to_0p249());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_0_to_1_0());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                propertySet.InsertScalar("TEnd", 0F);
+                propertySet.InsertScalar("TStart", 0F);
+                BindProperty(_pathGeometry_08, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_08);
+                BindProperty(_pathGeometry_08, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_08);
                 return result;
             }
 
-            // Layer (Shape): T2b-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - Layer aggregator
+            // Layer: T2b-Y
             CompositionPathGeometry PathGeometry_09()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_05());
-                result.StartAnimation("TrimStart", TrimStartScalarAnimation_0p29_to_0_0());
-                var controller = result.TryGetAnimationController("TrimStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p411_to_0p665_0());
-                controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_09 != null) return _pathGeometry_09;
+                var result = _pathGeometry_09 = _c.CreatePathGeometry(Path_5());
                 return result;
             }
 
-            // Layer (Shape): T2a-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - Layer aggregator
+            // Layer: T2a-Y
             CompositionPathGeometry PathGeometry_10()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_06());
-                result.StartAnimation("TrimStart", TrimStartScalarAnimation_0p5_to_0_0());
-                var controller = result.TryGetAnimationController("TrimStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p5_to_1_0());
-                controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_10 != null) return _pathGeometry_10;
+                var result = _pathGeometry_10 = _c.CreatePathGeometry(Path_6());
                 return result;
             }
 
-            // Layer (Shape): T2b-B
-            //   Path 1
-            // Path 1.PathGeometry
+            // - Layer aggregator
+            // Layer: T2b-B
             CompositionPathGeometry PathGeometry_11()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_05);
-                result.StartAnimation("TrimStart", TrimStartScalarAnimation_0p29_to_0_1());
-                var controller = result.TryGetAnimationController("TrimStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p411_to_0p665_1());
-                controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_11 != null) return _pathGeometry_11;
+                var result = _pathGeometry_11 = _c.CreatePathGeometry(Path_5());
                 return result;
             }
 
-            // Layer (Shape): T1b-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - Layer aggregator
+            // Layer: T1b-Y
             CompositionPathGeometry PathGeometry_12()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_07());
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p117_to_1_0());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_12 != null) return _pathGeometry_12;
+                var result = _pathGeometry_12 = _c.CreatePathGeometry(Path_7());
                 return result;
             }
 
-            // Layer (Shape): T1b-B
-            //   Path 1
-            // Path 1.PathGeometry
+            // - Layer aggregator
+            // Layer: T1b-B
             CompositionPathGeometry PathGeometry_13()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_07);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p117_to_1_1());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_13 != null) return _pathGeometry_13;
+                var result = _pathGeometry_13 = _c.CreatePathGeometry(Path_7());
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_14()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_04);
+                if (_pathGeometry_14 != null) return _pathGeometry_14;
+                var result = _pathGeometry_14 = _c.CreatePathGeometry(Path_4());
                 var propertySet = result.Properties;
-                propertySet.InsertScalar("TStart", 0);
-                propertySet.InsertScalar("TEnd", 0);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", _tStartScalarAnimation_0_to_0p249);
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_0_to_1_1());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                propertySet.InsertScalar("TEnd", 0F);
+                propertySet.InsertScalar("TStart", 0F);
+                BindProperty(_pathGeometry_14, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_14);
+                BindProperty(_pathGeometry_14, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_14);
                 return result;
             }
 
-            // Layer (Shape): T2a-B
-            //   Path 1
-            // Path 1.PathGeometry
+            // - Layer aggregator
+            // Layer: T2a-B
             CompositionPathGeometry PathGeometry_15()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_06);
-                result.StartAnimation("TrimStart", TrimStartScalarAnimation_0p5_to_0_1());
-                var controller = result.TryGetAnimationController("TrimStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p5_to_1_1());
-                controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                if (_pathGeometry_15 != null) return _pathGeometry_15;
+                var result = _pathGeometry_15 = _c.CreatePathGeometry(Path_6());
                 return result;
             }
 
-            // Transforms: T1a-Y
-            //   Path 1
-            // Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: T1a-B
+            // Transforms: T1a-B
             CompositionPathGeometry PathGeometry_16()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_04);
+                if (_pathGeometry_16 != null) return _pathGeometry_16;
+                var result = _pathGeometry_16 = _c.CreatePathGeometry(Path_4());
                 result.TrimStart = 0.248999998F;
-                result.StartAnimation("TrimEnd", TrimEndScalarAnimation_0p249_to_0p891());
-                var controller = result.TryGetAnimationController("TrimEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_17()
             {
-                var result = _c.CreatePathGeometry(CompositionPath_08());
+                if (_pathGeometry_17 != null) return _pathGeometry_17;
+                var result = _pathGeometry_17 = _c.CreatePathGeometry(Path_8());
                 var propertySet = result.Properties;
-                propertySet.InsertScalar("TStart", 0.800000012F);
                 propertySet.InsertScalar("TEnd", 0.810000002F);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p8_to_0());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_0p81_to_0p734_0());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                propertySet.InsertScalar("TStart", 0.800000012F);
+                BindProperty(_pathGeometry_17, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_17);
+                BindProperty(_pathGeometry_17, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_17);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_18()
             {
-                var result = _c.CreatePathGeometry(_compositionPath_08);
+                if (_pathGeometry_18 != null) return _pathGeometry_18;
+                var result = _pathGeometry_18 = _c.CreatePathGeometry(Path_8());
                 var propertySet = result.Properties;
-                propertySet.InsertScalar("TStart", 0.800000012F);
                 propertySet.InsertScalar("TEnd", 0.810000002F);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p8_to_0p3());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_0p81_to_0p734_1());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                propertySet.InsertScalar("TStart", 0.800000012F);
+                BindProperty(_pathGeometry_18, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_18);
+                BindProperty(_pathGeometry_18, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_18);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_19()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_09()));
+                if (_pathGeometry_19 != null) return _pathGeometry_19;
+                var result = _pathGeometry_19 = _c.CreatePathGeometry(new CompositionPath(Geometry_09()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_00());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_00());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_19, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_19);
+                BindProperty(_pathGeometry_19, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_19);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_20()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_10()));
+                if (_pathGeometry_20 != null) return _pathGeometry_20;
+                var result = _pathGeometry_20 = _c.CreatePathGeometry(new CompositionPath(Geometry_10()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_01());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_01());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_20, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_20);
+                BindProperty(_pathGeometry_20, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_20);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_21()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_11()));
+                if (_pathGeometry_21 != null) return _pathGeometry_21;
+                var result = _pathGeometry_21 = _c.CreatePathGeometry(new CompositionPath(Geometry_11()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_02());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_02());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_21, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_21);
+                BindProperty(_pathGeometry_21, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_21);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_22()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_12()));
+                if (_pathGeometry_22 != null) return _pathGeometry_22;
+                var result = _pathGeometry_22 = _c.CreatePathGeometry(new CompositionPath(Geometry_12()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", _tStartScalarAnimation_0p87_to_0_02);
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", _tEndScalarAnimation_1_to_0_02);
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_22, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_22);
+                BindProperty(_pathGeometry_22, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_22);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_23()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_13()));
+                if (_pathGeometry_23 != null) return _pathGeometry_23;
+                var result = _pathGeometry_23 = _c.CreatePathGeometry(new CompositionPath(Geometry_13()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_03());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_03());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_23, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_23);
+                BindProperty(_pathGeometry_23, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_23);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_24()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_14()));
+                if (_pathGeometry_24 != null) return _pathGeometry_24;
+                var result = _pathGeometry_24 = _c.CreatePathGeometry(new CompositionPath(Geometry_14()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_04());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", _tEndScalarAnimation_1_to_0_03);
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_24, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_24);
+                BindProperty(_pathGeometry_24, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_24);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_25()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_15()));
+                if (_pathGeometry_25 != null) return _pathGeometry_25;
+                var result = _pathGeometry_25 = _c.CreatePathGeometry(new CompositionPath(Geometry_15()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_05());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_04());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_25, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_25);
+                BindProperty(_pathGeometry_25, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_25);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_26()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_16()));
+                if (_pathGeometry_26 != null) return _pathGeometry_26;
+                var result = _pathGeometry_26 = _c.CreatePathGeometry(new CompositionPath(Geometry_16()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_06());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_05());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_26, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_26);
+                BindProperty(_pathGeometry_26, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_26);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_27()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_17()));
+                if (_pathGeometry_27 != null) return _pathGeometry_27;
+                var result = _pathGeometry_27 = _c.CreatePathGeometry(new CompositionPath(Geometry_17()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_07());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_06());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_27, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_27);
+                BindProperty(_pathGeometry_27, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_27);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_28()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_18()));
+                if (_pathGeometry_28 != null) return _pathGeometry_28;
+                var result = _pathGeometry_28 = _c.CreatePathGeometry(new CompositionPath(Geometry_18()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_08());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", _tEndScalarAnimation_1_to_0_06);
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_28, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_28);
+                BindProperty(_pathGeometry_28, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_28);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_29()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_19()));
+                if (_pathGeometry_29 != null) return _pathGeometry_29;
+                var result = _pathGeometry_29 = _c.CreatePathGeometry(new CompositionPath(Geometry_19()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_09());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_07());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_29, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_29);
+                BindProperty(_pathGeometry_29, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_29);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_30()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_20()));
+                if (_pathGeometry_30 != null) return _pathGeometry_30;
+                var result = _pathGeometry_30 = _c.CreatePathGeometry(new CompositionPath(Geometry_20()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_10());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_08());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_30, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_30);
+                BindProperty(_pathGeometry_30, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_30);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_31()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_21()));
+                if (_pathGeometry_31 != null) return _pathGeometry_31;
+                var result = _pathGeometry_31 = _c.CreatePathGeometry(new CompositionPath(Geometry_21()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_11());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_09());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_31, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_31);
+                BindProperty(_pathGeometry_31, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_31);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_32()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_22()));
+                if (_pathGeometry_32 != null) return _pathGeometry_32;
+                var result = _pathGeometry_32 = _c.CreatePathGeometry(new CompositionPath(Geometry_22()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_12());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_10());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_32, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_32);
+                BindProperty(_pathGeometry_32, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_32);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_33()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_23()));
+                if (_pathGeometry_33 != null) return _pathGeometry_33;
+                var result = _pathGeometry_33 = _c.CreatePathGeometry(new CompositionPath(Geometry_23()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_13());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_11());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_33, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_33);
+                BindProperty(_pathGeometry_33, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_33);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_34()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_24()));
+                if (_pathGeometry_34 != null) return _pathGeometry_34;
+                var result = _pathGeometry_34 = _c.CreatePathGeometry(new CompositionPath(Geometry_24()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_14());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", _tEndScalarAnimation_1_to_0_11);
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_34, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_34);
+                BindProperty(_pathGeometry_34, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_34);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_35()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_25()));
+                if (_pathGeometry_35 != null) return _pathGeometry_35;
+                var result = _pathGeometry_35 = _c.CreatePathGeometry(new CompositionPath(Geometry_25()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_15());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_12());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_35, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_35);
+                BindProperty(_pathGeometry_35, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_35);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_36()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_26()));
+                if (_pathGeometry_36 != null) return _pathGeometry_36;
+                var result = _pathGeometry_36 = _c.CreatePathGeometry(new CompositionPath(Geometry_26()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_16());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_13());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_36, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_36);
+                BindProperty(_pathGeometry_36, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_36);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_37()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_27()));
+                if (_pathGeometry_37 != null) return _pathGeometry_37;
+                var result = _pathGeometry_37 = _c.CreatePathGeometry(new CompositionPath(Geometry_27()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_17());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", _tEndScalarAnimation_1_to_0_13);
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_37, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_37);
+                BindProperty(_pathGeometry_37, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_37);
                 return result;
             }
 
-            // Path 1.PathGeometry
             CompositionPathGeometry PathGeometry_38()
             {
-                var result = _c.CreatePathGeometry(new CompositionPath(Geometry_28()));
+                if (_pathGeometry_38 != null) return _pathGeometry_38;
+                var result = _pathGeometry_38 = _c.CreatePathGeometry(new CompositionPath(Geometry_28()));
                 var propertySet = result.Properties;
+                propertySet.InsertScalar("TEnd", 1F);
                 propertySet.InsertScalar("TStart", 0.870000005F);
-                propertySet.InsertScalar("TEnd", 1);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Min(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimStart", _reusableExpressionAnimation);
-                _reusableExpressionAnimation.ClearAllParameters();
-                _reusableExpressionAnimation.Expression = "Max(my.TStart, my.TEnd)";
-                _reusableExpressionAnimation.SetReferenceParameter("my", result);
-                result.StartAnimation("TrimEnd", _reusableExpressionAnimation);
-                result.StartAnimation("TStart", TStartScalarAnimation_0p87_to_0_18());
-                var controller = result.TryGetAnimationController("TStart");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("TEnd", TEndScalarAnimation_1_to_0_14());
-                controller = result.TryGetAnimationController("TEnd");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                BindProperty(_pathGeometry_38, "TrimStart", "Min(my.TStart,my.TEnd)", "my", _pathGeometry_38);
+                BindProperty(_pathGeometry_38, "TrimEnd", "Max(my.TStart,my.TEnd)", "my", _pathGeometry_38);
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_00()
+            // - Layer aggregator
+            // Offset:<187.5, 333.5>
+            // Rectangle Path 1.RectangleGeometry
+            CompositionRectangleGeometry Rectangle_375x667()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(43.2630005F, 59.75F), StepThenHoldEasingFunction());
-                result.InsertKeyFrame(0.536312878F, new Vector2(43.2630005F, 59.75F), HoldThenStepEasingFunction());
-                result.InsertKeyFrame(0.603351951F, new Vector2(62.5130005F, 59.75F), CubicBezierEasingFunction_00());
-                result.InsertKeyFrame(0.642458081F, new Vector2(63.7630005F, 59.75F), CubicBezierEasingFunction_01());
+                var result = _c.CreateRectangleGeometry();
+                result.Offset = new Vector2(-187.5F, -333.5F);
+                result.Size = new Vector2(375F, 667F);
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_01()
+            // Layer aggregator
+            // Rectangle Path 1
+            CompositionSpriteShape SpriteShape_00()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(164.781998F, 57.4729996F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.536312878F, new Vector2(164.781998F, 57.4729996F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.553072631F, new Vector2(164.781998F, 55.4729996F), CubicBezierEasingFunction_02());
-                result.InsertKeyFrame(0.569832385F, new Vector2(164.781998F, 57.4729996F), CubicBezierEasingFunction_03());
-                result.InsertKeyFrame(0.586592197F, new Vector2(164.781998F, 56.9090004F), _cubicBezierEasingFunction_02);
-                result.InsertKeyFrame(0.603351951F, new Vector2(164.781998F, 57.4729996F), _cubicBezierEasingFunction_03);
+                // Offset:<187.5, 333.5>
+                var geometry = Rectangle_375x667();
+                var result = CreateSpriteShape(geometry, new Matrix3x2(1F, 0F, 0F, 1F, 187.5F, 333.5F), ColorBrush_AlmostDarkTurquoise_FF00D1C1());;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_02()
+            // - - Layer aggregator
+            // - Layer: Dot-Y
+            // Transforms: Dot-Y
+            // Ellipse Path 1
+            CompositionSpriteShape SpriteShape_01()
             {
-                var result = _positionVector2Animation_02 = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(119.167F, 57.4790001F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.469273746F, new Vector2(119.167F, 57.4790001F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.513966501F, new Vector2(137.167007F, 57.4790001F), CubicBezierEasingFunction_05());
-                result.InsertKeyFrame(0.536312878F, new Vector2(134.167007F, 57.4790001F), CubicBezierEasingFunction_06());
+                // Offset:<196, 267>
+                var geometry = Ellipse_4p6();
+                var result = CreateSpriteShape(geometry, new Matrix3x2(1F, 0F, 0F, 1F, 196F, 267F), ColorBrush_White());;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_03()
+            // - Layer aggregator
+            // Layer: E3-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_02()
             {
-                var result = _positionVector2Animation_03 = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(93.5940018F, 62.8610001F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.43575418F, new Vector2(93.5940018F, 62.8610001F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.491620123F, new Vector2(92.6259995F, 82.8290024F), _cubicBezierEasingFunction_07);
-                result.InsertKeyFrame(0.513966501F, new Vector2(92.8440018F, 77.8610001F), CubicBezierEasingFunction_08());
+                // Offset:<344.674, 261.877>
+                var result = CreateSpriteShape(PathGeometry_00(), new Matrix3x2(1F, 0F, 0F, 1F, 344.674011F, 261.877014F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.56200027F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_04()
+            // - Layer aggregator
+            // Layer: E3-B
+            // Path 1
+            CompositionSpriteShape SpriteShape_03()
             {
-                var result = _positionVector2Animation_04 = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(109.092003F, 33.6100006F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.463687152F, new Vector2(109.092003F, 33.6100006F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.513966501F, new Vector2(121.092003F, 33.6100006F), _cubicBezierEasingFunction_07);
+                // Offset:<344.739, 261.877>
+                var result = CreateSpriteShape(PathGeometry_01(), new Matrix3x2(1F, 0F, 0F, 1F, 344.739014F, 261.877014F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.56200027F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_05()
+            // - Layer aggregator
+            // Layer: I-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_04()
             {
-                var result = _positionVector2Animation_05 = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(113.714996F, 9.14599991F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.441340774F, new Vector2(113.714996F, 9.14599991F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.491620123F, new Vector2(137.714996F, 9.14599991F), _cubicBezierEasingFunction_07);
-                result.InsertKeyFrame(0.513966501F, new Vector2(133.714996F, 9.14599991F), _cubicBezierEasingFunction_08);
+                // Offset:<304.135, 282.409>
+                var result = CreateSpriteShape(PathGeometry_02(), new Matrix3x2(1F, 0F, 0F, 1F, 304.13501F, 282.408997F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Square;
+                result.StrokeStartCap = CompositionStrokeCap.Square;
+                result.StrokeEndCap = CompositionStrokeCap.Square;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 8.39999962F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_06()
+            // - Layer aggregator
+            // Layer: I-B
+            // Path 1
+            CompositionSpriteShape SpriteShape_05()
             {
-                var result = _positionVector2Animation_06 = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(39.0429993F, 48.6780014F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.312849164F, new Vector2(39.0429993F, 48.6780014F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.357541889F, new Vector2(39.0429993F, 45.6780014F), _cubicBezierEasingFunction_05);
+                // Offset:<304.135, 282.409>
+                var result = CreateSpriteShape(PathGeometry_03(), new Matrix3x2(1F, 0F, 0F, 1F, 304.13501F, 282.408997F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Square;
+                result.StrokeStartCap = CompositionStrokeCap.Square;
+                result.StrokeEndCap = CompositionStrokeCap.Square;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_07()
+            // - Layer aggregator
+            // Layer: E2-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_06()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.SetReferenceParameter("_", _root);
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(-62.7919998F, 73.0569992F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.17318435F, new Vector2(-62.7919998F, 73.0569992F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.196966484F, new Vector2(-53.7919998F, 7.55700016F), _cubicBezierEasingFunction_04);
-                result.InsertExpressionKeyFrame(0.245809957F, "(Pow(1 - _.t0, 3) * Vector2((-53.792),7.557)) + (3 * Square(1 - _.t0) * _.t0 * Vector2((-53.792),7.557)) + (3 * (1 - _.t0) * Square(_.t0) * Vector2((-52.82329),(-71.07968))) + (Pow(_.t0, 3) * Vector2((-33.667),(-72.818)))", _stepThenHoldEasingFunction);
-                result.InsertExpressionKeyFrame(0.301675886F, "(Pow(1 - _.t0, 3) * Vector2((-33.667),(-72.818))) + (3 * Square(1 - _.t0) * _.t0 * Vector2((-17.45947),(-74.28873))) + (3 * (1 - _.t0) * Square(_.t0) * Vector2((-14.167),102.182)) + (Pow(_.t0, 3) * Vector2((-14.167),102.182))", _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, new Vector2(-14.1669998F, 102.181999F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.351955295F, new Vector2(-14.1669998F, 59.1819992F), CubicBezierEasingFunction_14());
-                result.InsertKeyFrame(0.407821238F, new Vector2(-14.1669998F, 62.1819992F), CubicBezierEasingFunction_15());
+                // Offset:<331.664, 238.14>
+                var result = CreateSpriteShape(PathGeometry_04(), new Matrix3x2(1F, 0F, 0F, 1F, 331.664001F, 238.139999F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 8.39999962F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_08()
+            // - Layer aggregator
+            // Layer: E2-B
+            // Path 1
+            CompositionSpriteShape SpriteShape_07()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.SetReferenceParameter("_", _root);
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(-62.7919998F, 73.0569992F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.17318435F, new Vector2(-62.7919998F, 73.0569992F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.196966484F, new Vector2(-53.7919998F, 7.55700016F), _cubicBezierEasingFunction_04);
-                result.InsertExpressionKeyFrame(0.245809957F, "(Pow(1 - _.t1, 3) * Vector2((-53.792),7.557)) + (3 * Square(1 - _.t1) * _.t1 * Vector2((-53.792),7.557)) + (3 * (1 - _.t1) * Square(_.t1) * Vector2((-52.82329),(-71.07968))) + (Pow(_.t1, 3) * Vector2((-33.667),(-72.818)))", _stepThenHoldEasingFunction);
-                result.InsertExpressionKeyFrame(0.301675886F, "(Pow(1 - _.t1, 3) * Vector2((-33.667),(-72.818))) + (3 * Square(1 - _.t1) * _.t1 * Vector2((-17.45947),(-74.28873))) + (3 * (1 - _.t1) * Square(_.t1) * Vector2((-14.167),102.182)) + (Pow(_.t1, 3) * Vector2((-14.167),102.182))", _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, new Vector2(-14.1669998F, 102.181999F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.351955295F, new Vector2(-14.1669998F, 59.1819992F), _cubicBezierEasingFunction_14);
-                result.InsertKeyFrame(0.407821238F, new Vector2(-14.1669998F, 62.1819992F), _cubicBezierEasingFunction_15);
+                // Offset:<331.664, 238.14>
+                var result = CreateSpriteShape(PathGeometry_05(), new Matrix3x2(1F, 0F, 0F, 1F, 331.664001F, 238.139999F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.56200027F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_09()
+            // - Layer aggregator
+            // Layer: E1-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_08()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(39.875F, 60), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.156424582F, new Vector2(39.875F, 60), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.301675975F, new Vector2(79.375F, 60), _cubicBezierEasingFunction_04);
+                // Offset:<344.672, 214.842>
+                var result = CreateSpriteShape(PathGeometry_06(), new Matrix3x2(1F, 0F, 0F, 1F, 344.671997F, 214.841995F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 8.39999962F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_10()
+            // - Layer aggregator
+            // Layer: E1-B
+            // Path 1
+            CompositionSpriteShape SpriteShape_09()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(-33.6669998F, 8.18200016F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.156424582F, new Vector2(-33.6669998F, 8.18200016F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.223463684F, new Vector2(-33.6669998F, -72.8180008F), CubicBezierEasingFunction_18());
-                result.InsertKeyFrame(0.301675975F, new Vector2(-33.6669998F, 102.056999F), CubicBezierEasingFunction_19());
+                // Offset:<344.672, 214.842>
+                var result = CreateSpriteShape(PathGeometry_07(), new Matrix3x2(1F, 0F, 0F, 1F, 344.671997F, 214.841995F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.56200027F;
                 return result;
             }
 
-            // Position
-            Vector2KeyFrameAnimation PositionVector2Animation_11()
+            // - Layer aggregator
+            // Layer: T1a-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_10()
             {
-                var result = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(295.770996F, 108.994003F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.104395606F, new Vector2(35.7709999F, 108.994003F), CubicBezierEasingFunction_25());
+                // Offset:<227.677, 234.375>
+                var result = CreateSpriteShape(PathGeometry_08(), new Matrix3x2(1F, 0F, 0F, 1F, 227.677002F, 234.375F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 8.39999962F;
                 return result;
             }
 
-            // Radius
-            Vector2KeyFrameAnimation RadiusVector2Animation()
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_11()
             {
-                var result = _radiusVector2Animation = _c.CreateVector2KeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, new Vector2(1.5F, 1.5F), _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, new Vector2(1.5F, 1.5F), _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.340782136F, new Vector2(22.2999992F, 22.2999992F), CubicBezierEasingFunction_13());
+                // Offset:<-56.5, 83.5>
+                if (_spriteShape_11 != null) return _spriteShape_11;
+                var result = _spriteShape_11 = CreateSpriteShape(PathGeometry_09(), new Matrix3x2(1F, 0F, 0F, 1F, -56.5F, 83.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_12()
+            {
+                // Offset:<221.198, 330.758>
+                if (_spriteShape_12 != null) return _spriteShape_12;
+                var result = _spriteShape_12 = CreateSpriteShape(PathGeometry_10(), new Matrix3x2(1F, 0F, 0F, 1F, 221.197998F, 330.757996F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Square;
+                result.StrokeStartCap = CompositionStrokeCap.Square;
+                result.StrokeEndCap = CompositionStrokeCap.Square;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_13()
+            {
+                // Offset:<-56.5, 83.5>
+                if (_spriteShape_13 != null) return _spriteShape_13;
+                var result = _spriteShape_13 = CreateSpriteShape(PathGeometry_11(), new Matrix3x2(1F, 0F, 0F, 1F, -56.5F, 83.5F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_14()
+            {
+                // Offset:<186.256, 349.081>
+                if (_spriteShape_14 != null) return _spriteShape_14;
+                var result = _spriteShape_14 = CreateSpriteShape(PathGeometry_12(), new Matrix3x2(1F, 0F, 0F, 1F, 186.255997F, 349.080994F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeLineJoin = CompositionStrokeLineJoin.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 8.39999962F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_15()
+            {
+                // Offset:<186.256, 349.081>
+                if (_spriteShape_15 != null) return _spriteShape_15;
+                var result = _spriteShape_15 = CreateSpriteShape(PathGeometry_13(), new Matrix3x2(1F, 0F, 0F, 1F, 186.255997F, 349.080994F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeLineJoin = CompositionStrokeLineJoin.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: O-Y
+            // Ellipse Path 1
+            CompositionSpriteShape SpriteShape_16()
+            {
+                // Offset:<196, 267>
+                var result = CreateSpriteShape(Ellipse_0_0(), new Matrix3x2(1F, 0F, 0F, 1F, 196F, 267F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeThickness = 8.80000019F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: O-Y
+            // Ellipse Path 1
+            CompositionSpriteShape SpriteShape_17()
+            {
+                // Offset:<196, 267>
+                var result = CreateSpriteShape(Ellipse_0_1(), new Matrix3x2(1F, 0F, 0F, 1F, 196F, 267F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T1a-Y 2
+            // Path 1
+            CompositionSpriteShape SpriteShape_18()
+            {
+                // Offset:<227.677, 234.375>
+                var result = CreateSpriteShape(PathGeometry_14(), new Matrix3x2(1F, 0F, 0F, 1F, 227.677002F, 234.375F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 8.39999962F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_19()
+            {
+                // Offset:<221.198, 330.758>
+                if (_spriteShape_19 != null) return _spriteShape_19;
+                var result = _spriteShape_19 = CreateSpriteShape(PathGeometry_15(), new Matrix3x2(1F, 0F, 0F, 1F, 221.197998F, 330.757996F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Square;
+                result.StrokeStartCap = CompositionStrokeCap.Square;
+                result.StrokeEndCap = CompositionStrokeCap.Square;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T1a-B
+            // Path 1
+            CompositionSpriteShape SpriteShape_20()
+            {
+                // Offset:<227.677, 234.375>
+                var result = CreateSpriteShape(PathGeometry_16(), new Matrix3x2(1F, 0F, 0F, 1F, 227.677002F, 234.375F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: Dot-Y
+            // Transforms: Dot-Y
+            // Ellipse Path 1
+            CompositionSpriteShape SpriteShape_21()
+            {
+                // Offset:<196, 267>
+                var geometry = Ellipse_4p7();
+                var result = CreateSpriteShape(geometry, new Matrix3x2(1F, 0F, 0F, 1F, 196F, 267F), ColorBrush_White());;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_22()
+            {
+                // Offset:<109.52901, 354.143>
+                if (_spriteShape_22 != null) return _spriteShape_22;
+                var result = _spriteShape_22 = CreateSpriteShape(PathGeometry_17(), new Matrix3x2(1F, 0F, 0F, 1F, 109.529007F, 354.143005F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 8.39999962F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_23()
+            {
+                // Offset:<109.52901, 354.143>
+                if (_spriteShape_23 != null) return _spriteShape_23;
+                var result = _spriteShape_23 = CreateSpriteShape(PathGeometry_18(), new Matrix3x2(1F, 0F, 0F, 1F, 109.529007F, 354.143005F));;
+                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 5F;
+                result.StrokeThickness = 9.19400024F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot1
+            // Ellipse Path 1
+            CompositionSpriteShape SpriteShape_24()
+            {
+                // Offset:<196, 267>
+                var geometry = Ellipse_4p7();
+                var result = CreateSpriteShape(geometry, new Matrix3x2(1F, 0F, 0F, 1F, 196F, 267F), ColorBrush_White());;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S1-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_25()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_19(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S1-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_26()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_20(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S7
+            // Path 1
+            CompositionSpriteShape SpriteShape_27()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_21(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S7
+            // Path 1
+            CompositionSpriteShape SpriteShape_28()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_22(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_29()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_23(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_30()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_24(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_31()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_25(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y
+            // Path 1
+            CompositionSpriteShape SpriteShape_32()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_26(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 2
+            // Path 1
+            CompositionSpriteShape SpriteShape_33()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_27(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 2
+            // Path 1
+            CompositionSpriteShape SpriteShape_34()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_28(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 2
+            // Path 1
+            CompositionSpriteShape SpriteShape_35()
+            {
+                // Offset:<179.5, 333.5>
+                var result = CreateSpriteShape(PathGeometry_29(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_36()
+            {
+                // Offset:<179.5, 333.5>
+                if (_spriteShape_36 != null) return _spriteShape_36;
+                var result = _spriteShape_36 = CreateSpriteShape(PathGeometry_30(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_37()
+            {
+                // Offset:<179.5, 333.5>
+                if (_spriteShape_37 != null) return _spriteShape_37;
+                var result = _spriteShape_37 = CreateSpriteShape(PathGeometry_31(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // Layer aggregator
+            // Path 1
+            CompositionSpriteShape SpriteShape_38()
+            {
+                // Offset:<179.5, 333.5>
+                if (_spriteShape_38 != null) return _spriteShape_38;
+                var result = _spriteShape_38 = CreateSpriteShape(PathGeometry_32(), new Matrix3x2(1F, 0F, 0F, 1F, 179.5F, 333.5F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 1.5F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 3
+            // Path 1
+            CompositionSpriteShape SpriteShape_39()
+            {
+                // Offset:<212.662, 248.428>, Rotation:97.90000401019934 degrees
+                var result = CreateSpriteShape(PathGeometry_33(), new Matrix3x2(-0.137444615F, 0.99050945F, -0.99050945F, -0.137444615F, 212.662003F, 248.427994F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 3
+            // Path 1
+            CompositionSpriteShape SpriteShape_40()
+            {
+                // Offset:<212.662, 248.428>, Rotation:97.90000401019934 degrees
+                var result = CreateSpriteShape(PathGeometry_34(), new Matrix3x2(-0.137444615F, 0.99050945F, -0.99050945F, -0.137444615F, 212.662003F, 248.427994F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 3
+            // Path 1
+            CompositionSpriteShape SpriteShape_41()
+            {
+                // Offset:<212.662, 248.428>, Rotation:97.90000401019934 degrees
+                var result = CreateSpriteShape(PathGeometry_35(), new Matrix3x2(-0.137444615F, 0.99050945F, -0.99050945F, -0.137444615F, 212.662003F, 248.427994F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 4
+            // Path 1
+            CompositionSpriteShape SpriteShape_42()
+            {
+                // Offset:<207.662, 419.42798>, Rotation:-89.09999525232098 degrees,
+                // Scale:<0.99999994, 0.99999994>
+                var result = CreateSpriteShape(PathGeometry_36(), new Matrix3x2(0.0157073997F, -0.999876618F, 0.999876618F, 0.0157073997F, 207.662003F, 419.427979F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 4
+            // Path 1
+            CompositionSpriteShape SpriteShape_43()
+            {
+                // Offset:<207.662, 419.42798>, Rotation:-89.09999525232098 degrees,
+                // Scale:<0.99999994, 0.99999994>
+                var result = CreateSpriteShape(PathGeometry_37(), new Matrix3x2(0.0157073997F, -0.999876618F, 0.999876618F, 0.0157073997F, 207.662003F, 419.427979F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 4
+            // Path 1
+            CompositionSpriteShape SpriteShape_44()
+            {
+                // Offset:<207.662, 419.42798>, Rotation:-89.09999525232098 degrees,
+                // Scale:<0.99999994, 0.99999994>
+                var result = CreateSpriteShape(PathGeometry_38(), new Matrix3x2(0.0157073997F, -0.999876618F, 0.999876618F, 0.0157073997F, 207.662003F, 419.427979F));;
+                result.StrokeBrush = ColorBrush_White();
+                result.StrokeDashCap = CompositionStrokeCap.Round;
+                result.StrokeStartCap = CompositionStrokeCap.Round;
+                result.StrokeEndCap = CompositionStrokeCap.Round;
+                result.StrokeMiterLimit = 2F;
+                result.StrokeThickness = 2F;
                 return result;
             }
 
             // The root of the composition.
             ContainerVisual Root()
             {
+                if (_root != null) return _root;
                 var result = _root = _c.CreateContainerVisual();
                 var propertySet = result.Properties;
-                propertySet.InsertScalar("Progress", 0);
-                propertySet.InsertScalar("t0", 0);
-                propertySet.InsertScalar("t1", 0);
-                var children = result.Children;
-                children.InsertAtTop(ShapeVisual());
-                result.StartAnimation("t0", ScalarAnimation_0_to_1());
-                var controller = result.TryGetAnimationController("t0");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
-                result.StartAnimation("t1", _scalarAnimation_0_to_1);
-                controller = result.TryGetAnimationController("t1");
-                controller.Pause();
-                controller.StartAnimation("Progress", _scalarExpressionAnimation);
+                propertySet.InsertScalar("Progress", 0F);
+                propertySet.InsertScalar("t0", 0F);
+                // Layer aggregator
+                result.Children.InsertAtTop(ShapeVisual_0());
                 return result;
             }
 
-            // Rectangle Path 1
-            // Rectangle Path 1.RectangleGeometry
-            CompositionRoundedRectangleGeometry RoundedRectangle_375x667()
+            CubicBezierEasingFunction CubicBezierEasingFunction_0()
             {
-                var result = _c.CreateRoundedRectangleGeometry();
-                result.CornerRadius = new Vector2(9.99999997E-07F, 9.99999997E-07F);
-                result.Offset = new Vector2(-187.5F, -333.5F);
-                result.Size = new Vector2(375, 667);
-                return result;
+                return _cubicBezierEasingFunction_0 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.180000007F, 1F));
             }
 
-            ScalarKeyFrameAnimation ScalarAnimation_0_to_1()
+            CubicBezierEasingFunction CubicBezierEasingFunction_1()
             {
-                var result = _scalarAnimation_0_to_1 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.196966588F, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.245809957F, 1, CubicBezierEasingFunction_26());
-                result.InsertKeyFrame(0.245810062F, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675886F, 1, CubicBezierEasingFunction_27());
-                return result;
+                return _cubicBezierEasingFunction_1 = _c.CreateCubicBezierEasingFunction(new Vector2(0.819999993F, 0F), new Vector2(0.833000004F, 0.833000004F));
             }
 
-            ExpressionAnimation ScalarExpressionAnimation()
+            CubicBezierEasingFunction CubicBezierEasingFunction_2()
             {
-                var result = _scalarExpressionAnimation = _c.CreateExpressionAnimation();
+                return _cubicBezierEasingFunction_2 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.833000004F, 0.833000004F));
+            }
+
+            CubicBezierEasingFunction CubicBezierEasingFunction_3()
+            {
+                return _cubicBezierEasingFunction_3 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.666999996F, 1F));
+            }
+
+            CubicBezierEasingFunction CubicBezierEasingFunction_4()
+            {
+                return _cubicBezierEasingFunction_4 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.119999997F, 1F));
+            }
+
+            CubicBezierEasingFunction CubicBezierEasingFunction_5()
+            {
+                return _cubicBezierEasingFunction_5 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0F), new Vector2(0.119999997F, 1F));
+            }
+
+            CubicBezierEasingFunction CubicBezierEasingFunction_6()
+            {
+                return _cubicBezierEasingFunction_6 = _c.CreateCubicBezierEasingFunction(new Vector2(0.300999999F, 0F), new Vector2(0.666999996F, 1F));
+            }
+
+            CubicBezierEasingFunction CubicBezierEasingFunction_7()
+            {
+                return _cubicBezierEasingFunction_7 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.0599999987F, 1F));
+            }
+
+            CubicBezierEasingFunction CubicBezierEasingFunction_8()
+            {
+                return _cubicBezierEasingFunction_8 = _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.337000012F, 1F));
+            }
+
+            ExpressionAnimation RootProgress()
+            {
+                if (_rootProgress != null) return _rootProgress;
+                var result = _rootProgress = _c.CreateExpressionAnimation("_.Progress");
                 result.SetReferenceParameter("_", _root);
-                result.Expression = "_.Progress";
                 return result;
             }
 
-            ShapeVisual ShapeVisual()
+            ScalarKeyFrameAnimation t0ScalarAnimation_0_to_1()
             {
-                var result = _c.CreateShapeVisual();
-                result.Size = new Vector2(375, 667);
-                var shapes = result.Shapes;
-                // Rectangle Path 1
-                shapes.Add(SpriteShape_00());
-                // Layer (Shape): Dot-Y
-                shapes.Add(ContainerShape_00());
-                // Layer (Shape): E3-Y
-                shapes.Add(ContainerShape_04());
-                // Layer (Shape): E3-B
-                shapes.Add(ContainerShape_07());
-                // Layer (Shape): I-Y
-                shapes.Add(ContainerShape_10());
-                // Layer (Shape): I-B
-                shapes.Add(ContainerShape_13());
-                // Layer (Shape): E2-Y
-                shapes.Add(ContainerShape_16());
-                // Layer (Shape): E2-B
-                shapes.Add(ContainerShape_19());
-                // Layer (Shape): E1-Y
-                shapes.Add(ContainerShape_22());
-                // Layer (Shape): E1-B
-                shapes.Add(ContainerShape_25());
-                // Layer (Shape): T1a-Y
-                shapes.Add(ContainerShape_28());
-                // Layer (Shape): T2b-Y
-                shapes.Add(ContainerShape_31());
-                // Layer (Shape): T2a-Y
-                shapes.Add(ContainerShape_32());
-                // Layer (Shape): T2b-B
-                shapes.Add(ContainerShape_33());
-                // Layer (Shape): T1b-Y
-                shapes.Add(ContainerShape_34());
-                // Layer (Shape): T1b-B
-                shapes.Add(ContainerShape_35());
-                // Layer (Shape): O-Y
-                shapes.Add(ContainerShape_36());
-                // Layer (Shape): O-B
-                shapes.Add(ContainerShape_39());
-                // Layer (Shape): T1a-Y 2
-                shapes.Add(ContainerShape_42());
-                // Layer (Shape): T2a-B
-                shapes.Add(ContainerShape_45());
-                // Layer (Shape): T1a-B
-                shapes.Add(ContainerShape_46());
-                // Layer (Shape): Dot-Y
-                shapes.Add(ContainerShape_49());
-                // Layer (Shape): L-Y
-                shapes.Add(ContainerShape_53());
-                // Layer (Shape): L-B
-                shapes.Add(ContainerShape_54());
-                // Layer (Shape): Dot1
-                shapes.Add(ContainerShape_55());
-                // Layer (Shape): S1-Y
-                shapes.Add(ContainerShape_58());
-                // Layer (Shape): S2-Y
-                shapes.Add(ContainerShape_59());
-                // Layer (Shape): S7
-                shapes.Add(ContainerShape_60());
-                // Layer (Shape): S8
-                shapes.Add(ContainerShape_61());
-                // Layer (Shape): S3-Y
-                shapes.Add(ContainerShape_62());
-                // Layer (Shape): S4-Y
-                shapes.Add(ContainerShape_63());
-                // Layer (Shape): S5-Y
-                shapes.Add(ContainerShape_64());
-                // Layer (Shape): S6-Y
-                shapes.Add(ContainerShape_65());
-                // Layer (Shape): S3-Y 2
-                shapes.Add(ContainerShape_66());
-                // Layer (Shape): S4-Y 2
-                shapes.Add(ContainerShape_67());
-                // Layer (Shape): S5-Y 2
-                shapes.Add(ContainerShape_68());
-                // Layer (Shape): S11
-                shapes.Add(ContainerShape_69());
-                // Layer (Shape): S12
-                shapes.Add(ContainerShape_70());
-                // Layer (Shape): S13
-                shapes.Add(ContainerShape_71());
-                // Layer (Shape): S3-Y 3
-                shapes.Add(ContainerShape_72());
-                // Layer (Shape): S4-Y 3
-                shapes.Add(ContainerShape_73());
-                // Layer (Shape): S5-Y 3
-                shapes.Add(ContainerShape_74());
-                // Layer (Shape): S3-Y 4
-                shapes.Add(ContainerShape_75());
-                // Layer (Shape): S4-Y 4
-                shapes.Add(ContainerShape_76());
-                // Layer (Shape): S5-Y 4
-                shapes.Add(ContainerShape_77());
-                return result;
-            }
-
-            // Rectangle Path 1
-            CompositionSpriteShape SpriteShape_00()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 187.5F, 333.5F);
-                result.FillBrush = ColorBrush_AlmostDarkTurquoise_FF00D1C1();
-                result.Geometry = RoundedRectangle_375x667();
-                return result;
-            }
-
-            // Transforms: Dot-Y
-            // Ellipse Path 1
-            CompositionSpriteShape SpriteShape_01()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 196, 267);
-                result.FillBrush = ColorBrush_White();
-                result.Geometry = Ellipse_4p6();
-                return result;
-            }
-
-            // Transforms: E3-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_02()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 344.674011F, 261.877014F);
-                result.Geometry = PathGeometry_00();
-                result.StrokeBrush = ColorBrush_AlmostTeal_FF007A87();
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.56200027F;
-                return result;
-            }
-
-            // Transforms: E3-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_03()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 344.739014F, 261.877014F);
-                result.Geometry = PathGeometry_01();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.56200027F;
-                return result;
-            }
-
-            // Transforms: I-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_04()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 304.13501F, 282.408997F);
-                result.Geometry = PathGeometry_02();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Square;
-                result.StrokeEndCap = CompositionStrokeCap.Square;
-                result.StrokeStartCap = CompositionStrokeCap.Square;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Transforms: I-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_05()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 304.13501F, 282.408997F);
-                result.Geometry = PathGeometry_03();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Square;
-                result.StrokeEndCap = CompositionStrokeCap.Square;
-                result.StrokeStartCap = CompositionStrokeCap.Square;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Transforms: E2-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_06()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 331.664001F, 238.139999F);
-                result.Geometry = PathGeometry_04();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Transforms: E2-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_07()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 331.664001F, 238.139999F);
-                result.Geometry = PathGeometry_05();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.56200027F;
-                return result;
-            }
-
-            // Transforms: E1-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_08()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 344.671997F, 214.841995F);
-                result.Geometry = PathGeometry_06();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Transforms: E1-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_09()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 344.671997F, 214.841995F);
-                result.Geometry = PathGeometry_07();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.56200027F;
-                return result;
-            }
-
-            // Transforms: T1a-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_10()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 227.677002F, 234.375F);
-                result.Geometry = PathGeometry_08();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Layer (Shape): T2b-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_11()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, -56.5F, 83.5F);
-                result.Geometry = PathGeometry_09();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Layer (Shape): T2a-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_12()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 221.197998F, 330.757996F);
-                result.Geometry = PathGeometry_10();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Square;
-                result.StrokeEndCap = CompositionStrokeCap.Square;
-                result.StrokeStartCap = CompositionStrokeCap.Square;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Layer (Shape): T2b-B
-            // Path 1
-            CompositionSpriteShape SpriteShape_13()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, -56.5F, 83.5F);
-                result.Geometry = PathGeometry_11();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Layer (Shape): T1b-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_14()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 186.255997F, 349.080994F);
-                result.Geometry = PathGeometry_12();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeLineJoin = CompositionStrokeLineJoin.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Layer (Shape): T1b-B
-            // Path 1
-            CompositionSpriteShape SpriteShape_15()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 186.255997F, 349.080994F);
-                result.Geometry = PathGeometry_13();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeLineJoin = CompositionStrokeLineJoin.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Transforms: O-Y
-            // Ellipse Path 1
-            CompositionSpriteShape SpriteShape_16()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 196, 267);
-                result.Geometry = Ellipse_0_0();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 8.80000019F;
-                return result;
-            }
-
-            // Transforms: O-B
-            // Ellipse Path 1
-            CompositionSpriteShape SpriteShape_17()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 196, 267);
-                result.Geometry = Ellipse_0_1();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Transforms: T1a-Y 2
-            // Path 1
-            CompositionSpriteShape SpriteShape_18()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 227.677002F, 234.375F);
-                result.Geometry = PathGeometry_14();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Layer (Shape): T2a-B
-            // Path 1
-            CompositionSpriteShape SpriteShape_19()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 221.197998F, 330.757996F);
-                result.Geometry = PathGeometry_15();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Square;
-                result.StrokeEndCap = CompositionStrokeCap.Square;
-                result.StrokeStartCap = CompositionStrokeCap.Square;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Transforms: T1a-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_20()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 227.677002F, 234.375F);
-                result.Geometry = PathGeometry_16();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Transforms: Dot-Y
-            // Ellipse Path 1
-            CompositionSpriteShape SpriteShape_21()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 196, 267);
-                result.FillBrush = _colorBrush_White;
-                result.Geometry = Ellipse_4p7();
-                return result;
-            }
-
-            // Layer (Shape): L-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_22()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 109.529007F, 354.143005F);
-                result.Geometry = PathGeometry_17();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 8.39999962F;
-                return result;
-            }
-
-            // Layer (Shape): L-B
-            // Path 1
-            CompositionSpriteShape SpriteShape_23()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 109.529007F, 354.143005F);
-                result.Geometry = PathGeometry_18();
-                result.StrokeBrush = _colorBrush_AlmostTeal_FF007A87;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 10;
-                result.StrokeThickness = 9.19400024F;
-                return result;
-            }
-
-            // Transforms: Dot1
-            // Ellipse Path 1
-            CompositionSpriteShape SpriteShape_24()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 196, 267);
-                result.FillBrush = _colorBrush_White;
-                result.Geometry = _ellipse_4p7;
-                return result;
-            }
-
-            // Layer (Shape): S1-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_25()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_19();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S2-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_26()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_20();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S7
-            // Path 1
-            CompositionSpriteShape SpriteShape_27()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_21();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S8
-            // Path 1
-            CompositionSpriteShape SpriteShape_28()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_22();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S3-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_29()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_23();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S4-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_30()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_24();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S5-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_31()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_25();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S6-Y
-            // Path 1
-            CompositionSpriteShape SpriteShape_32()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_26();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S3-Y 2
-            // Path 1
-            CompositionSpriteShape SpriteShape_33()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_27();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S4-Y 2
-            // Path 1
-            CompositionSpriteShape SpriteShape_34()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_28();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S5-Y 2
-            // Path 1
-            CompositionSpriteShape SpriteShape_35()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_29();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S11
-            // Path 1
-            CompositionSpriteShape SpriteShape_36()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_30();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S12
-            // Path 1
-            CompositionSpriteShape SpriteShape_37()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_31();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S13
-            // Path 1
-            CompositionSpriteShape SpriteShape_38()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(1, 0, 0, 1, 179.5F, 333.5F);
-                result.Geometry = PathGeometry_32();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 1.5F;
-                return result;
-            }
-
-            // Layer (Shape): S3-Y 3
-            // Path 1
-            CompositionSpriteShape SpriteShape_39()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(-0.137444615F, 0.99050945F, -0.99050945F, -0.137444615F, 212.662003F, 248.427994F);
-                result.Geometry = PathGeometry_33();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S4-Y 3
-            // Path 1
-            CompositionSpriteShape SpriteShape_40()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(-0.137444615F, 0.99050945F, -0.99050945F, -0.137444615F, 212.662003F, 248.427994F);
-                result.Geometry = PathGeometry_34();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S5-Y 3
-            // Path 1
-            CompositionSpriteShape SpriteShape_41()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(-0.137444615F, 0.99050945F, -0.99050945F, -0.137444615F, 212.662003F, 248.427994F);
-                result.Geometry = PathGeometry_35();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S3-Y 4
-            // Path 1
-            CompositionSpriteShape SpriteShape_42()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(0.0157073997F, -0.999876618F, 0.999876618F, 0.0157073997F, 207.662003F, 419.427979F);
-                result.Geometry = PathGeometry_36();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S4-Y 4
-            // Path 1
-            CompositionSpriteShape SpriteShape_43()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(0.0157073997F, -0.999876618F, 0.999876618F, 0.0157073997F, 207.662003F, 419.427979F);
-                result.Geometry = PathGeometry_37();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            // Layer (Shape): S5-Y 4
-            // Path 1
-            CompositionSpriteShape SpriteShape_44()
-            {
-                var result = _c.CreateSpriteShape();
-                result.TransformMatrix = new Matrix3x2(0.0157073997F, -0.999876618F, 0.999876618F, 0.0157073997F, 207.662003F, 419.427979F);
-                result.Geometry = PathGeometry_38();
-                result.StrokeBrush = _colorBrush_White;
-                result.StrokeDashCap = CompositionStrokeCap.Round;
-                result.StrokeEndCap = CompositionStrokeCap.Round;
-                result.StrokeStartCap = CompositionStrokeCap.Round;
-                result.StrokeMiterLimit = 4;
-                result.StrokeThickness = 2;
-                return result;
-            }
-
-            StepEasingFunction StepThenHoldEasingFunction()
-            {
-                var result = _stepThenHoldEasingFunction = _c.CreateStepEasingFunction();
-                result.IsInitialStepSingleFrame = true;
+                // Frame 35.26.
+                var result = CreateScalarKeyFrameAnimation(0.196966499F, 0F, StepThenHoldEasingFunction());
+                result.SetReferenceParameter("_", _root);
+                // Frame 44.
+                result.InsertKeyFrame(0.245810047F, 1F, _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.197999999F), new Vector2(0.638000011F, 1F)));
+                // Frame 44.
+                result.InsertKeyFrame(0.245810062F, 0F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675946F, 1F, _c.CreateCubicBezierEasingFunction(new Vector2(0.523000002F, 0F), new Vector2(0.795000017F, 1F)));
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_0_to_1_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.413407832F, 1, CubicBezierEasingFunction_10());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0F, HoldThenStepEasingFunction());
+                // Frame 74.
+                result.InsertKeyFrame(0.413407832F, 1F, CubicBezierEasingFunction_6());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_0_to_1_1()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 1, _cubicBezierEasingFunction_10);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0F, HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 1F, CubicBezierEasingFunction_6());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_0p81_to_0p734_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.810000002F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.0893854722F, 0.810000002F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.150837988F, 0.734000027F, CubicBezierEasingFunction_22());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.810000002F, StepThenHoldEasingFunction());
+                // Frame 16.
+                result.InsertKeyFrame(0.0893854722F, 0.810000002F, HoldThenStepEasingFunction());
+                // Frame 27.
+                result.InsertKeyFrame(0.150837988F, 0.734000027F, CubicBezierEasingFunction_8());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_0p81_to_0p734_1()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.810000002F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.100558661F, 0.810000002F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.162011176F, 0.734000027F, _cubicBezierEasingFunction_22);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.810000002F, StepThenHoldEasingFunction());
+                // Frame 18.
+                result.InsertKeyFrame(0.100558661F, 0.810000002F, HoldThenStepEasingFunction());
+                // Frame 29.
+                result.InsertKeyFrame(0.162011176F, 0.734000027F, CubicBezierEasingFunction_8());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_00()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.162011176F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.184357539F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.201117322F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 29.
+                result.InsertKeyFrame(0.162011176F, 1F, HoldThenStepEasingFunction());
+                // Frame 33.
+                result.InsertKeyFrame(0.184357539F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 36.
+                result.InsertKeyFrame(0.201117322F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_01()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.162011176F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.184357539F, 0.690559983F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.201117322F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 29.
+                result.InsertKeyFrame(0.162011176F, 1F, HoldThenStepEasingFunction());
+                // Frame 33.
+                result.InsertKeyFrame(0.184357539F, 0.690559983F, CubicBezierEasingFunction_2());
+                // Frame 36.
+                result.InsertKeyFrame(0.201117322F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_02()
             {
-                var result = _tEndScalarAnimation_1_to_0_02 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.363128483F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.391061455F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.418994427F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                if (_tEndScalarAnimation_1_to_0_02 != null) return _tEndScalarAnimation_1_to_0_02;
+                var result = _tEndScalarAnimation_1_to_0_02 = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 65.
+                result.InsertKeyFrame(0.363128483F, 1F, HoldThenStepEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_03()
             {
-                var result = _tEndScalarAnimation_1_to_0_03 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                if (_tEndScalarAnimation_1_to_0_03 != null) return _tEndScalarAnimation_1_to_0_03;
+                var result = _tEndScalarAnimation_1_to_0_03 = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 1F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_04()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.758560002F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 1F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.758560002F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_05()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.704559982F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 1F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.704559982F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_06()
             {
-                var result = _tEndScalarAnimation_1_to_0_06 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.541899443F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.558659196F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.597765386F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                if (_tEndScalarAnimation_1_to_0_06 != null) return _tEndScalarAnimation_1_to_0_06;
+                var result = _tEndScalarAnimation_1_to_0_06 = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, 1F, HoldThenStepEasingFunction());
+                // Frame 100.
+                result.InsertKeyFrame(0.558659196F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 107.
+                result.InsertKeyFrame(0.597765386F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_07()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.541899443F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.558659196F, 0.758560002F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.597765386F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, 1F, HoldThenStepEasingFunction());
+                // Frame 100.
+                result.InsertKeyFrame(0.558659196F, 0.758560002F, CubicBezierEasingFunction_2());
+                // Frame 107.
+                result.InsertKeyFrame(0.597765386F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_08()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.446927369F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.463687152F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.486033529F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 80.
+                result.InsertKeyFrame(0.446927369F, 1F, HoldThenStepEasingFunction());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 87.
+                result.InsertKeyFrame(0.486033529F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_09()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.469273746F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.486033529F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.508379877F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, 1F, HoldThenStepEasingFunction());
+                // Frame 87.
+                result.InsertKeyFrame(0.486033529F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 91.
+                result.InsertKeyFrame(0.508379877F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_10()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.47486034F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.502793312F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.525139689F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, 1F, HoldThenStepEasingFunction());
+                // Frame 90.
+                result.InsertKeyFrame(0.502793312F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 94.
+                result.InsertKeyFrame(0.525139689F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_11()
             {
-                var result = _tEndScalarAnimation_1_to_0_11 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.458100557F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                if (_tEndScalarAnimation_1_to_0_11 != null) return _tEndScalarAnimation_1_to_0_11;
+                var result = _tEndScalarAnimation_1_to_0_11 = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 1F, HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_12()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 0.758560002F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.458100557F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 1F, HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 0.758560002F, CubicBezierEasingFunction_2());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_13()
             {
-                var result = _tEndScalarAnimation_1_to_0_13 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.441340774F, 0.663559973F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.463687152F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                if (_tEndScalarAnimation_1_to_0_13 != null) return _tEndScalarAnimation_1_to_0_13;
+                var result = _tEndScalarAnimation_1_to_0_13 = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 1F, HoldThenStepEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, 0.663559973F, CubicBezierEasingFunction_2());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TEnd
             ScalarKeyFrameAnimation TEndScalarAnimation_1_to_0_14()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.441340774F, 0.758560002F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.463687152F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 1F, HoldThenStepEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, 0.758560002F, CubicBezierEasingFunction_2());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
-            // Layer (Shape): E3-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_00()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.469273746F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.569832385F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): I-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_01()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.43575418F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.519553065F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): E2-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_02()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.463687152F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.536312878F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): E1-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_03()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.441340774F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.525139689F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T1a-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_04()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.329608947F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.87150836F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T2b-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_05()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.424580991F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.513966501F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T2a-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_06()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.402234644F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.497206718F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T1b-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_07()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.391061455F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.899441361F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): Dot-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_08()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.156424582F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_09()
-            {
-                var result = _transformMatrix_11ScalarAnimation_1_to_0_09 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.167597771F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.206703916F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_10()
-            {
-                var result = _transformMatrix_11ScalarAnimation_1_to_0_10 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.363128483F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_11()
-            {
-                var result = _transformMatrix_11ScalarAnimation_1_to_0_11 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.301675975F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.357541889F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_12()
-            {
-                var result = _transformMatrix_11ScalarAnimation_1_to_0_12 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.541899443F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.597765386F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): S11
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_13()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.446927369F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.502793312F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): S12
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_14()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.469273746F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.525139689F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): S13
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_15()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.47486034F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.530726254F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_16()
-            {
-                var result = _transformMatrix_11ScalarAnimation_1_to_0_16 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.418994427F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.463687152F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_1_to_0_17()
-            {
-                var result = _transformMatrix_11ScalarAnimation_1_to_0_17 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.424580991F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.469273746F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): Dot1
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_0()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.0949720666F, 0, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): Dot-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_00()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.536312878F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): E3-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_01()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.513966501F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_02()
-            {
-                var result = _transformMatrix_11ScalarAnimation_to_1_02 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.452513963F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): E2-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_03()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.480446935F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): E1-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_04()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.469273746F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T2b-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_05()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.458100557F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_06()
-            {
-                var result = _transformMatrix_11ScalarAnimation_to_1_06 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.301675975F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T1a-Y 2
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_07()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.329608947F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T2a-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_08()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.418994427F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): T1a-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_09()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.391061455F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): L-Y
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_10()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.0893854722F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Layer (Shape): L-B
-            ScalarKeyFrameAnimation TransformMatrix_11ScalarAnimation_to_1_11()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0.100558661F, 1, _holdThenStepEasingFunction);
-                return result;
-            }
-
-            // Transforms: E3-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p316_0()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.469273746F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.513966501F, 0.316000015F, CubicBezierEasingFunction_04());
-                return result;
-            }
-
-            // Transforms: E3-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p316_1()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.513966501F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.541899443F, 0.316000015F, _cubicBezierEasingFunction_04);
-                return result;
-            }
-
-            // Transforms: E1-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p375_0()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.441340774F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.491620123F, 0.375F, _cubicBezierEasingFunction_07);
-                return result;
-            }
-
-            // Transforms: E1-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p375_1()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.469273746F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.519553065F, 0.375F, _cubicBezierEasingFunction_07);
-                return result;
-            }
-
-            // Transforms: E2-Y
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - - Layer aggregator
+            // - - Layer: E2-Y
+            // - ShapeGroup: Group 3 Offset:<331.664, 238.14>
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p43_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.463687152F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.513966501F, 0.430000007F, _cubicBezierEasingFunction_07);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0F, HoldThenStepEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, 0.430000007F, CubicBezierEasingFunction_4());
                 return result;
             }
 
-            // Transforms: E2-Y
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - - Layer aggregator
+            // - - Layer: E2-B
+            // - Transforms: E2-B
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p43_1()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.480446935F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.530726254F, 0.430000007F, _cubicBezierEasingFunction_07);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 86.
+                result.InsertKeyFrame(0.480446935F, 0F, HoldThenStepEasingFunction());
+                // Frame 95.
+                result.InsertKeyFrame(0.530726254F, 0.430000007F, CubicBezierEasingFunction_4());
                 return result;
             }
 
-            // Transforms: I-Y
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - - Layer aggregator
+            // - - Layer: E3-Y
+            // - ShapeGroup: Group 1 Offset:<344.674, 261.877>
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p316_0()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, 0F, HoldThenStepEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, 0.316000015F, CubicBezierEasingFunction_2());
+                return result;
+            }
+
+            // - - - Layer aggregator
+            // - - Layer: E3-B
+            // - Transforms: E3-B Offset:<0.06500244, 0>
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p316_1()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, 0F, HoldThenStepEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, 0.316000015F, CubicBezierEasingFunction_2());
+                return result;
+            }
+
+            // - - - Layer aggregator
+            // - - Layer: E1-Y
+            // - ShapeGroup: Group 2 Offset:<344.672, 214.842>
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p375_0()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, 0F, HoldThenStepEasingFunction());
+                // Frame 88.
+                result.InsertKeyFrame(0.491620123F, 0.375F, CubicBezierEasingFunction_4());
+                return result;
+            }
+
+            // - - - Layer aggregator
+            // - - Layer: E1-B
+            // - Transforms: E1-B
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p375_1()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, 0F, HoldThenStepEasingFunction());
+                // Frame 93.
+                result.InsertKeyFrame(0.519553065F, 0.375F, CubicBezierEasingFunction_4());
+                return result;
+            }
+
+            // - - - Layer aggregator
+            // - - Layer: I-Y
+            // - ShapeGroup: Group 6 Offset:<304.135, 282.409>
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p457_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.491620123F, 0.456999987F, CubicBezierEasingFunction_07());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 0F, HoldThenStepEasingFunction());
+                // Frame 88.
+                result.InsertKeyFrame(0.491620123F, 0.456999987F, CubicBezierEasingFunction_4());
                 return result;
             }
 
-            // Transforms: I-Y
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - - Layer aggregator
+            // - - Layer: I-B
+            // - Transforms: I-B
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_0_to_0p457_1()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.452513963F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.508379877F, 0.456999987F, _cubicBezierEasingFunction_07);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 81.
+                result.InsertKeyFrame(0.452513963F, 0F, HoldThenStepEasingFunction());
+                // Frame 91.
+                result.InsertKeyFrame(0.508379877F, 0.456999987F, CubicBezierEasingFunction_4());
                 return result;
             }
 
-            // Layer (Shape): T1b-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p117_to_1_0()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.116999999F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.391061455F, 0.116999999F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 1, _cubicBezierEasingFunction_04);
-                return result;
-            }
-
-            // Layer (Shape): T1b-B
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p117_to_1_1()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.116999999F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.452513963F, 0.116999999F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.491620123F, 1, CubicBezierEasingFunction_12());
-                return result;
-            }
-
-            // Transforms: T1a-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p249_to_0p891()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.248999998F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.391061455F, 0.248999998F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.469273746F, 0.890999973F, CubicBezierEasingFunction_17());
-                return result;
-            }
-
-            // Layer (Shape): T2b-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p411_to_0p665_0()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.411000013F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 0.411000013F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.47486034F, 0.665000021F, _cubicBezierEasingFunction_07);
-                return result;
-            }
-
-            // Layer (Shape): T2b-B
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimEnd
-            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p411_to_0p665_1()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.411000013F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.458100557F, 0.411000013F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.508379877F, 0.665000021F, _cubicBezierEasingFunction_07);
-                return result;
-            }
-
-            // Layer (Shape): T2a-Y
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: T2a-Y
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_0p5_to_1_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.5F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.402234644F, 0.5F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.458100557F, 1, _cubicBezierEasingFunction_11);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.5F, StepThenHoldEasingFunction());
+                // Frame 72.
+                result.InsertKeyFrame(0.402234644F, 0.5F, HoldThenStepEasingFunction());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 1F, CubicBezierEasingFunction_7());
                 return result;
             }
 
-            // Layer (Shape): T2a-B
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: T2a-B
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_0p5_to_1_1()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.5F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 0.5F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.47486034F, 1, _cubicBezierEasingFunction_11);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.5F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0.5F, HoldThenStepEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, 1F, CubicBezierEasingFunction_7());
                 return result;
             }
 
-            // Transforms: O-B
-            //   Ellipse Path 1
-            //     Ellipse Path 1.EllipseGeometry
+            // - - Layer aggregator
+            // - Layer: T1b-Y
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p117_to_1_0()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.116999999F, StepThenHoldEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, 0.116999999F, HoldThenStepEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 1F, CubicBezierEasingFunction_2());
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: T1b-B
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p117_to_1_1()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.116999999F, StepThenHoldEasingFunction());
+                // Frame 81.
+                result.InsertKeyFrame(0.452513963F, 0.116999999F, HoldThenStepEasingFunction());
+                // Frame 88.
+                result.InsertKeyFrame(0.491620123F, 1F, _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.209999993F, 1F)));
+                return result;
+            }
+
+            // - - - Layer aggregator
+            // - - Layer: T1a-B
+            // - Transforms: T1a-B
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p249_to_0p891()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.248999998F, StepThenHoldEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, 0.248999998F, HoldThenStepEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, 0.890999973F, _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.672999978F, 1F)));
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: T2b-Y
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p411_to_0p665_0()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.411000013F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 0.411000013F, HoldThenStepEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, 0.665000021F, CubicBezierEasingFunction_4());
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: T2b-B
+            // TrimEnd
+            ScalarKeyFrameAnimation TrimEndScalarAnimation_0p411_to_0p665_1()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.411000013F, StepThenHoldEasingFunction());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0.411000013F, HoldThenStepEasingFunction());
+                // Frame 91.
+                result.InsertKeyFrame(0.508379877F, 0.665000021F, CubicBezierEasingFunction_4());
+                return result;
+            }
+
+            // - - - Layer aggregator
+            // - - Layer: O-Y
+            // - ShapeGroup: Ellipse 1 Offset:<196, 267>
+            // Ellipse Path 1.EllipseGeometry
             // TrimEnd
             ScalarKeyFrameAnimation TrimEndScalarAnimation_1_to_0p88()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 1, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 1, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.351955295F, 0.879999995F, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 1F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 1F, HoldThenStepEasingFunction());
+                // Frame 63.
+                result.InsertKeyFrame(0.351955295F, 0.879999995F, CubicBezierEasingFunction_2());
                 return result;
             }
 
-            // Transforms: O-B
-            //   Ellipse Path 1
-            //     Ellipse Path 1.EllipseGeometry
+            // - - - Layer aggregator
+            // - - Layer: O-Y
+            // - ShapeGroup: Ellipse 1 Offset:<196, 267>
+            // Ellipse Path 1.EllipseGeometry
             // TrimStart
             ScalarKeyFrameAnimation TrimStartScalarAnimation_0_to_0p399()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.351955295F, 0.300000012F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.508379877F, 0.398999989F, CubicBezierEasingFunction_16());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0F, HoldThenStepEasingFunction());
+                // Frame 63.
+                result.InsertKeyFrame(0.351955295F, 0.300000012F, CubicBezierEasingFunction_2());
+                // Frame 91.
+                result.InsertKeyFrame(0.508379877F, 0.398999989F, _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 1F), new Vector2(0.432000011F, 1F)));
                 return result;
             }
 
-            // Layer (Shape): T2b-Y
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimStart
-            ScalarKeyFrameAnimation TrimStartScalarAnimation_0p29_to_0_0()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.289999992F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 0.289999992F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.47486034F, 0, _cubicBezierEasingFunction_07);
-                return result;
-            }
-
-            // Layer (Shape): T2b-B
-            //   Path 1
-            //     Path 1.PathGeometry
-            // TrimStart
-            ScalarKeyFrameAnimation TrimStartScalarAnimation_0p29_to_0_1()
-            {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.289999992F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.458100557F, 0.289999992F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.508379877F, 0, _cubicBezierEasingFunction_07);
-                return result;
-            }
-
-            // Layer (Shape): T2a-Y
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: T2a-Y
             // TrimStart
             ScalarKeyFrameAnimation TrimStartScalarAnimation_0p5_to_0_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.5F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.402234644F, 0.5F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.458100557F, 0, CubicBezierEasingFunction_11());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.5F, StepThenHoldEasingFunction());
+                // Frame 72.
+                result.InsertKeyFrame(0.402234644F, 0.5F, HoldThenStepEasingFunction());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0F, CubicBezierEasingFunction_7());
                 return result;
             }
 
-            // Layer (Shape): T2a-B
-            //   Path 1
-            //     Path 1.PathGeometry
+            // - - Layer aggregator
+            // - Layer: T2a-B
             // TrimStart
             ScalarKeyFrameAnimation TrimStartScalarAnimation_0p5_to_0_1()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.5F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 0.5F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.47486034F, 0, _cubicBezierEasingFunction_11);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.5F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0.5F, HoldThenStepEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, 0F, CubicBezierEasingFunction_7());
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: T2b-Y
+            // TrimStart
+            ScalarKeyFrameAnimation TrimStartScalarAnimation_0p29_to_0_0()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.289999992F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 0.289999992F, HoldThenStepEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, 0F, CubicBezierEasingFunction_4());
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: T2b-B
+            // TrimStart
+            ScalarKeyFrameAnimation TrimStartScalarAnimation_0p29_to_0_1()
+            {
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.289999992F, StepThenHoldEasingFunction());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0.289999992F, HoldThenStepEasingFunction());
+                // Frame 91.
+                result.InsertKeyFrame(0.508379877F, 0F, CubicBezierEasingFunction_4());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0_to_0p249()
             {
-                var result = _tStartScalarAnimation_0_to_0p249 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.391061455F, 0.248999998F, CubicBezierEasingFunction_09());
+                // Frame 0.
+                if (_tStartScalarAnimation_0_to_0p249 != null) return _tStartScalarAnimation_0_to_0p249;
+                var result = _tStartScalarAnimation_0_to_0p249 = CreateScalarKeyFrameAnimation(0F, 0F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0F, HoldThenStepEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, 0.248999998F, _c.CreateCubicBezierEasingFunction(new Vector2(0.300999999F, 0F), new Vector2(0.833000004F, 1F)));
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p8_to_0()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.800000012F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.0893854722F, 0.800000012F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.111731842F, 0.5F, CubicBezierEasingFunction_20());
-                result.InsertKeyFrame(0.156424582F, 0, CubicBezierEasingFunction_21());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.800000012F, StepThenHoldEasingFunction());
+                // Frame 16.
+                result.InsertKeyFrame(0.0893854722F, 0.800000012F, HoldThenStepEasingFunction());
+                // Frame 20.
+                result.InsertKeyFrame(0.111731842F, 0.5F, _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.703000009F, 0.856999993F)));
+                // Frame 28.
+                result.InsertKeyFrame(0.156424582F, 0F, _c.CreateCubicBezierEasingFunction(new Vector2(0.333000004F, 0.202000007F), new Vector2(0.938000023F, 1F)));
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p8_to_0p3()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.800000012F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.100558661F, 0.800000012F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.128491625F, 0.5F, CubicBezierEasingFunction_23());
-                result.InsertKeyFrame(0.30726257F, 0.300000012F, CubicBezierEasingFunction_24());
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.800000012F, StepThenHoldEasingFunction());
+                // Frame 18.
+                result.InsertKeyFrame(0.100558661F, 0.800000012F, HoldThenStepEasingFunction());
+                // Frame 23.
+                result.InsertKeyFrame(0.128491625F, 0.5F, _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.703000009F, 0.82099998F)));
+                // Frame 55.
+                result.InsertKeyFrame(0.30726257F, 0.300000012F, _c.CreateCubicBezierEasingFunction(new Vector2(0.0370000005F, 0.167999998F), new Vector2(0.263000011F, 1F)));
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_00()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.162011176F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.184357539F, 0.375330001F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.201117322F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 29.
+                result.InsertKeyFrame(0.162011176F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 33.
+                result.InsertKeyFrame(0.184357539F, 0.375330001F, CubicBezierEasingFunction_2());
+                // Frame 36.
+                result.InsertKeyFrame(0.201117322F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_01()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.162011176F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.184357539F, 0.253329992F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.201117322F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 29.
+                result.InsertKeyFrame(0.162011176F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 33.
+                result.InsertKeyFrame(0.184357539F, 0.253329992F, CubicBezierEasingFunction_2());
+                // Frame 36.
+                result.InsertKeyFrame(0.201117322F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_02()
             {
-                var result = _tStartScalarAnimation_0p87_to_0_02 = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.363128483F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.391061455F, 0.212329999F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.418994427F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                if (_tStartScalarAnimation_0p87_to_0_02 != null) return _tStartScalarAnimation_0p87_to_0_02;
+                var result = _tStartScalarAnimation_0p87_to_0_02 = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 65.
+                result.InsertKeyFrame(0.363128483F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, 0.212329999F, CubicBezierEasingFunction_2());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_03()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.421330005F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.421330005F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_04()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.438329995F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.438329995F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_05()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.506330013F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.506330013F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_06()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.301675975F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.318435758F, 0.439330012F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.357541889F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 57.
+                result.InsertKeyFrame(0.318435758F, 0.439330012F, CubicBezierEasingFunction_2());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_07()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.541899443F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.558659196F, 0.421330005F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.597765386F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 100.
+                result.InsertKeyFrame(0.558659196F, 0.421330005F, CubicBezierEasingFunction_2());
+                // Frame 107.
+                result.InsertKeyFrame(0.597765386F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_08()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.541899443F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.558659196F, 0.438329995F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.597765386F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 100.
+                result.InsertKeyFrame(0.558659196F, 0.438329995F, CubicBezierEasingFunction_2());
+                // Frame 107.
+                result.InsertKeyFrame(0.597765386F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_09()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.541899443F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.558659196F, 0.506330013F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.597765386F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 100.
+                result.InsertKeyFrame(0.558659196F, 0.506330013F, CubicBezierEasingFunction_2());
+                // Frame 107.
+                result.InsertKeyFrame(0.597765386F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_10()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.446927369F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.463687152F, 0.212329999F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.486033529F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 80.
+                result.InsertKeyFrame(0.446927369F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0.212329999F, CubicBezierEasingFunction_2());
+                // Frame 87.
+                result.InsertKeyFrame(0.486033529F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_11()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.469273746F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.486033529F, 0.212329999F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.508379877F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 87.
+                result.InsertKeyFrame(0.486033529F, 0.212329999F, CubicBezierEasingFunction_2());
+                // Frame 91.
+                result.InsertKeyFrame(0.508379877F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_12()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.47486034F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.502793312F, 0.212329999F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.525139689F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 90.
+                result.InsertKeyFrame(0.502793312F, 0.212329999F, CubicBezierEasingFunction_2());
+                // Frame 94.
+                result.InsertKeyFrame(0.525139689F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_13()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 0.421330005F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.458100557F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 0.421330005F, CubicBezierEasingFunction_2());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_14()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 0.438329995F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.458100557F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 0.438329995F, CubicBezierEasingFunction_2());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_15()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.418994427F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.43575418F, 0.506330013F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.458100557F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, 0.506330013F, CubicBezierEasingFunction_2());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_16()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.441340774F, 0.421330005F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.463687152F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, 0.421330005F, CubicBezierEasingFunction_2());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_17()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.441340774F, 0.438329995F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.463687152F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, 0.438329995F, CubicBezierEasingFunction_2());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
             // TStart
             ScalarKeyFrameAnimation TStartScalarAnimation_0p87_to_0_18()
             {
-                var result = _c.CreateScalarKeyFrameAnimation();
-                result.Duration = TimeSpan.FromTicks(c_durationTicks);
-                result.InsertKeyFrame(0, 0.870000005F, _stepThenHoldEasingFunction);
-                result.InsertKeyFrame(0.424580991F, 0.870000005F, _holdThenStepEasingFunction);
-                result.InsertKeyFrame(0.441340774F, 0.506330013F, _cubicBezierEasingFunction_04);
-                result.InsertKeyFrame(0.463687152F, 0, _cubicBezierEasingFunction_04);
+                // Frame 0.
+                var result = CreateScalarKeyFrameAnimation(0F, 0.870000005F, StepThenHoldEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, 0.870000005F, HoldThenStepEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, 0.506330013F, CubicBezierEasingFunction_2());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, 0F, CubicBezierEasingFunction_2());
                 return result;
             }
 
-            internal AnimatedVisual(Compositor compositor)
+            // Layer aggregator
+            ShapeVisual ShapeVisual_0()
             {
-                var d2dIid = new Guid(ID2D1Factory_IID);
-                _d2d = D2D1CreateFactory(0, in d2dIid, IntPtr.Zero);
+                var result = _c.CreateShapeVisual();
+                result.Size = new Vector2(375F, 667F);
+                var shapes = result.Shapes;
+                // Offset:<187.5, 333.5>
+                shapes.Add(SpriteShape_00());
+                // Layer: Dot-Y
+                shapes.Add(ContainerShape_00());
+                // Layer: E3-Y
+                shapes.Add(ContainerShape_02());
+                // Layer: E3-B
+                shapes.Add(ContainerShape_03());
+                // Layer: I-Y
+                shapes.Add(ContainerShape_04());
+                // Layer: I-B
+                shapes.Add(ContainerShape_05());
+                // Layer: E2-Y
+                shapes.Add(ContainerShape_06());
+                // Layer: E2-B
+                shapes.Add(ContainerShape_07());
+                // Layer: E1-Y
+                shapes.Add(ContainerShape_08());
+                // Layer: E1-B
+                shapes.Add(ContainerShape_09());
+                // Layer: T1a-Y
+                shapes.Add(ContainerShape_10());
+                // Layer: T2b-Y
+                shapes.Add(SpriteShape_11());
+                // Layer: T2a-Y
+                shapes.Add(SpriteShape_12());
+                // Layer: T2b-B
+                shapes.Add(SpriteShape_13());
+                // Layer: T1b-Y
+                shapes.Add(SpriteShape_14());
+                // Layer: T1b-B
+                shapes.Add(SpriteShape_15());
+                // Layer: O-Y
+                shapes.Add(ContainerShape_11());
+                // Layer: T1a-Y 2
+                shapes.Add(ContainerShape_12());
+                // Layer: T2a-B
+                shapes.Add(SpriteShape_19());
+                // Layer: T1a-B
+                shapes.Add(ContainerShape_13());
+                // Layer: Dot-Y
+                shapes.Add(ContainerShape_14());
+                // Layer: L-Y
+                shapes.Add(SpriteShape_22());
+                // Layer: L-B
+                shapes.Add(SpriteShape_23());
+                // Layer: Dot1
+                shapes.Add(ContainerShape_16());
+                // Layer: S1-Y
+                shapes.Add(ContainerShape_17());
+                // Layer: S7
+                shapes.Add(ContainerShape_18());
+                // Layer: S3-Y
+                shapes.Add(ContainerShape_19());
+                // Layer: S3-Y 2
+                shapes.Add(ContainerShape_20());
+                // Layer: S11
+                shapes.Add(SpriteShape_36());
+                // Layer: S12
+                shapes.Add(SpriteShape_37());
+                // Layer: S13
+                shapes.Add(SpriteShape_38());
+                // Layer: S3-Y 3
+                shapes.Add(ContainerShape_21());
+                // Layer: S3-Y 4
+                shapes.Add(ContainerShape_22());
+                return result;
+            }
+
+            StepEasingFunction HoldThenStepEasingFunction()
+            {
+                if (_holdThenStepEasingFunction != null) return _holdThenStepEasingFunction;
+                var result = _holdThenStepEasingFunction = _c.CreateStepEasingFunction();
+                result.IsFinalStepSingleFrame = true;
+                return result;
+            }
+
+            StepEasingFunction StepThenHoldEasingFunction()
+            {
+                if (_stepThenHoldEasingFunction != null) return _stepThenHoldEasingFunction;
+                var result = _stepThenHoldEasingFunction = _c.CreateStepEasingFunction();
+                result.IsInitialStepSingleFrame = true;
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: Dot-Y
+            // Transforms: Dot-Y
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_00()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(-153.528F, -206.753998F), StepThenHoldEasingFunction());
+                // Frame 96.
+                result.InsertKeyFrame(0.536312878F, new Vector2(-153.528F, -206.753998F), HoldThenStepEasingFunction());
+                // Frame 108.
+                result.InsertKeyFrame(0.603351951F, new Vector2(-134.278F, -206.753998F), _c.CreateCubicBezierEasingFunction(new Vector2(0F, 0F), new Vector2(0F, 0.811999977F)));
+                // Frame 115.
+                result.InsertKeyFrame(0.642458081F, new Vector2(-133.028F, -206.753998F), _c.CreateCubicBezierEasingFunction(new Vector2(0.389999986F, 0.707000017F), new Vector2(0.708000004F, 1F)));
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot-Y
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_01()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(104.781998F, -2.52699995F), StepThenHoldEasingFunction());
+                // Frame 96.
+                result.InsertKeyFrame(0.536312878F, new Vector2(104.781998F, -2.52699995F), HoldThenStepEasingFunction());
+                // Frame 99.
+                result.InsertKeyFrame(0.553072631F, new Vector2(104.781998F, -4.52699995F), CubicBezierEasingFunction_0());
+                // Frame 102.
+                result.InsertKeyFrame(0.569832385F, new Vector2(104.781998F, -2.52699995F), CubicBezierEasingFunction_1());
+                // Frame 105.
+                result.InsertKeyFrame(0.586592197F, new Vector2(104.781998F, -3.09100008F), CubicBezierEasingFunction_0());
+                // Frame 108.
+                result.InsertKeyFrame(0.603351951F, new Vector2(104.781998F, -2.52699995F), CubicBezierEasingFunction_1());
+                return result;
+            }
+
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_02()
+            {
+                // Frame 0.
+                if (_offsetVector2Animation_02 != null) return _offsetVector2Animation_02;
+                var result = _offsetVector2Animation_02 = CreateVector2KeyFrameAnimation(0F, new Vector2(-225.957001F, -204.322006F), StepThenHoldEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, new Vector2(-225.957001F, -204.322006F), HoldThenStepEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, new Vector2(-207.957001F, -204.322006F), CubicBezierEasingFunction_3());
+                // Frame 96.
+                result.InsertKeyFrame(0.536312878F, new Vector2(-210.957001F, -204.322006F), _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0F), new Vector2(0.666999996F, 1F)));
+                return result;
+            }
+
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_03()
+            {
+                // Frame 0.
+                if (_offsetVector2Animation_03 != null) return _offsetVector2Animation_03;
+                var result = _offsetVector2Animation_03 = CreateVector2KeyFrameAnimation(0F, new Vector2(-210.207993F, -219.320999F), StepThenHoldEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, new Vector2(-210.207993F, -219.320999F), HoldThenStepEasingFunction());
+                // Frame 88.
+                result.InsertKeyFrame(0.491620123F, new Vector2(-211.175995F, -199.352997F), CubicBezierEasingFunction_4());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, new Vector2(-210.957993F, -204.320999F), CubicBezierEasingFunction_5());
+                return result;
+            }
+
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_04()
+            {
+                // Frame 0.
+                if (_offsetVector2Animation_04 != null) return _offsetVector2Animation_04;
+                var result = _offsetVector2Animation_04 = CreateVector2KeyFrameAnimation(0F, new Vector2(-222.957993F, -204.322006F), StepThenHoldEasingFunction());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, new Vector2(-222.957993F, -204.322006F), HoldThenStepEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, new Vector2(-210.957993F, -204.322006F), CubicBezierEasingFunction_4());
+                return result;
+            }
+
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_05()
+            {
+                // Frame 0.
+                if (_offsetVector2Animation_05 != null) return _offsetVector2Animation_05;
+                var result = _offsetVector2Animation_05 = CreateVector2KeyFrameAnimation(0F, new Vector2(-230.957001F, -205.695999F), StepThenHoldEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, new Vector2(-230.957001F, -205.695999F), HoldThenStepEasingFunction());
+                // Frame 88.
+                result.InsertKeyFrame(0.491620123F, new Vector2(-206.957001F, -205.695999F), CubicBezierEasingFunction_4());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, new Vector2(-210.957001F, -205.695999F), CubicBezierEasingFunction_5());
+                return result;
+            }
+
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_06()
+            {
+                // Frame 0.
+                if (_offsetVector2Animation_06 != null) return _offsetVector2Animation_06;
+                var result = _offsetVector2Animation_06 = CreateVector2KeyFrameAnimation(0F, new Vector2(-210.957001F, -201.322006F), StepThenHoldEasingFunction());
+                // Frame 56.
+                result.InsertKeyFrame(0.312849164F, new Vector2(-210.957001F, -201.322006F), HoldThenStepEasingFunction());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, new Vector2(-210.957001F, -204.322006F), CubicBezierEasingFunction_3());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: O-Y
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_07()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(-259.583008F, -193.447006F), StepThenHoldEasingFunction());
+                result.SetReferenceParameter("_", _root);
+                // Frame 31.
+                result.InsertKeyFrame(0.17318435F, new Vector2(-259.583008F, -193.447006F), HoldThenStepEasingFunction());
+                // Frame 35.26.
+                result.InsertKeyFrame(0.196966484F, new Vector2(-250.582993F, -258.946991F), CubicBezierEasingFunction_2());
+                // Frame 44.
+                result.InsertExpressionKeyFrame(0.245810047F, "Pow(1-_.t0,3)*Vector2(-250.583,-258.947)+(3*Square(1-_.t0)*_.t0*Vector2(-250.583,-258.947))+(3*(1-_.t0)*Square(_.t0)*Vector2(-249.6143,-337.5837))+(Pow(_.t0,3)*Vector2(-230.458,-339.322))", StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertExpressionKeyFrame(0.301675946F, "Pow(1-_.t0,3)*Vector2(-230.458,-339.322)+(3*Square(1-_.t0)*_.t0*Vector2(-214.2505,-340.7927))+(3*(1-_.t0)*Square(_.t0)*Vector2(-210.958,-164.322))+(Pow(_.t0,3)*Vector2(-210.958,-164.322))", StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(-210.957993F, -164.322006F), StepThenHoldEasingFunction());
+                // Frame 63.
+                result.InsertKeyFrame(0.351955295F, new Vector2(-210.957993F, -207.322006F), _c.CreateCubicBezierEasingFunction(new Vector2(0.180000007F, 0F), new Vector2(0.34799999F, 1F)));
+                // Frame 73.
+                result.InsertKeyFrame(0.407821238F, new Vector2(-210.957993F, -204.322006F), _c.CreateCubicBezierEasingFunction(new Vector2(0.693000019F, 0F), new Vector2(0.270000011F, 1F)));
+                return result;
+            }
+
+            // - - Layer aggregator
+            // - Layer: Dot-Y
+            // Transforms: Dot-Y
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_08()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(-156.916F, -206.503998F), StepThenHoldEasingFunction());
+                // Frame 28.
+                result.InsertKeyFrame(0.156424582F, new Vector2(-156.916F, -206.503998F), HoldThenStepEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(-117.416F, -206.503998F), CubicBezierEasingFunction_2());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot-Y
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_09()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(-93.6669998F, -51.8180008F), StepThenHoldEasingFunction());
+                // Frame 28.
+                result.InsertKeyFrame(0.156424582F, new Vector2(-93.6669998F, -51.8180008F), HoldThenStepEasingFunction());
+                // Frame 40.
+                result.InsertKeyFrame(0.223463684F, new Vector2(-93.6669998F, -132.817993F), _c.CreateCubicBezierEasingFunction(new Vector2(0.166999996F, 0.166999996F), new Vector2(0.25999999F, 1F)));
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(-93.6669998F, 42.0569992F), _c.CreateCubicBezierEasingFunction(new Vector2(0.74000001F, 0F), new Vector2(0.833000004F, 0.833000004F)));
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot1
+            // Offset
+            Vector2KeyFrameAnimation OffsetVector2Animation_10()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(98.9800034F, -157.509995F), HoldThenStepEasingFunction());
+                // Frame 18.69.
+                result.InsertKeyFrame(0.104395606F, new Vector2(-161.020004F, -157.509995F), _c.CreateCubicBezierEasingFunction(new Vector2(0.823000014F, 0F), new Vector2(0.833000004F, 0.833000004F)));
+                return result;
+            }
+
+            // Radius
+            Vector2KeyFrameAnimation RadiusVector2Animation()
+            {
+                // Frame 0.
+                if (_radiusVector2Animation != null) return _radiusVector2Animation;
+                var result = _radiusVector2Animation = CreateVector2KeyFrameAnimation(0F, new Vector2(1.5F, 1.5F), StepThenHoldEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(1.5F, 1.5F), HoldThenStepEasingFunction());
+                // Frame 61.
+                result.InsertKeyFrame(0.340782136F, new Vector2(22.2999992F, 22.2999992F), _c.CreateCubicBezierEasingFunction(new Vector2(0.333000004F, 0F), new Vector2(0.666999996F, 1F)));
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_00()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 96.
+                result.InsertKeyFrame(0.536312878F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: E3-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_01()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 102.
+                result.InsertKeyFrame(0.569832385F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: E3-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_02()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: I-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_03()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 78.
+                result.InsertKeyFrame(0.43575418F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 93.
+                result.InsertKeyFrame(0.519553065F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_04()
+            {
+                // Frame 0.
+                if (_shapeVisibilityAnimation_04 != null) return _shapeVisibilityAnimation_04;
+                var result = _shapeVisibilityAnimation_04 = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 81.
+                result.InsertKeyFrame(0.452513963F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: E2-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_05()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 96.
+                result.InsertKeyFrame(0.536312878F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: E2-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_06()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 86.
+                result.InsertKeyFrame(0.480446935F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: E1-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_07()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 79.
+                result.InsertKeyFrame(0.441340774F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 94.
+                result.InsertKeyFrame(0.525139689F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: E1-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_08()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T1a-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_09()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 59.
+                result.InsertKeyFrame(0.329608947F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 156.
+                result.InsertKeyFrame(0.87150836F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T2b-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_10()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 92.
+                result.InsertKeyFrame(0.513966501F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T2a-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_11()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 72.
+                result.InsertKeyFrame(0.402234644F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 89.
+                result.InsertKeyFrame(0.497206718F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T2b-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_12()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 82.
+                result.InsertKeyFrame(0.458100557F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T1b-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_13()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 161.
+                result.InsertKeyFrame(0.899441361F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: O-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_14()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T1a-Y 2
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_15()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 59.
+                result.InsertKeyFrame(0.329608947F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T2a-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_16()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: T1a-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_17()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 70.
+                result.InsertKeyFrame(0.391061455F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_18()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 28.
+                result.InsertKeyFrame(0.156424582F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: L-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_19()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 16.
+                result.InsertKeyFrame(0.0893854722F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: L-B
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_20()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 18.
+                result.InsertKeyFrame(0.100558661F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: Dot1
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_21()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 17.
+                result.InsertKeyFrame(0.0949720666F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S1-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_22()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 30.
+                result.InsertKeyFrame(0.167597771F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 37.
+                result.InsertKeyFrame(0.206703916F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S7
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_23()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 65.
+                result.InsertKeyFrame(0.363128483F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_24()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 54.
+                result.InsertKeyFrame(0.301675975F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 64.
+                result.InsertKeyFrame(0.357541889F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 2
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_25()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 97.
+                result.InsertKeyFrame(0.541899443F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 107.
+                result.InsertKeyFrame(0.597765386F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S11
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_26()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 80.
+                result.InsertKeyFrame(0.446927369F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 90.
+                result.InsertKeyFrame(0.502793312F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S12
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_27()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 94.
+                result.InsertKeyFrame(0.525139689F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S13
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_28()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 85.
+                result.InsertKeyFrame(0.47486034F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 95.
+                result.InsertKeyFrame(0.530726254F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 3
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_29()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 75.
+                result.InsertKeyFrame(0.418994427F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 83.
+                result.InsertKeyFrame(0.463687152F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            // - Layer aggregator
+            // Layer: S3-Y 4
+            Vector2KeyFrameAnimation ShapeVisibilityAnimation_30()
+            {
+                // Frame 0.
+                var result = CreateVector2KeyFrameAnimation(0F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                // Frame 76.
+                result.InsertKeyFrame(0.424580991F, new Vector2(1F, 1F), HoldThenStepEasingFunction());
+                // Frame 84.
+                result.InsertKeyFrame(0.469273746F, new Vector2(0F, 0F), HoldThenStepEasingFunction());
+                return result;
+            }
+
+            internal LottieLogo_AnimatedVisual(
+                Compositor compositor
+                )
+            {
                 _c = compositor;
                 _reusableExpressionAnimation = compositor.CreateExpressionAnimation();
                 Root();
             }
 
-            Visual IAnimatedVisual.RootVisual => _root;
-            TimeSpan IAnimatedVisual.Duration => TimeSpan.FromTicks(c_durationTicks);
-            Vector2 IAnimatedVisual.Size => new Vector2(375, 667);
+            public Visual RootVisual => _root;
+            public TimeSpan Duration => TimeSpan.FromTicks(c_durationTicks);
+            public Vector2 Size => new Vector2(375F, 667F);
             void IDisposable.Dispose() => _root?.Dispose();
 
-#pragma warning disable 0649
-            ref struct D2D1_RECT_F
+            internal static bool IsRuntimeCompatible()
             {
-                internal float left;
-                internal float top;
-                internal float right;
-                internal float bottom;
-            }
-
-            ref struct D2D1_ROUNDED_RECT
-            {
-                internal D2D1_RECT_F rect;
-                internal float radiusX;
-                internal float radiusY;
-            }
-
-#pragma warning restore 0649
-
-            ref struct D2D1_BEZIER_SEGMENT
-            {
-                internal Vector2 Point1;
-                internal Vector2 Point2;
-                internal Vector2 Point3;
-            }
-
-            const string ID2D1Factory_IID = "06152247-6f50-465a-9245-118bfd3b6007";
-            [DllImport("D2D1", PreserveSig = false)]
-            static extern ID2D1Factory D2D1CreateFactory(int type, in Guid riid, IntPtr options);
-
-            [Guid(ID2D1Factory_IID), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-            interface ID2D1Factory
-            {
-                void _unused0();
-                void _unused1();
-                [return: MarshalAs(UnmanagedType.IUnknown)] object CreateRectangleGeometry(in D2D1_RECT_F rectangle);
-                [return: MarshalAs(UnmanagedType.IUnknown)] object CreateRoundedRectangleGeometry(in D2D1_ROUNDED_RECT roundedRectangle);
-                void _unused4();
-                void _unused5();
-                void _unused6();
-                ID2D1PathGeometry CreatePathGeometry();
-            }
-
-            [Guid("0657AF73-53FD-47CF-84FF-C8492D2A80A3"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
-            interface IGeometrySource2DInterop
-            {
-                ID2D1Geometry GetGeometry();
-                ID2D1Geometry TryGetGeometryUsingFactory(ID2D1Factory factory);
-            }
-
-            [Guid("2cd906a1-12e2-11dc-9fed-001143a055f9"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
-            interface ID2D1Geometry
-            {
-            }
-
-            [Guid("2cd906a5-12e2-11dc-9fed-001143a055f9"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
-            interface ID2D1PathGeometry : ID2D1Geometry
-            {
-                void _unused0();
-                void _unused1();
-                void _unused2();
-                void _unused3();
-                void _unused4();
-                void _unused5();
-                void _unused6();
-                void _unused7();
-                void _unused8();
-                void _unused9();
-                void _unused10();
-                void _unused11();
-                void _unused12();
-                void _unused13();
-                ID2D1GeometrySink Open();
-            }
-
-            [Guid("2cd9069f-12e2-11dc-9fed-001143a055f9"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown), ComImport]
-            interface ID2D1GeometrySink
-            {
-                [PreserveSig] void SetFillMode(int fillMode);
-                void _unused1();
-                [PreserveSig] void BeginFigure(Vector2 startPoint, int figureBegin);
-                [PreserveSig] void AddLines(in Vector2 points, int count);
-                [PreserveSig] void AddBeziers(in D2D1_BEZIER_SEGMENT beziers, int count);
-                [PreserveSig] void EndFigure(int figureEnd);
-                void Close();
-            }
-
-            sealed class GeometrySource2D : Windows.Graphics.IGeometrySource2D, IGeometrySource2DInterop
-            {
-                readonly ID2D1Geometry _geometry;
-
-                internal GeometrySource2D(ID2D1Geometry geometry)
-                {
-                    _geometry = geometry;
-                }
-                ID2D1Geometry IGeometrySource2DInterop.GetGeometry() => _geometry;
-                ID2D1Geometry IGeometrySource2DInterop.TryGetGeometryUsingFactory(ID2D1Factory factory) => throw new NotImplementedException();
+                return Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 12);
             }
         }
     }

--- a/dev/Generated/AnimatedVisualPlayer.properties.cpp
+++ b/dev/Generated/AnimatedVisualPlayer.properties.cpp
@@ -13,6 +13,7 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 
 #include "AnimatedVisualPlayer.g.cpp"
 
+GlobalDependencyProperty AnimatedVisualPlayerProperties::s_ActiveProperty{ nullptr };
 GlobalDependencyProperty AnimatedVisualPlayerProperties::s_AutoPlayProperty{ nullptr };
 GlobalDependencyProperty AnimatedVisualPlayerProperties::s_DiagnosticsProperty{ nullptr };
 GlobalDependencyProperty AnimatedVisualPlayerProperties::s_DurationProperty{ nullptr };
@@ -30,6 +31,17 @@ AnimatedVisualPlayerProperties::AnimatedVisualPlayerProperties()
 
 void AnimatedVisualPlayerProperties::EnsureProperties()
 {
+    if (!s_ActiveProperty)
+    {
+        s_ActiveProperty =
+            InitializeDependencyProperty(
+                L"Active",
+                winrt::name_of<bool>(),
+                winrt::name_of<winrt::AnimatedVisualPlayer>(),
+                false /* isAttached */,
+                ValueHelper<bool>::BoxValueIfNecessary(true),
+                winrt::PropertyChangedCallback(&OnActivePropertyChanged));
+    }
     if (!s_AutoPlayProperty)
     {
         s_AutoPlayProperty =
@@ -133,6 +145,7 @@ void AnimatedVisualPlayerProperties::EnsureProperties()
 
 void AnimatedVisualPlayerProperties::ClearProperties()
 {
+    s_ActiveProperty = nullptr;
     s_AutoPlayProperty = nullptr;
     s_DiagnosticsProperty = nullptr;
     s_DurationProperty = nullptr;
@@ -142,6 +155,14 @@ void AnimatedVisualPlayerProperties::ClearProperties()
     s_PlaybackRateProperty = nullptr;
     s_SourceProperty = nullptr;
     s_StretchProperty = nullptr;
+}
+
+void AnimatedVisualPlayerProperties::OnActivePropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::AnimatedVisualPlayer>();
+    winrt::get_self<AnimatedVisualPlayer>(owner)->OnActivePropertyChanged(args);
 }
 
 void AnimatedVisualPlayerProperties::OnAutoPlayPropertyChanged(
@@ -182,6 +203,19 @@ void AnimatedVisualPlayerProperties::OnStretchPropertyChanged(
 {
     auto owner = sender.as<winrt::AnimatedVisualPlayer>();
     winrt::get_self<AnimatedVisualPlayer>(owner)->OnStretchPropertyChanged(args);
+}
+
+void AnimatedVisualPlayerProperties::Active(bool value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<AnimatedVisualPlayer*>(this)->SetValue(s_ActiveProperty, ValueHelper<bool>::BoxValueIfNecessary(value));
+    }
+}
+
+bool AnimatedVisualPlayerProperties::Active()
+{
+    return ValueHelper<bool>::CastOrUnbox(static_cast<AnimatedVisualPlayer*>(this)->GetValue(s_ActiveProperty));
 }
 
 void AnimatedVisualPlayerProperties::AutoPlay(bool value)

--- a/dev/Generated/AnimatedVisualPlayer.properties.h
+++ b/dev/Generated/AnimatedVisualPlayer.properties.h
@@ -9,6 +9,9 @@ class AnimatedVisualPlayerProperties
 public:
     AnimatedVisualPlayerProperties();
 
+    void Active(bool value);
+    bool Active();
+
     void AutoPlay(bool value);
     bool AutoPlay();
 
@@ -36,6 +39,7 @@ public:
     void Stretch(winrt::Stretch const& value);
     winrt::Stretch Stretch();
 
+    static winrt::DependencyProperty ActiveProperty() { return s_ActiveProperty; }
     static winrt::DependencyProperty AutoPlayProperty() { return s_AutoPlayProperty; }
     static winrt::DependencyProperty DiagnosticsProperty() { return s_DiagnosticsProperty; }
     static winrt::DependencyProperty DurationProperty() { return s_DurationProperty; }
@@ -46,6 +50,7 @@ public:
     static winrt::DependencyProperty SourceProperty() { return s_SourceProperty; }
     static winrt::DependencyProperty StretchProperty() { return s_StretchProperty; }
 
+    static GlobalDependencyProperty s_ActiveProperty;
     static GlobalDependencyProperty s_AutoPlayProperty;
     static GlobalDependencyProperty s_DiagnosticsProperty;
     static GlobalDependencyProperty s_DurationProperty;
@@ -58,6 +63,10 @@ public:
 
     static void EnsureProperties();
     static void ClearProperties();
+
+    static void OnActivePropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnAutoPlayPropertyChanged(
         winrt::DependencyObject const& sender,


### PR DESCRIPTION
## Description
This PR adds new interface `IAnimatedVisual2`, this interface provides methods that allow to destroy or re-instantiate all the animations that are used by animated visual. This can help reduce the CPU overhead when animated visual is idle.

Also exposing new methods Freeze/Unfreeze/CanFreeze on `AnimatedVisualPlayer` that allows to control behavior of the animated visual.

### This is currently a draft