### PR TITLE
[InkToolBar] Disable text scaling for inktoolbar buttons

### DIFF
--- a/dev/CommonStyles/InkToolbar_themeresources.xaml
+++ b/dev/CommonStyles/InkToolbar_themeresources.xaml
@@ -251,6 +251,7 @@
         <Setter Property="FocusVisualMargin" Value="-3" />
         <Setter Property="Padding" Value="2,2,2,2" />
         <Setter Property="Margin" Value="2,2,2,2" />
+        <Setter Property="IsTextScaleFactorEnabled" Value="False" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     </Style>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Setting IsTextScalingFactorEnabled to false fixes the issue of the icons scaling when they should not.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #6106 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->

![Screenshot of inktoolbar with text scaling to 225% showing icons not scaling anymore as expected](https://user-images.githubusercontent.com/16122379/141181823-419ba04e-75f7-44ed-b0da-aaf25f7af89f.png)
