### PR TITLE
[Mica] Fix crash accessing BaseWindowHandler::m_capabilities from Capabilities::Changed handler

### DIFF
--- a/dev/Materials/Backdrop/MicaController.cpp
+++ b/dev/Materials/Backdrop/MicaController.cpp
@@ -51,7 +51,6 @@ bool MicaController::SetTarget(winrt::Windows::UI::Xaml::Window const& xamlWindo
         return false;
     }
 
-    // m_windowHandler = std::make_unique<SystemBackdropComponentInternal::XamlWindowHandler>(this, xamlWindow);
     m_windowHandler = winrt::make_self<SystemBackdropComponentInternal::XamlWindowHandler>(this, xamlWindow);
 
     // Ensure we are in the correct policy state only *after* creating the appropriate WindowHandler.

--- a/dev/Materials/Backdrop/MicaController.cpp
+++ b/dev/Materials/Backdrop/MicaController.cpp
@@ -51,7 +51,8 @@ bool MicaController::SetTarget(winrt::Windows::UI::Xaml::Window const& xamlWindo
         return false;
     }
 
-    m_windowHandler = std::make_unique<SystemBackdropComponentInternal::XamlWindowHandler>(this, xamlWindow);
+    // m_windowHandler = std::make_unique<SystemBackdropComponentInternal::XamlWindowHandler>(this, xamlWindow);
+    m_windowHandler = winrt::make_self<SystemBackdropComponentInternal::XamlWindowHandler>(this, xamlWindow);
 
     // Ensure we are in the correct policy state only *after* creating the appropriate WindowHandler.
     // If we start in high contrast mode, the controller will query the window handler for the correct system fallback color.

--- a/dev/Materials/Backdrop/MicaController.h
+++ b/dev/Materials/Backdrop/MicaController.h
@@ -51,7 +51,8 @@ private:
     winrt::CompositionBrush m_currentBrush{ nullptr };
     winrt::Windows::UI::Composition::Compositor m_compositor{ nullptr };
     winrt::weak_ref<winrt::Microsoft::UI::Private::Controls::ICompositionSupportsSystemBackdrop> m_target{ nullptr };
-    std::unique_ptr<SystemBackdropComponentInternal::BaseWindowHandler> m_windowHandler{ nullptr };
+    //std::unique_ptr<SystemBackdropComponentInternal::BaseWindowHandler> m_windowHandler{ nullptr };
+    com_ptr<SystemBackdropComponentInternal::BaseWindowHandler> m_windowHandler{ nullptr };
 
     bool m_isActive{ false };
     bool m_isExplicitFallbackColorSet{ false };

--- a/dev/Materials/Backdrop/MicaController.h
+++ b/dev/Materials/Backdrop/MicaController.h
@@ -51,7 +51,6 @@ private:
     winrt::CompositionBrush m_currentBrush{ nullptr };
     winrt::Windows::UI::Composition::Compositor m_compositor{ nullptr };
     winrt::weak_ref<winrt::Microsoft::UI::Private::Controls::ICompositionSupportsSystemBackdrop> m_target{ nullptr };
-    //std::unique_ptr<SystemBackdropComponentInternal::BaseWindowHandler> m_windowHandler{ nullptr };
     com_ptr<SystemBackdropComponentInternal::BaseWindowHandler> m_windowHandler{ nullptr };
 
     bool m_isActive{ false };

