### PR TITLE
TabView: Separate border lines into being everywhere except the selected tab

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -926,6 +926,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 var increaseScrollButton = FindElement.ByName<Button>("IncreaseScrollButton");
                 increaseScrollButton.Click();
                 Wait.ForIdle();
+                increaseScrollButton.Click();
+                Wait.ForIdle();
                 var readTabViewWidthButton = new Button(FindElement.ByName("GetActualWidthButton"));
                 readTabViewWidthButton.Click();
                 Wait.ForIdle();

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -705,7 +705,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 CloseTabAndVerifyWidth("Tab 3", 500, "False;False;");
 
-                CloseTabAndVerifyWidth("Tab 5", 420, "False;False;");
+                CloseTabAndVerifyWidth("Tab 5", 430, "False;False;");
 
                 CloseTabAndVerifyWidth("Tab 4", 450, "False;False;");
 
@@ -726,7 +726,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Closing tab:" + tabName);
                 FindCloseButton(FindElement.ByName(tabName)).Click();
                 Wait.ForIdle();
-                Log.Comment("Verifying TabView width");
+                Log.Comment("Verifying TabView width -- expected " + expectedValue + ", actual " + GetActualTabViewWidth());
                 Verify.IsTrue(Math.Abs(GetActualTabViewWidth() - expectedValue) < pixelTolerance);
                 Verify.AreEqual(expectedScrollbuttonStates, FindElement.ByName("ScrollButtonStatus").GetText());
 

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -282,7 +282,11 @@ void TabView::UpdateTabBorderVisualStates()
     for (int i = 0; i < numItems; i++)
     {
         auto state = L"NormalBorder";
-        if (!m_isDragging && selectedIndex != -1)
+        if (m_isDragging)
+        {
+            state = L"NoBorder";
+        }
+        else if (selectedIndex != -1)
         {
             if (i == selectedIndex - 1)
             {
@@ -299,7 +303,27 @@ void TabView::UpdateTabBorderVisualStates()
             winrt::VisualStateManager::GoToState(tvi, state, false /*useTransitions*/);
         }
     }
+}
 
+void TabView::UpdateBorderVisualStates()
+{
+    // Update border line on all tabs
+    UpdateTabBorderVisualStates();
+
+    // Update border lines on the TabView
+    winrt::VisualStateManager::GoToState(*this, m_isDragging ? L"SingleBorder" : L"NormalBorder", false /*useTransitions*/);
+
+    // Update border lines in the inner TabViewListView
+    if (const auto lv = m_listView.get())
+    {
+        winrt::VisualStateManager::GoToState(lv, m_isDragging ? L"NoBorder" : L"NormalBorder", false /*useTransitions*/);
+    }
+
+    // Update border lines in the ScrollViewer
+    if (const auto scroller = m_scrollViewer.get())
+    {
+        winrt::VisualStateManager::GoToState(scroller, m_isDragging ? L"NoBorder" : L"NormalBorder", false /*useTransitions*/);
+    }
 }
 
 void TabView::OnSelectedItemPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -791,7 +815,7 @@ void TabView::OnListViewDragItemsStarting(const winrt::IInspectable& sender, con
 
     m_tabDragStartingEventSource(*this, *myArgs);
 
-    UpdateTabBorderVisualStates();
+    UpdateBorderVisualStates();
 }
 
 void TabView::OnListViewDragOver(const winrt::IInspectable& sender, const winrt::DragEventArgs& args)
@@ -821,7 +845,7 @@ void TabView::OnListViewDragItemsCompleted(const winrt::IInspectable& sender, co
         m_tabDroppedOutsideEventSource(*this, *tabDroppedArgs);
     }
 
