### PR TITLE
Fix WebView2 navigation with non-ascii URIs

### DIFF
--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -11,8 +11,16 @@ function AllChangedFilesAreSkippable
     foreach($file in $files)
     {
         Write-Host "Checking '$file'"
-        $ext = [System.IO.Path]::GetExtension($file)
-        $fileIsSkippable = $ext -in $skipExts
+        try
+        {
+            $ext = [System.IO.Path]::GetExtension($file)
+            $fileIsSkippable = $ext -in $skipExts
+        }
+        catch
+        {
+            $fileIsSkippable = $false
+        }
+
         Write-Host "File '$file' is skippable: '$fileIsSkippable'"
 
         if(!$fileIsSkippable)

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -609,7 +609,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MouseWheelScrollTest");
-                
+
                 var webview = FindElement.ById("MyWebView2");
                 // Mouse wheel delta amount required per initial velocity unit
                 const int mouseWheelDeltaForVelocityUnit = -4000;  // scroll downwards
@@ -749,7 +749,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         // See comment on Focus_BasicTabTest() for details on test mechanism.
-        [TestMethod] 
+        [TestMethod]
         [TestProperty("TestSuite", "A")]
         public void Focus_ReverseTabTest()
         {
@@ -807,7 +807,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         // See comment on Focus_BasicTabTest() for details on test mechanism.
-        [TestMethod] 
+        [TestMethod]
         [TestProperty("TestSuite", "A")]
         public void Focus_BackAndForthTabTest()
         {
@@ -956,7 +956,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        [TestMethod] 
+        [TestMethod]
         [TestProperty("TestSuite", "A")]
         public void MultipleWebviews_FocusTest()
         {
@@ -1021,7 +1021,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        [TestMethod] 
+        [TestMethod]
         [TestProperty("TestSuite", "B")]
         public void MultipleWebviews_BasicRenderingTest()
         {
@@ -1078,10 +1078,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 var result = new Edit(FindElement.ById("TestResult"));
                 ChooseTest("CopyPasteTest");
-                
+
                 var CopyPasteTextBox1 = new Edit(FindElement.ById("CopyPasteTextBox1"));
                 var CopyPasteTextBox2 = new Edit(FindElement.ById("CopyPasteTextBox2"));
-                
+
                 // Copy text to SimpleInputPage's text box page.
                 CopyPasteTextBox1.SetFocus();
                 DoSelectAllByKeyboard();
@@ -1742,7 +1742,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 CompleteTestAndWaitForWebMessageResult("ParentVisibilityTurnedOnTest");
             }
         }
-		
+
         [TestMethod]
         [TestProperty("Ignore", "True")] // TODO_WebView2: Enable when we can change DPI for a test
         [TestProperty("TestSuite", "C")]
@@ -1762,7 +1762,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 var status2 = new Edit(FindElement.ById("Status2"));
 
                 // Click the button in the middle of the webview. It should be square 35.
-                InputHelper.MoveMouse(webview, 0 , 0);
+                InputHelper.MoveMouse(webview, 0, 0);
                 Log.Comment("Do left click...");
                 PointerInput.Press(PointerButtons.Primary);
                 PointerInput.Release(PointerButtons.Primary);
@@ -1995,21 +1995,21 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("PointerReleaseWithoutPressTest");
-                
+
                 var webview = FindElement.ById("MyWebView2");
                 Rectangle bounds = webview.BoundingRectangle;
-                
+
                 // First, click outside the webview. Then with the mouse button still pressed, 
                 // drag into the webview and release the mouse button. This should neither 
                 // send a message to CoreWebView2, nor should it crash the app.
-                
+
                 var point = new Point(bounds.X + bounds.Width + 20, bounds.Y + 20);
                 PointerInput.Move(point);
                 PointerInput.Press(PointerButtons.Primary);
                 point = new Point(bounds.X + bounds.Width - 20, bounds.Y + 20);
                 PointerInput.Move(point);
                 PointerInput.Release(PointerButtons.Primary);
-                
+
                 CompleteTestAndWaitForResult("PointerReleaseWithoutPressTest");
             }
         }
@@ -2134,6 +2134,37 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             {
                 ChooseTest("UserAgentTest");
                 CompleteTestAndWaitForResult("UserAgentTest");
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        public void NonAsciiUriTest()
+        {
+            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
+            {
+                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
+                return;
+            }
+
+            using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
+            {
+                // Navigate to a uri with a non-ascii characters
+                ChooseTest("NonAsciiUriTest");
+                CompleteTestAndWaitForResult("NonAsciiUriTest");
+
+                // At the end of the test, we should only have gotten one NavigationStarting message.
+                // All messages would have been printed to the MessageLog, so count the NavigationStarting
+                // messages there.
+                int count = 0;
+                var logBox = new Edit(FindElement.ById("MessageLog"));
+                var messageWords = logBox.GetText().Split(' ');
+                foreach (string word in messageWords)
+                {
+                    if (word.Equals("NavigationStarting")) count++;
+                }
+
+                Verify.AreEqual(count, 1);
             }
         }
 

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -1154,44 +1154,54 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Result should be "Hello 123 World" via:
                 // Write Hello Wor after navigating to textbox in webview.
                 Button x1 = new Button(FindElement.ById("TabStopButton1")); // Xaml TabStop 1
+                Log.Comment("Set focus on x1 and verify it has keyboard focus...");
                 x1.SetFocus();
                 Wait.ForIdle();
                 Verify.IsTrue(x1.HasKeyboardFocus);
+
+                Log.Comment("Tab to w1...");
                 KeyboardHelper.PressKey(Key.Tab);
                 WaitForFocus("w1");
+
+                Log.Comment("Inject 'Hello Wor'...");
                 TextInput.SendText("Hello Wor");
-                // Inject Left arrow three times.
+
+                Log.Comment("Inject left arrow three times...");
                 KeyboardHelper.PressKey(Key.Left);
                 KeyboardHelper.PressKey(Key.Left);
                 KeyboardHelper.PressKey(Key.Left);
-                // Inject "123 "
+                
+                Log.Comment("Inject '123 '...");
                 TextInput.SendText("123 ");
-                // Inject right arrow three times
+                
+                Log.Comment("Inject right arrow three times...");
                 KeyboardHelper.PressKey(Key.Right);
                 KeyboardHelper.PressKey(Key.Right);
                 KeyboardHelper.PressKey(Key.Right);
-                // Inject "ld"
+                
+                Log.Comment("Inject 'ld'...");
                 TextInput.SendText("ld");
-                // Test simultaneous keyboard inputs
+                
+                Log.Comment("Test simultaneous keyboard inputs by injecting shift+left twice...");
                 KeyboardHelper.PressKey(Key.Left, ModifierKey.Shift);
                 KeyboardHelper.PressKey(Key.Left, ModifierKey.Shift);
                 TextInput.SendText("m");
+
                 // Copy out to PasteBox1 for verification.
+                Log.Comment("Select All by keyboard...");
                 DoSelectAllByKeyboard();
+                Log.Comment("Copy selected...");
                 CopySelected();
+                Log.Comment("Move focus to CopyPasteTextBox2...");
                 CopyPasteTextBox2.SetFocus();
+                Log.Comment("Paste clipboard...");
                 PasteClipboard();
 
-                // Tab to button
-                x1.SetFocus();
-                Wait.ForIdle();
-                Verify.IsTrue(x1.HasKeyboardFocus);
-                KeyboardHelper.PressKey(Key.Tab);
-                KeyboardHelper.PressKey(Key.Tab);
-                WaitForFocus("b1");
-                // Inject "ENTER"
-                KeyboardHelper.PressKey(Key.Enter);
-                Wait.ForIdle();
+                string expectedText = "Hello 123 Worm";
+                string textResult = CopyPasteTextBox2.GetText();
+                Verify.IsTrue(textResult == expectedText,
+                              string.Format("Test {0}: Expected text {1} did not match with sampled text {2}.",
+                                            "BasicKeyboardTest", expectedText, textResult));
 
                 CompleteTestAndWaitForResult("BasicKeyboardTest");
             }

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -1066,6 +1066,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         //    the Xaml app to provide an isolated 'copy from webview' test.
         [TestMethod]
         [TestProperty("TestSuite", "B")]
+        [TestProperty("Ignore", "True")] // Task 37000273
         public void CopyPasteTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml
@@ -59,6 +59,7 @@
                             <ComboBoxItem AutomationProperties.Name="NavigateToVideoTest">NavigateToVideoTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="NavigationErrorTest">NavigationErrorTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="NavigationStartingTest">NavigationStartingTest</ComboBoxItem>
+                            <ComboBoxItem AutomationProperties.Name="NonAsciiUriTest">NonAsciiUriTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="ParentVisibilityHiddenTest">ParentVisibilityHiddenTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="ParentVisibilityTurnedOnTest">ParentVisibilityTurnedOnTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="PointerReleaseWithoutPressTest">PointerReleaseWithoutPressTest</ComboBoxItem>

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -196,6 +196,7 @@ namespace MUXControlsTestApp
             CloseThenDPIChangeTest,
             AddHostObjectToScriptTest,
             UserAgentTest,
+            NonAsciiUriTest,
         };
 
         // Map of TestList entry to its webpage (index in TestPageNames[])