--- a/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
+++ b/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
@@ -55,15 +55,14 @@ namespace SystemBackdropComponentInternal
 
         m_capabilities = winrt::Windows::UI::Composition::CompositionCapabilities::GetForCurrentView();
         m_capabilitiesEventRevoker = { m_capabilities, m_capabilities.Changed(
-            [weakThis = get_weak(), weakCapabilities = winrt::make_weak(m_capabilities), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
+            [weakThis = get_weak(), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
             {
-                dispatcherQueue.TryEnqueue([weakCapabilities, weakThis]()
+                dispatcherQueue.TryEnqueue([weakThis]()
                     {
                         auto strongThis= weakThis.get();
-                        auto capabilities = weakCapabilities.get();
-                        if (strongThis && capabilities)
+                        if (strongThis)
                         {
-                            if (capabilities.AreEffectsFast())
+                            if (strongThis->m_capabilities.AreEffectsFast())
                             {
                                 strongThis->m_policy->SetIncompatibleGraphicsDevice(false);
                             }
@@ -79,15 +78,14 @@ namespace SystemBackdropComponentInternal
 
         m_uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
         m_uiSettingsEventRevoker = m_uiSettings.AdvancedEffectsEnabledChanged(winrt::auto_revoke,
-            [weakThis = get_weak(), weakUiSettings = winrt::make_weak(m_uiSettings), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
+            [weakThis = get_weak(), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
             {
-                dispatcherQueue.TryEnqueue([weakUiSettings, weakThis]()
+                dispatcherQueue.TryEnqueue([weakThis]()
                     {
-                        auto uiSettings = weakUiSettings.get();
                         auto strongThis = weakThis.get();
-                        if (strongThis && uiSettings)
+                        if (strongThis)
                         {
-                            if (uiSettings.AdvancedEffectsEnabled())
+                            if (strongThis->m_uiSettings.AdvancedEffectsEnabled())
                             {
                                 strongThis->m_policy->SetTransparencyDisabled(false);
                             }

--- a/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
+++ b/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
@@ -31,65 +31,72 @@ namespace SystemBackdropComponentInternal
 
         m_policy = std::make_unique<SystemBackdropPolicyStateMachine>(SystemBackdropPolicyState::Active);
 
-        m_powerManagerEventRevoker = winrt::Windows::System::Power::PowerManager::EnergySaverStatusChanged(winrt::auto_revoke, [&](auto&&, auto&&)
+        m_powerManagerEventRevoker = winrt::Windows::System::Power::PowerManager::EnergySaverStatusChanged(winrt::auto_revoke,
+            [weakThis = get_weak(), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
             {
-                m_dispatcherQueue.TryEnqueue([&]()
+                dispatcherQueue.TryEnqueue([weakThis]()
                     {
-                        if (winrt::Windows::System::Power::PowerManager::EnergySaverStatus() == winrt::Windows::System::Power::EnergySaverStatus::On)
+                        auto strongThis = weakThis.get();
+                        if (strongThis)
                         {
-                            m_policy->SetPowerSavingMode(true);
-                        }
-                        else
-                        {
-                            m_policy->SetPowerSavingMode(false);
-                        }
+                            if (winrt::Windows::System::Power::PowerManager::EnergySaverStatus() == winrt::Windows::System::Power::EnergySaverStatus::On)
+                            {
+                                strongThis->m_policy->SetPowerSavingMode(true);
+                            }
+                            else
+                            {
+                                strongThis->m_policy->SetPowerSavingMode(false);
+                            }
 
-                        ActivateOrDeactivateController();
+                            strongThis->ActivateOrDeactivateController();
+                        }
                     });
             });
 
         m_capabilities = winrt::Windows::UI::Composition::CompositionCapabilities::GetForCurrentView();
-        m_capabilitiesEventRevoker = { m_capabilities, m_capabilities.Changed([&](auto&&, auto&&)
+        m_capabilitiesEventRevoker = { m_capabilities, m_capabilities.Changed(
+            [weakThis = get_weak(), weakCapabilities = winrt::make_weak(m_capabilities), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
             {
-                auto capabilitiesWeakRef = winrt::make_weak(m_capabilities);
-
-                m_dispatcherQueue.TryEnqueue([capabilitiesWeakRef, this]()
+                dispatcherQueue.TryEnqueue([weakCapabilities, weakThis]()
                     {
-                        if (auto capabilities = capabilitiesWeakRef.get())
+                        auto strongThis= weakThis.get();
+                        auto capabilities = weakCapabilities.get();
+                        if (strongThis && capabilities)
                         {
                             if (capabilities.AreEffectsFast())
                             {
-                                m_policy->SetIncompatibleGraphicsDevice(false);
+                                strongThis->m_policy->SetIncompatibleGraphicsDevice(false);
                             }
                             else
                             {
-                                m_policy->SetIncompatibleGraphicsDevice(true);
+                                strongThis->m_policy->SetIncompatibleGraphicsDevice(true);
                             }
 
-                            ActivateOrDeactivateController();
+                            strongThis->ActivateOrDeactivateController();
                         }
                     });
             }) };
 
         m_uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
-        m_uiSettingsEventRevoker = m_uiSettings.AdvancedEffectsEnabledChanged(winrt::auto_revoke, [&](auto&&, auto&&)
+        m_uiSettingsEventRevoker = m_uiSettings.AdvancedEffectsEnabledChanged(winrt::auto_revoke,
+            [weakThis = get_weak(), weakUiSettings = winrt::make_weak(m_uiSettings), dispatcherQueue = m_dispatcherQueue](auto&&, auto&&)
             {
-                auto uiSettingsWeakRef = winrt::make_weak(m_uiSettings);
-
-                m_dispatcherQueue.TryEnqueue([uiSettingsWeakRef, this]()
+                dispatcherQueue.TryEnqueue([weakUiSettings, weakThis]()
                     {
-                        if (auto uiSettings = uiSettingsWeakRef.get())
+                        auto uiSettings = weakUiSettings.get();
+                        auto strongThis = weakThis.get();
+                        if (strongThis && uiSettings)
                         {
                             if (uiSettings.AdvancedEffectsEnabled())
                             {
-                                m_policy->SetTransparencyDisabled(false);
+                                strongThis->m_policy->SetTransparencyDisabled(false);
                             }
                             else
                             {
-                                m_policy->SetTransparencyDisabled(true);
+                                strongThis->m_policy->SetTransparencyDisabled(true);
                             }
 
-                            ActivateOrDeactivateController();
+                            strongThis->ActivateOrDeactivateController();
                         }
                     });
             });

--- a/dev/Materials/Backdrop/SystemBackdropWindowHandler.h
+++ b/dev/Materials/Backdrop/SystemBackdropWindowHandler.h
@@ -61,7 +61,7 @@ namespace SystemBackdropComponentInternal
         winrt::event_token m_token{};
     };
 
-    struct BaseWindowHandler
+    struct BaseWindowHandler : public winrt::implements<BaseWindowHandler, winrt::IInspectable>
     {
         virtual ~BaseWindowHandler()
         {


### PR DESCRIPTION
BaseWindowHandler (owned by MicaController) subscribes to Windows::UI::Composition::CompositionCapabilities::Changed event. The current Changed handler captures 'this' by reference  and tries to access this->m_capabilities. It's possible the handler is invoked after BaseWindowHandler is already cleaned up and access via this is invalid. To fix, capture this as a weak_ptr and resolve it before accessing class members in the handler.

Originally BaseWindowHandler was a simple C++ struct;  make it derive from winrt::implements<..., IInspectable> to support ref counting and strong/weak refs.

The same problematic pattern was used for UISettings::AdvancedEffectsEnabledChanged and PowerManager::EnergySaverStatusChanged, so apply the fix there as well.