-    UpdateTabBorderVisualStates();
+    UpdateBorderVisualStates();
 }
 
 void TabView::UpdateTabContent()

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -271,20 +271,20 @@ void TabView::OnSelectedIndexPropertyChanged(const winrt::DependencyPropertyChan
     SetTabSeparatorOpacity(SelectedIndex() - 1);
     SetTabSeparatorOpacity(SelectedIndex());
 
-    UpdateTabBorderVisualStates();
+    UpdateTabBottomBorderLineVisualStates();
 }
 
-void TabView::UpdateTabBorderVisualStates()
+void TabView::UpdateTabBottomBorderLineVisualStates()
 {
     const int numItems = static_cast<int>(TabItems().Size());
     const int selectedIndex = SelectedIndex();
 
     for (int i = 0; i < numItems; i++)
     {
-        auto state = L"NormalBorder";
+        auto state = L"NormalBottomBorderLine";
         if (m_isDragging)
         {
-            state = L"NoBorder";
+            state = L"NoBottomBorderLine";
         }
         else if (selectedIndex != -1)
         {
@@ -305,24 +305,24 @@ void TabView::UpdateTabBorderVisualStates()
     }
 }
 
-void TabView::UpdateBorderVisualStates()
+void TabView::UpdateBottomBorderLineVisualStates()
 {
     // Update border line on all tabs
-    UpdateTabBorderVisualStates();
+    UpdateTabBottomBorderLineVisualStates();
 
     // Update border lines on the TabView
-    winrt::VisualStateManager::GoToState(*this, m_isDragging ? L"SingleBorder" : L"NormalBorder", false /*useTransitions*/);
+    winrt::VisualStateManager::GoToState(*this, m_isDragging ? L"SingleBottomBorderLine" : L"NormalBottomBorderLine", false /*useTransitions*/);
 
     // Update border lines in the inner TabViewListView
     if (const auto lv = m_listView.get())
     {
-        winrt::VisualStateManager::GoToState(lv, m_isDragging ? L"NoBorder" : L"NormalBorder", false /*useTransitions*/);
+        winrt::VisualStateManager::GoToState(lv, m_isDragging ? L"NoBottomBorderLine" : L"NormalBottomBorderLine", false /*useTransitions*/);
     }
 
     // Update border lines in the ScrollViewer
     if (const auto scroller = m_scrollViewer.get())
     {
-        winrt::VisualStateManager::GoToState(scroller, m_isDragging ? L"NoBorder" : L"NormalBorder", false /*useTransitions*/);
+        winrt::VisualStateManager::GoToState(scroller, m_isDragging ? L"NoBottomBorderLine" : L"NormalBottomBorderLine", false /*useTransitions*/);
     }
 }
 
@@ -561,7 +561,7 @@ void TabView::OnListViewLoaded(const winrt::IInspectable&, const winrt::RoutedEv
         }
     }
 
-    UpdateTabBorderVisualStates();
+    UpdateTabBottomBorderLineVisualStates();
 }
 
 void TabView::OnTabStripPointerExited(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
@@ -757,7 +757,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
         }
     }
 
-    UpdateTabBorderVisualStates();
+    UpdateTabBottomBorderLineVisualStates();
 }
 
 void TabView::OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args)
@@ -815,7 +815,7 @@ void TabView::OnListViewDragItemsStarting(const winrt::IInspectable& sender, con
 
     m_tabDragStartingEventSource(*this, *myArgs);
 
-    UpdateBorderVisualStates();
+    UpdateBottomBorderLineVisualStates();
 }
 
 void TabView::OnListViewDragOver(const winrt::IInspectable& sender, const winrt::DragEventArgs& args)
@@ -845,7 +845,7 @@ void TabView::OnListViewDragItemsCompleted(const winrt::IInspectable& sender, co
         m_tabDroppedOutsideEventSource(*this, *tabDroppedArgs);
     }
 
-    UpdateBorderVisualStates();
+    UpdateBottomBorderLineVisualStates();
 }
 
 void TabView::UpdateTabContent()

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -990,15 +990,30 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths, bool fillAllAvailableSpac
 
                     // If we should fill all of the available space, use scrollviewer dimensions
                     auto const padding = Padding();
