### PR TITLE
[TabView] Fix bug where removing tabs from tabcollection would not resize tabs

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -796,6 +796,95 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void VerifySizingBehaviorModifyingCollectionRemovingLastItem()
+        {
+            int pixelTolerance = 5;
+
+            using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
+            {
+
+                Log.Comment("Verifying sizing behavior when removing the last tab from tab collection");
+                CloseTabAndVerifyWidth("Tab 5", 500, 100);
+
+                CloseTabAndVerifyWidth("Tab 4", 500, 100);
+
+                CloseTabAndVerifyWidth("Tab 3", 500, 140);
+
+                CloseTabAndVerifyWidth("Tab 2", 500, 225);
+            }
+
+            void CloseTabAndVerifyWidth(string tabName, int expectedWidth, int expectedItemWidth)
+            {
+                Log.Comment("Closing tab:" + tabName);
+                new Button(FindElement.ByName("RemoveLastItemButton")).Click();
+                Wait.ForIdle();
+                new Button(FindElement.ByName("GetActualWidthButton")).Click(); 
+                Log.Comment("Verifying TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedWidth) < pixelTolerance);
+                var firstTabItemWidth = GetFirstTabItemWidth();
+                Verify.IsTrue(Math.Abs(firstTabItemWidth - expectedItemWidth) < pixelTolerance);
+            }
+
+            double GetActualTabViewWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewWidth"));
+
+                return double.Parse(tabviewWidth.GetText());
+            }
+
+            double GetFirstTabItemWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewHeaderWidth"));
+
+                return double.Parse(tabviewWidth.GetText().Split(".")[0]);
+            }
+        }
+
+        [TestMethod]
+        public void VerifySizingBehaviorModifyingCollectionRemovingSecondItem()
+        {
+            int pixelTolerance = 5;
+
+            using (var setup = new TestSetupHelper(new[] { "TabView Tests", "TabViewTabClosingBehaviorButton" }))
+            {
+
+                Log.Comment("Verifying sizing behavior when removing the second tab from tab collection");
+                CloseTabAndVerifyWidth("Tab 5", 500, 100);
+
+                CloseTabAndVerifyWidth("Tab 4", 500, 100);
+
+                CloseTabAndVerifyWidth("Tab 3", 500, 140);
+
+                CloseTabAndVerifyWidth("Tab 2", 500, 225);
+            }
+
+            void CloseTabAndVerifyWidth(string tabName, int expectedWidth, int expectedItemWidth)
+            {
+                Log.Comment("Closing tab:" + tabName);
+                new Button(FindElement.ByName("RemoveMiddleItemButton")).Click();
+                Wait.ForIdle();
+                new Button(FindElement.ByName("GetActualWidthButton")).Click();
+                Log.Comment("Verifying TabView width");
+                Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedWidth) < pixelTolerance);
+                Verify.IsTrue(Math.Abs(GetFirstTabItemWidth() - expectedItemWidth) < pixelTolerance);
+            }
+
+            double GetActualTabViewWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewWidth"));
+
+                return double.Parse(tabviewWidth.GetText());
+            }
+
+            double GetFirstTabItemWidth()
+            {
+                var tabviewWidth = new TextBlock(FindElement.ByName("TabViewHeaderWidth"));
+
+                return double.Parse(tabviewWidth.GetText().Split(".")[0]);
+            }
+        }
+
+        [TestMethod]
         public void VerifySizingBehaviorOnTabCloseComingFromCtrlF4()
         {
             int pixelTolerance = 10;

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -678,15 +678,10 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
                 }
 
             }