@@ -255,6 +256,7 @@ namespace MUXControlsTestApp
             { TestList.CloseThenDPIChangeTest, 0 },
             { TestList.AddHostObjectToScriptTest, 0 },
             { TestList.UserAgentTest, 0 },
+            { TestList.NonAsciiUriTest, 7 },
         };
 
         readonly string[] TestPageNames =
@@ -266,6 +268,7 @@ namespace MUXControlsTestApp
             "SimplePageWithText.html",
             "SimpleInputPage.html",
             "SimplePageWithManyButtons.html",
+            "SimplePageWithNonÅscií.html",
         };
 
         readonly WebView2Common _helpers;
@@ -660,6 +663,16 @@ namespace MUXControlsTestApp
                         WebView2Common.LoadWebPage(newWebView2, TestPageNames[TestInfoDictionary[test]]);
                     }
                     break;
+                case TestList.NonAsciiUriTest:
+                    {
+                        // Put the URI with non-ascii characters in a TextBox, so we can easily copy/paste for manual testing.
+                        var box = FindName("CopyPasteTextBox2") as TextBox;
+                        string fileLocation = WebView2Common.GetTestPageUri("SimplePageWithNonÅscií.html").ToString();
+                        string query = "?query=";
+                        box.Text = fileLocation + query;
+                        WebView2Common.LoadWebPage(MyWebView2, TestPageNames[TestInfoDictionary[test]]);
+                    }
+                    break;
                 default:
                     WebView2Common.LoadWebPage(MyWebView2, TestPageNames[TestInfoDictionary[test]]);
                     break;