+
+                    double headerWidth = 0.0;
+                    double footerWidth = 0.0;
+                    if (auto&& itemsPresenter = m_itemsPresenter.get())
+                    {
+                        if (auto const header = itemsPresenter.Header().try_as<winrt::FrameworkElement>())
+                        {
+                            headerWidth = header.ActualWidth();
+                        }
+                        if (auto const footer = itemsPresenter.Footer().try_as<winrt::FrameworkElement>())
+                        {
+                            footerWidth = footer.ActualWidth();
+                        }
+                    }
+
                     if (fillAllAvailableSpace)
                     {
                         // Calculate the proportional width of each tab given the width of the ScrollViewer.
-                        auto const tabWidthForScroller = (availableWidth - (padding.Left + padding.Right)) / (double)(TabItems().Size());
+                        auto const tabWidthForScroller = (availableWidth - (padding.Left + padding.Right + headerWidth + footerWidth)) / (double)(TabItems().Size());
                         tabWidth = std::clamp(tabWidthForScroller, minTabWidth, maxTabWidth);
                     }
                     else
                     {
-                        double availableTabViewSpace = (tabColumn.ActualWidth() - (padding.Left + padding.Right));
+                        double availableTabViewSpace = (tabColumn.ActualWidth() - (padding.Left + padding.Right + headerWidth + footerWidth));
                         if (const auto increaseButton = m_scrollIncreaseButton.get())
                         {
                             if (increaseButton.Visibility() == winrt::Visibility::Visible)
@@ -1022,8 +1037,8 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths, bool fillAllAvailableSpac
 
 
                     // Size tab column to needed size
-                    tabColumn.MaxWidth(availableWidth);
-                    auto requiredWidth = tabWidth * TabItems().Size();
+                    tabColumn.MaxWidth(availableWidth + headerWidth + footerWidth);
+                    auto requiredWidth = tabWidth * TabItems().Size() + headerWidth + footerWidth;
                     if (requiredWidth > availableWidth - (padding.Left + padding.Right))
                     {
                         tabColumn.Width(winrt::GridLengthHelper::FromPixels(availableWidth));

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -164,6 +164,8 @@ private:
 
     int GetItemCount();
 
+    void UpdateTabBorderVisualStates();
+
     winrt::TabViewItem FindTabViewItemFromDragItem(const winrt::IInspectable& item);
 
     bool m_updateTabWidthOnPointerLeave{ false };
@@ -215,4 +217,6 @@ private:
     winrt::hstring m_tabCloseButtonTooltipText{};
 
     winrt::Size previousAvailableSize{};
+
+    bool m_isDragging{ false };
 };

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -164,6 +164,7 @@ private:
 
     int GetItemCount();
 
+    void UpdateBorderVisualStates();
     void UpdateTabBorderVisualStates();
 
     winrt::TabViewItem FindTabViewItemFromDragItem(const winrt::IInspectable& item);

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -164,8 +164,8 @@ private:
 
     int GetItemCount();
 
-    void UpdateBorderVisualStates();
-    void UpdateTabBorderVisualStates();
+    void UpdateBottomBorderLineVisualStates();
+    void UpdateTabBottomBorderLineVisualStates();
 
     winrt::TabViewItem FindTabViewItemFromDragItem(const winrt::IInspectable& item);
 

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -26,6 +26,18 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="NormalBorder"/>
+                                <VisualState x:Name="SingleBorder">
+                                    <VisualState.Setters>
+                                        <Setter Target="LeftBorder.(Grid.ColumnSpan)" Value="4"/>
+                                        <Setter Target="RightBorder.Visibility" Value="Collapsed"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
                         <Grid x:Name="TabContainerGrid"
                                 Background="{TemplateBinding Background}"
                                 XYFocusKeyboardNavigation="Enabled">
@@ -37,9 +49,9 @@
                                 <ColumnDefinition Width="*" x:Name="RightContentColumn"/>
                             </Grid.ColumnDefinitions>
 
-                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
+                            <Border x:Name="LeftBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
 
-                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
+                            <Border x:Name="RightBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
 
                             <ContentPresenter
                                 Grid.Column="0"
@@ -156,6 +168,16 @@
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
+
+                            <VisualStateGroup>
+                                <VisualState x:Name="NormalBorder"/>
+                                <VisualState x:Name="NoBorder">
+                                    <VisualState.Setters>
+                                        <Setter Target="LeftBorder.Visibility" Value="Collapsed"/>
+                                        <Setter Target="RightBorder.Visibility" Value="Collapsed"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
                         <ScrollViewer x:Name="ScrollViewer"
@@ -205,6 +227,18 @@
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}">
 
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="NormalBorder"/>
+                                <VisualState x:Name="NoBorder">
+                                    <VisualState.Setters>
+                                        <Setter Target="LeftBorder.Visibility" Value="Collapsed"/>
+                                        <Setter Target="RightBorder.Visibility" Value="Collapsed"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
@@ -212,9 +246,9 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
-                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
+                            <Border x:Name="LeftBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
 
-                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" VerticalAlignment="Bottom"/>
+                            <Border x:Name="RightBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" VerticalAlignment="Bottom"/>
 
                             <Border x:Name="ScrollDecreaseButtonContainer"
                                 Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
@@ -667,6 +701,11 @@
                                 <VisualState x:Name="RightOfSelectedTab">
                                     <VisualState.Setters>
                                         <Setter Target="BottomBorderLine.Margin" Value="2,0,0,0"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="NoBorder">
+                                    <VisualState.Setters>
+                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -28,11 +28,11 @@
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup>
-                                <VisualState x:Name="NormalBorder"/>
-                                <VisualState x:Name="SingleBorder">
+                                <VisualState x:Name="NormalBottomBorderLine"/>
+                                <VisualState x:Name="SingleBottomBorderLine">
                                     <VisualState.Setters>
-                                        <Setter Target="LeftBorder.(Grid.ColumnSpan)" Value="4"/>
-                                        <Setter Target="RightBorder.Visibility" Value="Collapsed"/>
+                                        <Setter Target="LeftBottomBorderLine.(Grid.ColumnSpan)" Value="4"/>
+                                        <Setter Target="RightBottomBorderLine.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -49,9 +49,9 @@
                                 <ColumnDefinition Width="*" x:Name="RightContentColumn"/>
                             </Grid.ColumnDefinitions>
 
-                            <Border x:Name="LeftBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
+                            <Border x:Name="LeftBottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" VerticalAlignment="Bottom"/>
 
-                            <Border x:Name="RightBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
+                            <Border x:Name="RightBottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
 
                             <ContentPresenter
                                 Grid.Column="0"
@@ -152,29 +152,29 @@
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup>
-                                <VisualState x:Name="LeftBorderNormal" />
-                                <VisualState x:Name="LeftBorderShort">
+                                <VisualState x:Name="LeftBottomBorderLineNormal" />
+                                <VisualState x:Name="LeftBottomBorderLineShort">
                                     <VisualState.Setters>
-                                        <Setter Target="LeftBorder.Width" Value="2" />
+                                        <Setter Target="LeftBottomBorderLine.Width" Value="2" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
 
                             <VisualStateGroup>
-                                <VisualState x:Name="RightBorderNormal" />
-                                <VisualState x:Name="RightBorderShort">
+                                <VisualState x:Name="RightBottomBorderLineNormal" />
+                                <VisualState x:Name="RightBottomBorderLineShort">
                                     <VisualState.Setters>
-                                        <Setter Target="RightBorder.Width" Value="2" />
+                                        <Setter Target="RightBottomBorderLine.Width" Value="2" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
 
                             <VisualStateGroup>
-                                <VisualState x:Name="NormalBorder"/>
-                                <VisualState x:Name="NoBorder">
+                                <VisualState x:Name="NormalBottomBorderLine"/>
+                                <VisualState x:Name="NoBottomBorderLine">
                                     <VisualState.Setters>
-                                        <Setter Target="LeftBorder.Visibility" Value="Collapsed"/>
-                                        <Setter Target="RightBorder.Visibility" Value="Collapsed"/>
+                                        <Setter Target="LeftBottomBorderLine.Visibility" Value="Collapsed"/>
+                                        <Setter Target="RightBottomBorderLine.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -201,12 +201,12 @@
                                 Padding="{TemplateBinding Padding}">
                                 <ItemsPresenter.Header>
                                     <Grid Width="4">
-                                        <Border x:Name="LeftBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Width="4" Height="1" VerticalAlignment="Bottom" HorizontalAlignment="Left"/>
+                                        <Border x:Name="LeftBottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Width="4" Height="1" VerticalAlignment="Bottom" HorizontalAlignment="Left"/>
                                     </Grid>
                                 </ItemsPresenter.Header>
                                 <ItemsPresenter.Footer>
                                     <Grid Width="4">
-                                        <Border x:Name="RightBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Width="4" Height="1" VerticalAlignment="Bottom" HorizontalAlignment="Right"/>
+                                        <Border x:Name="RightBottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Width="4" Height="1" VerticalAlignment="Bottom" HorizontalAlignment="Right"/>
                                     </Grid>
                                 </ItemsPresenter.Footer>
                             </ItemsPresenter>
@@ -229,11 +229,11 @@
 
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup>
-                                <VisualState x:Name="NormalBorder"/>
-                                <VisualState x:Name="NoBorder">
+                                <VisualState x:Name="NormalBottomBorderLine"/>
+                                <VisualState x:Name="NoBottomBorderLine">
                                     <VisualState.Setters>
-                                        <Setter Target="LeftBorder.Visibility" Value="Collapsed"/>
-                                        <Setter Target="RightBorder.Visibility" Value="Collapsed"/>
+                                        <Setter Target="LeftBottomBorderLine.Visibility" Value="Collapsed"/>
+                                        <Setter Target="RightBottomBorderLine.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -246,9 +246,9 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
-                            <Border x:Name="LeftBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
+                            <Border x:Name="LeftBottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" VerticalAlignment="Bottom"/>
 
-                            <Border x:Name="RightBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" VerticalAlignment="Bottom"/>
+                            <Border x:Name="RightBottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" VerticalAlignment="Bottom"/>
 
                             <Border x:Name="ScrollDecreaseButtonContainer"
                                 Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
@@ -692,7 +692,7 @@
                             </VisualStateGroup>
 
                             <VisualStateGroup>
-                                <VisualState x:Name="NormalBorder"/>
+                                <VisualState x:Name="NormalBottomBorderLine"/>
                                 <VisualState x:Name="LeftOfSelectedTab">
                                     <VisualState.Setters>
                                         <Setter Target="BottomBorderLine.Margin" Value="0,0,2,0"/>
@@ -703,7 +703,7 @@
                                         <Setter Target="BottomBorderLine.Margin" Value="2,0,0,0"/>
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="NoBorder">
+                                <VisualState x:Name="NoBottomBorderLine">
                                     <VisualState.Setters>
                                         <Setter Target="BottomBorderLine.Visibility" Value="Collapsed"/>
                                     </VisualState.Setters>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -37,7 +37,9 @@
                                 <ColumnDefinition Width="*" x:Name="RightContentColumn"/>
                             </Grid.ColumnDefinitions>
 
-                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.ColumnSpan="4" VerticalAlignment="Bottom"/>
+                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
+
+                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
 
                             <ContentPresenter
                                 Grid.Column="0"
@@ -135,6 +137,27 @@
                         BorderThickness="{TemplateBinding BorderThickness}"
                         contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="LeftBorderNormal" />
+                                <VisualState x:Name="LeftBorderShort">
+                                    <VisualState.Setters>
+                                        <Setter Target="LeftBorder.Width" Value="2" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                            <VisualStateGroup>
+                                <VisualState x:Name="RightBorderNormal" />
+                                <VisualState x:Name="RightBorderShort">
+                                    <VisualState.Setters>
+                                        <Setter Target="RightBorder.Width" Value="2" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
                         <ScrollViewer x:Name="ScrollViewer"
                             Grid.Column="1"
                             AutomationProperties.AccessibilityView="Raw"
@@ -153,7 +176,18 @@
                             Style="{StaticResource TabScrollViewerStyle}">
 
                             <ItemsPresenter x:Name="TabsItemsPresenter"
-                                Padding="{TemplateBinding Padding}" />
+                                Padding="{TemplateBinding Padding}">
+                                <ItemsPresenter.Header>
+                                    <Grid Width="4">
+                                        <Border x:Name="LeftBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Width="4" Height="1" VerticalAlignment="Bottom" HorizontalAlignment="Left"/>
+                                    </Grid>
+                                </ItemsPresenter.Header>
+                                <ItemsPresenter.Footer>
+                                    <Grid Width="4">
+                                        <Border x:Name="RightBorder" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Width="4" Height="1" VerticalAlignment="Bottom" HorizontalAlignment="Right"/>
+                                    </Grid>
+                                </ItemsPresenter.Footer>
+                            </ItemsPresenter>
 
                         </ScrollViewer>
                     </Border>
@@ -178,6 +212,10 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
+                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="0" VerticalAlignment="Bottom"/>
+
+                            <Border BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.Column="2" VerticalAlignment="Bottom"/>
+
                             <Border x:Name="ScrollDecreaseButtonContainer"
                                 Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
                                 Padding="{ThemeResource TabViewItemLeftScrollButtonContainerPadding}"
@@ -190,6 +228,7 @@
                                     Content="&#xEDD9;"
                                     Style="{ThemeResource TabViewScrollButtonStyle}"/>
                             </Border>
+                            
                             <ScrollContentPresenter x:Name="ScrollContentPresenter"
                                 Grid.Column="1"
                                 Padding="1,0,0,0"
@@ -390,6 +429,7 @@
 
                                 <VisualState x:Name="Selected">
                                     <VisualState.Setters>
+                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed"/>
                                         <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible"/>
                                         <Setter Target="RightRadiusRenderTriangle.Visibility" Value="Visible"/>
                                         <Setter Target="RightRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
@@ -412,6 +452,7 @@
 
                                 <VisualState x:Name="PointerOverSelected">
                                     <VisualState.Setters>
+                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed"/>
                                         <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible"/>
                                         <Setter Target="RightRadiusRenderTriangle.Visibility" Value="Visible"/>
                                         <Setter Target="RightRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
@@ -434,6 +475,7 @@
 
                                 <VisualState x:Name="PressedSelected">
                                     <VisualState.Setters>
+                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed"/>
                                         <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible"/>
                                         <Setter Target="RightRadiusRenderTriangle.Visibility" Value="Visible"/>
                                         <Setter Target="RightRadiusRenderTriangle.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
@@ -553,14 +595,6 @@
                                                  Storyboard.TargetProperty="Opacity"
                                                  To="{ThemeResource ListViewItemReorderTargetThemeOpacity}"
                                                  Duration="0:0:0.240" />
-                                        <DoubleAnimation Storyboard.TargetName="LayoutRootScale"
-                                                 Storyboard.TargetProperty="ScaleX"
-                                                 To="{ThemeResource ListViewItemReorderTargetThemeScale}"
-                                                 Duration="0:0:0.240" />
-                                        <DoubleAnimation Storyboard.TargetName="LayoutRootScale"
-                                                 Storyboard.TargetProperty="ScaleY"
-                                                 To="{ThemeResource ListViewItemReorderTargetThemeScale}"
-                                                 Duration="0:0:0.240" />
                                     </Storyboard>
                                 </VisualState>
 
@@ -622,9 +656,24 @@
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
+
+                            <VisualStateGroup>
+                                <VisualState x:Name="NormalBorder"/>
+                                <VisualState x:Name="LeftOfSelectedTab">
+                                    <VisualState.Setters>
+                                        <Setter Target="BottomBorderLine.Margin" Value="0,0,2,0"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="RightOfSelectedTab">
+                                    <VisualState.Setters>
+                                        <Setter Target="BottomBorderLine.Margin" Value="2,0,0,0"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
 
-
+                        <Border x:Name="BottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.ColumnSpan="3" VerticalAlignment="Bottom"/>
+                        
                         <Path x:Name="LeftRadiusRenderArc"
                             x:Load="False"
                             Fill="{ThemeResource CardStrokeColorDefault}"

--- a/dev/TabView/TabViewListView.cpp
+++ b/dev/TabView/TabViewListView.cpp
@@ -17,6 +17,21 @@ TabViewListView::TabViewListView()
     SetDefaultStyleKey(this);
 
     ContainerContentChanging({ this, &TabViewListView::OnContainerContentChanging });
+
+    RegisterPropertyChangedCallback(winrt::Selector::SelectedIndexProperty(), { this, &TabViewListView::OnSelectedIndexPropertyChanged });
+}
+
+void TabViewListView::OnSelectedIndexPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
+{
+    winrt::VisualStateManager::GoToState(
+        *this,
+        (SelectedIndex() == 0) ? L"LeftBorderShort" : L"LeftBorderNormal",
+        false /*useTransitions*/);
+
+    winrt::VisualStateManager::GoToState(
+        *this,
+        (SelectedIndex() == (int)(Items().Size() - 1)) ? L"RightBorderShort" : L"RightBorderNormal",
+        false /*useTransitions*/);
 }
 
 // IItemsControlOverrides

