### PR TITLE
Adding MicaController RuntimeProfiler recording

### DIFF
--- a/dev/CommonStyles/TestUI/CalendarViewPage.xaml.cs
+++ b/dev/CommonStyles/TestUI/CalendarViewPage.xaml.cs
@@ -78,21 +78,25 @@ namespace MUXControlsTestApp
         {
             if (hasDensityBars.IsChecked.Value)
             {
-                bool isToday = dayItem.Date.Date.Equals(DateTime.Now.Date);
+                Calendar calendar = new Calendar();
+                calendar.SetDateTime(dayItem.Date);
+                
+                DateTime today = DateTime.Now.Date;
+                bool isToday = calendar.Day == today.Day && calendar.Month == today.Month && calendar.Year == today.Year;
 
-                if (dayItem.Date.Day % 6 == 0 || isToday)
+                if (calendar.Day % 6 == 0 || isToday)
                 {
                     List<Color> densityColors = new List<Color>();
 
                     densityColors.Add(Colors.Green);
                     densityColors.Add(Colors.Green);
 
-                    if (dayItem.Date.Day % 4 == 0 || isToday)
+                    if (calendar.Day % 4 == 0 || isToday)
                     {
                         densityColors.Add(Colors.Blue);
                         densityColors.Add(Colors.Blue);
                     }
-                    if (dayItem.Date.Day % 9 == 0 || isToday)
+                    if (calendar.Day % 9 == 0 || isToday)
                     {
                         densityColors.Add(Colors.Orange);
                     }
@@ -113,9 +117,20 @@ namespace MUXControlsTestApp
 
         private void SetBlackout(CalendarViewDayItem dayItem)
         {
-            dayItem.IsBlackout = 
-                (isSundayBlackedOut.IsChecked.Value && dayItem.Date.DayOfWeek == System.DayOfWeek.Sunday) ||
-                (isTodayBlackedOut.IsChecked.Value && dayItem.Date.Date.Equals(DateTime.Now.Date));
+            Calendar calendar = new Calendar();
+
+            calendar.SetDateTime(dayItem.Date);
+            
+            bool isBlackout = isSundayBlackedOut.IsChecked.Value && calendar.DayOfWeek == Windows.Globalization.DayOfWeek.Sunday;
+
+            if (!isBlackout && isTodayBlackedOut.IsChecked.Value)
+            {
+                Calendar calendarToday = new Calendar();
+                calendarToday.SetToNow();
+                isBlackout = calendar.Day == calendarToday.Day && calendar.Month == calendarToday.Month && calendar.Year == calendarToday.Year;
+            }
+
+            dayItem.IsBlackout = isBlackout;
         }
 
         private void SelectionMode_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/dev/Materials/Backdrop/MicaController.cpp
+++ b/dev/Materials/Backdrop/MicaController.cpp
@@ -2,9 +2,15 @@
 #include "common.h"
 
 #include "MicaController.h"
+#include "RuntimeProfiler.h"
 #include "SystemBackdropBrushFactory.h"
 
 #include "MicaController.g.cpp"
+
+MicaController::MicaController()
+{
+    __RP_Marker_ClassById(RuntimeProfiler::ProfId_MicaController);
+}
 
 MicaController::~MicaController()
 {

--- a/dev/Materials/Backdrop/MicaController.h
+++ b/dev/Materials/Backdrop/MicaController.h
@@ -7,7 +7,7 @@
 
 struct MicaController : winrt::implementation::MicaControllerT<MicaController>, SystemBackdropComponentInternal::ISystemBackdropController
 {
-    MicaController() = default;
+    MicaController();
     ~MicaController();
 
     bool SetTarget(winrt::Windows::UI::Xaml::Window const& xamlWindow);

--- a/dev/Telemetry/RuntimeProfiler.h
+++ b/dev/Telemetry/RuntimeProfiler.h
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 
@@ -57,6 +57,7 @@ namespace RuntimeProfiler
         ProfId_AnimatedIcon,
         ProfId_InfoBadge,
         ProfId_WebView2,
+        ProfId_MicaController,
         ProfId_Size // ProfId_Size is the last always. 
     } ProfilerClassId;
 

--- a/test/MUXControlsTestApp/MainPage.xaml
+++ b/test/MUXControlsTestApp/MainPage.xaml
@@ -61,7 +61,7 @@
         </ScrollViewer>
         <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Center">
             <CheckBox x:Name="LongAnimationsDisabled" AutomationProperties.AutomationId="LongAnimationsDisabled" Content="Long Animations Disabled" Checked="LongAnimationsDisabled_Checked" Unchecked="LongAnimationsDisabled_Unchecked" Margin="10,0,0,0"/>
-
+            <Button x:Name="GarbageCollection" Content="GarbageCollection" VerticalAlignment="Center" Click="GarbageCollection_Click" Margin="5"/>
             <ComboBox
                 x:Name="LanguageChooser"
                 Header="Languages"

--- a/test/MUXControlsTestApp/MainPage.xaml
+++ b/test/MUXControlsTestApp/MainPage.xaml
@@ -61,7 +61,6 @@
         </ScrollViewer>
         <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Center">
             <CheckBox x:Name="LongAnimationsDisabled" AutomationProperties.AutomationId="LongAnimationsDisabled" Content="Long Animations Disabled" Checked="LongAnimationsDisabled_Checked" Unchecked="LongAnimationsDisabled_Unchecked" Margin="10,0,0,0"/>
-            <Button x:Name="GarbageCollection" Content="GarbageCollection" VerticalAlignment="Center" Click="GarbageCollection_Click" Margin="5"/>
             <ComboBox
                 x:Name="LanguageChooser"
                 Header="Languages"

--- a/test/MUXControlsTestApp/MainPage.xaml.cs
+++ b/test/MUXControlsTestApp/MainPage.xaml.cs
@@ -222,6 +222,13 @@ namespace MUXControlsTestApp
             }
         }
 
+        private void GarbageCollection_Click(object sender, RoutedEventArgs e)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
         private void LanguageChooser_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             MUXControlsTestApp.App.LanguageOverride = (string)((ComboBoxItem)LanguageChooser.SelectedItem).Content;

--- a/test/MUXControlsTestApp/MainPage.xaml.cs
+++ b/test/MUXControlsTestApp/MainPage.xaml.cs
@@ -222,13 +222,6 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void GarbageCollection_Click(object sender, RoutedEventArgs e)
-        {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-        }
-
         private void LanguageChooser_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             MUXControlsTestApp.App.LanguageOverride = (string)((ComboBoxItem)LanguageChooser.SelectedItem).Content;

--- a/test/TestAppUtils/TestFrame.cs
+++ b/test/TestAppUtils/TestFrame.cs
@@ -79,9 +79,7 @@ namespace MUXControlsTestApp
                 _currentPageTextBlock.Text = (e.Parameter is string ? e.Parameter as string : "");
             }
 
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            GarbageCollection_Click(null, null);
         }
 
         protected override void OnApplyTemplate()
