### PR TITLE
TabView fixes

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -782,18 +782,15 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
 
 void TabView::OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args)
 {
-    if(!m_isDragging)
+    if (auto&& listView = m_listView.get())
     {
-        if (auto&& listView = m_listView.get())
-        {
-            SelectedIndex(listView.SelectedIndex());
-            SelectedItem(listView.SelectedItem());
-        }
-
-        UpdateTabContent();
-
-        m_selectionChangedEventSource(*this, args);
+        SelectedIndex(listView.SelectedIndex());
+        SelectedItem(listView.SelectedItem());
     }
+
+    UpdateTabContent();
+
+    m_selectionChangedEventSource(*this, args);
 }
 
 winrt::TabViewItem TabView::FindTabViewItemFromDragItem(const winrt::IInspectable& item)

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -687,11 +687,31 @@ void TabView::OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, con
         // Presenter size didn't change because of item being removed, so update manually
         UpdateScrollViewerDecreaseAndIncreaseButtonsViewState();
         UpdateTabWidths();
+        // Make sure that the selected tab is fully in view and not cut off
+        BringSelectedTabIntoView();
+    }
+}
+
+void TabView::BringSelectedTabIntoView()
+{
+    if(SelectedItem())
+    {
+        auto tvi = SelectedItem().try_as<winrt::TabViewItem>();
+        if (!tvi)
+        {
+            tvi = ContainerFromItem(SelectedItem()).try_as<winrt::TabViewItem>();
+        }
+        winrt::get_self<TabViewItem>(tvi)->StartBringTabIntoView();
     }
 }
 
 void TabView::OnItemsChanged(winrt::IInspectable const& item)
 {
+    if(m_isDragging)
+    {
+        return;
+    }
+
     if (auto args = item.as<winrt::IVectorChangedEventArgs>())
     {
         m_tabItemsChangedEventSource(*this, args);
@@ -762,17 +782,18 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
 
 void TabView::OnListViewSelectionChanged(const winrt::IInspectable& sender, const winrt::SelectionChangedEventArgs& args)
 {
-
-    
-    if (auto&& listView = m_listView.get())
+    if(!m_isDragging)
     {
-        SelectedIndex(listView.SelectedIndex());
-        SelectedItem(listView.SelectedItem());
+        if (auto&& listView = m_listView.get())
+        {
+            SelectedIndex(listView.SelectedIndex());
+            SelectedItem(listView.SelectedItem());
+        }
+
+        UpdateTabContent();
+
+        m_selectionChangedEventSource(*this, args);
     }
-
-    UpdateTabContent();
-
-    m_selectionChangedEventSource(*this, args);
 }
 
 winrt::TabViewItem TabView::FindTabViewItemFromDragItem(const winrt::IInspectable& item)
@@ -831,6 +852,13 @@ void TabView::OnListViewDrop(const winrt::IInspectable& sender, const winrt::Dra
 void TabView::OnListViewDragItemsCompleted(const winrt::IInspectable& sender, const winrt::DragItemsCompletedEventArgs& args)
 {
     m_isDragging = false;
+
+    // Selection change was disabled during drag, update SelectedIndex now
+    if (auto&& listView = m_listView.get())
+    {
+        SelectedIndex(listView.SelectedIndex());
+        SelectedItem(listView.SelectedItem());
+    }
 
     auto item = args.Items().GetAt(0);
     auto tab = FindTabViewItemFromDragItem(item);

--- a/dev/TabView/TabView.h
+++ b/dev/TabView/TabView.h
@@ -148,6 +148,7 @@ private:
 
     bool RequestCloseCurrentTab();
     bool SelectNextTab(int increment);
+    void BringSelectedTabIntoView();
 
     void UpdateSelectedItem();
     void UpdateSelectedIndex();

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -11,6 +11,7 @@
 #include "SharedHelpers.h"
 
 static constexpr auto c_overlayCornerRadiusKey = L"OverlayCornerRadius"sv;
+static constexpr int c_targetRectWidthIncrement = 2;
 
 TabViewItem::TabViewItem()
 {
@@ -151,7 +152,7 @@ void TabViewItem::OnIsSelectedPropertyChanged(const winrt::DependencyObject& sen
     if (IsSelected())
     {
         SetValue(winrt::Canvas::ZIndexProperty(), box_value(20));
-        StartBringIntoView();
+        StartBringTabIntoView();
     }
     else
     {
@@ -500,4 +501,12 @@ void TabViewItem::OnIconSourceChanged()
         templateSettings->IconElement(nullptr);
         winrt::VisualStateManager::GoToState(*this, L"NoIcon"sv, false);
     }
+}
+
+void TabViewItem::StartBringTabIntoView()
+{
+    // we need to set the TargetRect to be slightly wider than the TabViewItem size in order to avoid cutting off the end of the Tab
+    winrt::BringIntoViewOptions options;
+    options.TargetRect(winrt::Rect{ 0, 0, DesiredSize().Width + c_targetRectWidthIncrement, DesiredSize().Height});
+    StartBringIntoView(options);
 }

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -44,6 +44,8 @@ public:
     winrt::TabView GetParentTabView();
     void SetParentTabView(winrt::TabView const& tabView);
 
+    void StartBringTabIntoView();
+
 private:
     tracker_ref<winrt::Button> m_closeButton{ this };
     tracker_ref<winrt::ToolTip> m_toolTip{ this };


### PR DESCRIPTION
## Description

This PR fixes the following bugs:

1. When selecting a partially hidden tab when in overflow state, the full tab does not come into view (end of the tab is cut off from view). Updated StartBringIntoView() to add pixel padding to the TargetRect width.
2. Tab is cut off when creating a new tab where the last tab is selected and changes to scrolling mode.
3. Rearranging a selected tab does not keep the tab in view after being dropped

## Motivation and Context
Fixes internal bugs 37609293, 37608918, 37608607