--- a/dev/TabView/TabViewListView.cpp
+++ b/dev/TabView/TabViewListView.cpp
@@ -25,12 +25,12 @@ void TabViewListView::OnSelectedIndexPropertyChanged(const winrt::DependencyObje
 {
     winrt::VisualStateManager::GoToState(
         *this,
-        (SelectedIndex() == 0) ? L"LeftBorderShort" : L"LeftBorderNormal",
+        (SelectedIndex() == 0) ? L"LeftBottomBorderLineShort" : L"LeftBottomBorderLineNormal",
         false /*useTransitions*/);
 
     winrt::VisualStateManager::GoToState(
         *this,
-        (SelectedIndex() == (int)(Items().Size() - 1)) ? L"RightBorderShort" : L"RightBorderNormal",
+        (SelectedIndex() == (int)(Items().Size() - 1)) ? L"RightBottomBorderLineShort" : L"RightBottomBorderLineNormal",
         false /*useTransitions*/);
 }
 

--- a/dev/TabView/TabViewListView.h
+++ b/dev/TabView/TabViewListView.h
@@ -18,5 +18,6 @@ public:
 
 private:
     void OnContainerContentChanging(const winrt::IInspectable& sender, const winrt::ContainerContentChangingEventArgs& args);
+    void OnSelectedIndexPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
 };
 

