### PR TITLE
WebView2 hides cursor if it stops getting input

### DIFF
--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -398,7 +398,7 @@ void WebView2::ResetPointerHelper(const winrt::PointerRoutedEventArgs& args)
 
     if (m_isPointerOver)
     {
-        m_isPointerOver = true;
+        m_isPointerOver = false;
         winrt::CoreWindow::GetForCurrentThread().PointerCursor(m_oldCursor);
         m_oldCursor = nullptr;
     }


### PR DESCRIPTION
Because m_isPointerOver wasn't getting reset to false, we then kept trying to set the pointer back to null incorrectly.

Fixes #6168