### PR TITLE
Adding more lightweight styling to AppBarButton

### DIFF
--- a/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -35,6 +35,7 @@
             <StaticResource x:Key="AppBarButtonSubItemChevronForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <Visibility x:Key="AppBarButtonHasFlyoutChevronVisibility">Visible</Visibility>
             <x:String x:Key="AppBarButtonFlyoutGlyph">&#xE974;</x:String>
+            <x:Double x:Key="AppBarButtonFlyoutFontSize">8</x:Double>
         </ResourceDictionary>
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="AppBarButtonBackground" ResourceKey="SystemControlTransparentBrush" />
@@ -64,6 +65,7 @@
             <StaticResource x:Key="AppBarButtonSubItemChevronForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
             <Visibility x:Key="AppBarButtonHasFlyoutChevronVisibility">Visible</Visibility>
             <x:String x:Key="AppBarButtonFlyoutGlyph">&#xE974;</x:String>
+            <x:Double x:Key="AppBarButtonFlyoutFontSize">8</x:Double>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="AppBarButtonBackground" ResourceKey="SubtleFillColorTransparentBrush" />
@@ -93,6 +95,7 @@
             <StaticResource x:Key="AppBarButtonSubItemChevronForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <Visibility x:Key="AppBarButtonHasFlyoutChevronVisibility">Visible</Visibility>
             <x:String x:Key="AppBarButtonFlyoutGlyph">&#xE974;</x:String>
+            <x:Double x:Key="AppBarButtonFlyoutFontSize">8</x:Double>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
@@ -421,9 +424,9 @@
                                 Grid.Column="2"
                                 Glyph="{ThemeResource AppBarButtonFlyoutGlyph}"
                                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                FontSize="8"
+                                FontSize="{ThemeResource AppBarButtonFlyoutFontSize}"
                                 AutomationProperties.AccessibilityView="Raw"
-                                Foreground="{ThemeResource MenuFlyoutSubItemChevron}"
+                                Foreground="{ThemeResource AppBarButtonSubItemChevronForeground}"
                                 VerticalAlignment="Top"
                                 Margin="-23,20,12,0"
                                 MirroredWhenRightToLeft="True"


### PR DESCRIPTION
There are two additional elements in AppBarButton's chevron glyph that people would like to be able to change through lightweight styling: the font size, and the foreground color.  We actually already had a lightweight style for the foreground color, but mistakenly didn't use it in the Foreground property of the FontIcon.  I fixed that and added a resource for font size, and added a test to verify that changes to these resources propagates properly.