--- a/dev/TabView/TabView_themeresources.xaml
+++ b/dev/TabView/TabView_themeresources.xaml
@@ -204,7 +204,7 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="TabViewHeaderPadding">4,8,4,0</Thickness>
+    <Thickness x:Key="TabViewHeaderPadding">0,8,0,0</Thickness>
     <Thickness x:Key="TabViewItemHeaderPadding">8,3,4,3</Thickness>
     <Thickness x:Key="TabViewSelectedItemHeaderPadding">9,3,5,4</Thickness>
 

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -133,6 +133,12 @@
                     TabDroppedOutside="TabViewTabDroppedOutside"
                     AddTabButtonClick="AddButtonClick">
 
+                    <controls:TabView.Resources>
+                        <ResourceDictionary>
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="#88FFFFFF"/>
+                        </ResourceDictionary>
+                    </controls:TabView.Resources>
+
                     <controls:TabView.TabStripFooter>
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -166,20 +172,20 @@
                         </StackPanel>
                     </controls:TabViewItem>
 
-                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab" IsClosable="True" Foreground="Red" Background="Green">
+                    <controls:TabViewItem x:Name="SecondTab" Header="SecondTab" IsClosable="True">
                         <controls:TabViewItem.IconSource>
                             <controls:SymbolIconSource Symbol="Shop"/>
                         </controls:TabViewItem.IconSource>
 
