### PR TITLE
Update PGO queue

### DIFF
--- a/build/MUX-PGOInstrument.yml
+++ b/build/MUX-PGOInstrument.yml
@@ -66,11 +66,11 @@ jobs:
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'
-        closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.Open.xaml'
+        closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.xaml'
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
-        closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.Open.xaml'
+        closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.xaml'
 
 - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
   parameters:

--- a/build/MUX-PGOInstrument.yml
+++ b/build/MUX-PGOInstrument.yml
@@ -66,11 +66,11 @@ jobs:
       Release_x86:
         buildPlatform: 'x86'
         buildConfiguration: 'Release'
-        closedHelixTargetQueues: 'windows.10.amd64.client19h1.xaml'
+        closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.Open.xaml'
       Release_x64:
         buildPlatform: 'x64'
         buildConfiguration: 'Release'
-        closedHelixTargetQueues: 'windows.10.amd64.client19h1.xaml'
+        closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.Open.xaml'
 
 - template: AzurePipelinesTemplates\MUX-ProcessTestResults-Job.yml
   parameters:


### PR DESCRIPTION
We no longer use the 19H1 queue for running tests. This was causing the PGO pipeline to fail.

The PGO Pipeline is already failing with a separate issue due to nuget package versioning. This PR does not address that issue.