### PR TITLE
Fix issue where pips pagers crash when the next or previous arrow button is clicked in RTL flow direction

### DIFF
--- a/dev/PipsPager/InteractionTests/PipsPagerTests.cs
+++ b/dev/PipsPager/InteractionTests/PipsPagerTests.cs
@@ -326,7 +326,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 elements = new PipsPagerElements();
                 Button getButtonSizesButton = elements.GetPipsPagerButtonSizesButton();
                 getButtonSizesButton.InvokeAndWait();
-                
+
                 TextBlock horizontalOrientationPipsPagerButtonWidth = elements.GetHorizontalOrientationPipsPagerButtonWidthTextBlock();
                 TextBlock horizontalOrientationPipsPagerButtonHeight = elements.GetHorizontalOrientationPipsPagerButtonHeightTextBlock();
 
@@ -362,6 +362,20 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Verify.AreEqual("20", horizontalOrientationPipsPagerButtonWidth.DocumentText);
                 Verify.AreEqual("12", horizontalOrientationPipsPagerButtonHeight.DocumentText);
+            }
+        }
+
+
+        [TestMethod]
+        [TestProperty("TestSuite", "F")]
+        public void PipsPagerRTLDoesNotCrash()
+        {
+            using (var setup = new TestSetupHelper("PipsPager Tests"))
+            {
+                elements = new PipsPagerElements();
+                TestSetupHelper.SetInnerFrameFlowDirection(FlowDirection.RightToLeft);
+                SetNextPageButtonVisibilityMode(ButtonVisibilityMode.Visible);
+                InputHelper.LeftClick(elements.GetNextPageButton());
             }
         }
     }

--- a/dev/PipsPager/PipsPager_themeresources.xaml
+++ b/dev/PipsPager/PipsPager_themeresources.xaml
@@ -207,21 +207,21 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <FontIcon
-                            x:Name="Content"
-                            FontSize="{TemplateBinding FontSize}"
-                            FontFamily="{TemplateBinding FontFamily}"
-                            Glyph="{TemplateBinding Content}"
-                            MirroredWhenRightToLeft="True"
-                            Foreground="{TemplateBinding Foreground}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            AutomationProperties.AccessibilityView="Raw"
-                            RenderTransformOrigin="0.5, 0.5">
-                            <FontIcon.RenderTransform>
+                        <Border RenderTransformOrigin="0.5, 0.5">
+                            <Border.RenderTransform>
                                 <ScaleTransform x:Name="ScaleTransform" ScaleY="1" ScaleX="1" />
-                            </FontIcon.RenderTransform>
-                        </FontIcon>
+                            </Border.RenderTransform>
+                            <FontIcon
+                                x:Name="Content"
+                                FontSize="{TemplateBinding FontSize}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                Glyph="{TemplateBinding Content}"
+                                MirroredWhenRightToLeft="True"
+                                Foreground="{TemplateBinding Foreground}"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                AutomationProperties.AccessibilityView="Raw"/>
+                        </Border>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/dev/RatingControl/InteractionTests/RatingControlTests.cs
+++ b/dev/RatingControl/InteractionTests/RatingControlTests.cs
@@ -85,9 +85,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Verify.AreEqual("1", textBlock.DocumentText);
 
-                Log.Comment("Verify a left key on an RTL rating increases the rating.");
-                Button rtlbutton = new Button(FindElement.ByName("RTLButton"));
-                rtlbutton.Invoke();
+                Log.Comment("Verify a left key on an RTL rating increases the rating."); 
+                TestSetupHelper.SetInnerFrameFlowDirection(FlowDirection.RightToLeft);
                 Wait.ForIdle();
 
                 KeyboardHelper.PressKey(ratingUIObject, Key.Left);
@@ -107,7 +106,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(ratingUIObject, Key.Up);
                 Verify.AreEqual("5", textBlock.DocumentText);
 
-                rtlbutton.Invoke();
+                TestSetupHelper.SetInnerFrameFlowDirection(FlowDirection.LeftToRight);
                 Wait.ForIdle();
 
                 Log.Comment("Verify home/end keys in LTR");

