### PR TITLE
MUX Experimental: Remove hard-coded package version from GetLocalizedStringResourceFromWinUI 

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -79,6 +79,7 @@ PublishFile -IfExists $FullBuildOutput\WpfApp\ $UnpackagedAppsDir
 # Publish pdbs:
 $symbolsOutputDir = "$($FullPublishDir)\Symbols\"
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\Microsoft.UI.Xaml.pdb $symbolsOutputDir
+PublishFile -IfExists $FullBuildOutput\Microsoft.Experimental.UI.Xaml\Microsoft.Experimental.UI.Xaml.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\IXMPTestApp.TAEF\IXMPTestApp.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControls.Test\MUXControls.Test.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestApp.TAEF\MUXControlsTestApp.pdb $symbolsOutputDir


### PR DESCRIPTION
This function was using a hardcoded string to look up resources from Microsoft.UI.Xaml.2.6 framework package. This means that Microsoft.Experimental.UI.Xaml nuget package could only be used with WinUI 2.6 release. This PR updates the code to find any Microsoft.UI.Xaml.* framework package to use for finding localized resources.

This also ensures that Microsoft.Experimental.UI.Xaml.pdb debugging symbols get published to the drop in the Pipeline.

Closes #6242