### PR TITLE
Fix occasional WebView2 Crash when restoring minimized app (0x80070057)

### DIFF
--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1255,14 +1255,25 @@ void WebView2::FireCoreWebView2Initialized(winrt::hresult exception)
     m_coreWebView2InitializedEventSource(*this, *eventArgs);
 }
 
-void WebView2::HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::RoutedEventArgs&) noexcept
+void WebView2::HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::RoutedEventArgs&)
 {
     if (m_coreWebView && m_xamlFocusChangeInfo.m_isPending)
     {
         // In current CoreWebView2 API, MoveFocus is not expected to fail, so set m_webHasFocus here rather than
         // in asynchronous (MOJO/cross-proc) CoreWebView2 GotFocus event.
         m_webHasFocus = true;
-        m_coreWebViewController.MoveFocus(m_xamlFocusChangeInfo.m_storedMoveFocusReason);
+        try
+        {
+            m_coreWebViewController.MoveFocus(m_xamlFocusChangeInfo.m_storedMoveFocusReason);
+        }
+        catch (winrt::hresult_error e)
+        {
+            if (e.code().value != E_INVALIDARG)
+            {
+                throw;
+            }
+        }
+
         m_xamlFocusChangeInfo.m_isPending = false;
     }
 }

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1259,8 +1259,6 @@ void WebView2::HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, c
 {
     if (m_coreWebView && m_xamlFocusChangeInfo.m_isPending)
     {
-        // In current CoreWebView2 API, MoveFocus is not expected to fail, so set m_webHasFocus here rather than
-        // in asynchronous (MOJO/cross-proc) CoreWebView2 GotFocus event.
         m_webHasFocus = true;
         try
         {
@@ -1268,6 +1266,12 @@ void WebView2::HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, c
         }
         catch (winrt::hresult_error e)
         {
+            // Occasionally, a request to restore the minimized window does not complete. This triggers
+            // FocusManager to set Xaml Focus to WV2 and consequently into CWV2 MoveFocus() call above, 
+            // which in turn will attempt ::SetFocus() on InputHWND, and that will fail with E_INVALIDARG
+            // since that HWND remains minimized. Work around by ignoring this error here. Sine the app
+            // is minimized, focus state is not relevant - the next (successful) attempt to restrore the app
+            // will set focus into WV2/CWV2 correctly.
             if (e.code().value != E_INVALIDARG)
             {
                 throw;

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1259,17 +1259,17 @@ void WebView2::HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, c
 {
     if (m_coreWebView && m_xamlFocusChangeInfo.m_isPending)
     {
-        m_webHasFocus = true;
         try
         {
             m_coreWebViewController.MoveFocus(m_xamlFocusChangeInfo.m_storedMoveFocusReason);
+            m_webHasFocus = true;
         }
         catch (winrt::hresult_error e)
         {
             // Occasionally, a request to restore the minimized window does not complete. This triggers
             // FocusManager to set Xaml Focus to WV2 and consequently into CWV2 MoveFocus() call above, 
             // which in turn will attempt ::SetFocus() on InputHWND, and that will fail with E_INVALIDARG
-            // since that HWND remains minimized. Work around by ignoring this error here. Sine the app
+            // since that HWND remains minimized. Work around by ignoring this error here. Since the app
             // is minimized, focus state is not relevant - the next (successful) attempt to restrore the app
             // will set focus into WV2/CWV2 correctly.
             if (e.code().value != E_INVALIDARG)
@@ -1277,7 +1277,6 @@ void WebView2::HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, c
                 throw;
             }
         }
-
         m_xamlFocusChangeInfo.m_isPending = false;
     }
 }

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -146,7 +146,7 @@ private:
     void HandlePointerCaptureLost(const winrt::Windows::Foundation::IInspectable&, const winrt::PointerRoutedEventArgs& args);
     void HandleKeyDown(const winrt::Windows::Foundation::IInspectable&, const winrt::KeyRoutedEventArgs& e);
     void HandleGettingFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::GettingFocusEventArgs& args) noexcept;
-    void HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::RoutedEventArgs&) noexcept;
+    void HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::RoutedEventArgs&);
     void HandleAcceleratorKeyActivated(const winrt::Windows::UI::Core::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args) noexcept;
     void HandleXamlRootChanged();
     void HandleSizeChanged(const winrt::IInspectable& /*sender*/, const winrt::SizeChangedEventArgs& args);


### PR DESCRIPTION
If an app is minimized while WebView2 has focus, and is then restored, it occasionally crashes with 0x80070057/ERROR_INVALID_PARAMETER. In my local repro, i observe this on ~1 out of 20 tries. In such cases the Windows restore operation is initiated but for some reason not completed; the app remains minimized. Nonetheless Xaml internal focus handling proceeds to restore focus to WebVIew2, which in turn calls CoreWebView2Controller::MoveFocus to restore web element focus. The latter call fails in Win32 ::SetFocus() API w/ ERROR_INVALID_PARAMETER; this is expected since the target HWND remained minimized.

The fix is to ignore HR 0x80070057 in this situation. Since the app remained minimized in the repro case, there is no observable effect and no additional state cleanup is required. The next attempt to restore the app should restore focus correctly. 