### PR TITLE
TabView Miscellaneous Fixes

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -288,7 +288,11 @@ void TabView::UpdateTabBottomBorderLineVisualStates()
         }
         else if (selectedIndex != -1)
         {
-            if (i == selectedIndex - 1)
+            if (i == selectedIndex)
+            {
+                state = L"NoBottomBorderLine";
+            }
+            else if (i == selectedIndex - 1)
             {
                 state = L"LeftOfSelectedTab";
             }

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -43,7 +43,7 @@
                                 XYFocusKeyboardNavigation="Enabled">
 
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" x:Name="LeftContentColumn"/>
+                                <ColumnDefinition Width="Auto" MinWidth="2"  x:Name="LeftContentColumn"/>
                                 <ColumnDefinition Width="Auto" x:Name="TabColumn"/>
                                 <ColumnDefinition Width="Auto" x:Name="AddButtonColumn"/>
                                 <ColumnDefinition Width="*" x:Name="RightContentColumn"/>
@@ -241,7 +241,7 @@
 
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" MinWidth="2" />
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -140,7 +140,7 @@
                     </controls:TabView.Resources>
 
                     <controls:TabView.TabStripHeader>
-                        <TextBlock Grid.Column="0" Text="Middle" Margin="6,3,6,0" VerticalAlignment="Left" FontSize="14"/>
+                        <TextBlock Grid.Column="0" Text="Left" Margin="6,3,6,0" VerticalAlignment="Center" FontSize="14"/>
                     </controls:TabView.TabStripHeader>
 
                     <controls:TabView.TabStripFooter>

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -139,10 +139,6 @@
                         </ResourceDictionary>
                     </controls:TabView.Resources>
 
-                    <controls:TabView.TabStripHeader>
-                        <TextBlock Grid.Column="0" Text="Left" Margin="6,3,6,0" VerticalAlignment="Center" FontSize="14"/>
-                    </controls:TabView.TabStripHeader>
-
                     <controls:TabView.TabStripFooter>
                         <Grid>
                             <Grid.ColumnDefinitions>

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -139,6 +139,10 @@
                         </ResourceDictionary>
                     </controls:TabView.Resources>
 
+                    <controls:TabView.TabStripHeader>
+                        <TextBlock Grid.Column="0" Text="Middle" Margin="6,3,6,0" VerticalAlignment="Left" FontSize="14"/>
+                    </controls:TabView.TabStripHeader>
+
                     <controls:TabView.TabStripFooter>
                         <Grid>
                             <Grid.ColumnDefinitions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**Fix jostle when rearranging tabs:**
- VisualState changes to `LeftBottomBorderLine` was causing its width to collapse to 0, causing a shift of 4px
- Solution: Add MinWidth on Columns containing `LeftBottomBorderLine`


**Contour line appears under selected rearranged tabs:**
-  `UpdateTabBottomBorderLineVisualStates()` Does not have a conditional statement for when the tab is selected
- Thus, when `!m_isDragging`, it transitions the tab back to `"NormalBottomBorderLine"` setting `BottomBorderLine.Visibility` to true when it shouldn't be

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes internal bug 37609120 and 37609038