### PR TITLE
Move to build WinUI with latest Windows SDK (22000)

### DIFF
--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -8,7 +8,7 @@
     <SDKVersionRS5>10.0.17763.0</SDKVersionRS5>
     <SDKVersion19H1>10.0.18362.0</SDKVersion19H1>
     <SDKVersion21H1>10.0.22000.0</SDKVersion21H1>
-    <!-- <SDKVersionInsider>10.0.DONOTUSE.0</SDKVersionInsider> -->
+    <SDKVersionInsider>10.0.22000.0</SDKVersionInsider> <!-- Matches SDKVersion21H1 -->
   </PropertyGroup>
   <PropertyGroup>
     <!-- By default we use the publicly shipped SDK version which is 21H1 now -->

--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- By default we use the publicly shipped SDK version which is 21H1 now -->
-    <MuxSdkVersion>$(SDKVersion21H1)</MuxSdkVersion>
+    <MuxSdkVersion Condition="$(UseInsiderSDK) != 'true'">$(SDKVersion21H1)</MuxSdkVersion>
 
     <!-- Setting UseInsiderSDK will allow the code to build to the newest insider SDK 
          In order to get this from a cmd prompt run 

--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -7,11 +7,12 @@
     <SDKVersionRS4>10.0.17134.0</SDKVersionRS4>
     <SDKVersionRS5>10.0.17763.0</SDKVersionRS5>
     <SDKVersion19H1>10.0.18362.0</SDKVersion19H1>
-    <SDKVersionInsider>10.0.21681.0</SDKVersionInsider>
+    <SDKVersion21H1>10.0.22000.0</SDKVersion21H1>
+    <!-- <SDKVersionInsider>10.0.DONOTUSE.0</SDKVersionInsider> -->
   </PropertyGroup>
   <PropertyGroup>
-    <!-- By default we use the publicly shipped SDK version which is 19H1 now -->
-    <MuxSdkVersion Condition="$(UseInsiderSDK) != 'true'">$(SDKVersion19H1)</MuxSdkVersion>
+    <!-- By default we use the publicly shipped SDK version which is 21H1 now -->
+    <MuxSdkVersion>$(SDKVersion21H1)</MuxSdkVersion>
 
     <!-- Setting UseInsiderSDK will allow the code to build to the newest insider SDK 
          In order to get this from a cmd prompt run 

--- a/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
@@ -1,5 +1,5 @@
 parameters:
-  sdkVersion: 18362
+  sdkVersion: 22000
 
 steps:
   - task: powershell@2
@@ -8,30 +8,3 @@ steps:
       filePath: build\Install-WindowsSdkISO.ps1
       arguments: ${{ parameters.sdkVersion }}
     displayName: 'Install Windows SDK (${{ parameters.sdkVersion }})'
-
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    condition: eq(variables['UseInsiderSDK'], 'true')
-    displayName: 'Install Insider Windows SDK Part 1'
-    inputs:
-      command: custom
-      arguments: 'install InternalWindowsSDK-part1 -NonInteractive -Version 1.0.7 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
-
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    condition: eq(variables['UseInsiderSDK'], 'true')
-    displayName: 'Install Insider Windows SDK Part 2'
-    inputs:
-      command: custom
-      arguments: 'install InternalWindowsSDK-part2 -NonInteractive -Version 1.0.7 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
-
-  - task: CmdLine@1
-    condition: eq(variables['UseInsiderSDK'], 'true')
-    displayName: 'Merge Insider Windows SDK Parts'
-    inputs:
-      filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\MergeNupkgParts.cmd'
-
-  - task: CmdLine@1
-    condition: eq(variables['UseInsiderSDK'], 'true')
-    displayName: 'Set up Insider Windows SDK'
-    inputs:
-      filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\SetUpInternalWindowsSDK.cmd'
-

--- a/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallWindowsSDK-Steps.yml
@@ -8,3 +8,31 @@ steps:
       filePath: build\Install-WindowsSdkISO.ps1
       arguments: ${{ parameters.sdkVersion }}
     displayName: 'Install Windows SDK (${{ parameters.sdkVersion }})'
