### PR TITLE
Revert `WidthExpansionDelta`

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -678,7 +678,7 @@ void CommandBarFlyoutCommandBar::UpdateTemplateSettings()
             collapsedWidth = static_cast<float>(expandedWidth);
         }
 
-        flyoutTemplateSettings->WidthExpansionDelta(0);
+        flyoutTemplateSettings->WidthExpansionDelta(collapsedWidth - expandedWidth);
         flyoutTemplateSettings->WidthExpansionAnimationStartPosition(-flyoutTemplateSettings->WidthExpansionDelta() / 2.0);
         flyoutTemplateSettings->WidthExpansionAnimationEndPosition(-flyoutTemplateSettings->WidthExpansionDelta());
         flyoutTemplateSettings->ContentClipRect({ 0, 0, static_cast<float>(expandedWidth), primaryItemsRootDesiredSize.Height });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert `WidthExpansionDelta` change from #6044 as it removes the CommandBarFlyout expansion animations. However, this causes a separate issue where there is a weird crop when PrimaryCommandItems are added dynamically. 

This issue is filed as a separate bug here: #6345