### PR TITLE
TabView gap between active tab and active content fix

### DIFF
--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -105,7 +105,8 @@ void TabViewItem::UpdateTabGeometry()
 {
     auto const templateSettings = winrt::get_self<TabViewItemTemplateSettings>(TabViewTemplateSettings());
 
-    auto const height = ActualHeight();
+    // Need to increment actual height by 1 due to 'SelectedBackgroundPath' not being drawn correctly in non-100% scale factors
+    auto const height = ActualHeight() + 1;
     auto const popupRadius = unbox_value<winrt::CornerRadius>(ResourceAccessor::ResourceLookup(*this, box_value(c_overlayCornerRadiusKey)));
     auto const leftCorner = popupRadius.TopLeft;
     auto const rightCorner = popupRadius.TopRight;

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -105,8 +105,7 @@ void TabViewItem::UpdateTabGeometry()
 {
     auto const templateSettings = winrt::get_self<TabViewItemTemplateSettings>(TabViewTemplateSettings());
 
-    // Need to increment actual height by 1 due to 'SelectedBackgroundPath' not being drawn correctly in non-100% scale factors
-    auto const height = ActualHeight() + 1;
+    auto const height = ActualHeight();
     auto const popupRadius = unbox_value<winrt::CornerRadius>(ResourceAccessor::ResourceLookup(*this, box_value(c_overlayCornerRadiusKey)));
     auto const leftCorner = popupRadius.TopLeft;
     auto const rightCorner = popupRadius.TopRight;
@@ -116,11 +115,11 @@ void TabViewItem::UpdateTabGeometry()
     
     WCHAR strOut[1024];
     StringCchPrintf(strOut, ARRAYSIZE(strOut), data,
-        height - 1,
+        height,
         leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
         ActualWidth() - (leftCorner + rightCorner),
         rightCorner, rightCorner, rightCorner, rightCorner,
-        height - (4 + rightCorner + 1));
+        height - (4 + rightCorner));
 
     const auto geometry = winrt::XamlReader::Load(strOut).try_as<winrt::Geometry>();
 

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -10,7 +10,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid x:Name="BackgroundGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
@@ -53,6 +53,11 @@
                 <Button x:Name="ScrollTabViewToTheRight" AutomationProperties.Name="ScrollTabViewToTheRight" Content="Scroll TabView To the Right" Margin="0,0,0,8" Click="TabViewScrollToTheRightButton_Click" />
 
                 <Button x:Name="ShortLongTextButton" AutomationProperties.Name="ShortLongTextButton" Content="Short/Long Text" Margin="0,0,0,8" Click="ShortLongTextButton_Click" />
+                <Button x:Name="HomeTabOverlapCheck" AutomationProperties.Name="HomeTabOverlapCheck" Content="Set HomeTabOverlapCheck" Margin="0,0,0,8" Click="HomeTabOverlapCheck_Click" />
+                <Button x:Name="SetActiveTabTransparent" AutomationProperties.Name="SetActiveTabTransparent" Content="Set ActiveTab Transparent" Margin="0,0,0,8" Click="SetActiveTabTransparent_Click" />
+                <Button x:Name="SetActiveContentTransparent" AutomationProperties.Name="SetActiveContentTransparent" Content="Set ActiveContent Transparent" Margin="0,0,0,8" Click="SetActiveContentTransparent_Click" />
+                <Button x:Name="ClearOverlapCheck" AutomationProperties.Name="ClearOverlapCheck" Content="Clear OverlapCheck" Margin="0,0,0,8" Click="ClearOverlapCheck_Click" />
+                
                 <StackPanel Orientation="Horizontal">
                     <Button Click="SetColorsButton_Click" Content="Set Colors"/>
                     <Button Click="ClearColorsButton_Click" Content="Clear Colors"/>

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -10,6 +10,8 @@ using Windows.UI.Xaml.Markup;
 using Windows.UI;
 using System.Windows.Input;
 using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Shapes;
+using System.Reflection;
 
 using TabView = Microsoft.UI.Xaml.Controls.TabView;
 using TabViewItem = Microsoft.UI.Xaml.Controls.TabViewItem;
@@ -55,7 +57,15 @@ namespace MUXControlsTestApp
                 itemSource.Add(item);
             }
             DataBindingTabView.TabItemsSource = itemSource;
