### PR TITLE
TabView bottom border gap fix

### DIFF
--- a/dev/TabView/TabViewListView.cpp
+++ b/dev/TabView/TabViewListView.cpp
@@ -23,15 +23,7 @@ TabViewListView::TabViewListView()
 
 void TabViewListView::OnSelectedIndexPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
 {
-    winrt::VisualStateManager::GoToState(
-        *this,
-        (SelectedIndex() == 0) ? L"LeftBottomBorderLineShort" : L"LeftBottomBorderLineNormal",
-        false /*useTransitions*/);
-
-    winrt::VisualStateManager::GoToState(
-        *this,
-        (SelectedIndex() == (int)(Items().Size() - 1)) ? L"RightBottomBorderLineShort" : L"RightBottomBorderLineNormal",
-        false /*useTransitions*/);
+    UpdateBottomBorderVisualState();
 }
 
 // IItemsControlOverrides
@@ -60,6 +52,7 @@ void TabViewListView::OnItemsChanged(winrt::IInspectable const& item)
         const auto internalTabView = winrt::get_self<TabView>(tabView);
         internalTabView->OnItemsChanged(item);
     }
+    UpdateBottomBorderVisualState();
 }
 
 void TabViewListView::PrepareContainerForItemOverride(const winrt::DependencyObject& element, const winrt::IInspectable& item)
@@ -91,4 +84,17 @@ void TabViewListView::OnContainerContentChanging(const winrt::IInspectable& send
         const auto internalTabView = winrt::get_self<TabView>(tabView);
         internalTabView->UpdateTabContent();
     }
+}
+
+void TabViewListView::UpdateBottomBorderVisualState()
+{
+    winrt::VisualStateManager::GoToState(
+        *this,
+        (SelectedIndex() == 0) ? L"LeftBottomBorderLineShort" : L"LeftBottomBorderLineNormal",
+        false /*useTransitions*/);
+
+    winrt::VisualStateManager::GoToState(
+        *this,
+        (SelectedIndex() == (int)(Items().Size() - 1)) ? L"RightBottomBorderLineShort" : L"RightBottomBorderLineNormal",
+        false /*useTransitions*/);
 }

--- a/dev/TabView/TabViewListView.h
+++ b/dev/TabView/TabViewListView.h
@@ -19,5 +19,6 @@ public:
 private:
     void OnContainerContentChanging(const winrt::IInspectable& sender, const winrt::ContainerContentChangingEventArgs& args);
     void OnSelectedIndexPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
+    void UpdateBottomBorderVisualState();
 };
 


### PR DESCRIPTION
 Gap appears in bottom border when adding a new tab and the last tab was selected
![image](https://user-images.githubusercontent.com/6562139/151460444-cfaa71df-c7bd-4b67-bf94-87d2c5f474d7.png)

## Motivation and Context
Fixes internal bug 37608826