+
+  # Not currently in use. Uncomment when we need to use an Insider/Internal SDK again.
+  # - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  #   condition: eq(variables['UseInsiderSDK'], 'true')
+  #   displayName: 'Install Insider Windows SDK Part 1'
+  #   inputs:
+  #     command: custom
+  #     arguments: 'install InternalWindowsSDK-part1 -NonInteractive -Version 1.0.7 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
+
+  # - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  #   condition: eq(variables['UseInsiderSDK'], 'true')
+  #   displayName: 'Install Insider Windows SDK Part 2'
+  #   inputs:
+  #     command: custom
+  #     arguments: 'install InternalWindowsSDK-part2 -NonInteractive -Version 1.0.7 -Source https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUIInternalWindowsSDK/nuget/v3/index.json -OutputDirectory packages -PackageSaveMode nupkg'
+
+  # - task: CmdLine@1
+  #   condition: eq(variables['UseInsiderSDK'], 'true')
+  #   displayName: 'Merge Insider Windows SDK Parts'
+  #   inputs:
+  #     filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\MergeNupkgParts.cmd'
+
+  # - task: CmdLine@1
+  #   condition: eq(variables['UseInsiderSDK'], 'true')
+  #   displayName: 'Set up Insider Windows SDK'
+  #   inputs:
+  #     filename: '$(Build.SourcesDirectory)\tools\InternalWindowsSDKNuget\SetUpInternalWindowsSDK.cmd'
+

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -89,7 +89,7 @@ private:
     tracker_ref<winrt::FrameworkElement> m_secondaryItemsRoot{ this };
     tracker_ref<winrt::ButtonBase> m_moreButton{ this };
     weak_ref<winrt::CommandBarFlyout> m_owningFlyout{ nullptr };
-    winrt::IPopup4::ActualPlacementChanged_revoker m_overflowPopupActualPlacementChangedRevoker{};
+    winrt::Popup::ActualPlacementChanged_revoker m_overflowPopupActualPlacementChangedRevoker{};
     RoutedEventHandler_revoker m_keyDownRevoker{};
     winrt::UIElement::PreviewKeyDown_revoker m_secondaryItemsRootPreviewKeyDownRevoker{};
     winrt::FrameworkElement::SizeChanged_revoker m_secondaryItemsRootSizeChangedRevoker{};

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.idl
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.idl
@@ -1,29 +1,29 @@
-﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
-{
+﻿// namespace MU_PRIVATE_CONTROLS_NAMESPACE
+// {
 
-[MUX_INTERNAL]
-[webhosthidden]
-[uuid(1870b836-df2f-5fc6-a5f2-748ed6ce7321)]
-interface IPopup4
-{
-    Windows.UI.Xaml.FrameworkElement PlacementTarget;
-    Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode DesiredPlacement;
-    Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode ActualPlacement{ get; };
+// [MUX_INTERNAL]
+// [webhosthidden]
+// [uuid(1870b836-df2f-5fc6-a5f2-748ed6ce7321)]
+// interface IPopup4
+// {
+//     Windows.UI.Xaml.FrameworkElement PlacementTarget;
+//     Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode DesiredPlacement;
+//     Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode ActualPlacement{ get; };
 
-    event Windows.Foundation.EventHandler<Object> ActualPlacementChanged;
-};
+//     event Windows.Foundation.EventHandler<Object> ActualPlacementChanged;
+// };
 
-[MUX_INTERNAL]
-[webhosthidden]
-[uuid(98ffd442-a3f5-534c-906d-88b72a78126b)]
-interface IAutomationPropertiesStatics9
-{
-    Windows.UI.Xaml.DependencyProperty ControlTypeProperty{ get; };
-    Windows.UI.Xaml.Automation.Peers.AutomationControlType GetControlType(Windows.UI.Xaml.UIElement element);
-    void SetControlType(Windows.UI.Xaml.UIElement element, Windows.UI.Xaml.Automation.Peers.AutomationControlType value);
-};
+// [MUX_INTERNAL]
+// [webhosthidden]
+// [uuid(98ffd442-a3f5-534c-906d-88b72a78126b)]
+// interface IAutomationPropertiesStatics9
+// {
+//     Windows.UI.Xaml.DependencyProperty ControlTypeProperty{ get; };
+//     Windows.UI.Xaml.Automation.Peers.AutomationControlType GetControlType(Windows.UI.Xaml.UIElement element);
+//     void SetControlType(Windows.UI.Xaml.UIElement element, Windows.UI.Xaml.Automation.Peers.AutomationControlType value);
+// };
 
-}
+// }
 
 namespace MU_XCP_NAMESPACE
 {
@@ -66,25 +66,25 @@ unsealed runtimeclass CommandBarFlyoutCommandBar : Windows.UI.Xaml.Controls.Comm
     CommandBarFlyoutCommandBarTemplateSettings FlyoutTemplateSettings { get; };
 };
 
