### PR TITLE
NavigationView Overflow Items Minor UI Fixes

### DIFF
--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -362,7 +362,7 @@
                                                 <Flyout.FlyoutPresenterStyle>
                                                     <Style TargetType="FlyoutPresenter">
                                                         <Setter Property="Padding" Value="{ThemeResource TopNavigationViewOverflowMenuPadding}" />
-                                                        <!-- Set negative top margin to make the flyout align exactly with the button -->
+                                                        
                                                         <Setter Property="Margin" Value="0,0,0,0" />
                                                         <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
                                                         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -362,8 +362,6 @@
                                                 <Flyout.FlyoutPresenterStyle>
                                                     <Style TargetType="FlyoutPresenter">
                                                         <Setter Property="Padding" Value="{ThemeResource TopNavigationViewOverflowMenuPadding}" />
-                                                        
-                                                        <Setter Property="Margin" Value="0,0,0,0" />
                                                         <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
                                                         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
                                                         <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />

--- a/dev/NavigationView/NavigationView.xaml
+++ b/dev/NavigationView/NavigationView.xaml
@@ -363,7 +363,7 @@
                                                     <Style TargetType="FlyoutPresenter">
                                                         <Setter Property="Padding" Value="{ThemeResource TopNavigationViewOverflowMenuPadding}" />
                                                         <!-- Set negative top margin to make the flyout align exactly with the button -->
-                                                        <Setter Property="Margin" Value="0,-4,0,0" />
+                                                        <Setter Property="Margin" Value="0,0,0,0" />
                                                         <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
                                                         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
                                                         <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -306,8 +306,8 @@
     <CornerRadius x:Key="NavigationViewMinimalContentGridCornerRadius">0</CornerRadius>
 
     <!-- The two resources below must be defined at the app level in order to take effect. -->
-    <Thickness x:Key="TopNavigationViewOverflowMenuPadding">0,8</Thickness>
-    <Thickness x:Key="NavigationViewItemChildrenMenuFlyoutPadding">0,8</Thickness>
+    <Thickness x:Key="TopNavigationViewOverflowMenuPadding">0,2</Thickness>
+    <Thickness x:Key="NavigationViewItemChildrenMenuFlyoutPadding">0,2</Thickness>
 
     <!-- The resource below must be defined at the app level in order to affect the expand/collapse chevron font size
          used in the Top NavigationView's Overflow menu. -->
@@ -1217,7 +1217,10 @@
                 <ControlTemplate TargetType="primitives:NavigationViewItemPresenter">
                     <Grid
                         x:Name="LayoutRoot"
-                        Height="36" 
+                        Height="36"
+				  Margin="{StaticResource NavigationViewItemButtonMargin}"
+				  contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
+				  contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         Background="{TemplateBinding Background}"
                         Control.IsTemplateFocusTarget="True">
                         <Grid.Resources>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -1218,9 +1218,9 @@
                     <Grid
                         x:Name="LayoutRoot"
                         Height="36"
-				  Margin="{StaticResource NavigationViewItemButtonMargin}"
-				  contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
-				  contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        Margin="{StaticResource NavigationViewItemButtonMargin}"
+                        contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                         Background="{TemplateBinding Background}"
                         Control.IsTemplateFocusTarget="True">
                         <Grid.Resources>


### PR DESCRIPTION
## Description
> Fixed Corner Radius Issue for Items Appearing in Overflow when the PaneDisplayMode is Top or LeftCompact
> Fixed Top/Bottom and Left/Right Margin Difference for Overflow Navigation Items
> Fixed Top Margin for OverflowButton Flyout when in Top Navigation Mode.

## Motivation and Context
The change is required to align the UI of Overflow Items with other elements in WinUI such as Menus and CommandBar Overflow.

## How Has This Been Tested?
Tested locally with small sample app. Screenshots attached.

## Screenshots (if appropriate):
![NavigationViewMinorIssues](https://user-images.githubusercontent.com/58418307/154798507-10e3a1a3-f341-4fa6-9250-30331f2214d1.png)
![NavigationViewMinorIssuesFixed](https://user-images.githubusercontent.com/58418307/154798510-ac9cdb99-86d5-4b7a-b986-17e5850fcefd.png)