### PR TITLE
Fix issue where an originally-collapsed WebView2 can't be interacted with

### DIFF
--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -2157,6 +2157,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 ElementCache.Clear();
                 var webview = FindElement.ById("MyWebView2");
                 Verify.IsTrue(webview.IsOffscreen == false);
+
+                // Click in the webview to ensure we can interact with it
+                Rectangle bounds = webview.BoundingRectangle;
+                Log.Comment("Bounds = X:{0}, Y:{1}, Width:{2}, Height:{3}", bounds.X, bounds.Y, bounds.Width, bounds.Height);
+                var point = new Point(bounds.X + 20, bounds.Y + 20);
+                Log.Comment("Move mouse to ({0}, {1})", bounds.X + 20, bounds.Y + 20);
+                PointerInput.Move(point);
+
+                PointerInput.Press(PointerButtons.Primary);
+                PointerInput.Release(PointerButtons.Primary);
+                Wait.ForIdle();
+
+                WaitForWebMessageResult("HiddenThenVisibleTest");
             }
         }
 
@@ -2173,6 +2186,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 ElementCache.Clear();
                 var webview = FindElement.ById("MyWebView2");
                 Verify.IsTrue(webview.IsOffscreen == false);
+
+                // Click in the webview to ensure we can interact with it
+                Rectangle bounds = webview.BoundingRectangle;
+                Log.Comment("Bounds = X:{0}, Y:{1}, Width:{2}, Height:{3}", bounds.X, bounds.Y, bounds.Width, bounds.Height);
+                var point = new Point(bounds.X + 20, bounds.Y + 20);
+                Log.Comment("Move mouse to ({0}, {1})", bounds.X + 20, bounds.Y + 20);
+                PointerInput.Move(point);
+
+                PointerInput.Press(PointerButtons.Primary);
+                PointerInput.Release(PointerButtons.Primary);
+                Wait.ForIdle();
+
+                WaitForWebMessageResult("ParentHiddenThenVisibleTest");
             }
         }
 

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -2144,10 +2144,42 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        public void HiddenThenVisibleTest()
+        {
+            using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
+            {
+                ChooseTest("HiddenThenVisibleTest");
+                CompleteTestAndWaitForResult("HiddenThenVisibleTest");
+
+                // Clear the cache so we can find the new webview
+                ElementCache.Clear();
+                var webview = FindElement.ById("MyWebView2");
+                Verify.IsTrue(webview.IsOffscreen == false);
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        public void ParentHiddenThenVisibleTest()
+        {
+            using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
+            {
+                ChooseTest("ParentHiddenThenVisibleTest");
+                CompleteTestAndWaitForResult("ParentHiddenThenVisibleTest");
+
+                // Clear the cache so we can find the new webview
+                ElementCache.Clear();
+                var webview = FindElement.ById("MyWebView2");
+                Verify.IsTrue(webview.IsOffscreen == false);
+            }
+        }
+
         private static void BeginSubTest(string testName, string testDescription)
         {
             Log.Comment(Environment.NewLine + testName + ": " + testDescription);
-            
+
             Log.Comment("Resetting event and exception counts...");
             Button resetCounts_Button = new Button(FindElement.ById("ResetCounts_Button"));
             resetCounts_Button.Invoke();

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -880,7 +880,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Comment("Focus on tabstop1");
                 x1.SetFocus();
                 Wait.ForIdle();
-                Verify.IsTrue(x1.HasKeyboardFocus);
+                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
 
                 Log.Comment("Tab tabstop1 -> MyWebView2");
                 KeyboardHelper.PressKey(Key.Tab);
@@ -1167,13 +1167,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 PointerInput.Press(PointerButtons.Primary);
                 PointerInput.Move(outsidePoint);
                 PointerInput.Release(PointerButtons.Primary);
-                Wait.ForIdle();
 
                 // Move mouse back across text
                 // If the WebView did not correctly handle captured mouse input then the text will be deselected
                 // due to the WebView still thinking that the mouse's left-button is pressed.
                 PointerInput.Move(startPoint);
-                Wait.ForIdle();
 
                 using (var pasteTestWaiter = new ValueChangedEventWaiter(CopyPasteTextBox2, "MouseCaptureResult"))
                 {
@@ -1338,7 +1336,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("Ignore", "True")] // Task 31708332: WebView2 Touch Tests still failing on Helix
-        [TestProperty("Ignore", "True")]  //Task 31704068: Unreliable tests: WebView2 BasicTapTouchTest, BasicFlingTouchTest, BasicLongPressTouchTest
         [TestProperty("TestSuite", "B")]
         public void BasicTapTouchTest()
         {
@@ -1366,7 +1363,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("Ignore", "True")] // Task 31708332: WebView2 Touch Tests still failing on Helix
-        [TestProperty("Ignore", "True")]  //Task 31704068: Unreliable tests: WebView2 BasicTapTouchTest, BasicFlingTouchTest, BasicLongPressTouchTest
         [TestProperty("TestSuite", "B")]
         public void BasicFlingTouchTest()
         {
@@ -1553,7 +1549,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 CompleteTestAndWaitForResult("ReparentElementTest");
 
                 // Ensure that the moved WebView is still visible
-                Log.Comment("ReparentElementTest Test App Result ignored due to RTB issues with the test.  Verifying from the test runner.");
                 WebView2Temporary.WebView2RenderingVerifier.VerifyInstances("ReparentElementTest");
             }
         }
@@ -2013,7 +2008,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod] // Test fails because .NET UWP doesn't support Object -> VARIANT marshalling.
         [TestProperty("TestSuite", "D")]
-        [TestProperty("Ignore", "True")] // 32510465
+        [TestProperty("Ignore", "True")]
         public void AddHostObjectToScriptTest()
         {
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml
@@ -42,6 +42,7 @@
                             <ComboBoxItem AutomationProperties.Name="Focus_MouseActivateTest">Focus_MouseActivateTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="Focus_ReverseTabTest">Focus_ReverseTabTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="GoBackAndForwardTest">GoBackAndForwardTest</ComboBoxItem>
+                            <ComboBoxItem AutomationProperties.Name="HiddenThenVisibleTest">HiddenThenVisibleTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="HostNameToFolderMappingTest">HostNameToFolderMappingTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="HtmlDropdownTest">HtmlDropdownTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseCaptureTest">MouseCaptureTest</ComboBoxItem>
@@ -63,6 +64,7 @@
                             <ComboBoxItem AutomationProperties.Name="NavigationStartingTest">NavigationStartingTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="NonAsciiUriTest">NonAsciiUriTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="OffTreeWebViewInputTest">OffTreeWebViewInputTest</ComboBoxItem>
+                            <ComboBoxItem AutomationProperties.Name="ParentHiddenThenVisibleTest">ParentHiddenThenVisibleTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="ParentVisibilityHiddenTest">ParentVisibilityHiddenTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="ParentVisibilityTurnedOnTest">ParentVisibilityTurnedOnTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="PointerReleaseWithoutPressTest">PointerReleaseWithoutPressTest</ComboBoxItem>

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml
@@ -175,7 +175,7 @@
                             </ScrollViewer>
                         </StackPanel>
                         <StackPanel Orientation="Vertical">
-                            <TextBlock Text="RTB:" FontWeight="Bold" FontSize="11" Margin="0,2,0,2"/>
+                            <TextBlock Text="Focus:" FontWeight="Bold" FontSize="11" Margin="0,2,0,2"/>
                             <Border Width="400" Height="320" BorderBrush="Blue" BorderThickness="1" HorizontalAlignment="Left" Visibility="Visible">
                                 <ScrollViewer x:Name="focusScrollViewer" VerticalScrollBarVisibility="Visible">
                                     <TextBlock x:Name="focusLog" ></TextBlock>

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -262,8 +262,8 @@ namespace MUXControlsTestApp
             { TestList.NonAsciiUriTest, 7 },
             { TestList.OffTreeWebViewInputTest, 1 },
             { TestList.HtmlDropdownTest, 5 },
-            { TestList.HiddenThenVisibleTest, 0 },
-            { TestList.ParentHiddenThenVisibleTest, 0 },
+            { TestList.HiddenThenVisibleTest, 1 },
+            { TestList.ParentHiddenThenVisibleTest, 1 },
         };
 
         readonly string[] TestPageNames =
@@ -1179,6 +1179,11 @@ namespace MUXControlsTestApp
                         break;
 
                     case TestList.OffTreeWebViewInputTest:
+                        expectedStringResult = "Left mouse button clicked.";
+                        break;
+
+                    case TestList.HiddenThenVisibleTest:
+                    case TestList.ParentHiddenThenVisibleTest:
                         expectedStringResult = "Left mouse button clicked.";
                         break;
 

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -197,6 +197,8 @@ namespace MUXControlsTestApp
             NonAsciiUriTest,
             OffTreeWebViewInputTest,
             HtmlDropdownTest,
+            HiddenThenVisibleTest,
+            ParentHiddenThenVisibleTest
         };
 
         // Map of TestList entry to its webpage (index in TestPageNames[])
