### PR TITLE
[BreadcrumbBar] Fix issue where setting ItemsSource was not respected

### DIFF
--- a/dev/Breadcrumb/APITests/BreadcrumbTests.cs
+++ b/dev/Breadcrumb/APITests/BreadcrumbTests.cs
@@ -14,6 +14,7 @@ using System.Security.Cryptography.X509Certificates;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Automation.Provider;
 using System.Linq;
+using System.Collections.ObjectModel;
 
 #if USING_TAEF
 using WEX.TestExecution;
@@ -394,5 +395,69 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             }
         }
 
+        [TestMethod]
+        public void VerifyCollectionChangeGetsRespected()
+        {
+            BreadcrumbBar breadcrumb = null;
+            ItemsRepeater breadcrumbItemsRepeater = null;
+            RunOnUIThread.Execute(() =>
+            {
+                // Set a custom ItemTemplate to be wrapped in a BreadcrumbBarItem.
+                var itemTemplate = (DataTemplate)XamlReader.Load(
+                        @"<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                            xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                            xmlns:controls='using:Microsoft.UI.Xaml.Controls'
+                            xmlns:local='using:Windows.UI.Xaml.Tests.MUXControls.ApiTests'>
+                            <controls:BreadcrumbBarItem Content='{Binding}'>
+                                <controls:BreadcrumbBarItem.ContentTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text='{Binding MockProperty}'/>
+                                    </DataTemplate>
+                                </controls:BreadcrumbBarItem.ContentTemplate>
+                            </controls:BreadcrumbBarItem>
+                        </DataTemplate>");
+
+
+                breadcrumb = new BreadcrumbBar();
+                breadcrumb.ItemsSource = new List<MockClass>() {
+                    new MockClass { MockProperty = "Node 1" },
+                    new MockClass { MockProperty = "Node 2" },
+                };
+                breadcrumb.ItemTemplate = itemTemplate;
+
+                var stackPanel = new StackPanel();
+                stackPanel.Children.Add(breadcrumb);
+
+                Content = stackPanel;
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                breadcrumbItemsRepeater = (ItemsRepeater)breadcrumb.FindVisualChildByName("PART_ItemsRepeater");
+                Verify.IsNotNull(breadcrumbItemsRepeater, "The underlying items repeater could not be retrieved");
+
+                var breadcrumbNode2 = breadcrumbItemsRepeater.TryGetElement(1) as BreadcrumbBarItem;
+                Verify.IsNotNull(breadcrumbNode2, "Our custom ItemTemplate should have been wrapped in a BreadcrumbBarItem.");
+
+                breadcrumb.ItemsSource = new List<MockClass>() {
+                    new MockClass { MockProperty = "Node 1" },
+                    new MockClass { MockProperty = "Node 2" },
+                    new MockClass { MockProperty = "Node 3" },
+                    new MockClass { MockProperty = "Node 4" },
+                };
+            });
+
+            IdleSynchronizer.Wait();
+
+
+            RunOnUIThread.Execute(() =>
+            {
+                var breadcrumbNode3 = breadcrumbItemsRepeater.TryGetElement(3) as BreadcrumbBarItem;
+                Verify.IsNotNull(breadcrumbNode3, "A fourth item should have been rendered by the BreadcrumControl");
+            });
+        }
     }
 }

--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -62,7 +62,7 @@ void BreadcrumbBar::OnApplyTemplate()
         itemsRepeater.Layout(*m_itemsRepeaterLayout);
         itemsRepeater.ItemsSource(winrt::make<Vector<IInspectable>>());
         itemsRepeater.ItemTemplate(*m_itemsRepeaterElementFactory);
-        
+
         m_itemsRepeaterElementPreparedRevoker = itemsRepeater.ElementPrepared(winrt::auto_revoke, { this, &BreadcrumbBar::OnElementPreparedEvent });
         m_itemsRepeaterElementIndexChangedRevoker = itemsRepeater.ElementIndexChanged(winrt::auto_revoke, { this, &BreadcrumbBar::OnElementIndexChangedEvent });
         m_itemsRepeaterElementClearingRevoker = itemsRepeater.ElementClearing(winrt::auto_revoke, { this, &BreadcrumbBar::OnElementClearingEvent });
@@ -148,7 +148,11 @@ void BreadcrumbBar::UpdateItemsRepeaterItemsSource()
     if (ItemsSource())
     {
         m_breadcrumbItemsSourceView = winrt::ItemsSourceView(ItemsSource());
-
+        if (const auto& itemsRepeater = m_itemsRepeater.get())
+        {
+            m_itemsIterable = winrt::make_self<BreadcrumbIterable>(ItemsSource());
+            itemsRepeater.ItemsSource(*m_itemsIterable);
+        }
         if (m_breadcrumbItemsSourceView)
         {
             m_itemsSourceChanged = m_breadcrumbItemsSourceView.CollectionChanged(winrt::auto_revoke, { this, &BreadcrumbBar::OnBreadcrumbBarItemsSourceCollectionChanged });
@@ -410,7 +414,7 @@ void BreadcrumbBar::OnGettingFocus(const winrt::IInspectable&, const winrt::Gett
                             args.Handled(true);
                         }
                     }
-                }   
+                }
             }
 
             // Focus was already in the repeater: in RS3+ Selection follows focus unless control is held down.
@@ -568,8 +572,8 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
             args.Handled(true);
             return;
         }
-        else if ( (flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadRight)) ||
-                    (!flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadLeft)) )
+        else if ((flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadRight)) ||
+            (!flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadLeft)))
         {
             if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Next))
             {
@@ -588,7 +592,7 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
             return;
         }
         else if ((flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadLeft)) ||
-                    (!flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadRight)))
+            (!flowDirectionIsLTR && (args.OriginalKey() == winrt::VirtualKey::GamepadDPadRight)))
         {
             if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Previous))
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When itemssource was changed, the itemsrepeater was not provided the new itemssource.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #5986 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new API test
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->