-                        <StackPanel Padding="16">
-                            <TextBlock Text="Shop text"/>
+                        <StackPanel Padding="16" Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
+                            <TextBlock>Shop text</TextBlock>
                             <Button Content="SecondTabButton" AutomationProperties.Name="SecondTabButton"/>
                         </StackPanel>
                     </controls:TabViewItem>
 
                     <controls:TabViewItem x:Name="LongHeaderTab" AutomationProperties.Name="LongHeaderTab" Header="Long Header No Icon">
-                        <StackPanel Padding="16">
-                            <TextBlock Text="Emoji text"/>
+                        <StackPanel Padding="16" Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
+                            <TextBlock >Emoji text</TextBlock>
                             <Button Content="Button 3"/>
                         </StackPanel>
                     </controls:TabViewItem>
@@ -189,8 +195,8 @@
                             <controls:SymbolIconSource Symbol="Video"/>
                         </controls:TabViewItem.IconSource>
 
-                        <StackPanel>
-                            <TextBlock Padding="16" Text="This tab can't be closed."/>
+                        <StackPanel Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
+                            <TextBlock Padding="16">This tab can't be closed.</TextBlock>
                         </StackPanel>
                     </controls:TabViewItem>
 
@@ -199,8 +205,8 @@
                             <controls:SymbolIconSource Symbol="Admin"/>
                         </controls:TabViewItem.IconSource>
 