@@ -260,6 +262,8 @@ namespace MUXControlsTestApp
             { TestList.NonAsciiUriTest, 7 },
             { TestList.OffTreeWebViewInputTest, 1 },
             { TestList.HtmlDropdownTest, 5 },
+            { TestList.HiddenThenVisibleTest, 0 },
+            { TestList.ParentHiddenThenVisibleTest, 0 },
         };
 
         readonly string[] TestPageNames =
@@ -565,9 +569,7 @@ namespace MUXControlsTestApp
                 case TestList.SourceBeforeLoadTest:
                     {
                         // Remove existing WebView, we're going to replace it
-                        RemoveWebViewEventHandlers(MyWebView2);
-                        Border parentBorder = MyWebView2.Parent as Border;
-                        parentBorder.Child = null;
+                        Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
 
                         Uri uri = WebView2Common.GetTestPageUri("SimplePageWithButton.html");
                         var newWebView2 = new WebView2() {
@@ -612,9 +614,7 @@ namespace MUXControlsTestApp
                 case TestList.WindowlessPopupTest:
                     {
                         // Remove existing WebView so it doesn't get confused with the one in the popup
-                        RemoveWebViewEventHandlers(MyWebView2);
-                        Border parentBorder = MyWebView2.Parent as Border;
-                        parentBorder.Child = null;
+                        _ = RemoveExistingWebViewControl(MyWebView2);
 
                         // Create popup contents: a new webview
                         var webviewInPopup = new WebView2() {
@@ -662,9 +662,7 @@ namespace MUXControlsTestApp
                 case TestList.CursorUpdateTest:
                     {
                         // Remove existing WebView, we're going to replace it
-                        RemoveWebViewEventHandlers(MyWebView2);
-                        Border parentBorder = MyWebView2.Parent as Border;
-                        parentBorder.Child = null;
+                        Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
 
                         // Insert webview with public ProtectedCursor
                         var newWebView2 = new WebView2WithCursor() {
@@ -691,10 +689,67 @@ namespace MUXControlsTestApp
                 case TestList.OffTreeWebViewInputTest:
                     {
                         // Remove existing webview
-                        RemoveWebViewEventHandlers(MyWebView2);
-                        Border parentBorder = MyWebView2.Parent as Border;
-                        parentBorder.Child = null;
+                        Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
                         parentBorder.BorderBrush = new SolidColorBrush(Colors.Pink);
+                    }
+                    break;
+                case TestList.HiddenThenVisibleTest:
+                    {
+                        // Remove existing WebView, we're going to replace it with a hidden one
+                        Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
+                        var parentStackPanel = parentBorder.Parent as StackPanel;
+                        parentStackPanel.Children.Remove(parentBorder);
+
+                        // Create a new border that gets its size from the webview
+                        var newBorder = new Border() {
+                            BorderBrush = new SolidColorBrush(Colors.Red),
+                            BorderThickness = new Thickness(5)
+                        };
+
+                        // Add a new, collapsed WebView2 into the tree
+                        var uri = WebView2Common.GetTestPageUri("SimplePage.html");
+                        var newWebView2 = new WebView2() {
+                            Name = "MyWebView2",
+                            Margin = new Thickness(8, 8, 8, 8),
+                            Width = 670,
+                            Height = 370,
+                            Source = uri,
+                            Visibility = Visibility.Collapsed,
+                        };
+                        AutomationProperties.SetName(newWebView2, "MyWebView2");
+                        newBorder.Child = newWebView2;
+                        parentStackPanel.Children.Add(newBorder);
+                        AddWebViewEventHandlers(newWebView2);
+                    }
+                    break;
+                case TestList.ParentHiddenThenVisibleTest:
+                    {
+                        // Remove existing WebView, we're going to replace it with a hidden one
+                        Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
+                        var parentStackPanel = parentBorder.Parent as StackPanel;
+                        parentStackPanel.Children.Remove(parentBorder);
+
+                        // Create a new, collapsed border that gets its size from the webview
+                        var newBorder = new Border() {
+                            BorderBrush = new SolidColorBrush(Colors.Red),
+                            BorderThickness = new Thickness(5),
+                            Visibility = Visibility.Collapsed
+                        };
+
+                        // Add a new WebView2 into the tree
+                        var uri = WebView2Common.GetTestPageUri("SimplePage.html");
+                        var newWebView2 = new WebView2() {
+                            Name = "MyWebView2",
+                            Margin = new Thickness(8, 8, 8, 8),
+                            Width = 670,
+                            Height = 370,
+                            Source = uri,
+                            Visibility = Visibility.Visible,
+                        };
+                        AutomationProperties.SetName(newWebView2, "MyWebView2");
+                        newBorder.Child = newWebView2;
+                        parentStackPanel.Children.Add(newBorder);
+                        AddWebViewEventHandlers(newWebView2);
                     }
                     break;
                 default:
@@ -901,6 +956,14 @@ namespace MUXControlsTestApp
             };
             stackPanel.Children.Add(border);
             WebView2Collection.Children.Add(stackPanel);
+        }
+
+        Border RemoveExistingWebViewControl(WebView2 webview)
+        {
+            RemoveWebViewEventHandlers(webview);
+            Border parentBorder = webview.Parent as Border;
+            parentBorder.Child = null;
+            return parentBorder;
         }
 
         void AddWebViewEventHandlers(WebView2 webview)
@@ -1805,6 +1868,36 @@ namespace MUXControlsTestApp
                             logger.Verify(selctedOption.Equals("\"2\""),
                                 string.Format("Test {0} Failed, Expected option \"2\" to be selcted, actually got {1}",
                                     selectedTest, selctedOption));;
+                        }
+                        break;
+                    case TestList.HiddenThenVisibleTest:
+                        {
+                            logger.Verify(MyWebView2.Visibility == Visibility.Collapsed,
+                                 string.Format("Test {0}: Incorrect setup, Expected MyWebView2.Visibility to be Collapsed, was {1}",
+                                    selectedTest, MyWebView2.Visibility));
+
+                            // Make WebView2 visible
+                            MyWebView2.Visibility = Visibility.Visible;
+
+                            logger.Verify(MyWebView2.IsHitTestVisible,
+                                 string.Format("Test {0}: Failed, Expected MyWebView2.IsHitTestVisible to be true, was {1}",
+                                    selectedTest, MyWebView2.IsHitTestVisible));
+                        }
+                        break;
+                    case TestList.ParentHiddenThenVisibleTest:
+                        {
+                            var parentBorder = MyWebView2.Parent as Border;
+
+                            logger.Verify(parentBorder.Visibility == Visibility.Collapsed,
+                                 string.Format("Test {0}: Incorrect setup, Expected MyWebView2.Visibility to be Collapsed, was {1}",
+                                    selectedTest, parentBorder.Visibility));
+
+                            // Make WebView2's parent Border visible
+                            parentBorder.Visibility = Visibility.Visible;
+
+                            logger.Verify(MyWebView2.IsHitTestVisible,
+                                 string.Format("Test {0}: Failed, Expected MyWebView2.IsHitTestVisible to be true, was {1}",
+                                    selectedTest, MyWebView2.IsHitTestVisible));
                         }
                         break;
 

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -541,7 +541,7 @@ namespace MUXControlsTestApp
                     {
                         AddWebViewControl("MyWebView2B");
                         AddWebViewControl("MyWebView2C");
-                        WebView2Common.LoadWebPage(MyWebView2, TestPageNames[0]);
+                        WebView2Common.LoadWebPage(MyWebView2, TestPageNames[TestInfoDictionary[test]]);
                     }
                     break;
                 case TestList.MultipleWebviews_FocusTest:
@@ -707,7 +707,7 @@ namespace MUXControlsTestApp
                         };
 
                         // Add a new, collapsed WebView2 into the tree
-                        var uri = WebView2Common.GetTestPageUri("SimplePage.html");
+                        var uri = WebView2Common.GetTestPageUri(TestPageNames[TestInfoDictionary[test]]);
                         var newWebView2 = new WebView2() {
                             Name = "MyWebView2",
                             Margin = new Thickness(8, 8, 8, 8),
@@ -737,7 +737,7 @@ namespace MUXControlsTestApp
                         };
 
                         // Add a new WebView2 into the tree
-                        var uri = WebView2Common.GetTestPageUri("SimplePage.html");
+                        var uri = WebView2Common.GetTestPageUri(TestPageNames[TestInfoDictionary[test]]);
                         var newWebView2 = new WebView2() {
                             Name = "MyWebView2",
                             Margin = new Thickness(8, 8, 8, 8),

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1792,7 +1792,8 @@ void WebView2::CheckAndUpdateWebViewPosition()
         return;
     }
 
-    // Check if the position of the WebView within the window has changed
+    // Check if the position of the WebView2 within the window has changed
+    bool changed = false;
     auto transform = TransformToVisual(nullptr);
     auto topLeft = transform.TransformPoint(winrt::Point(0, 0));
 
@@ -1803,17 +1804,27 @@ void WebView2::CheckAndUpdateWebViewPosition()
     {
         m_webViewScaledPosition.X = scaledTopLeftX;
         m_webViewScaledPosition.Y = scaledTopLeftY;
+        changed = true;
     }
 
-    m_webViewScaledSize.X = ceil(static_cast<float>(ActualWidth()) * m_rasterizationScale);
-    m_webViewScaledSize.Y = ceil(static_cast<float>(ActualHeight()) * m_rasterizationScale);
+    auto scaledSizeX = ceil(static_cast<float>(ActualWidth()) * m_rasterizationScale);
+    auto scaledSizeY = ceil(static_cast<float>(ActualHeight()) * m_rasterizationScale);
+    if (scaledSizeX != m_webViewScaledSize.X || scaledSizeY != m_webViewScaledSize.Y)
+    {
+        m_webViewScaledSize.X = scaledSizeX;
+        m_webViewScaledSize.Y = scaledSizeY;
+        changed = true;
+    }
 
-    // We create the Bounds using X, Y, width, and height
-    m_coreWebViewController.Bounds({
-        (m_webViewScaledPosition.X),
-        (m_webViewScaledPosition.Y),
-        (m_webViewScaledSize.X),
-        (m_webViewScaledSize.Y) });
+    if (changed)
+    {
+        // We create the Bounds using X, Y, width, and height
+        m_coreWebViewController.Bounds({
+            (m_webViewScaledPosition.X),
+            (m_webViewScaledPosition.Y),
+            (m_webViewScaledSize.X),
+            (m_webViewScaledSize.Y) });
+    }
 }
 
 winrt::Rect WebView2::GetBoundingRectangle()
@@ -1823,7 +1834,6 @@ winrt::Rect WebView2::GetBoundingRectangle()
         (m_webViewScaledPosition.Y),
         (m_webViewScaledSize.X),
         (m_webViewScaledSize.Y) });
