### PR TITLE
[ContentDialog] Update background smoke for HC

### DIFF
--- a/dev/CommonStyles/ContentDialog_themeresources.xaml
+++ b/dev/CommonStyles/ContentDialog_themeresources.xaml
@@ -29,7 +29,7 @@
         <ResourceDictionary x:Key="HighContrast">
             <StaticResource x:Key="ContentDialogForeground" ResourceKey="SystemColorWindowTextColorBrush" />
             <StaticResource x:Key="ContentDialogBackground" ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="ContentDialogSmokeFill" ResourceKey="SystemColorWindowColorBrush" />
+            <SolidColorBrush x:Key="ContentDialogSmokeFill" Color="{ThemeResource SystemColorWindowColor}" Opacity="0.8"/>
             <StaticResource x:Key="ContentDialogTopOverlay" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="ContentDialogBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />
             <StaticResource x:Key="ContentDialogSeparatorBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />


### PR DESCRIPTION
Based on user feedback, some smoke is preferred in HC scenarios as well.

Before and after, aqua:
![aqua-before](https://user-images.githubusercontent.com/29714167/141009622-235a1676-44bb-47e0-a34f-b8da7c805c56.png)
![aqua-updated](https://user-images.githubusercontent.com/29714167/141009628-870564be-d50b-4fdb-b6ff-9307ad5b6c14.png)]

Before and after, desert:
![desert-before](https://user-images.githubusercontent.com/29714167/141009669-88f2be2a-6380-40a6-a9b2-30ce98968dd0.png)

![desert-updated](https://user-images.githubusercontent.com/29714167/141009685-4b04e931-6980-449e-ac87-1b47431a5ed4.png)