-// Needed so we can access these enum and interfaces until they ship in the official SDK.
-[MUX_PUBLIC]
-[webhosthidden]
-enum PopupPlacementMode
-{
-    Auto,
-    Top,
-    Bottom,
-    Left,
-    Right,
-    TopEdgeAlignedLeft,
-    TopEdgeAlignedRight,
-    BottomEdgeAlignedLeft,
-    BottomEdgeAlignedRight,
-    LeftEdgeAlignedTop,
-    LeftEdgeAlignedBottom,
-    RightEdgeAlignedTop,
-    RightEdgeAlignedBottom,
-};
+// // Needed so we can access these enum and interfaces until they ship in the official SDK.
+// [MUX_PUBLIC]
+// [webhosthidden]
+// enum PopupPlacementMode
+// {
+//     Auto,
+//     Top,
+//     Bottom,
+//     Left,
+//     Right,
+//     TopEdgeAlignedLeft,
+//     TopEdgeAlignedRight,
+//     BottomEdgeAlignedLeft,
+//     BottomEdgeAlignedRight,
+//     LeftEdgeAlignedTop,
+//     LeftEdgeAlignedBottom,
+//     RightEdgeAlignedTop,
+//     RightEdgeAlignedBottom,
+// };
 
 [MUX_PUBLIC]
 [webhosthidden]

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.idl
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.idl
@@ -1,31 +1,4 @@
-﻿// namespace MU_PRIVATE_CONTROLS_NAMESPACE
-// {
-
-// [MUX_INTERNAL]
-// [webhosthidden]
-// [uuid(1870b836-df2f-5fc6-a5f2-748ed6ce7321)]
-// interface IPopup4
-// {
-//     Windows.UI.Xaml.FrameworkElement PlacementTarget;
-//     Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode DesiredPlacement;
-//     Microsoft.UI.Xaml.Controls.Primitives.PopupPlacementMode ActualPlacement{ get; };
-
-//     event Windows.Foundation.EventHandler<Object> ActualPlacementChanged;
-// };
-
-// [MUX_INTERNAL]
-// [webhosthidden]
-// [uuid(98ffd442-a3f5-534c-906d-88b72a78126b)]
-// interface IAutomationPropertiesStatics9
-// {
-//     Windows.UI.Xaml.DependencyProperty ControlTypeProperty{ get; };
-//     Windows.UI.Xaml.Automation.Peers.AutomationControlType GetControlType(Windows.UI.Xaml.UIElement element);
-//     void SetControlType(Windows.UI.Xaml.UIElement element, Windows.UI.Xaml.Automation.Peers.AutomationControlType value);
-// };
-
-// }
-
-namespace MU_XCP_NAMESPACE
+﻿namespace MU_XCP_NAMESPACE
 {
 
 [MUX_PUBLIC]
@@ -65,26 +38,6 @@ unsealed runtimeclass CommandBarFlyoutCommandBar : Windows.UI.Xaml.Controls.Comm
     [MUX_PROPERTY_NEEDS_DP_FIELD]
     CommandBarFlyoutCommandBarTemplateSettings FlyoutTemplateSettings { get; };
 };