-    }
 }
 
 void WebView2::SetCoreWebViewAndVisualSize(const float width, const float height)

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -833,24 +833,28 @@ void WebView2::CreateMissingAnaheimWarning()
     Content(warning);
 }
 
-// We could have a child TextBlock (see CreateMissingAnaheimWarning), make sure it is visited by Measure pass.
+// We could have a child Grid (see AddChildPanel) or a child TextBlock (see CreateMissingAnaheimWarning).
+// Make sure it is visited by the Measure pass.
 winrt::Size WebView2::MeasureOverride(winrt::Size const& availableSize)
 {
-    //if (auto child = Content().try_as<winrt::FrameworkElement>())
-    //{
-    //    Content().Measure(availableSize);
-    //}
+    if (auto child = Content().try_as<winrt::FrameworkElement>())
+    {
+        child.Measure(availableSize);
+        return availableSize;
+    }
 
     return __super::MeasureOverride(availableSize);
 }
 
-// We could have a child TextBlock (see CreateMissingAnaheimWarning), make sure it is visited by Arrange pass.
+// We could have a child Grid (see AddChildPanel) or a child TextBlock (see CreateMissingAnaheimWarning).
+// Make sure it is visited by the Arrange pass.
 winrt::Size WebView2::ArrangeOverride(winrt::Size const& finalSize)
 {
-    //if (auto child = Content().try_as<winrt::FrameworkElement>())
-    //{
-    //    Content().Arrange(winrt::Rect{ winrt::Point{0,0}, finalSize });
-    //}
+    if (auto child = Content().try_as<winrt::FrameworkElement>())
+    {
+        child.Arrange(winrt::Rect{ winrt::Point{0,0}, finalSize });
+        return finalSize;
+    }
 
     return __super::ArrangeOverride(finalSize);
 }