--- a/test/TestAppUtils/TestFrame.cs
+++ b/test/TestAppUtils/TestFrame.cs
@@ -31,6 +31,7 @@ namespace MUXControlsTestApp
         private Button _goFullScreenInvokerButton = null;
         private Button _toggleThemeButton = null;
         private ToggleButton _innerFrameInLabDimensions = null;
+        private ToggleButton _enableRTL = null;
         private TextBlock _currentPageTextBlock = null;
         private Type _mainPageType = null;
         private ContentPresenter _pagePresenter = null;
@@ -123,6 +124,18 @@ namespace MUXControlsTestApp
                 _innerFrameInLabDimensions_Unchecked(null, null);
             }
 
+            _enableRTL = (ToggleButton)GetTemplateChild("EnableRTL");
+            _enableRTL.Checked += _enableRTL_Checked;
+            _enableRTL.Unchecked += _enableRTL_Unchecked;
+            if (_enableRTL.IsChecked == true)
+            {
+                _enableRTL_Checked(null, null);
+            }
+            else
+            {
+                _enableRTL_Unchecked(null, null);
+            }
+
             _goBackInvokerButton = (Button)GetTemplateChild("GoBackInvokerButton");
             _goBackInvokerButton.Click += GoBackInvokerButton_Click;
 
@@ -132,22 +145,6 @@ namespace MUXControlsTestApp
             _goFullScreenInvokerButton = (Button)GetTemplateChild("FullScreenInvokerButton");
             _goFullScreenInvokerButton.Click += GoFullScreenInvokeButton_Click;
             _keyInputReceived = (CheckBox)GetTemplateChild("KeyInputReceived");
-        }
-
-        private void _innerFrameInLabDimensions_Click(object sender, RoutedEventArgs e)
-        {
-            if(double.IsInfinity(_pagePresenter.MaxWidth))
-            {
-                // Not CI mode, so enter it now
-                _pagePresenter.MaxWidth = 1024;
-                _pagePresenter.MaxHeight = 664;
-            }
-            else
-            {
-                // We are already in "CI mode"
-                _pagePresenter.ClearValue(MaxWidthProperty);
-                _pagePresenter.ClearValue(MaxHeightProperty);
-            }
         }
 
         private void _innerFrameInLabDimensions_Checked(object sender, RoutedEventArgs e)
@@ -162,6 +159,16 @@ namespace MUXControlsTestApp
             // Leave CI mode
             _pagePresenter.ClearValue(MaxWidthProperty);
             _pagePresenter.ClearValue(MaxHeightProperty);
+        }
+
+        private void _enableRTL_Checked(object sender, RoutedEventArgs e)
+        {
+            _pagePresenter.FlowDirection = FlowDirection.RightToLeft;
+        }
+
+        private void _enableRTL_Unchecked(object sender, RoutedEventArgs e)
+        {
+            _pagePresenter.FlowDirection = FlowDirection.LeftToRight;
         }
 
         private void ToggleThemeButton_Click(object sender,RoutedEventArgs e)

--- a/test/TestAppUtils/Themes/Generic.xaml
+++ b/test/TestAppUtils/Themes/Generic.xaml
@@ -61,6 +61,11 @@
                                         IsChecked="True" Margin="0,0,4,0"
                                         AutomationProperties.AutomationId="__InnerFrameInLabDimensions"
                                         Content="Render innerframe in lab dimensions"/>
+                                    <ToggleButton
+                                        x:Name="EnableRTL"
+                                        IsChecked="False" Margin="0,0,4,0"
+                                        AutomationProperties.AutomationId="__EnableRTL"
+                                        Content="Enable RTL"/>
 
                                     <TextBlock x:Name="CurrentPageTextBlock" AutomationProperties.AutomationId="__CurrentPage"  FontSize="18" VerticalAlignment="Center" Margin="10,0,0,0"/>
                                 </StackPanel>

