### PR TITLE
TabView scroll into view fix

### DIFF
--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -151,7 +151,10 @@ void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sen
     if (IsSelected())
     {
         SetValue(winrt::Canvas::ZIndexProperty(), box_value(20));
-        StartBringIntoView();
+        // we need to set the TargetRect to be slightly wider than the TabViewItem size in order to avoid cutting off the end of the Tab
+        auto bringIntoViewOptions = winrt::BringIntoViewOptions();
+        bringIntoViewOptions.TargetRect(winrt::Rect{ 0, 0, DesiredSize().Width+2, DesiredSize().Height});
+        StartBringIntoView(bringIntoViewOptions);
     }
     else
     {

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -152,9 +152,9 @@ void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sen
     {
         SetValue(winrt::Canvas::ZIndexProperty(), box_value(20));
         // we need to set the TargetRect to be slightly wider than the TabViewItem size in order to avoid cutting off the end of the Tab
-        auto bringIntoViewOptions = winrt::BringIntoViewOptions();
-        bringIntoViewOptions.TargetRect(winrt::Rect{ 0, 0, DesiredSize().Width+2, DesiredSize().Height});
-        StartBringIntoView(bringIntoViewOptions);
+        winrt::BringIntoViewOptions options;
+        options.TargetRect(winrt::Rect{ 0, 0, DesiredSize().Width+2, DesiredSize().Height});
+        StartBringIntoView(options);
     }
     else
     {


### PR DESCRIPTION
## Description
When selecting a partially hidden tab when in overflow state, the full tab does not come into view (end of the tab is cut off from view). Updated StartBringIntoView() to add pixel padding to the TargetRect width.

## Motivation and Context
Fixes internal bug 37609293