@@ -1522,23 +1526,7 @@ void WebView2::AddChildPanel()
 {
     auto panelContent = winrt::Grid();
     panelContent.Background(winrt::SolidColorBrush(winrt::Colors::Transparent()));
-    panelContent.Height(this->ActualHeight());
-    panelContent.Width(this->ActualWidth());
     Content(panelContent);
-}
-
-void WebView2::ResizeChildPanel()
-{
-    auto content = this->Content();
-    if (content)
-    {
-        auto panelContent = content.as<winrt::Grid>();
-        if (panelContent)
-        {
-            panelContent.Height(this->ActualHeight());
-            panelContent.Width(this->ActualWidth());
-        }
-    }
 }
 
 void WebView2::CreateAndSetVisual()
@@ -1764,7 +1752,6 @@ void WebView2::HandleXamlRootChanged()
 void WebView2::HandleSizeChanged(const winrt::IInspectable& /*sender*/, const winrt::SizeChangedEventArgs& args)
 {
     SetCoreWebViewAndVisualSize(args.NewSize().Width, args.NewSize().Height);
-    ResizeChildPanel();
 }
 
 void WebView2::HandleRendered(const winrt::IInspectable& /*sender*/, const winrt::IInspectable& /*args*/)

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1505,7 +1505,13 @@ void WebView2::TryCompleteInitialization()
             [this](auto&&, auto&&) { UpdateDefaultBackgroundColor(); });
     }
 
