### PR TITLE
Enable Software Bill of Materials task in Release build

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
@@ -90,3 +90,6 @@ steps:
     parameters:
       buildOutputDir: $(buildOutputDir)
       signOutput: ${{parameters.signOutput}}
+
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -1,6 +1,7 @@
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
+  Packaging.EnableSBOMSigning: true
 jobs:
 - job: Build
   # Skip the build job if we are reusing the output of a previous build.

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -2,14 +2,6 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 variables:
   minimumExpectedTestsExecutedCount: 35  # Sanity check for minimum expected tests to be reported
 jobs:
-- job: ComponentDetection
-  pool:
-    vmImage: 'windows-2019'
-
-  steps:
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-
 - job: Build
   # Skip the build job if we are reusing the output of a previous build.
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
@@ -68,59 +60,64 @@ jobs:
     parameters:
       signOutput: true
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Generate SBOM manifest'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# Create Nuget Package
-- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-  parameters:
-    jobName: CreateNugetPackage
-    dependsOn: Build
-    signOutput: true
-    useReleaseTag: '$(MUXFinalRelease)'
-    prereleaseVersionTag: prerelease
+# # Create Nuget Package
+# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+#   parameters:
+#     jobName: CreateNugetPackage
+#     dependsOn: Build
+#     signOutput: true
+#     useReleaseTag: '$(MUXFinalRelease)'
+#     prereleaseVersionTag: prerelease
 
-- template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
-  parameters:
-    dependsOn: Build
+# - template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
+#   parameters:
+#     dependsOn: Build
 
-# Build solution that depends on nuget package
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildNugetPkgTests'
-    buildArtifactName: 'NugetPkgTestsDrop'
-    runTestJobName: 'RunNugetPkgTestsInHelix'
-    helixType: 'test/nuget'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: false
+# # Build solution that depends on nuget package
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildNugetPkgTests'
+#     buildArtifactName: 'NugetPkgTestsDrop'
+#     runTestJobName: 'RunNugetPkgTestsInHelix'
+#     helixType: 'test/nuget'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: false
 
-# Framework package tests
-- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-  parameters:
-    buildJobName: 'BuildFrameworkPkgTests'
-    buildArtifactName: 'FrameworkPkgTestsDrop'
-    runTestJobName: 'RunFrameworkPkgTestsInHelix'
-    helixType: 'test/frpkg'
-    dependsOn: CreateNugetPackage
-    useFrameworkPkg: true
+# # Framework package tests
+# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#   parameters:
+#     buildJobName: 'BuildFrameworkPkgTests'
+#     buildArtifactName: 'FrameworkPkgTestsDrop'
+#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
+#     helixType: 'test/frpkg'
+#     dependsOn: CreateNugetPackage
+#     useFrameworkPkg: true
 
-- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-  parameters:
-    dependsOn:
-    - RunNugetPkgTestsInHelix
-    - RunFrameworkPkgTestsInHelix
-    rerunPassesRequiredToAvoidFailure: 5
-    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+#   parameters:
+#     dependsOn:
+#     - RunNugetPkgTestsInHelix
+#     - RunFrameworkPkgTestsInHelix
+#     rerunPassesRequiredToAvoidFailure: 5
+#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
-# NuGet package WACK tests
-- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-  parameters:
-    name: 'NugetPkgWACKTests'
-    dependsOn: BuildNugetPkgTests
-    artifactName: 'NugetPkgTestsDrop'
+# # NuGet package WACK tests
+# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+#   parameters:
+#     name: 'NugetPkgWACKTests'
+#     dependsOn: BuildNugetPkgTests
+#     artifactName: 'NugetPkgTestsDrop'
 
-# Framework package WACK tests
-- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-  parameters:
-    name: 'FrameworkPkgWACKTests'
-    dependsOn: BuildFrameworkPkgTests
-    artifactName: 'FrameworkPkgTestsDrop'
+# # Framework package WACK tests
+# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+#   parameters:
+#     name: 'FrameworkPkgWACKTests'
+#     dependsOn: BuildFrameworkPkgTests
+#     artifactName: 'FrameworkPkgTestsDrop'

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -37,6 +37,7 @@ jobs:
     appxPackageDir : $(build.artifactStagingDirectory)\$(buildConfiguration)\$(buildPlatform)\AppxPackages
     buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
     publishDir : $(Build.ArtifactStagingDirectory)
+    sbomdir: $(Build.ArtifactStagingDirectory)\sbom\$(buildConfiguration)\$(buildPlatform)
   steps:
 
   # Download and extract nuget package with non-stubbed MicrosoftTelemetry.h header