-            // Last item removed, update sizes
-            // The index of the last element is "Size() - 1", but in TabItems, it is already removed.
             if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
             {
                 m_updateTabWidthOnPointerLeave = true;
-                if (args.Index() == TabItems().Size())
-                {
-                    UpdateTabWidths(true, false);
-                }
+                UpdateTabWidths(true, false);
             }
         }
         else

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -688,7 +688,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
             }
             if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
             {
-                if (!m_pointerInTabstrip)
+                if (!m_pointerInTabstrip || args.Index() == TabItems().Size())
                 {
                     UpdateTabWidths(true, false);
                 }

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -510,7 +510,7 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
 
 void TabView::OnTabStripPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
 {
-    m_pointerInTabstrip = true;
+    m_pointerInTabstrip = false;
     if (m_updateTabWidthOnPointerLeave)
     {
         auto scopeGuard = gsl::finally([this]()

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -86,6 +86,7 @@ void TabView::OnApplyTemplate()
     {
         m_tabContainerGrid.set(containerGrid);
         m_tabStripPointerExitedRevoker = containerGrid.PointerExited(winrt::auto_revoke, { this,&TabView::OnTabStripPointerExited });
+        m_tabStripPointerEnteredRevoker = containerGrid.PointerEntered(winrt::auto_revoke, { this,&TabView::OnTabStripPointerEntered });
     }
 
     if (!SharedHelpers::Is21H1OrHigher())
@@ -355,6 +356,7 @@ void TabView::UnhookEventsAndClearFields()
     m_addButtonClickRevoker.revoke();
     m_itemsPresenterSizeChangedRevoker.revoke();
     m_tabStripPointerExitedRevoker.revoke();
+    m_tabStripPointerEnteredRevoker.revoke();
     m_scrollViewerLoadedRevoker.revoke();
     m_scrollViewerViewChangedRevoker.revoke();
     m_scrollDecreaseClickRevoker.revoke();
@@ -508,6 +510,7 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
 
 void TabView::OnTabStripPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
 {
+    m_pointerInTabstrip = true;
     if (m_updateTabWidthOnPointerLeave)
     {
         auto scopeGuard = gsl::finally([this]()
@@ -516,6 +519,11 @@ void TabView::OnTabStripPointerExited(const winrt::IInspectable& sender, const w
         });
         UpdateTabWidths();
     }
+}
+
+void TabView::OnTabStripPointerEntered(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
+{
+    m_pointerInTabstrip = true;
 }
 
 void TabView::OnScrollViewerLoaded(const winrt::IInspectable&, const winrt::RoutedEventArgs& args)
@@ -680,8 +688,10 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
             }
             if (TabWidthMode() == winrt::TabViewWidthMode::Equal)
             {
-                m_updateTabWidthOnPointerLeave = true;
-                UpdateTabWidths(true, false);
+                if (!m_pointerInTabstrip)
+                {
+                    UpdateTabWidths(true, false);
+                }
             }
         }
         else

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -134,6 +134,7 @@ private:
 
     void OnListViewLoaded(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     void OnTabStripPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
+    void OnTabStripPointerEntered(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args);
     void OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args);
 
     void OnListViewDragItemsStarting(const winrt::IInspectable& sender, const winrt::DragItemsStartingEventArgs& args);
@@ -166,6 +167,7 @@ private:
     winrt::TabViewItem FindTabViewItemFromDragItem(const winrt::IInspectable& item);
 
     bool m_updateTabWidthOnPointerLeave{ false };
+    bool m_pointerInTabstrip{ false };
 
     tracker_ref<winrt::ColumnDefinition> m_leftContentColumn{ this };
     tracker_ref<winrt::ColumnDefinition> m_tabColumn{ this };
@@ -186,6 +188,7 @@ private:
 
     winrt::ListView::Loaded_revoker m_listViewLoadedRevoker{};
     winrt::ListView::PointerExited_revoker m_tabStripPointerExitedRevoker{};
+    winrt::ListView::PointerEntered_revoker m_tabStripPointerEnteredRevoker{};
     winrt::Selector::SelectionChanged_revoker m_listViewSelectionChangedRevoker{};
     winrt::UIElement::GettingFocus_revoker m_listViewGettingFocusRevoker{};
 

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml
@@ -20,10 +20,10 @@
                     TabCloseRequested="TabViewTabCloseRequested"
                     AddTabButtonClick="AddButtonClick">
 
-                    <muxc:TabViewItem Header="Tab 0" AutomationProperties.Name="Tab 0"/>
+                    <muxc:TabViewItem Header="Tab 0" x:Name="Tab0" AutomationProperties.Name="Tab 0"/>
                     <muxc:TabViewItem Header="Tab 1" AutomationProperties.Name="Tab 1"/>
                     <muxc:TabViewItem Header="Tab 2" AutomationProperties.Name="Tab 2"/>
-                    <muxc:TabViewItem Header="Tab 3" x:Name="Tab3" AutomationProperties.Name="Tab 3"/>
+                    <muxc:TabViewItem Header="Tab 3" AutomationProperties.Name="Tab 3"/>
                     <muxc:TabViewItem Header="Tab 4" AutomationProperties.Name="Tab 4"/>
                     <muxc:TabViewItem Header="Tab 5" AutomationProperties.Name="Tab 5"/>
                 </muxc:TabView>
@@ -43,6 +43,8 @@
                 <Button AutomationProperties.Name="IncreaseScrollButton"
                         Click="IncreaseScrollButton_Click"
                         Content="Increase scroll" />
+                <Button AutomationProperties.Name="RemoveMiddleItemButton" Click="RemoveMiddleItem_Click" Content="Remove Middle item"/>
+                <Button AutomationProperties.Name="RemoveLastItemButton" Click="RemoveLastItem_Click" Content="Remove last item"/>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewTabClosingBehaviorPage.xaml.cs
@@ -50,7 +50,7 @@ namespace MUXControlsTestApp
             Tabs.TabItems.Remove(e.Tab);
 
             TabViewWidth.Text = Tabs.ActualWidth.ToString();
-            TabViewHeaderWidth.Text = Tab3.Width.ToString();
+            TabViewHeaderWidth.Text = Tab0.Width.ToString();
 
             var scrollButtonStateValue = "";
 
@@ -63,13 +63,21 @@ namespace MUXControlsTestApp
             ScrollButtonStatus.Text = scrollButtonStateValue;
         }
 
+        public void GetFirstItemWidthButton_Click(object sender, RoutedEventArgs e)
+        {
+            // This is the smallest width that fits our content without any scrolling.
+            TabViewWidth.Text = Tabs.ActualWidth.ToString();
+
+            // Header width
+            TabViewHeaderWidth.Text = Tab0.Width.ToString();
+        }
         public void GetActualWidthsButton_Click(object sender, RoutedEventArgs e)
         {
             // This is the smallest width that fits our content without any scrolling.
             TabViewWidth.Text = Tabs.ActualWidth.ToString();
 
             // Header width
-            TabViewHeaderWidth.Text = Tab3.Width.ToString();
+            TabViewHeaderWidth.Text = Tab0.Width.ToString();
         }
 
         public void IncreaseScrollButton_Click(object sender, RoutedEventArgs e)
@@ -78,5 +86,14 @@ namespace MUXControlsTestApp
             sv.ChangeView(10000, null, null, disableAnimation: true);
         }
 
+        private void RemoveMiddleItem_Click(object sender, RoutedEventArgs e)
+        {
+            Tabs.TabItems.RemoveAt(1);
+        }
+
+        private void RemoveLastItem_Click(object sender, RoutedEventArgs e)
+        {
+            Tabs.TabItems.RemoveAt(Tabs.TabItems.Count - 1);
+        }
     }
 }