-
-// // Needed so we can access these enum and interfaces until they ship in the official SDK.
-// [MUX_PUBLIC]
-// [webhosthidden]
-// enum PopupPlacementMode
-// {
-//     Auto,
-//     Top,
-//     Bottom,
-//     Left,
-//     Right,
-//     TopEdgeAlignedLeft,
-//     TopEdgeAlignedRight,
-//     BottomEdgeAlignedLeft,
-//     BottomEdgeAlignedRight,
-//     LeftEdgeAlignedTop,
-//     LeftEdgeAlignedBottom,
-//     RightEdgeAlignedTop,
-//     RightEdgeAlignedBottom,
-// };
 
 [MUX_PUBLIC]
 [webhosthidden]

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBarAutomationProperties.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBarAutomationProperties.cpp
@@ -18,7 +18,7 @@
 
         if (auto automationPropertiesStatics9 = automationPropertiesStatics.try_as<winrt::IAutomationPropertiesStatics9>())
         {
-            automationPropertiesStatics9.SetControlType(senderAsUIE, unbox_value<winrt::AutomationControlType>(args.NewValue()));
+            automationPropertiesStatics9.SetAutomationControlType(senderAsUIE, unbox_value<winrt::AutomationControlType>(args.NewValue()));
         }
     }
 }

--- a/dev/CommonStyles/CommonStyles.vcxitems
+++ b/dev/CommonStyles/CommonStyles.vcxitems
@@ -162,7 +162,6 @@
       <ControlsResourcesVersion>Version2</ControlsResourcesVersion>
       <Version>21H1</Version>
       <Type>ThemeResources</Type>
-      <RequireInsiderSDK>true</RequireInsiderSDK>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)ListViewItem_themeresources.xaml">
       <ControlsResourcesVersion>Version2</ControlsResourcesVersion>
@@ -173,7 +172,6 @@
       <ControlsResourcesVersion>Version2</ControlsResourcesVersion>
       <Version>21H1</Version>
       <Type>ThemeResources</Type>
-      <RequireInsiderSDK>true</RequireInsiderSDK>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)ListViewItem_themeresources_v1.xaml">
       <ControlsResourcesVersion>Version1</ControlsResourcesVersion>
@@ -279,7 +277,6 @@
       <ControlsResourcesVersion>Version2</ControlsResourcesVersion>
       <Version>21H1</Version>
       <Type>ThemeResources</Type>
-      <RequireInsiderSDK>true</RequireInsiderSDK>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)CalendarView_themeresources_v1.xaml">
       <ControlsResourcesVersion>Version1</ControlsResourcesVersion>

--- a/dev/CommonStyles/TestUI/CalendarViewPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/CalendarViewPage.xaml.cs
@@ -178,7 +178,6 @@ namespace MUXControlsTestApp
 
         private void SetDayItemMargin_Click(object sender, RoutedEventArgs e)
         {
-#if USE_INSIDER_SDK
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
             {
                 string[] thicknessParts = dayItemMargin.Text.Split(',');
@@ -195,12 +194,10 @@ namespace MUXControlsTestApp
                     float.Parse(thicknessParts[2]),
                     float.Parse(thicknessParts[3]));
             }
-#endif
         }
 
         private void SetMonthYearItemMargin_Click(object sender, RoutedEventArgs e)
         {
-#if USE_INSIDER_SDK
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
             {
                 string[] thicknessParts = monthYearItemMargin.Text.Split(',');
@@ -217,12 +214,10 @@ namespace MUXControlsTestApp
                     float.Parse(thicknessParts[2]),
                     float.Parse(thicknessParts[3]));
             }
-#endif
         }
 
         private void SetFirstOfMonthLabelMargin_Click(object sender, RoutedEventArgs e)
         {
-#if USE_INSIDER_SDK
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
             {
                 string[] thicknessParts = firstOfMonthLabelMargin.Text.Split(',');
@@ -239,12 +234,10 @@ namespace MUXControlsTestApp
                     float.Parse(thicknessParts[2]),
                     float.Parse(thicknessParts[3]));
             }
-#endif
         }
 
         private void SetFirstOfYearDecadeLabelMargin_Click(object sender, RoutedEventArgs e)
         {
-#if USE_INSIDER_SDK
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
             {
                 string[] thicknessParts = firstOfYearDecadeLabelMargin.Text.Split(',');
@@ -261,7 +254,6 @@ namespace MUXControlsTestApp
                     float.Parse(thicknessParts[2]),
                     float.Parse(thicknessParts[3]));
             }