+
+            backgroundColorCache = BackgroundGrid.Background;
+            activeTabContentBackgroundBrushCache = FirstTabContent.Background;
+            CacheFirstTabSelectedBackgroundPathFill();
         }
+
+        private Brush backgroundColorCache;
+        private Brush activeTabSelectedBackgroundPathBrushCache;
+        private Brush activeTabContentBackgroundBrushCache;
 
         protected async override void OnNavigatedTo(Windows.UI.Xaml.Navigation.NavigationEventArgs args) 
         {
@@ -409,6 +419,96 @@ namespace MUXControlsTestApp
             FirstTab.Header = "s";
             LongHeaderTab.Header = "long long long long long long long long";
         }
+
+        private void HomeTabOverlapCheck_Click(object sender, RoutedEventArgs e)
+        {
+            var redBrush = new SolidColorBrush();
+            redBrush.Color = Colors.Red;
+            BackgroundGrid.Background = redBrush;
+
+            var tabBrush = new SolidColorBrush();
+            tabBrush.Color = Colors.Blue;
+            SetFirstTabSelectedBackgroundPathFill(tabBrush);
+
+            var contentBrush = new SolidColorBrush();
+            contentBrush.Color = Colors.Green;
+            FirstTabContent.Background = contentBrush;
+        }
+
+        private void SetActiveTabTransparent_Click(object sender, RoutedEventArgs e)
+        {
+            var tabBrush = new SolidColorBrush();
+            tabBrush.Color = Colors.Transparent;
+            SetFirstTabSelectedBackgroundPathFill(tabBrush);
+        }
+
+        private void SetActiveContentTransparent_Click(object sender, RoutedEventArgs e)
+        {
+            var contentBrush = new SolidColorBrush();
+            contentBrush.Color = Colors.Transparent;
+            FirstTabContent.Background = contentBrush;
+        }
+
+        private void ClearOverlapCheck_Click(object sender, RoutedEventArgs e)
+        {
+            BackgroundGrid.Background = backgroundColorCache;
+
+            if(activeTabSelectedBackgroundPathBrushCache != null)
+            {
+                FrameworkElement selectedBackgroundPath = FindFrameworkElementWithName("SelectedBackgroundPath", FirstTab);
+                if(selectedBackgroundPath != null)
+                {
+                    (selectedBackgroundPath as Path).Fill = activeTabSelectedBackgroundPathBrushCache;
+                }
+            }
+
+            if(activeTabContentBackgroundBrushCache != null)
+            {
+                FirstTabContent.Background = activeTabContentBackgroundBrushCache;
+            }
+        }
+
+        private void CacheFirstTabSelectedBackgroundPathFill()
+        {
+            FrameworkElement selectedBackgroundPath = FindFrameworkElementWithName("SelectedBackgroundPath", FirstTab);
+            if(selectedBackgroundPath != null)
+            {
+                activeTabSelectedBackgroundPathBrushCache = (selectedBackgroundPath as Path).Fill;
+            }
+        }
+
+        private void SetFirstTabSelectedBackgroundPathFill(Brush newBrush)
+        {
+            FrameworkElement selectedBackgroundPath = FindFrameworkElementWithName("SelectedBackgroundPath", FirstTab);
+            if(selectedBackgroundPath != null)
+            {
+                (selectedBackgroundPath as Path).Fill = newBrush;
+            }
+        }
+
+        private FrameworkElement FindFrameworkElementWithName(string name, DependencyObject startNode)
+        {
+            int count = VisualTreeHelper.GetChildrenCount(startNode);
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
+                if ((current.GetType()).Equals(typeof(FrameworkElement)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(FrameworkElement))))
+                {
+                    FrameworkElement fe = (FrameworkElement)current;
+                    if(fe.Name == name)
+                    {
+                        return fe;
+                    }
+                }
+                var result = FindFrameworkElementWithName(name, current);
+                if(result != null)
+                {
+                    return result;
+                }
+            }
+            return null;
+        }
+
         private void SetColorsButton_Click(object sender, RoutedEventArgs e)
         {
             var foregroundBrush = new SolidColorBrush();


### PR DESCRIPTION
## Description
Gap between active tab and active tab content when device scale factor is not 100%
![image](https://user-images.githubusercontent.com/6562139/152056975-aed0f718-da2d-4dd3-872c-0ff8e2fbd699.png)

The `SelectedBackgroundPath` path is not being drawn all the way down in non-100% scale factors. Layout rounding API does not seem to fix this. I added an extra pixel to `TabGeometry` which is being used to draw the background. That fixed the drawing at non-100% scale factors while still looking correct at 100% scale.

# Motivation and Context
fixes internal bugs 37332027

# Screenshots

Pre-Fix on top of Post-Fix

100% scale
![image](https://user-images.githubusercontent.com/6562139/155436076-6487bd03-be90-4946-8384-33f009fdaca3.png)
![image](https://user-images.githubusercontent.com/6562139/155436083-b7b1dafa-8838-45dc-a5c7-525bf825d387.png)
![image](https://user-images.githubusercontent.com/6562139/155438345-7a481f33-00a6-4d28-b54d-670e0d2f550c.png)
![image](https://user-images.githubusercontent.com/6562139/155436677-d6a6d712-91a7-4e15-8666-210318190d73.png)


125% scale
![image](https://user-images.githubusercontent.com/6562139/155436146-52d2acd1-d5f6-47bd-bb9b-43304d6c2312.png)
![image](https://user-images.githubusercontent.com/6562139/155436156-918a9d96-7cfb-4ac4-927b-7f435f325a7b.png)
![image](https://user-images.githubusercontent.com/6562139/155438352-ce6887dd-ac2a-4ed2-abf1-41ba3c92ee97.png)
![image](https://user-images.githubusercontent.com/6562139/155436683-57353091-cc8f-43b8-ad40-f0a3ddabac76.png)


150% scale
![image](https://user-images.githubusercontent.com/6562139/155436161-db638b65-3fcd-4c5e-b8fc-b03308dea55f.png)
![image](https://user-images.githubusercontent.com/6562139/155436164-58586e2a-8c45-4751-87c4-66030ca18b56.png)
![image](https://user-images.githubusercontent.com/6562139/155438370-75905515-45e3-44c5-86ee-e67794d9a178.png)
![image](https://user-images.githubusercontent.com/6562139/155439908-d763fb86-67aa-4320-85d3-1ca0bfc05afe.png)


175% scale
![image](https://user-images.githubusercontent.com/6562139/155436169-8ea925ea-3ac0-4d9d-9447-6657d631009d.png)
![image](https://user-images.githubusercontent.com/6562139/155436175-a4244449-9a31-458e-b881-7a0385295a2c.png)
![image](https://user-images.githubusercontent.com/6562139/155438383-d7fc2bf4-b96e-480f-b092-3b2f0430264d.png)
![image](https://user-images.githubusercontent.com/6562139/155439917-df687da0-10d3-4439-862b-815603592127.png)


200% scale
![image](https://user-images.githubusercontent.com/6562139/155436186-ba4ceb1a-f979-44e0-8fcc-eacb2d3810af.png)
![image](https://user-images.githubusercontent.com/6562139/155436206-75c72fe5-1006-4cd8-821a-619348c2b028.png)
![image](https://user-images.githubusercontent.com/6562139/155438391-14737580-2f3c-418c-be58-d7e384589ced.png)
![image](https://user-images.githubusercontent.com/6562139/155436729-fe4a19d1-e0b4-4c92-bd50-60d3805500a6.png)