--- a/test/testinfra/MUXTestInfra/Infra/Application.cs
+++ b/test/testinfra/MUXTestInfra/Infra/Application.cs
@@ -274,7 +274,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 catch (Exception ex)
                 {
                     Log.Comment("Failed to launch app. Exception: " + ex.ToString());
-                    
+
                     if (retries < MaxLaunchRetries)
                     {
                         Log.Comment("UAPApp.Launch might not have waited long enough, trying again {0}", retries);
@@ -354,7 +354,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
             // 3. Use the Process obj we found when this Application object was initialized.
             // This is just a sanity check. Under normal circumstances, there should only be 
             // one app process. 
-            
+
             var appProcesses = Process.GetProcessesByName(_appProcessName).ToList();
 
             if (appWindowsProccessId != -1)
@@ -541,103 +541,102 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 #if !USING_TAEF
         private void InstallTestAppIfNeeded()
         {
-            return;
-            //string mostRecentlyBuiltAppx = string.Empty;
-            //DateTime timeMostRecentlyBuilt = DateTime.MinValue;
+            string mostRecentlyBuiltAppx = string.Empty;
+            DateTime timeMostRecentlyBuilt = DateTime.MinValue;
 
-            //var exclude = new[] { "Microsoft.NET.CoreRuntime", "Microsoft.VCLibs" };
+            var exclude = new[] { "Microsoft.NET.CoreRuntime", "Microsoft.VCLibs" };
 
-            //var files = Directory.GetFiles(_baseAppxDir, $"{_packageName}*.appx", SearchOption.AllDirectories).ToList();
-            //files.AddRange(Directory.GetFiles(_baseAppxDir, $"{_packageName}*.msix", SearchOption.AllDirectories));
+            var files = Directory.GetFiles(_baseAppxDir, $"{_packageName}*.appx", SearchOption.AllDirectories).ToList();
+            files.AddRange(Directory.GetFiles(_baseAppxDir, $"{_packageName}*.msix", SearchOption.AllDirectories));
 
-            //var filteredFiles = files.Where(f => !exclude.Any(Path.GetFileNameWithoutExtension(f).Contains));
+            var filteredFiles = files.Where(f => !exclude.Any(Path.GetFileNameWithoutExtension(f).Contains));
 
-            //if (filteredFiles.Count() == 0)
-            //{
-            //    throw new Exception(string.Format("Failed to find '*.appx' or '*.msix' in {0}'!", _baseAppxDir));
-            //}
+            if (filteredFiles.Count() == 0)
+            {
+                throw new Exception(string.Format("Failed to find '*.appx' or '*.msix' in {0}'!", _baseAppxDir));
+            }
 
-            //foreach (string file in filteredFiles)
-            //{
-            //    DateTime fileWriteTime = File.GetLastWriteTime(file);
+            foreach (string file in filteredFiles)
+            {
+                DateTime fileWriteTime = File.GetLastWriteTime(file);
 
-            //    if (fileWriteTime > timeMostRecentlyBuilt)
-            //    {
-            //        timeMostRecentlyBuilt = fileWriteTime;
-            //        mostRecentlyBuiltAppx = file;
-            //    }
-            //}
+                if (fileWriteTime > timeMostRecentlyBuilt)
+                {
+                    timeMostRecentlyBuilt = fileWriteTime;
+                    mostRecentlyBuiltAppx = file;
+                }
+            }
 
-            //PackageManager packageManager = new PackageManager();
-            //DeploymentResult result = null;
+            PackageManager packageManager = new PackageManager();
+            DeploymentResult result = null;
 
-            //var installedPackages = packageManager.FindPackagesForUser(string.Empty, _packageFamilyName);
-            //foreach (var installedPackage in installedPackages)
-            //{
-            //    Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
+            var installedPackages = packageManager.FindPackagesForUser(string.Empty, _packageFamilyName);
+            foreach (var installedPackage in installedPackages)
+            {
+                Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
 
-            //    AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
-            //    var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
-            //    removePackageOperation.Completed = (operation, status) =>
-            //    {
-            //        if (status != AsyncStatus.Started)
-            //        {
-            //            result = operation.GetResults();
-            //            removePackageCompleteEvent.Set();
-            //        }
-            //    };
-            //    removePackageCompleteEvent.WaitOne();
+                AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
+                var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
+                removePackageOperation.Completed = (operation, status) =>
+                {
+                    if (status != AsyncStatus.Started)
+                    {
+                        result = operation.GetResults();
+                        removePackageCompleteEvent.Set();
+                    }
+                };
+                removePackageCompleteEvent.WaitOne();
 
-            //    if (!string.IsNullOrEmpty(result.ErrorText))
-            //    {
-            //        Log.Error("Removal failed!");
-            //        Log.Error("Package removal ActivityId = {0}", result.ActivityId);
-            //        Log.Error("Package removal ErrorText = {0}", result.ErrorText);
-            //        Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
-            //    }
-            //    else
-            //    {
-            //        Log.Comment("Removal successful.");
-            //    }
-            //}
+                if (!string.IsNullOrEmpty(result.ErrorText))
+                {
+                    Log.Error("Removal failed!");
+                    Log.Error("Package removal ActivityId = {0}", result.ActivityId);
+                    Log.Error("Package removal ErrorText = {0}", result.ErrorText);
+                    Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
+                }
+                else
+                {
+                    Log.Comment("Removal successful.");
+                }
+            }
 
-            //Log.Comment("Installing AppX...");
+            Log.Comment("Installing AppX...");
 
-            //Log.Comment("Checking if the app's certificate is installed...");
+            Log.Comment("Checking if the app's certificate is installed...");
 
-            //// If the certificate for the app is not present, installing it requires elevation.
-            //// We'll run Add-AppDevPackage.ps1 without -Force in that circumstance so the user
-            //// can be prompted to allow elevation.  We don't want to run it without -Force all the time,
-            //// as that prompts the user to hit enter at the end of the install, which is an annoying
-            //// and unnecessary step. The parameter is the SHA-1 hash of the certificate.
+            // If the certificate for the app is not present, installing it requires elevation.
+            // We'll run Add-AppDevPackage.ps1 without -Force in that circumstance so the user
+            // can be prompted to allow elevation.  We don't want to run it without -Force all the time,
+            // as that prompts the user to hit enter at the end of the install, which is an annoying
+            // and unnecessary step. The parameter is the SHA-1 hash of the certificate.
 
-            //var certutilProcess = Process.Start(new ProcessStartInfo("certutil.exe",
-            //        string.Format("-verifystore TrustedPeople {0}", _certSerialNumber)) {
-            //    UseShellExecute = true
-            //});
-            //certutilProcess.WaitForExit();
+            var certutilProcess = Process.Start(new ProcessStartInfo("certutil.exe",
+                    string.Format("-verifystore TrustedPeople {0}", _certSerialNumber)) {
+                UseShellExecute = true
+            });
+            certutilProcess.WaitForExit();
 
-            //if(certutilProcess.ExitCode == 0)
-            //{
-            //    Log.Comment("Certificate is installed. Installing app...");
-            //}
-            //else
-            //{
-            //    Log.Comment("Certificate is not installed. Installing app and certificate...");
-            //}
+            if(certutilProcess.ExitCode == 0)
+            {
+                Log.Comment("Certificate is installed. Installing app...");
+            }
+            else
+            {
+                Log.Comment("Certificate is not installed. Installing app and certificate...");
+            }
 
-            //var powershellProcess = Process.Start(new ProcessStartInfo("powershell",
-            //        string.Format("-ExecutionPolicy Unrestricted -File {0}\\Add-AppDevPackage.ps1 {1}",
-            //            Path.GetDirectoryName(mostRecentlyBuiltAppx),
-            //            certutilProcess.ExitCode == 0 ? "-Force" : "")) {
-            //    UseShellExecute = true
-            //});
-            //powershellProcess.WaitForExit();
+            var powershellProcess = Process.Start(new ProcessStartInfo("powershell",
+                    string.Format("-ExecutionPolicy Unrestricted -File {0}\\Add-AppDevPackage.ps1 {1}",
+                        Path.GetDirectoryName(mostRecentlyBuiltAppx),
+                        certutilProcess.ExitCode == 0 ? "-Force" : "")) {
+                UseShellExecute = true
+            });
+            powershellProcess.WaitForExit();
 
-            //if (powershellProcess.ExitCode != 0)
-            //{
-            //    //throw new Exception(string.Format("Failed to install AppX for {0}!", _packageName));
-            //}
+            if (powershellProcess.ExitCode != 0)
+            {
+                throw new Exception(string.Format("Failed to install AppX for {0}!", _packageName));
+            }
         }
 #endif
 

--- a/test/testinfra/MUXTestInfra/Infra/Application.cs
+++ b/test/testinfra/MUXTestInfra/Infra/Application.cs
@@ -541,102 +541,103 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 #if !USING_TAEF
         private void InstallTestAppIfNeeded()
         {
-            string mostRecentlyBuiltAppx = string.Empty;
-            DateTime timeMostRecentlyBuilt = DateTime.MinValue;
+            return;
+            //string mostRecentlyBuiltAppx = string.Empty;
+            //DateTime timeMostRecentlyBuilt = DateTime.MinValue;
 
-            var exclude = new[] { "Microsoft.NET.CoreRuntime", "Microsoft.VCLibs" };
+            //var exclude = new[] { "Microsoft.NET.CoreRuntime", "Microsoft.VCLibs" };
 
-            var files = Directory.GetFiles(_baseAppxDir, $"{_packageName}*.appx", SearchOption.AllDirectories).ToList();
-            files.AddRange(Directory.GetFiles(_baseAppxDir, $"{_packageName}*.msix", SearchOption.AllDirectories));
+            //var files = Directory.GetFiles(_baseAppxDir, $"{_packageName}*.appx", SearchOption.AllDirectories).ToList();
+            //files.AddRange(Directory.GetFiles(_baseAppxDir, $"{_packageName}*.msix", SearchOption.AllDirectories));
 
-            var filteredFiles = files.Where(f => !exclude.Any(Path.GetFileNameWithoutExtension(f).Contains));
+            //var filteredFiles = files.Where(f => !exclude.Any(Path.GetFileNameWithoutExtension(f).Contains));
 
-            if (filteredFiles.Count() == 0)
-            {
-                throw new Exception(string.Format("Failed to find '*.appx' or '*.msix' in {0}'!", _baseAppxDir));
-            }
+            //if (filteredFiles.Count() == 0)
+            //{
+            //    throw new Exception(string.Format("Failed to find '*.appx' or '*.msix' in {0}'!", _baseAppxDir));
+            //}
 
-            foreach (string file in filteredFiles)
-            {
-                DateTime fileWriteTime = File.GetLastWriteTime(file);
+            //foreach (string file in filteredFiles)
+            //{
+            //    DateTime fileWriteTime = File.GetLastWriteTime(file);
 
-                if (fileWriteTime > timeMostRecentlyBuilt)
-                {
-                    timeMostRecentlyBuilt = fileWriteTime;
-                    mostRecentlyBuiltAppx = file;
-                }
-            }
+            //    if (fileWriteTime > timeMostRecentlyBuilt)
+            //    {
+            //        timeMostRecentlyBuilt = fileWriteTime;
+            //        mostRecentlyBuiltAppx = file;
+            //    }
+            //}
 
-            PackageManager packageManager = new PackageManager();
-            DeploymentResult result = null;
+            //PackageManager packageManager = new PackageManager();
+            //DeploymentResult result = null;
 
-            var installedPackages = packageManager.FindPackagesForUser(string.Empty, _packageFamilyName);
-            foreach (var installedPackage in installedPackages)
-            {
-                Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
+            //var installedPackages = packageManager.FindPackagesForUser(string.Empty, _packageFamilyName);
+            //foreach (var installedPackage in installedPackages)
+            //{
+            //    Log.Comment("Test AppX package already installed. Removing existing package by name: {0}", installedPackage.Id.FullName);
 
-                AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
-                var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
-                removePackageOperation.Completed = (operation, status) =>
-                {
-                    if (status != AsyncStatus.Started)
-                    {
-                        result = operation.GetResults();
-                        removePackageCompleteEvent.Set();
-                    }
-                };
-                removePackageCompleteEvent.WaitOne();
+            //    AutoResetEvent removePackageCompleteEvent = new AutoResetEvent(false);
+            //    var removePackageOperation = packageManager.RemovePackageAsync(installedPackage.Id.FullName);
+            //    removePackageOperation.Completed = (operation, status) =>
+            //    {
+            //        if (status != AsyncStatus.Started)
+            //        {
+            //            result = operation.GetResults();
+            //            removePackageCompleteEvent.Set();
+            //        }
+            //    };
+            //    removePackageCompleteEvent.WaitOne();
 
-                if (!string.IsNullOrEmpty(result.ErrorText))
-                {
-                    Log.Error("Removal failed!");
-                    Log.Error("Package removal ActivityId = {0}", result.ActivityId);
-                    Log.Error("Package removal ErrorText = {0}", result.ErrorText);
-                    Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
-                }
-                else
-                {
-                    Log.Comment("Removal successful.");
-                }
-            }
+            //    if (!string.IsNullOrEmpty(result.ErrorText))
+            //    {
+            //        Log.Error("Removal failed!");
+            //        Log.Error("Package removal ActivityId = {0}", result.ActivityId);
+            //        Log.Error("Package removal ErrorText = {0}", result.ErrorText);
+            //        Log.Error("Package removal ExtendedErrorCode = {0}", result.ExtendedErrorCode);
+            //    }
+            //    else
+            //    {
+            //        Log.Comment("Removal successful.");
+            //    }
+            //}
 
-            Log.Comment("Installing AppX...");
+            //Log.Comment("Installing AppX...");
 
-            Log.Comment("Checking if the app's certificate is installed...");
+            //Log.Comment("Checking if the app's certificate is installed...");
 
-            // If the certificate for the app is not present, installing it requires elevation.
-            // We'll run Add-AppDevPackage.ps1 without -Force in that circumstance so the user
-            // can be prompted to allow elevation.  We don't want to run it without -Force all the time,
-            // as that prompts the user to hit enter at the end of the install, which is an annoying
-            // and unnecessary step. The parameter is the SHA-1 hash of the certificate.
+            //// If the certificate for the app is not present, installing it requires elevation.
+            //// We'll run Add-AppDevPackage.ps1 without -Force in that circumstance so the user
+            //// can be prompted to allow elevation.  We don't want to run it without -Force all the time,
+            //// as that prompts the user to hit enter at the end of the install, which is an annoying
+            //// and unnecessary step. The parameter is the SHA-1 hash of the certificate.
 
-            var certutilProcess = Process.Start(new ProcessStartInfo("certutil.exe",
-                    string.Format("-verifystore TrustedPeople {0}", _certSerialNumber)) {
-                UseShellExecute = true
-            });
-            certutilProcess.WaitForExit();
+            //var certutilProcess = Process.Start(new ProcessStartInfo("certutil.exe",
+            //        string.Format("-verifystore TrustedPeople {0}", _certSerialNumber)) {
+            //    UseShellExecute = true
+            //});
+            //certutilProcess.WaitForExit();
 
-            if(certutilProcess.ExitCode == 0)
-            {
-                Log.Comment("Certificate is installed. Installing app...");
-            }
-            else
-            {
-                Log.Comment("Certificate is not installed. Installing app and certificate...");
-            }
+            //if(certutilProcess.ExitCode == 0)
+            //{
+            //    Log.Comment("Certificate is installed. Installing app...");
+            //}
+            //else
+            //{
+            //    Log.Comment("Certificate is not installed. Installing app and certificate...");
+            //}
 
-            var powershellProcess = Process.Start(new ProcessStartInfo("powershell",
-                    string.Format("-ExecutionPolicy Unrestricted -File {0}\\Add-AppDevPackage.ps1 {1}",
-                        Path.GetDirectoryName(mostRecentlyBuiltAppx),
-                        certutilProcess.ExitCode == 0 ? "-Force" : "")) {
-                UseShellExecute = true
-            });
-            powershellProcess.WaitForExit();
+            //var powershellProcess = Process.Start(new ProcessStartInfo("powershell",
+            //        string.Format("-ExecutionPolicy Unrestricted -File {0}\\Add-AppDevPackage.ps1 {1}",
+            //            Path.GetDirectoryName(mostRecentlyBuiltAppx),
+            //            certutilProcess.ExitCode == 0 ? "-Force" : "")) {
+            //    UseShellExecute = true
+            //});
+            //powershellProcess.WaitForExit();
 
-            if (powershellProcess.ExitCode != 0)
-            {
-                throw new Exception(string.Format("Failed to install AppX for {0}!", _packageName));
-            }
+            //if (powershellProcess.ExitCode != 0)
+            //{
+            //    //throw new Exception(string.Format("Failed to install AppX for {0}!", _packageName));
+            //}
         }
 #endif
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There was a condition that only removing the last tab would resize the tabs which was not the right behavior since tabs should always be resized when one gets removed from tab collection.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes https://github.com/microsoft/terminal/issues/9822
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new interaction tests
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
@zadjii-msft @beervoley FYI