### PR TITLE
[AnimatedIcon] Fix issue where setting source property would not resize AnimatedIcon properly

### DIFF
--- a/dev/AnimatedIcon/APITests/AnimatedIconTests.cs
+++ b/dev/AnimatedIcon/APITests/AnimatedIconTests.cs
@@ -427,5 +427,36 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 layoutUpdatedEvent.Set();
             }
         }
+    
+        [TestMethod]
+        public void ChangingSourcePropertyChanges()
+        {
+            AnimatedIcon icon = null;
+            RunOnUIThread.Execute(() =>
+            {
+                icon = new AnimatedIcon();
+                Content = new StackPanel() {
+                    Children = { icon }
+                };
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                // Icon width will be zero if the source property is not set.
+                Verify.IsTrue(Math.Abs(icon.ActualSize.Y) < 0.1);
+                icon.Source = new AnimatedChevronDownSmallVisualSource();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                // Icon will have a width if the AnimatedIcon also updated the visual tree to rerender.
+                Verify.IsTrue(Math.Abs(icon.ActualSize.Y) > 10);
+            });
+        }
     }
 }

--- a/dev/AnimatedIcon/APITests/AnimatedIconTests.cs
+++ b/dev/AnimatedIcon/APITests/AnimatedIconTests.cs
@@ -429,7 +429,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
     
         [TestMethod]
-        public void ChangingSourcePropertyChanges()
+        public void ChangingSourcePropertyChangesRenderSize()
         {
             AnimatedIcon icon = null;
             RunOnUIThread.Execute(() =>
@@ -445,8 +445,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                // Icon width will be zero if the source property is not set.
-                Verify.IsTrue(Math.Abs(icon.ActualSize.Y) < 0.1);
+                // Icon height will be zero if the source property is not set.
+                Verify.IsTrue(Math.Abs(icon.ActualHeight) < 0.1);
                 icon.Source = new AnimatedChevronDownSmallVisualSource();
             });
 
@@ -454,8 +454,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                // Icon will have a width if the AnimatedIcon also updated the visual tree to rerender.
-                Verify.IsTrue(Math.Abs(icon.ActualSize.Y) > 10);
+                // Icon will have a height if the AnimatedIcon also updated the visual tree to rerender.
+                Verify.IsTrue(Math.Abs(icon.ActualHeight) > 10);
             });
         }
     }

--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -476,6 +476,7 @@ void AnimatedIcon::OnSourcePropertyChanged(const winrt::DependencyPropertyChange
     {
         SetRootPanelChildToFallbackIcon();
     }
+    InvalidateMeasure();
 }
 
 void AnimatedIcon::UpdateMirrorTransform()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Issue was that the layout was not invalidated when setting the source property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #6659 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new API test
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->