### PR TITLE
Fix NavigationViewCrash with the attached revokers object pattern during cleanup. 

### DIFF
--- a/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -439,7 +439,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         {
             StackPanel root = null;
             AppBarButton appBarButton = null;
-            ManualResetEvent appBarButtonLoadedEvent = new(false);
+            ManualResetEvent appBarButtonLoadedEvent = new ManualResetEvent(false);
 
             RunOnUIThread.Execute(() =>
             {

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3,6 +3,8 @@
 
 #include "pch.h"
 #include "common.h"
+#include <mutex>
+#include <thread>
 
 #include "NavigationView.h"
 #include "Vector.h"
@@ -221,8 +223,7 @@ NavigationView::NavigationView()
 
     m_navigationViewItemsFactory = winrt::make_self<NavigationViewItemsFactory>();
 
-    if (!s_NavigationViewItemRevokersProperty)
-    {
+    std::call_once(s_NavigationViewItemRevokersPropertySet, [this]() {
         s_NavigationViewItemRevokersProperty =
             InitializeDependencyProperty(
                 L"NavigationViewItemRevokers",
@@ -230,7 +231,7 @@ NavigationView::NavigationView()
                 winrt::name_of<winrt::NavigationViewItem>(),
                 true /* isAttached */,
                 nullptr /* defaultValue */);
-    }
+        });
 }
 
 void NavigationView::OnSelectionModelChildrenRequested(const winrt::SelectionModel& selectionModel, const winrt::SelectionModelChildrenRequestedEventArgs& e)

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -179,6 +179,7 @@ void NavigationView::UnhookEventsAndClearFields(bool isFromDestructor)
     {
         m_selectionChangedRevoker.revoke();
         m_autoSuggestBoxQuerySubmittedRevoker.revoke();
+        ClearAllNavigationViewItemRevokers();
     }
 }
 
@@ -220,13 +221,16 @@ NavigationView::NavigationView()
 
     m_navigationViewItemsFactory = winrt::make_self<NavigationViewItemsFactory>();
 
-    s_NavigationViewItemRevokersProperty =
-        InitializeDependencyProperty(
-            L"NavigationViewItemRevokers",
-            winrt::name_of<winrt::IInspectable>(),
-            winrt::name_of<winrt::NavigationViewItem>(),
-            true /* isAttached */,
-            nullptr /* defaultValue */);
+    if (!s_NavigationViewItemRevokersProperty)
+    {
+        s_NavigationViewItemRevokersProperty =
+            InitializeDependencyProperty(
+                L"NavigationViewItemRevokers",
+                winrt::name_of<winrt::IInspectable>(),
+                winrt::name_of<winrt::NavigationViewItem>(),
+                true /* isAttached */,
+                nullptr /* defaultValue */);
+    }
 }
 
 void NavigationView::OnSelectionModelChildrenRequested(const winrt::SelectionModel& selectionModel, const winrt::SelectionModelChildrenRequestedEventArgs& e)
@@ -1253,14 +1257,7 @@ void NavigationView::OnRepeaterElementPrepared(const winrt::ItemsRepeater& ir, c
             }();
             winrt::get_self<NavigationViewItem>(nvi)->PropagateDepthToChildren(childDepth);
 
-            // Register for item events
-            auto nviRevokers = winrt::make_self<NavigationViewItemRevokers>();
-            nviRevokers->tappedRevoker = nvi.Tapped(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemTapped });
-            nviRevokers->keyDownRevoker = nvi.KeyDown(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemKeyDown });
-            nviRevokers->gotFocusRevoker = nvi.GotFocus(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemOnGotFocus });
-            nviRevokers->isSelectedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItemBase::IsSelectedProperty(), { this, &NavigationView::OnNavigationViewItemIsSelectedPropertyChanged });
-            nviRevokers->isExpandedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItem::IsExpandedProperty(), { this, &NavigationView::OnNavigationViewItemExpandedPropertyChanged });
-            nvi.SetValue(s_NavigationViewItemRevokersProperty, nviRevokers.as<winrt::IInspectable>());
+            SetNavigationViewItemRevokers(nvi);
         }
     }
 }
@@ -1295,8 +1292,7 @@ void NavigationView::OnRepeaterElementClearing(const winrt::ItemsRepeater& ir, c
         nvibImpl->IsTopLevelItem(false);
         if (auto nvi = nvib.try_as<winrt::NavigationViewItem>())
         {
-            // Revoke all the events that we were listing to on the item
-            nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+            ClearNavigationViewItemRevokers(nvi);
         }
     }
 }
@@ -3402,6 +3398,35 @@ void NavigationView::UpdateLeftNavigationOnlyVisualState(bool useTransitions)
 {
     const bool isToggleButtonVisible = IsPaneToggleButtonVisible();
     winrt::VisualStateManager::GoToState(*this, isToggleButtonVisible || !m_isLeftPaneTitleEmpty ? L"TogglePaneButtonVisible" : L"TogglePaneButtonCollapsed", false /*useTransitions*/);
+}
+
+void NavigationView::SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi)
+{
+    auto nviRevokers = winrt::make_self<NavigationViewItemRevokers>();
+    nviRevokers->tappedRevoker = nvi.Tapped(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemTapped });
+    nviRevokers->keyDownRevoker = nvi.KeyDown(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemKeyDown });
+    nviRevokers->gotFocusRevoker = nvi.GotFocus(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemOnGotFocus });
+    nviRevokers->isSelectedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItemBase::IsSelectedProperty(), { this, &NavigationView::OnNavigationViewItemIsSelectedPropertyChanged });
+    nviRevokers->isExpandedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItem::IsExpandedProperty(), { this, &NavigationView::OnNavigationViewItemExpandedPropertyChanged });
+
+    nvi.SetValue(s_NavigationViewItemRevokersProperty, nviRevokers.as<winrt::IInspectable>());
+
+    m_itemsWithRevokerObjects.insert(nvi);
+}
+
+void NavigationView::ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi)
+{
+    nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+    m_itemsWithRevokerObjects.erase(nvi);
+}
+
+void NavigationView::ClearAllNavigationViewItemRevokers()
+{
+    for (auto const nvi : m_itemsWithRevokerObjects)
+    {
+        nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+    }
+    m_itemsWithRevokerObjects.clear();
 }
 
 void NavigationView::InvalidateTopNavPrimaryLayout()

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -189,6 +189,7 @@ private:
     void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     void ClearAllNavigationViewItemRevokers();
     std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects{};
+    std::once_flag s_NavigationViewItemRevokersPropertySet;
 
     void InvalidateTopNavPrimaryLayout();
     // Measure functions for top navigation   

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -185,6 +185,10 @@ private:
     // revokers for NavigationViewItem events and allows them to get revoked when
     // the item gets cleaned up
     GlobalDependencyProperty s_NavigationViewItemRevokersProperty{ nullptr };
+    void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
+    void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
+    void ClearAllNavigationViewItemRevokers();
+    std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects{};
 
     void InvalidateTopNavPrimaryLayout();
     // Measure functions for top navigation   


### PR DESCRIPTION
Update NavigationView to track which items get a revokers object attached to them and to revoke those during deconstructing. Additionally ensure that the NavigationViewItemRevokers dependency property is only initialized once.
