### PR TITLE
TabViewItem: Make background of the selected tab all one path

### DIFF
--- a/dev/Generated/TabViewItemTemplateSettings.properties.cpp
+++ b/dev/Generated/TabViewItemTemplateSettings.properties.cpp
@@ -14,6 +14,7 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 #include "TabViewItemTemplateSettings.g.cpp"
 
 GlobalDependencyProperty TabViewItemTemplateSettingsProperties::s_IconElementProperty{ nullptr };
+GlobalDependencyProperty TabViewItemTemplateSettingsProperties::s_TabGeometryProperty{ nullptr };
 
 TabViewItemTemplateSettingsProperties::TabViewItemTemplateSettingsProperties()
 {
@@ -33,11 +34,23 @@ void TabViewItemTemplateSettingsProperties::EnsureProperties()
                 ValueHelper<winrt::IconElement>::BoxedDefaultValue(),
                 nullptr);
     }
+    if (!s_TabGeometryProperty)
+    {
+        s_TabGeometryProperty =
+            InitializeDependencyProperty(
+                L"TabGeometry",
+                winrt::name_of<winrt::Geometry>(),
+                winrt::name_of<winrt::TabViewItemTemplateSettings>(),
+                false /* isAttached */,
+                ValueHelper<winrt::Geometry>::BoxedDefaultValue(),
+                nullptr);
+    }
 }
 
 void TabViewItemTemplateSettingsProperties::ClearProperties()
 {
     s_IconElementProperty = nullptr;
+    s_TabGeometryProperty = nullptr;
 }
 
 void TabViewItemTemplateSettingsProperties::IconElement(winrt::IconElement const& value)
@@ -51,4 +64,17 @@ void TabViewItemTemplateSettingsProperties::IconElement(winrt::IconElement const
 winrt::IconElement TabViewItemTemplateSettingsProperties::IconElement()
 {
     return ValueHelper<winrt::IconElement>::CastOrUnbox(static_cast<TabViewItemTemplateSettings*>(this)->GetValue(s_IconElementProperty));
+}
+
+void TabViewItemTemplateSettingsProperties::TabGeometry(winrt::Geometry const& value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<TabViewItemTemplateSettings*>(this)->SetValue(s_TabGeometryProperty, ValueHelper<winrt::Geometry>::BoxValueIfNecessary(value));
+    }
+}
+
+winrt::Geometry TabViewItemTemplateSettingsProperties::TabGeometry()
+{
+    return ValueHelper<winrt::Geometry>::CastOrUnbox(static_cast<TabViewItemTemplateSettings*>(this)->GetValue(s_TabGeometryProperty));
 }

--- a/dev/Generated/TabViewItemTemplateSettings.properties.h
+++ b/dev/Generated/TabViewItemTemplateSettings.properties.h
@@ -12,9 +12,14 @@ public:
     void IconElement(winrt::IconElement const& value);
     winrt::IconElement IconElement();
 
+    void TabGeometry(winrt::Geometry const& value);
+    winrt::Geometry TabGeometry();
+
     static winrt::DependencyProperty IconElementProperty() { return s_IconElementProperty; }
+    static winrt::DependencyProperty TabGeometryProperty() { return s_TabGeometryProperty; }
 
     static GlobalDependencyProperty s_IconElementProperty;
+    static GlobalDependencyProperty s_TabGeometryProperty;
 
     static void EnsureProperties();
     static void ClearProperties();

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -178,7 +178,10 @@ unsealed runtimeclass TabViewItemTemplateSettings : Windows.UI.Xaml.DependencyOb
 
     Windows.UI.Xaml.Controls.IconElement IconElement;
 
+    Windows.UI.Xaml.Media.Geometry TabGeometry;
+
     static Windows.UI.Xaml.DependencyProperty IconElementProperty{ get; };
+    static Windows.UI.Xaml.DependencyProperty TabGeometryProperty{ get; };
 }
 
 }

--- a/dev/TabView/TabView.idl
+++ b/dev/TabView/TabView.idl
@@ -178,10 +178,17 @@ unsealed runtimeclass TabViewItemTemplateSettings : Windows.UI.Xaml.DependencyOb
 
     Windows.UI.Xaml.Controls.IconElement IconElement;
 
-    Windows.UI.Xaml.Media.Geometry TabGeometry;
+    [MUX_PUBLIC_V2]
+    {
+        Windows.UI.Xaml.Media.Geometry TabGeometry;
+    }
 
     static Windows.UI.Xaml.DependencyProperty IconElementProperty{ get; };
