### PR TITLE
[Experimental TitleBar] Collapse TitleText when empty

### DIFF
--- a/dev/TitleBar/TitleBar.cpp
+++ b/dev/TitleBar/TitleBar.cpp
@@ -97,6 +97,7 @@ void TitleBar::OnApplyTemplate()
     UpdateIcon();
     UpdateBackButton();
     UpdateTheme();
+    UpdateTitle();
 }
 
 void TitleBar::OnBackButtonClick(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args)
@@ -121,7 +122,7 @@ void TitleBar::OnCustomContentPropertyChanged(const winrt::DependencyPropertyCha
 
 void TitleBar::OnTitlePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
 {
-    UpdateTitle(args.NewValue().as<winrt::hstring>());
+    UpdateTitle();
 }
 
 void TitleBar::OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args)
@@ -270,9 +271,10 @@ void TitleBar::UpdateTheme()
     }
 }
 
-void TitleBar::UpdateTitle(const winrt::hstring& title)
+void TitleBar::UpdateTitle()
 {
-    if (title.empty())
+    const winrt::hstring titleText = Title();
+    if (titleText.empty())
     {
         winrt::VisualStateManager::GoToState(*this, L"TitleTextCollapsed", false);
     }

--- a/dev/TitleBar/TitleBar.cpp
+++ b/dev/TitleBar/TitleBar.cpp
@@ -119,6 +119,11 @@ void TitleBar::OnCustomContentPropertyChanged(const winrt::DependencyPropertyCha
     UpdateHeight();
 }
 
+void TitleBar::OnTitlePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
+{
+    UpdateTitle(args.NewValue().as<winrt::hstring>());
+}
+
 void TitleBar::OnSizeChanged(const winrt::IInspectable& sender, const winrt::SizeChangedEventArgs& args)
 {
     const auto titleTextBlock = m_titleTextBlock.get();
@@ -264,3 +269,16 @@ void TitleBar::UpdateTheme()
         }
     }
 }
+
+void TitleBar::UpdateTitle(const winrt::hstring& title)
+{
+    if (title.empty())
+    {
+        winrt::VisualStateManager::GoToState(*this, L"TitleTextCollapsed", false);
+    }
+    else
+    {
+        winrt::VisualStateManager::GoToState(*this, L"TitleTextVisible", false);
+    }
+}
+

--- a/dev/TitleBar/TitleBar.h
+++ b/dev/TitleBar/TitleBar.h
@@ -36,7 +36,7 @@ private:
     void UpdateBackButton();
     void UpdateHeight();
     void UpdateTheme();
-    void UpdateTitle(const winrt::hstring& newValue);
+    void UpdateTitle();
 
     void OnWindowActivated(const winrt::IInspectable& sender, const winrt::WindowActivatedEventArgs& args);
     void OnTitleBarMetricsChanged(const winrt::IInspectable& sender, const winrt::IInspectable& args);

--- a/dev/TitleBar/TitleBar.h
+++ b/dev/TitleBar/TitleBar.h
@@ -27,6 +27,7 @@ public:
     void OnIconSourcePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnIsBackButtonVisiblePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnCustomContentPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
+    void OnTitlePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
 private:
     void UpdateVisibility();
@@ -35,6 +36,7 @@ private:
     void UpdateBackButton();
     void UpdateHeight();
     void UpdateTheme();
+    void UpdateTitle(const winrt::hstring& newValue);
 
     void OnWindowActivated(const winrt::IInspectable& sender, const winrt::WindowActivatedEventArgs& args);
     void OnTitleBarMetricsChanged(const winrt::IInspectable& sender, const winrt::IInspectable& args);

--- a/dev/TitleBar/TitleBar.idl
+++ b/dev/TitleBar/TitleBar.idl
@@ -7,6 +7,7 @@ unsealed runtimeclass TitleBar : Windows.UI.Xaml.Controls.Control
 {
     TitleBar();
 
+    [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
     String Title{ get; set; };
 
     [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]

--- a/dev/TitleBar/TitleBar.xaml
+++ b/dev/TitleBar/TitleBar.xaml
@@ -44,6 +44,15 @@
                                 </VisualState>
                             </VisualStateGroup>
 
+                            <VisualStateGroup x:Name="TitleTextVisibilityGroup">
+                                <VisualState x:Name="TitleTextVisible" />
+                                <VisualState x:Name="TitleTextCollapsed">
+                                    <VisualState.Setters>
+                                        <Setter Target="TitleText.Visibility" Value="Collapsed" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+
                             <VisualStateGroup x:Name="FullScreenGroup">
                                 <VisualState x:Name="TitleBarVisible"/>
                                 <VisualState x:Name="TitleBarCollapsed">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
 When the TitleBar TitleText is empty make sure to collapse the TitleText Textblock so that it does not take any extra space.

- Add title property changed handler
- Add visual states for title visibility
- Apply visual state change if the title is empty or not
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Allows TitleBar consumers to have responsive UI and remove the extra space that an empty title was adding.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested via the MUXExpirementalTestApp.