-#endif
         }
 
         private void GetDayItemFontSize_Click(object sender, RoutedEventArgs e)
@@ -306,23 +298,19 @@ namespace MUXControlsTestApp
 
         private void SetCalendarItemCornerRadius_Click(object sender, RoutedEventArgs e)
         {
-#if USE_INSIDER_SDK
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
             {
                 PageCalendar2.CalendarItemCornerRadius = PageCalendar.CalendarItemCornerRadius = new CornerRadius(double.Parse(calendarItemCornerRadius.Text));
             }
-#endif
         }
 
         private void ResetCalendarItemCornerRadius_Click(object sender, RoutedEventArgs e)
         {
-#if USE_INSIDER_SDK
             if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
             {
                 PageCalendar.ClearValue(CalendarView.CalendarItemCornerRadiusProperty);
                 PageCalendar2.ClearValue(CalendarView.CalendarItemCornerRadiusProperty);
             }
-#endif
         }
 
         private void GetCalendarItemBorderThickness_Click(object sender, RoutedEventArgs e)
@@ -377,7 +365,6 @@ namespace MUXControlsTestApp
                 case 36: // CalendarViewDayItem.Background
                     return null;
                 default:
-#if USE_INSIDER_SDK
                     if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
                     {
                         switch (brushPropertyName.SelectedIndex)
@@ -424,7 +411,6 @@ namespace MUXControlsTestApp
                                 return null;
                         }
                     }
-#endif // USE_INSIDER_SDK
                     return null;
             }
         }
@@ -519,7 +505,6 @@ namespace MUXControlsTestApp
                     SetBackgrounds(PageCalendar, solidColorBrush);
                     SetBackgrounds(PageCalendar2, solidColorBrush);
                     break;
-#if USE_INSIDER_SDK
                 default:
                     if (PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.TwentyOneH1))
                     {
@@ -585,7 +570,6 @@ namespace MUXControlsTestApp
                         }
                     }
                     break;
-#endif // USE_INSIDER_SDK
             }
         }
 

--- a/dev/dll/Microsoft.UI.Xaml.Common.targets
+++ b/dev/dll/Microsoft.UI.Xaml.Common.targets
@@ -457,14 +457,14 @@
       <RS4StylePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS4' And '%(Type)' == 'DefaultStyle'" />
       <RS5StylePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS5' And '%(Type)' == 'DefaultStyle'" />
       <NineteenH1StylePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '19H1' And '%(Type)' == 'DefaultStyle'" />
-      <TwentyOneH1StylePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '21H1' And '%(Type)' == 'DefaultStyle' And ('%(RequireInsiderSDK)' == 'false' or '$(UseInsiderSDK)' == 'true')" />
+      <TwentyOneH1StylePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '21H1' And '%(Type)' == 'DefaultStyle'" />
       <RS1ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS1' And '%(Type)' == 'ThemeResources'" />
       <RS2ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS2' And '%(Type)' == 'ThemeResources'" />
       <RS3ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS3' And '%(Type)' == 'ThemeResources'" />
       <RS4ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS4' And '%(Type)' == 'ThemeResources'" />
       <RS5ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == 'RS5' And '%(Type)' == 'ThemeResources'" />
       <NineteenH1ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '19H1' And '%(Type)' == 'ThemeResources'" />
-      <TwentyOneH1ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '21H1' And '%(Type)' == 'ThemeResources' And ('%(RequireInsiderSDK)' == 'false' or '$(UseInsiderSDK)' == 'true')" />
+      <TwentyOneH1ThemeResourcePage Include="@(OrderedSharedPage)" Condition="'%(Version)' == '21H1' And '%(Type)' == 'ThemeResources'" />
     </ItemGroup>
   </Target>
   <PropertyGroup>