--- a/test/TestAppUtils/Themes/Generic.xaml
+++ b/test/TestAppUtils/Themes/Generic.xaml
@@ -65,6 +65,7 @@
                                         x:Name="EnableRTL"
                                         IsChecked="False" Margin="0,0,4,0"
                                         AutomationProperties.AutomationId="__EnableRTL"
+                                        IsTabStop="False"
                                         Content="Enable RTL"/>
 
                                     <TextBlock x:Name="CurrentPageTextBlock" AutomationProperties.AutomationId="__CurrentPage"  FontSize="18" VerticalAlignment="Center" Margin="10,0,0,0"/>

--- a/test/testinfra/MUXTestInfra/Infra/TestHelpers.cs
+++ b/test/testinfra/MUXTestInfra/Infra/TestHelpers.cs
@@ -176,19 +176,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
 
                 Log.Comment("__TestContentLoadedCheckBox checkbox checked, page has loaded");
 
-                ToggleButton tb = new ToggleButton(FindElement.ById("__InnerFrameInLabDimensions"));
-                if (tb.ToggleState != ToggleState.On && shouldRestrictInnerFrameSize)
-                {
-                    Log.Comment("toggling the __InnerFrameInLabDimensions toggle button to On.");
-                    tb.Toggle();
-                    Wait.ForIdle();
-                }
-                else if (tb.ToggleState != ToggleState.Off && !shouldRestrictInnerFrameSize)
-                {
-                    Log.Comment("toggling the __InnerFrameInLabDimensions toggle button to Off.");
-                    tb.Toggle();
-                    Wait.ForIdle();
-                }
+                SetInnerFrameInLabDimensions(shouldRestrictInnerFrameSize);
 
                 OpenedTestPages++;
             }
@@ -244,6 +232,39 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                         throw new InvalidOperationException("All attempts to set up test failed.");
                     }
                 }
+            }
+        }
+        public static void SetInnerFrameInLabDimensions(bool shouldRestrictInnerFrameSize)
+        {
+            ToggleButton tb = new ToggleButton(FindElement.ById("__InnerFrameInLabDimensions"));
+            if (tb.ToggleState != ToggleState.On && shouldRestrictInnerFrameSize)
+            {
+                Log.Comment("toggling the __InnerFrameInLabDimensions toggle button to On.");
+                tb.Toggle();
+                Wait.ForIdle();
+            }
+            else if (tb.ToggleState != ToggleState.Off && !shouldRestrictInnerFrameSize)
+            {
+                Log.Comment("toggling the __InnerFrameInLabDimensions toggle button to Off.");
+                tb.Toggle();
+                Wait.ForIdle();
+            }
+        }
+
+        public static void SetInnerFrameFlowDirection(FlowDirection flowDirection)
+        {
+            ToggleButton tb = new ToggleButton(FindElement.ById("__EnableRTL"));
+            if (tb.ToggleState != ToggleState.On && flowDirection == FlowDirection.RightToLeft)
+            {
+                Log.Comment("toggling the __EnableRTL toggle button to On.");
+                tb.Toggle();
+                Wait.ForIdle();
+            }
+            else if (tb.ToggleState != ToggleState.Off && flowDirection == FlowDirection.LeftToRight)
+            {
+                Log.Comment("toggling the __EnableRTL toggle button to Off.");
+                tb.Toggle();
+                Wait.ForIdle();
             }
         }
 


### PR DESCRIPTION
FontIcon has code in it that sets a render transform on itself when the flow direction is RTL and the MirroredWhenRIghtToLeft is set to true, in order to mirror the icon using a -1 x-dimension scale.  However the PipsPagerNavigationButtonBaseStyle sets a scale transform on the font icon in order to decrease the size of the icon in the pressed state.  This is done by referencing the scale transform by name.  However the font icon code is overriding the named scale transform with an unnammed one, resulting in a crash when the storyboard tries to reference the named scale transform.  We could work around this by referencing the scale transform by property rather than by name, but then we would need to manage the mirrored when RTL scale of -1 ourselves.  Instead I've separated the two scale transforms.