+    // WebView2 in WinUI 2 is a ContentControl that either renders its web content to a SpriteVisual, or in the case that
+    // the WebView2 Runtime is not installed, renders a message to that effect as its Content. In the case where the
+    // WebView2 starts with Visibility.Collapsed, hit testing code has trouble seeing the WebView2 if it does not have
+    // Content. To work around this, give the WebView2 a transparent Grid as Content that hit testing can find. The size
+    // of this Grid must be kept in sync with the size of the WebView2 (see ResizeChildPanel()).
     AddChildPanel();
+
     CreateAndSetVisual();
 
     // If we were recreating the webview after a core process failure, indicate that we have now recovered

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -837,11 +837,11 @@ void WebView2::CreateMissingAnaheimWarning()
 // Make sure it is visited by the Measure pass.
 winrt::Size WebView2::MeasureOverride(winrt::Size const& availableSize)
 {
-    if (auto child = Content().try_as<winrt::FrameworkElement>())
-    {
-        child.Measure(availableSize);
-        return availableSize;
-    }
+    //if (auto child = Content().try_as<winrt::FrameworkElement>())
+    //{
+    //    child.Measure(availableSize);
+    //    return child.DesiredSize;
+    //}
 
     return __super::MeasureOverride(availableSize);
 }

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1816,6 +1816,16 @@ void WebView2::CheckAndUpdateWebViewPosition()
         (m_webViewScaledSize.Y) });
 }
 