@@ -61,10 +62,12 @@ jobs:
     parameters:
       signOutput: true
 
+  - script: |
+     mkdir $(sbomdir)
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generate SBOM manifest'
     inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)\sbom\$(buildConfiguration)\$(buildPlatform)
+      BuildDropPath: $(sbomdir)
 
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -64,7 +64,7 @@ jobs:
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generate SBOM manifest'
     inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      BuildDropPath: $(Build.ArtifactStagingDirectory)\sbom\$(buildConfiguration)\$(buildPlatform)
 
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 

--- a/build/MUX-Release.yml
+++ b/build/MUX-Release.yml
@@ -71,57 +71,57 @@ jobs:
 
   - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# # Create Nuget Package
-# - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-#   parameters:
-#     jobName: CreateNugetPackage
-#     dependsOn: Build
-#     signOutput: true
-#     useReleaseTag: '$(MUXFinalRelease)'
-#     prereleaseVersionTag: prerelease
+# Create Nuget Package
+- template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+  parameters:
+    jobName: CreateNugetPackage
+    dependsOn: Build
+    signOutput: true
+    useReleaseTag: '$(MUXFinalRelease)'
+    prereleaseVersionTag: prerelease
 
-# - template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
-#   parameters:
-#     dependsOn: Build
+- template: AzurePipelinesTemplates\MUX-PushCBSVpack-Job.yml
+  parameters:
+    dependsOn: Build
 
-# # Build solution that depends on nuget package
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildNugetPkgTests'
-#     buildArtifactName: 'NugetPkgTestsDrop'
-#     runTestJobName: 'RunNugetPkgTestsInHelix'
-#     helixType: 'test/nuget'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: false
+# Build solution that depends on nuget package
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildNugetPkgTests'
+    buildArtifactName: 'NugetPkgTestsDrop'
+    runTestJobName: 'RunNugetPkgTestsInHelix'
+    helixType: 'test/nuget'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: false
 
-# # Framework package tests
-# - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#   parameters:
-#     buildJobName: 'BuildFrameworkPkgTests'
-#     buildArtifactName: 'FrameworkPkgTestsDrop'
-#     runTestJobName: 'RunFrameworkPkgTestsInHelix'
-#     helixType: 'test/frpkg'
-#     dependsOn: CreateNugetPackage
-#     useFrameworkPkg: true
+# Framework package tests
+- template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+  parameters:
+    buildJobName: 'BuildFrameworkPkgTests'
+    buildArtifactName: 'FrameworkPkgTestsDrop'
+    runTestJobName: 'RunFrameworkPkgTestsInHelix'
+    helixType: 'test/frpkg'
+    dependsOn: CreateNugetPackage
+    useFrameworkPkg: true
 
-# - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
-#   parameters:
-#     dependsOn:
-#     - RunNugetPkgTestsInHelix
-#     - RunFrameworkPkgTestsInHelix
-#     rerunPassesRequiredToAvoidFailure: 5
-#     minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
+- template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
+  parameters:
+    dependsOn:
+    - RunNugetPkgTestsInHelix
+    - RunFrameworkPkgTestsInHelix
+    rerunPassesRequiredToAvoidFailure: 5
+    minimumExpectedTestsExecutedCount: $(minimumExpectedTestsExecutedCount)
 
-# # NuGet package WACK tests
-# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-#   parameters:
-#     name: 'NugetPkgWACKTests'
-#     dependsOn: BuildNugetPkgTests
-#     artifactName: 'NugetPkgTestsDrop'
+# NuGet package WACK tests
+- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+  parameters:
+    name: 'NugetPkgWACKTests'
+    dependsOn: BuildNugetPkgTests
+    artifactName: 'NugetPkgTestsDrop'
 
-# # Framework package WACK tests
-# - template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
-#   parameters:
-#     name: 'FrameworkPkgWACKTests'
-#     dependsOn: BuildFrameworkPkgTests
-#     artifactName: 'FrameworkPkgTestsDrop'
+# Framework package WACK tests
+- template: AzurePipelinesTemplates\MUX-WACKTests-Job.yml
+  parameters:
+    name: 'FrameworkPkgWACKTests'
+    dependsOn: BuildFrameworkPkgTests
+    artifactName: 'FrameworkPkgTestsDrop'


### PR DESCRIPTION
This adds the SBOM generation task to our Release builds.

This task generates an spdx manifest file that lists all the dependencies of the built code to enable a Software Bill of Materials for the product.

See also: https://devblogs.microsoft.com/engineering-at-microsoft/generating-software-bills-of-materials-sboms-with-spdx-at-microsoft/