-                        <StackPanel>
-                            <TextBlock Padding="16" Text="This tab can't be selected."/>
+                        <StackPanel Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
+                            <TextBlock Padding="16">This tab can't be selected.</TextBlock>
                         </StackPanel>
                     </controls:TabViewItem>
 
@@ -209,7 +215,9 @@
                             <controls:SymbolIconSource Symbol="Contact"/>
                         </controls:TabViewItem.IconSource>
 
-                        <TextBlock x:Name="LastTabContent" AutomationProperties.Name="LastTabContent" Padding="16" Text="Contact text"/>
+                        <StackPanel Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
+                            <TextBlock x:Name="LastTabContent" AutomationProperties.Name="LastTabContent" Padding="16">Contact text</TextBlock>
+                        </StackPanel>
                     </controls:TabViewItem>
 
                 </controls:TabView>

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -338,7 +338,7 @@ namespace MUXControlsTestApp
         public void SetTabViewWidth_Click(object sender, RoutedEventArgs e)
         {
             // This is the smallest width that fits our content without any scrolling.
-            Tabs.Width = 744;
+            Tabs.Width = 752;
         }
 
         public void GetScrollButtonsVisible_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The single border line that ran underneath the selected tab doesn't work when the selected tab color is partly transparent. This change breaks it up to run underneath all of the pieces of TabView separately -- which is a lot of places -- except for the selected tab. When the user is dragging a tab, however, we hide all those individual pieces and show a single line again.