@@ -582,7 +582,41 @@
       <PageToBeCompiled Include="@(PageRequiringCustomCompilation)" Condition="'%(Filename)' == '21h1_compact_themeresources_v1' And ('$(CompactThemeResourceFileNeedsCompilation)' == 'True' Or !Exists('$(GeneratedFilesDir)\Themes\21h1_compact_themeresources_v1.xbf'))" />
     </ItemGroup>
     <Message Condition="'@(PageToBeCompiled)' != ''" Text="CustomCompile with min version %(PageToBeCompiled.MinSDKVersionRequired) for Pages: @(PageToBeCompiled)" />
-    <CompileXaml Condition="'@(PageToBeCompiled)' != ''" LanguageSourceExtension="$(DefaultLanguageSourceExtension)" Language="$(Language)" RootNamespace="$(RootNamespace)" XamlPages="@(PageToBeCompiled)" XamlApplications="@(ApplicationDefinition)" SdkXamlPages="@(SdkXamlItems)" PriIndexName="$(PriIndexName)" ProjectName="$(XamlProjectName)" IsPass1="False" DisableXbfGeneration="False" CodeGenerationControlFlags="$(XamlCodeGenerationControlFlags)" ClIncludeFiles="@(ClInclude)" CIncludeDirectories="$(XamlCppIncludeDirectories)" LocalAssembly="$(LocalAssembly)" ProjectPath="$(MSBuildProjectFullPath)" OutputPath="$(XamlGeneratedOutputPath)" OutputType="$(OutputType)" ReferenceAssemblyPaths="@(ReferenceAssemblyPaths)" ReferenceAssemblies="@(XamlReferencesToCompile)" ForceSharedStateShutdown="False" CompileMode="RealBuildPass2" XAMLFingerprint="$(XAMLFingerprint)" FingerprintIgnorePaths="$(XAMLFingerprintIgnorePaths)" VCInstallDir="$(VCInstallDir)" WindowsSdkPath="$(WindowsSdkPath)" GenXbf32Path="$(GenXbfPath)" SavedStateFile="$(XamlSavedStateFilePath)" RootsLog="$(XamlRootsLog)" SuppressWarnings="$(SuppressXamlWarnings)" XamlResourceMapName="$(XamlResourceMapName)" XamlComponentResourceLocation="$(XamlComponentResourceLocation)" TargetPlatformMinVersion="%(PageToBeCompiled.MinSDKVersionRequired)" PlatformXmlDir="$(PlatformXmlDir)">
+    <CompileXaml 
+        Condition="'@(PageToBeCompiled)' != ''" 
+        LanguageSourceExtension="$(DefaultLanguageSourceExtension)" 
+        Language="$(Language)" 
+        RootNamespace="$(RootNamespace)" 
+        XamlPages="@(PageToBeCompiled)" 
+        XamlApplications="@(ApplicationDefinition)" 
+        SdkXamlPages="@(SdkXamlItems)" 
+        PriIndexName="$(PriIndexName)" 
+        ProjectName="$(XamlProjectName)" 
+        IsPass1="False" 
+        DisableXbfGeneration="False" 
+        CodeGenerationControlFlags="$(XamlCodeGenerationControlFlags)" 
+        ClIncludeFiles="@(ClInclude)" 
+        CIncludeDirectories="$(XamlCppIncludeDirectories)" 
+        LocalAssembly="$(LocalAssembly)" 
+        ProjectPath="$(MSBuildProjectFullPath)" 
+        OutputPath="$(XamlGeneratedOutputPath)" 
+        OutputType="$(OutputType)" 
+        ReferenceAssemblyPaths="@(ReferenceAssemblyPaths)" 
+        ReferenceAssemblies="@(XamlReferencesToCompile)" 
+        ForceSharedStateShutdown="False" 
+        CompileMode="RealBuildPass2" 
+        XAMLFingerprint="$(XAMLFingerprint)" 
+        FingerprintIgnorePaths="$(XAMLFingerprintIgnorePaths)" 
+        VCInstallDir="$(VCInstallDir)" 
+        WindowsSdkPath="$(WindowsSdkPath)" 
+        GenXbf32Path="$(GenXbfPath)" 
+        SavedStateFile="$(XamlSavedStateFilePath)" 
+        RootsLog="$(XamlRootsLog)" 
+        SuppressWarnings="$(SuppressXamlWarnings)" 
+        XamlResourceMapName="$(XamlResourceMapName)" 
+        XamlComponentResourceLocation="$(XamlComponentResourceLocation)" 
+        TargetPlatformMinVersion="%(PageToBeCompiled.MinSDKVersionRequired)" 
+        PlatformXmlDir="$(PlatformXmlDir)">
       <Output Condition=" '$(ManagedAssembly)'!='false' " ItemName="Compile" TaskParameter="GeneratedCodeFiles" />
       <Output Condition=" '$(ManagedAssembly)'=='false' " ItemName="XamlGFiles" TaskParameter="GeneratedCodeFiles" />
       <!-- FileWrites is used in Microsoft.Common.Targets for "Clean" build -->