+winrt::Rect WebView2::GetBoundingRectangle()
+{
+    return winrt::Rect({
+        (m_webViewScaledPosition.X),
+        (m_webViewScaledPosition.Y),
+        (m_webViewScaledSize.X),
+        (m_webViewScaledSize.Y) });
+    }
+}
+
 void WebView2::SetCoreWebViewAndVisualSize(const float width, const float height)
 {
 #ifdef WINUI3

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -159,7 +159,6 @@ private:
     void DisconnectFromRootVisualTarget();
     void CreateAndSetVisual();
     void AddChildPanel();
-    void ResizeChildPanel();
 
     void CheckAndUpdateWebViewPosition();
     void CheckAndUpdateWindowPosition();

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -99,6 +99,8 @@ public:
 
     winrt::CoreWebView2 CoreWebView2();     // Getter for CoreWebView2 property (read-only)
 
+    winrt::Rect GetBoundingRectangle();
+
 private:
     bool ShouldNavigate(const winrt::Uri& uri);
     winrt::IAsyncAction OnSourceChanged(winrt::Uri providedUri);

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -155,6 +155,9 @@ private:
     void XamlRootChangedHelper(bool forceUpdate);
     void TryCompleteInitialization();
     void DisconnectFromRootVisualTarget();
+    void CreateAndSetVisual();
+    void AddChildPanel();
+    void ResizeChildPanel();
 
     void CheckAndUpdateWebViewPosition();
     void CheckAndUpdateWindowPosition();

--- a/dev/WebView2/WebView2AutomationPeer.cpp
+++ b/dev/WebView2/WebView2AutomationPeer.cpp
@@ -36,6 +36,12 @@ winrt::AutomationControlType WebView2AutomationPeer::GetAutomationControlTypeCor
     return winrt::AutomationControlType::Pane;
 }
 
