### PR TITLE
Navigationview: Fix init-once of the GlobalDependencyProperty

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3,8 +3,6 @@
 
 #include "pch.h"
 #include "common.h"
-#include <mutex>
-#include <thread>
 
 #include "NavigationView.h"
 #include "Vector.h"
@@ -223,7 +221,8 @@ NavigationView::NavigationView()
 
     m_navigationViewItemsFactory = winrt::make_self<NavigationViewItemsFactory>();
 
-    std::call_once(s_NavigationViewItemRevokersPropertySet, [this]() {
+    static const auto s_NavigationViewItemRevokersPropertyInit = []()
+    {
         s_NavigationViewItemRevokersProperty =
             InitializeDependencyProperty(
                 L"NavigationViewItemRevokers",
@@ -231,7 +230,8 @@ NavigationView::NavigationView()
                 winrt::name_of<winrt::NavigationViewItem>(),
                 true /* isAttached */,
                 nullptr /* defaultValue */);
-        });
+        return false;
+    }();
 }
 
 void NavigationView::OnSelectionModelChildrenRequested(const winrt::SelectionModel& selectionModel, const winrt::SelectionModelChildrenRequestedEventArgs& e)
@@ -3423,7 +3423,7 @@ void NavigationView::ClearNavigationViewItemRevokers(const winrt::NavigationView
 
 void NavigationView::ClearAllNavigationViewItemRevokers()
 {
-    for (auto const nvi : m_itemsWithRevokerObjects)
+    for (const auto& nvi : m_itemsWithRevokerObjects)
     {
         nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
     }

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -184,12 +184,11 @@ private:
     // displayed by the repeaters in this control. It is used to keep track of the
     // revokers for NavigationViewItem events and allows them to get revoked when
     // the item gets cleaned up
-    GlobalDependencyProperty s_NavigationViewItemRevokersProperty{ nullptr };
+    inline static GlobalDependencyProperty s_NavigationViewItemRevokersProperty{ nullptr };
     void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     void ClearAllNavigationViewItemRevokers();
-    std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects{};
-    std::once_flag s_NavigationViewItemRevokersPropertySet;
+    std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects;
 
     void InvalidateTopNavPrimaryLayout();
     // Measure functions for top navigation   


### PR DESCRIPTION
This commit fixes a bug in `NavigationView` where a `GlobalDependencyProperty`
was repeatedly instantiated in the constructor. Using the atomicity
of statics we ensure it's treated as a singleton instead.

## Description
Additionally this commit makes a minor change to use
references during loop iteration to avoid copies

## Motivation and Context
Related to #6240, which introduced this code.
Closes #6760.