### PR TITLE
Move PR Pipeline Setup Job to windows-latest agent pool

### DIFF
--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -4,6 +4,8 @@ variables:
   rerunPassesRequiredToAvoidFailure: 5
 jobs:
 - job: Setup
+  pool:
+    vmImage: 'windows-latest'
   steps:
     - task: powershell@2
       name: checkPayload


### PR DESCRIPTION
We were hitting this warning in the PR builds in the Setup job:

>##[warning]A brownout will take place on December, 15 3:00 PM - 4:30 PM UTC to raise awareness of the upcoming windows-2016 environment removal. For more details, see https://github.com/actions/virtual-environments/issues/4312

We need to move this Job to 'windows-latest'.