@@ -692,6 +705,8 @@ namespace MUXControlsTestApp
 
         private void OnNavigationStarting(WebView2 sender, CoreWebView2NavigationStartingEventArgs args)
         {
+            // Be careful if changing this message. The "NavigationStarting" string is expected
+            // to be logged exactly once per NavigationStarting event by the NonAsciiUriTest.
             AppendMessage(string.Format("[{0}]: Got NavigationStarting ({1}).", sender.Name, args.Uri));
 
             string expectedUri = "http://www.blockedbynavigationstarting.invalid/";

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -1262,21 +1262,6 @@ namespace MUXControlsTestApp
                         }
                         break;
 
-                    case TestList.BasicKeyboardTest:
-                        {
-                            string expectedMessage = "Input button clicked.";
-                            string receivedMessage = Status2.Text;
-                            logger.Verify((expectedMessage == receivedMessage),
-                                          string.Format("Test {0}: Expected web message {1} did not match received web message {2}.",
-                                                        selectedTest.ToString(), expectedMessage, receivedMessage));
-                            string expectedText = "Hello 123 Worm";
-                            string textResult = CopyPasteTextBox2.Text;
-                            logger.Verify((textResult == expectedText),
-                                          string.Format("Test {0}: Expected text {1} did not match with sampled text {2}.",
-                                                        selectedTest.ToString(), expectedText, textResult));
-                        }
-                        break;
-
                     case TestList.MouseCaptureTest:
                         {
                             string textResult = CopyPasteTextBox2.Text;

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -430,7 +430,7 @@ void WebView2::ResetPointerHelper(const winrt::PointerRoutedEventArgs& args)
 
 bool WebView2::ShouldNavigate(const winrt::Uri& uri)
 {
-    return uri != nullptr && uri.ToString() != m_stopNavigateOnUriChanged;
+    return uri != nullptr && uri.RawUri() != m_stopNavigateOnUriChanged;
 }
 
 winrt::IAsyncAction WebView2::OnSourceChanged(winrt::Uri providedUri)

--- a/test/MUXControlsTestApp/Assets/SimplePageWithNonÅscií.html
+++ b/test/MUXControlsTestApp/Assets/SimplePageWithNonÅscií.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Simple Page With NonAscii</title>
+    <style>
+        h1 {
+            background-color: #0080ff
+        }
+    </style>
+    <script>
+        function getParams()
+        {
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            var textBlock = document.getElementById("params");
+            const param = urlParams.get('query');
+            textBlock.innerHTML = param;
+        }
+    </script>
+</head>
+<body onload="getParams()">
+    <h1>Non-Ascii Page</h1> <br>
+    There's a URI with non-ascii characters in the clipboard paste text box that you can copy/paste and navigate to. <br>
+    You can also add non-ascii characters after the 'query' param and reload to see them working there. <br>
+    Here are some non-ascii characters to copy/paste: Å  €  ©  ¥  ²  →  ←  Ä  Ě  ö  ñ <br>
+    <br>
+    Query String = <h2 id="params"> </h2>
+</body>
+</html>


### PR DESCRIPTION
This change fixes an issue where navigating to a URI that contains non-ascii characters would cause the WebView2 to navigate an infinite number of times.

The Xaml WebView2’s Source can be set by us, or by the CoreWebView2 itself. When a Source change comes from the core (like it does on NavigationStarting, for example), we have to set the Source property on our side, but we want to know that this change came from the core and we shouldn’t tell the core to navigate to it again (which would cause an infinite loop). We stop ourselves by setting a flag around the call, and saving the Uri we know we’re already navigating to. If the Uris match, we don’t call into the core.

The issue was caused because we would save a [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding) string and compare it to the new URI directly. Instead, we should compare it to the new URI's RawUri, which is also percent-encoded.

When testing manually, selecting the NonAsciiUriTest will give the user a URI and various non-ascii characters that can be copied and pasted for additional testing.