+winrt::Rect WebView2AutomationPeer::GetBoundingRectangleCore()
+{
+    winrt::Rect boundingRect = GetImpl()->GetBoundingRectangle();
+    return boundingRect;
+}
+
 #if WINUI3
 HRESULT WebView2AutomationPeer::GetRawElementProviderSimple(_Outptr_opt_ IRawElementProviderSimple** value)
 {

--- a/dev/WebView2/WebView2AutomationPeer.h
+++ b/dev/WebView2/WebView2AutomationPeer.h
@@ -20,6 +20,7 @@ public:
     // IAutomationPeerOverrides
     winrt::hstring GetClassNameCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
+    winrt::Rect GetBoundingRectangleCore();
 
     winrt::IInspectable GetFocusedElementCore();
     winrt::IInspectable NavigateCore(winrt::AutomationNavigationDirection direction);


### PR DESCRIPTION
The main fix here is to add a Grid as Content for the WebView2. This allows WUX hit testing code to find the WebView2, but doesn't get in its way. The size of the Grid is kept in sync with the WebView2 control.

## Description
Other changes are:
* In CheckAndUpdateWebViewPosition(), we were updating the CoreWebView2 Controller's position/size every time. Changed that to only when something has changed.
* Removed unnecessary Wait.ForIdle()s, removing unnecessary Ignore tags, changing "RTB" header to "Focus"
* Pulled code to remove the WebView2 that tests start with into its own RemoveExistingWebViewControl() method

## Motivation and Context
Fixes #6256

## How Has This Been Tested?
Added two tests, HiddenThenVisibleTest and ParentHiddenThenVisibleTest. These tests can also be executed manually.