@@ -181,6 +179,13 @@ namespace MUXControlsTestApp
             }
             // Invert theme
             contentAsFrameworkElement.RequestedTheme = (contentAsFrameworkElement.RequestedTheme == ElementTheme.Light) ? ElementTheme.Dark : ElementTheme.Light;
+        }
+
+        private void GarbageCollection_Click(object sender, RoutedEventArgs e)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
         }
 
         private void GoFullScreenInvokeButton_Click(object sender, RoutedEventArgs e)

--- a/test/TestAppUtils/Themes/Generic.xaml
+++ b/test/TestAppUtils/Themes/Generic.xaml
@@ -67,7 +67,13 @@
                                         AutomationProperties.AutomationId="__EnableRTL"
                                         IsTabStop="False"
                                         Content="Enable RTL"/>
-
+                                    <Button x:Name="GarbageCollection"
+                                        VerticalAlignment="Stretch" Margin="0,0,4,0"
+                                        Style="{ThemeResource AccentButtonStyle}"
+                                        IsTabStop="False"
+                                        Content="Garbage Collection"
+                                        Click="GarbageCollection_Click"/>
+                                    
                                     <TextBlock x:Name="CurrentPageTextBlock" AutomationProperties.AutomationId="__CurrentPage"  FontSize="18" VerticalAlignment="Center" Margin="10,0,0,0"/>
                                 </StackPanel>
 


### PR DESCRIPTION
Three things happening in this PR:
- Recording the creation of the MicaController type for telemetry like we do with other WinUI 2.x controls/components. This is for internal work item 38097087.

- Adding a convenient garbage collection button to MuxControlsTestApp's main page. This comes handy when investigating memory leak bugs in the various test pages.

- Fixing the CalendarView test page which was broken after changing the time zone in the Settings app on the fly. The test CalendarView UI would not reflect the change correctly.