### PR TITLE
NavView IsPaneVisible Fix

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1820,7 +1820,7 @@ void NavigationView::UpdatePaneButtonsWidths()
     }();
  
     templateSettings->PaneToggleButtonWidth(newButtonWidths);
-    templateSettings->SmallerPaneToggleButtonWidth(newButtonWidths - 8);
+    templateSettings->SmallerPaneToggleButtonWidth(std::max(0.0, newButtonWidths - 8));
 }
 
 void NavigationView::OnBackButtonClicked(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args)

--- a/dev/NavigationView/NavigationViewItemPresenter.cpp
+++ b/dev/NavigationView/NavigationViewItemPresenter.cpp
@@ -140,7 +140,7 @@ void NavigationViewItemPresenter::UpdateCompactPaneLength(double compactPaneLeng
         const auto gridLength = compactPaneLength;
 
         templateSettings->IconWidth(gridLength);
-        templateSettings->SmallerIconWidth(gridLength - 8);
+        templateSettings->SmallerIconWidth(std::max(0.0, gridLength - 8));
     }
 }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/PaneBehaviorTests.cs
@@ -572,7 +572,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 19342138
         public void EnsurePaneCanBeHidden()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
@@ -589,7 +588,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Disabled as per tracking issue #3125 and internal issue 19342138
         public void EnsurePaneCanBeHiddenWithFixedWindowSize()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NavView was crashing whenever `IsPaneVisible` property is set to false. This is due to `SplitView.CompactPaneLength()` returning 0 when not visible, resulting in a negative value for `TemplateSettings.SmallerIconWidth`. 
- A check is now added to ensure the minimum value is 0.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #5971

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tests previously covering this scenario is now re-enabled to prevent regression.