-    static Windows.UI.Xaml.DependencyProperty TabGeometryProperty{ get; };
+
+    [MUX_PUBLIC_V2]
+    {
+        static Windows.UI.Xaml.DependencyProperty TabGeometryProperty{ get; };
+    }
 }
 
 }

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -391,15 +391,12 @@
                                 <VisualState x:Name="Selected">
                                     <VisualState.Setters>
                                         <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible"/>
-                                        <Setter Target="RightRadiusRenderTriangle.Visibility" Value="Visible"/>
-                                        <Setter Target="RightRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible"/>
-                                        <Setter Target="LeftRadiusRenderTriangle.Visibility" Value="Visible"/>
-                                        <Setter Target="LeftRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
+                                        <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible"/>
+                                        <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}"/>
                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}"/>
                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}"/>
-                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
                                         <Setter Target="TabContainer.Padding" Value="{ThemeResource TabViewSelectedItemHeaderPadding}"/>
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
@@ -413,15 +410,12 @@
                                 <VisualState x:Name="PointerOverSelected">
                                     <VisualState.Setters>
                                         <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible"/>
-                                        <Setter Target="RightRadiusRenderTriangle.Visibility" Value="Visible"/>
-                                        <Setter Target="RightRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible"/>
-                                        <Setter Target="LeftRadiusRenderTriangle.Visibility" Value="Visible"/>
-                                        <Setter Target="LeftRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
+                                        <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible"/>
+                                        <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}"/>
                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}"/>
                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}"/>
-                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
                                         <Setter Target="TabContainer.Padding" Value="{ThemeResource TabViewSelectedItemHeaderPadding}"/>
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
@@ -435,15 +429,12 @@
                                 <VisualState x:Name="PressedSelected">
                                     <VisualState.Setters>
                                         <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible"/>
-                                        <Setter Target="RightRadiusRenderTriangle.Visibility" Value="Visible"/>
-                                        <Setter Target="RightRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible"/>
-                                        <Setter Target="LeftRadiusRenderTriangle.Visibility" Value="Visible"/>
-                                        <Setter Target="LeftRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
+                                        <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible"/>
+                                        <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}"/>
                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}"/>
                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}"/>
-                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
                                         <Setter Target="TabContainer.Padding" Value="{ThemeResource TabViewSelectedItemHeaderPadding}"/>
                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
@@ -635,14 +626,6 @@
                             Width="4"
                             Data="M4 0C4 1.19469 3.47624 2.26706 2.64582 3H0C1.65685 3 3 1.65685 3 0H4Z" />
 
-                        <Path  x:Name="LeftRadiusRenderTriangle"
-                            x:Load="False"
-                            Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
-                            VerticalAlignment="Bottom"
-                            Margin="-4,0,0,0"
-                            Visibility="Collapsed"
-                            Data="M0 4H4V0C4 2.20914 2.20914 4 0 4Z" />
-
                         <Path x:Name="RightRadiusRenderArc"
                             x:Load="False"
                             Grid.Column="2"
@@ -654,14 +637,14 @@
                             Width="4"
                             Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z"/>
 
-                        <Path x:Name="RightRadiusRenderTriangle"
+                        <Path x:Name="SelectedBackgroundPath"
                             x:Load="False"
-                            Grid.Column="2"
-                            Visibility="Collapsed"
+                            Grid.ColumnSpan="3"
                             Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
                             VerticalAlignment="Bottom"
-                            Margin="0,0,-4,0"
-                            Data="M4 4H0V0C0 2.20914 1.79086 4 4 4Z"/>
+                            Margin="-4,0,-4,0"
+                            Visibility="Collapsed"
+                            Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}" />
 
                         <Border x:Name="TabSeparator"
                             HorizontalAlignment="Right"

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -58,6 +58,9 @@ private:
     void OnIconSourceChanged();
     void UpdateWidthModeVisualState();
 
+    void OnSizeChanged(const winrt::IInspectable&, const winrt::SizeChangedEventArgs& args);
+    void UpdateTabGeometry();
+
     bool m_firstTimeSettingToolTip{ true };
 
     winrt::ButtonBase::Click_revoker m_closeButtonClickRevoker{};


### PR DESCRIPTION
Instead of having the selected tab be composed of 3 parts (LeftRadiusRenderTriangle, TabContainer, RightRadiusRenderTriangle) which often do not abut properly in high DPI, I'm setting the tab background to be a single path (SelectedBackgroundPath), which is set from code and updated whenever the size of the TabViewItem updates. Fixes #5954.