--- a/dev/inc/CppWinRTIncludes.h
+++ b/dev/inc/CppWinRTIncludes.h
@@ -422,7 +422,9 @@ namespace winrt
     using ListViewItemPresenter = winrt::Windows::UI::Xaml::Controls::Primitives::ListViewItemPresenter;
     using OrientedVirtualizingPanel = winrt::Windows::UI::Xaml::Controls::Primitives::OrientedVirtualizingPanel;
     using Popup = winrt::Windows::UI::Xaml::Controls::Primitives::Popup;
+    using PopupPlacementMode = winrt::Windows::UI::Xaml::Controls::Primitives::PopupPlacementMode;
     using IPopup3 = winrt::Windows::UI::Xaml::Controls::Primitives::IPopup3;
+    using IPopup4 = winrt::Windows::UI::Xaml::Controls::Primitives::IPopup4;
     using RangeBase = winrt::Windows::UI::Xaml::Controls::Primitives::RangeBase;
     using RangeBaseValueChangedEventArgs = winrt::Windows::UI::Xaml::Controls::Primitives::RangeBaseValueChangedEventArgs;
     using RepeatButton = winrt::Windows::UI::Xaml::Controls::Primitives::RepeatButton;

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -27,9 +27,9 @@ Include the following workloads:
 
 While WinUI is designed to work against many versions of Windows, you will need 
 a fairly recent SDK in order to build WinUI. It's required that you install the 
-17763 and 18362 SDKs. You can download these via Visual Studio (check 
+17763 and 22000 SDKs. You can download these via Visual Studio (check 
 all the boxes when prompted), or you can manually download them from here: 
-https://developer.microsoft.com/windows/downloads/windows-10-sdk
+https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 
 
 ## Building the repository

--- a/mux.controls.props
+++ b/mux.controls.props
@@ -28,8 +28,7 @@
     <MinSDKVersionRequiredForRS4ThemeResource>$(SDKVersionRS4)</MinSDKVersionRequiredForRS4ThemeResource>
     <MinSDKVersionRequiredForRS5ThemeResource>$(SDKVersion19H1)</MinSDKVersionRequiredForRS5ThemeResource>
     <MinSDKVersionRequiredFor19H1ThemeResource>$(SDKVersion19H1)</MinSDKVersionRequiredFor19H1ThemeResource>
-    <MinSDKVersionRequiredFor21H1ThemeResource Condition="'$(UseInsiderSDK)' != 'true'">$(SDKVersion19H1)</MinSDKVersionRequiredFor21H1ThemeResource>
-    <MinSDKVersionRequiredFor21H1ThemeResource Condition="'$(UseInsiderSDK)' == 'true'">$(SDKVersionInsider)</MinSDKVersionRequiredFor21H1ThemeResource>
+    <MinSDKVersionRequiredFor21H1ThemeResource>$(SDKVersion21H1)</MinSDKVersionRequiredFor21H1ThemeResource>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Currently we build against Windows SDK 18362 for dev builds. For official builds was are using an internal Windows SDK. This was required because we needed to use some APIs that were added after 18362 that at the time had not made their way into an official SDK.

Now that there is a Windows 11 SDK, everything that we need is available in SDK 22000, so we switch to using this for all builds.

This has the advantage that dev builds and official builds are the same and it also means that we can get rid of the mechanism where we use the internal SDK in the official builds.