### PR TITLE
Update IsAPIContractVxAvailable to be multi thread safe.

### DIFF
--- a/dev/dll/SharedHelpers.cpp
+++ b/dev/dll/SharedHelpers.cpp
@@ -223,11 +223,11 @@ template <uint16_t APIVersion> bool SharedHelpers::IsAPIContractVxAvailable()
     static bool isAPIContractVxAvailable = false;
     if (!isAPIContractVxAvailableInitialized)
     {
-        isAPIContractVxAvailableInitialized = true;
         // The CBS package is only ever used as a part of the Windows build. Therefore, we can assume that
         // all API contracts are present since we can never be running these binaries on a windows build
         // that does not match the windows sdk these binaries were compiled against.
         isAPIContractVxAvailable = IsInCBSPackage() ? true : winrt::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
+        isAPIContractVxAvailableInitialized = true;
     }
 
     return isAPIContractVxAvailable;


### PR DESCRIPTION
Previously a thread could return an uninitialized value for isAPIContractVxAvailable if another thread was executing at the same time and flipped the initialized flag to true before intitializing the variable.