### PR TITLE
Update TabViewItem BrushResources

### DIFF
--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -86,10 +86,10 @@
             <Color x:Key="LayerOnAcrylicFillColorDefault">#09FFFFFF</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#09FFFFFF</Color>
 
-            <Color x:Key="LayerOnMicaAltFillColorDefault">#733A3A3A</Color>
-            <Color x:Key="LayerOnMicaAltFillColorSecondary">#0FFFFFFF</Color>
-            <Color x:Key="LayerOnMicaAltFillColorTertiary">#2C2C2C</Color>
-            <Color x:Key="LayerOnMicaAltFillColorTransparent">#00FFFFFF</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#733A3A3A</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0FFFFFFF</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#2C2C2C</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#00FFFFFF</Color>
 
             <Color x:Key="SolidBackgroundFillColorBase">#202020</Color>
             <Color x:Key="SolidBackgroundFillColorSecondary">#1C1C1C</Color>
@@ -198,10 +198,10 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
 
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaAltFillColorDefault}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaAltFillColorSecondary}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaAltFillColorTertiary}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaAltFillColorTransparent}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTransparent}" />
 
             <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
@@ -341,10 +341,10 @@
             <Color x:Key="LayerOnAcrylicFillColorDefault">#40FFFFFF</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#40FFFFFF</Color>
 
-            <Color x:Key="LayerOnMicaAltFillColorDefault">#B3FFFFFF</Color>
-            <Color x:Key="LayerOnMicaAltFillColorSecondary">#0A000000</Color>
-            <Color x:Key="LayerOnMicaAltFillColorTertiary">#F9F9F9</Color>
-            <Color x:Key="LayerOnMicaAltFillColorTransparent">#00000000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#B3FFFFFF</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0A000000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#F9F9F9</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#00000000</Color>
             
             <Color x:Key="SolidBackgroundFillColorBase">#F3F3F3</Color>
             <Color x:Key="SolidBackgroundFillColorSecondary">#EEEEEE</Color>
@@ -453,10 +453,10 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
 
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaAltFillColorDefault}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaAltFillColorSecondary}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaAltFillColorTertiary}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaAltFillColorTransparent}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTransparent}" />
 
             <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SolidBackgroundFillColorBase}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
@@ -604,10 +604,10 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}"/>
 
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorDefaultBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorSecondaryBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorTertiaryBrush" Color="{ThemeResource SystemColorHighlightColor}" />
-            <SolidColorBrush x:Key="LayerOnMicaAltFillColorTransparentBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{ThemeResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTransparentBrush" Color="{ThemeResource SystemColorButtonFaceColor}" />
 
             <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
@@ -691,10 +691,10 @@
             <Color x:Key="LayerFillColorAlt">#FF0000</Color>
             <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
-            <Color x:Key="LayerOnMicaAltFillColorDefault">#FF0000</Color>
-            <Color x:Key="LayerOnMicaAltFillColorSecondary">#FF0000</Color>
-            <Color x:Key="LayerOnMicaAltFillColorTertiary">#FF0000</Color>
-            <Color x:Key="LayerOnMicaAltFillColorTransparent">#FF0000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorBase">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorSecondary">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>

--- a/dev/TabView/TabView_themeresources.xaml
+++ b/dev/TabView/TabView_themeresources.xaml
@@ -7,11 +7,11 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaAltFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="TextFillColorTertiaryBrush" />
             <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="TextFillColorPrimaryBrush" />
@@ -73,11 +73,11 @@
 
         <ResourceDictionary x:Key="Dark">
             <StaticResource x:Key="TabViewBackground"                                       ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaAltFillColorSecondaryBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaAltFillColorDefaultBrush" />
-            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackground"                             ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundSelected"                     ResourceKey="SolidBackgroundFillColorTertiaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver"                  ResourceKey="LayerOnMicaBaseAltFillColorSecondaryBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundPressed"                      ResourceKey="LayerOnMicaBaseAltFillColorDefaultBrush" />
+            <StaticResource x:Key="TabViewItemHeaderBackgroundDisabled"                     ResourceKey="LayerOnMicaBaseAltFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewItemHeaderForeground"                             ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewItemHeaderForegroundPressed"                      ResourceKey="TextFillColorTertiaryBrush" />
             <StaticResource x:Key="TabViewItemHeaderForegroundSelected"                     ResourceKey="TextFillColorPrimaryBrush" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Update LayerOnMica* Resource Names: LayerOnMicaAlt ->LayerOnMicaBaseAlt
- Revert `TabViewItemHeaderBackgroundSelected` back to `SolidBackgroundFillColorTertiaryBrush`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes internal bug 38211686