### PR TITLE
Make PersonPicture initials display centered

### DIFF
--- a/dev/PersonPicture/PersonPicture.xaml
+++ b/dev/PersonPicture/PersonPicture.xaml
@@ -80,8 +80,8 @@
                             Foreground="{TemplateBinding Foreground}"
                             FontWeight="{TemplateBinding FontWeight}"
                             TextLineBounds="Tight"
+                            TextAlignment="Center"
                             VerticalAlignment="Center"
-                            HorizontalAlignment="Center"
                             IsTextScaleFactorEnabled="False"
                             Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualInitials}" />
 

--- a/test/MUXControlsTestApp/verification/PersonPicture-8.xml
+++ b/test/MUXControlsTestApp/verification/PersonPicture-8.xml
@@ -48,7 +48,7 @@
         Margin=0,0,0,0
         Name=InitialsTextBlock
         Padding=0,0,0,0
-        RenderSize=100,30
+        RenderSize=46,30
         Visibility=Visible
     [Windows.UI.Xaml.Controls.Grid]
         Background=[NULL]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PersonPicture initials can look slightly off-center. For instance, on my 125% display scale screen, letters look a little bit to the left. However, even a 100% display scale factor can still look off.

## Motivation and Context
This improves the visual appearance of PersonPicture when initials or an icon is shown.

## How Has This Been Tested?
Visually—see below.

## Screenshots (if appropriate):
These screenshots are at 125% scale.
With no image or initials/name:
![Two Person Pictures with the default avatar font icon. Left is off-center, right is visually centered.](https://user-images.githubusercontent.com/18747724/154861097-002ab387-da04-473c-a5f4-f5e2bf81ee4f.png)
With initials:
![Two Person Pictures with the letter M. Left is off-center, right is visually centered.](https://user-images.githubusercontent.com/18747724/154861128-b785a707-62de-469a-9e04-663dc3fa0d60.png)
Zoomed in so you can see how the antialiasing affects the visual perception of centered-ness.
![The same two Person Pictures with the letter M, left off-center, right visually centered, but zoomed in so individual pixels are visible](https://user-images.githubusercontent.com/18747724/154861175-3020ddd1-c401-40fc-a1f1-67d946421865.png)

This screenshot is at 100% scale:
![Two Person Pictures with the letter M. Left is off-center, right is visually centered.](https://user-images.githubusercontent.com/18747724/154861299-233d298d-06c4-4a8a-8034-efee518179d6.png)

There is one side affect that may or may not be desirable. In the current behavior, text that is clipped with the center in focus. In this PR, if text goes over, it starts at the left.

![Person Picture with initials set to PersonPicture. Left is current behavior: text clips in center. Right is proposed behavior: text clips on the right.](https://user-images.githubusercontent.com/18747724/154861433-d33529a3-d203-475c-be27-0c5a1f163bd7.png)
This is a PersonPicture with `Initials="PersonPicture"`. This is not a particularly realistic use case, but I figured it was worth mentioning in case the current behavior is deliberate.