### PR TITLE
Change all tabs to spaces

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -107,9 +107,9 @@ REM
 REM     NUGET Restore
 REM
 if "%PROJECTPATH%" NEQ "" (
-	call .\Tools\NugetWrapper.cmd restore -MSBuildPath "%MSBUILDDIRPATH%" -NonInteractive %PROJECTPATH%
+    call .\Tools\NugetWrapper.cmd restore -MSBuildPath "%MSBUILDDIRPATH%" -NonInteractive %PROJECTPATH%
 ) else (
-	call .\Tools\NugetWrapper.cmd restore -MSBuildPath "%MSBUILDDIRPATH%" -NonInteractive .\MUXControls.sln 
+    call .\Tools\NugetWrapper.cmd restore -MSBuildPath "%MSBUILDDIRPATH%" -NonInteractive .\MUXControls.sln 
 )
 
 REM

--- a/CustomInlineTasks.targets
+++ b/CustomInlineTasks.targets
@@ -30,12 +30,12 @@
                 for (int i = 0; i < SourceFiles.Length; i++)
                 {
                     string text = File.ReadAllText(SourceFiles[i]);
-                    
+
                     for (int j = 0; j < Patterns.Length; j++)
                     {
                         text = text.Replace(Patterns[j], Replacements[j]);
                     }
-                    
+
                     File.WriteAllText(DestinationFiles[i], text);
                 }
             }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <IsDebugTestConfiguration>false</IsDebugTestConfiguration>
     <IsDebugTestConfiguration Condition="'$(Configuration)' == 'Debug_test'">true</IsDebugTestConfiguration>
     <Configuration Condition="'$(Configuration)' == 'Debug_test'">Debug</Configuration>
-    
+
     <BaseOutputPath>$(MSBuildThisFileDirectory)BuildOutput\$(Configuration)\</BaseOutputPath>
     <BaseOutputPath Condition="'$(Configuration)' == 'Debug_test'">$(MSBuildThisFileDirectory)BuildOutput\Debug\</BaseOutputPath>
     <OutDir>$(BaseOutputPath)\$(Platform)\</OutDir>

--- a/InnerLoopAreas.props
+++ b/InnerLoopAreas.props
@@ -4,7 +4,7 @@
   <PropertyGroup Condition="$(SolutionName) == 'MUXControlsInnerLoop'">
     <!-- Features to include for inner loop build for example:-->
     <!-- <FeatureRepeaterEnabled>true</FeatureRepeaterEnabled> -->
-    
+
     <!-- Note that after modifying the file, you will need to close and reopen the solution -->
     <!-- for changes to be picked up correctly by Visual Studio and MSBUILD -->
   </PropertyGroup>

--- a/SdkVersion.props
+++ b/SdkVersion.props
@@ -14,8 +14,8 @@
     <!-- By default we use the publicly shipped SDK version which is 21H1 now -->
     <MuxSdkVersion Condition="$(UseInsiderSDK) != 'true'">$(SDKVersion21H1)</MuxSdkVersion>
 
-    <!-- Setting UseInsiderSDK will allow the code to build to the newest insider SDK 
-         In order to get this from a cmd prompt run 
+    <!-- Setting UseInsiderSDK will allow the code to build to the newest insider SDK
+         In order to get this from a cmd prompt run
          set UseInsiderSDK=true and then launch muxcontrols.sln from that cmd prompt -->
     <MuxSdkVersion Condition="$(UseInsiderSDK) == 'true'">$(SDKVersionInsider)</MuxSdkVersion>
   </PropertyGroup>

--- a/build/FrameworkPackage/MakeFrameworkPackage.cmd
+++ b/build/FrameworkPackage/MakeFrameworkPackage.cmd
@@ -12,8 +12,8 @@ pushd %~dp0
 powershell -ExecutionPolicy Unrestricted -NoLogo -NoProfile -Command "&{ %~dpn0.ps1 %*; exit $lastexitcode  }"
 
 if %ERRORLEVEL% NEQ 0 (
-	@echo ##vso[task.logissue type=error;] MakeFrameworkPackage failed with exit code %ERRORLEVEL%
-	goto END
+    @echo ##vso[task.logissue type=error;] MakeFrameworkPackage failed with exit code %ERRORLEVEL%
+    goto END
 )
 
 :END

--- a/build/NuSpecs/MakeAllAppx.cmd
+++ b/build/NuSpecs/MakeAllAppx.cmd
@@ -3,10 +3,10 @@ REM %~dp0 is position of script file
 
 
 if exist %~dp0"..\..\BuildOutput\Debug\x86\Microsoft.UI.Xaml" (
-	call %~dp0..\..\tools\MakeAppxHelper.cmd x86 debug %*
+    call %~dp0..\..\tools\MakeAppxHelper.cmd x86 debug %*
 )
 if exist %~dp0"..\..\BuildOutput\Release\x86\Microsoft.UI.Xaml" (
-	call %~dp0..\..\tools\MakeAppxHelper.cmd x86 release%*
+    call %~dp0..\..\tools\MakeAppxHelper.cmd x86 release%*
 )
 if exist %~dp0"..\..\BuildOutput\Debug\x64\Microsoft.UI.Xaml" (
   call %~dp0..\..\tools\MakeAppxHelper.cmd x64 debug %*

--- a/dev/AnimatedIcon/Docs/AnimatedIconDevDesign.md
+++ b/dev/AnimatedIcon/Docs/AnimatedIconDevDesign.md
@@ -51,19 +51,19 @@ An icon button template which has been updated to support using an animated icon
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualState x:Name="Normal">
-	                                    <VisualState.Setters>
-		                                    <Setter Target="Icon.(AnimatedIcon.State)" Value="Normal"/>
-	                                    </VisualSTate.Setters>
+                                        <VisualState.Setters>
+                                            <Setter Target="Icon.(AnimatedIcon.State)" Value="Normal"/>
+                                        </VisualSTate.Setters>
                                     </VisualState>
                                     <VisualState x:Name="PointerOver">
-		                                <VisualState.Setters>
-		                                    <Setter Target="Icon.(AnimatedIcon.State)" Value="Hover"/>
-	                                    </VisualSTate.Setters>
+                                        <VisualState.Setters>
+                                            <Setter Target="Icon.(AnimatedIcon.State)" Value="Hover"/>
+                                        </VisualSTate.Setters>
                                     </VisualState>
                                     <VisualState x:Name="Pressed">
-		                                <VisualState.Setters>
-		                                    <Setter Target="Icon.(AnimatedIcon.State)" Value="Pressed"/>
-	                                    </VisualSTate.Setters>
+                                        <VisualState.Setters>
+                                            <Setter Target="Icon.(AnimatedIcon.State)" Value="Pressed"/>
+                                        </VisualSTate.Setters>
                                     </VisualState>
                                 </VisualStateGroup>
                             </VisualStateManager.VisualStateGroups>
@@ -117,5 +117,5 @@ Downsides:
 
 Red Flags:
 - Adobe After Effects does not support multiple markers being placed on the same frame. I see two options to resolve this:
-	- Ask Designer to add all of the state names to a single markers comment, ie: "RestToHoverStart,HoverToRestEnd". This would require additional work from lottie gen.
-	- Do not allow designers to have animations which share end points.
+  - Ask Designer to add all of the state names to a single markers comment, ie: "RestToHoverStart,HoverToRestEnd". This would require additional work from lottie gen.
+  - Do not allow designers to have animations which share end points.

--- a/dev/AnimatedIcon/Docs/MultiStateSegmentLookupProposal.md
+++ b/dev/AnimatedIcon/Docs/MultiStateSegmentLookupProposal.md
@@ -63,10 +63,10 @@ Animated Icon is initially being published With a single state property, which h
 
 In order to specify an animation for every state transitions the Lottie author will need to specify 120 markers with the following format:
 
-|  [FromState]To[ToState]Start	 |       [FromState]To[ToState]End   |
+| [FromState]To[ToState]Start        | [FromState]To[ToState]End        |
 |:---:|:---:|
 | NormalDraggingToHoverDraggingStart | HoverDraggingToNormalDraggingEnd |
-| NormalDraggingToNormalOnStart            | NormalDraggingToNormalOnEnd            |
+| NormalDraggingToNormalOnStart      | NormalDraggingToNormalOnEnd      |
 
 ## Requirements
 

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -118,7 +118,7 @@ void AnimatedVisualPlayer::AnimationPlay::Start()
             m_batchCompletedToken = m_batch.Completed([this](winrt::IInspectable const&, winrt::CompositionBatchCompletedEventArgs const&)
                 {
                     if (m_owner) 
-                    {                        
+                    {
                         // If optimization is set to Resources - destroy animations immediately after player stops.
                         if (m_owner->AnimationOptimization() == winrt::PlayerAnimationOptimization::Resources)
                         {
@@ -952,13 +952,13 @@ void AnimatedVisualPlayer::UpdateContent()
     if (auto source3 = source.try_as<winrt::IAnimatedVisualSource3>())
     {
         animatedVisual = source3.TryCreateAnimatedVisual(m_rootVisual.Compositor(), diagnostics, createAnimations);
-		m_isAnimationsCreated = createAnimations;
+        m_isAnimationsCreated = createAnimations;
         m_animatedVisual.set(animatedVisual);
     }
     else
     {
         animatedVisual = source.TryCreateAnimatedVisual(m_rootVisual.Compositor(), diagnostics);
-		m_isAnimationsCreated = true;
+        m_isAnimationsCreated = true;
 
         // m_animatedVisual should be updated before DestroyAnimations call
         m_animatedVisual.set(animatedVisual);

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -444,7 +444,7 @@
                             Grid.Row="1"
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
-         		            contract5NotPresent:Foreground="{ThemeResource TextControlPlaceholderForeground}"
+                            contract5NotPresent:Foreground="{ThemeResource TextControlPlaceholderForeground}"
                             contract5Present:Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForeground}}"
                             Margin="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"

--- a/dev/CommonStyles/TextBox_themeresources_v1.xaml
+++ b/dev/CommonStyles/TextBox_themeresources_v1.xaml
@@ -326,7 +326,7 @@
                             Grid.Row="1"
                             Grid.Column="0"
                             Grid.ColumnSpan="2"
-         		            contract5NotPresent:Foreground="{ThemeResource TextControlPlaceholderForeground}"
+                            contract5NotPresent:Foreground="{ThemeResource TextControlPlaceholderForeground}"
                             contract5Present:Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForeground}}"
                             Margin="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}"

--- a/dev/ImageIcon/APITests/ImageIconTests.cs
+++ b/dev/ImageIcon/APITests/ImageIconTests.cs
@@ -33,12 +33,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                imageIcon = new ImageIcon();                               
+                imageIcon = new ImageIcon();
                 
                 /*
                 #3949 is created to re-enable this part
-                This is an unparented ImageIcon, so looking up the default foreground and verifying	
-                is a bit wierd. The colors are also chaning, so this is going to fail with those changes	
+                This is an unparented ImageIcon, so looking up the default foreground and verifying
+                is a bit wierd. The colors are also chaning, so this is going to fail with those changes
                 So commenting this check out for now to make the test more resilient.
 
                 var theme = Application.Current.RequestedTheme;

--- a/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Properties/Microsoft.UI.Xaml.rd.xml
+++ b/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Properties/Microsoft.UI.Xaml.rd.xml
@@ -27,7 +27,7 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="Microsoft.UI.Xaml">
 
-  	<!-- add directives for your library here -->
+    <!-- add directives for your library here -->
 
   </Library>
 </Directives>

--- a/dev/NavigationView/NavigationView_rs1_themeresources_v1.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources_v1.xaml
@@ -459,9 +459,9 @@
                             x:Name="PointerRectangle" 
                             Fill="Transparent"
                             Visibility="Collapsed"/>
-                        <Border		
-                            x:Name="RevealBorder"		
-                            BorderBrush="{TemplateBinding BorderBrush}"		
+                        <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" />
                         <FontIcon
                             x:Name="Icon"
@@ -527,9 +527,9 @@
                         <Rectangle 
                             x:Name="PointerRectangle" 
                             Fill="Transparent" />
-                        <Border		
-                            x:Name="RevealBorder"		
-                            BorderBrush="{TemplateBinding BorderBrush}"		
+                        <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" />
                         <FontIcon
                             x:Name="Icon"
@@ -843,9 +843,9 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         
-                        <Border		
-                            x:Name="RevealBorder"		
-                            BorderBrush="{TemplateBinding BorderBrush}"		
+                        <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" />
                         <Grid x:Name="PresenterContentRootGrid">
                             <!-- Wrap SelectionIndicator in a grid so that its offset is 0,0 - this enables the offset animation. -->
@@ -1003,9 +1003,9 @@
                         <Rectangle 
                             x:Name="PointerRectangle" 
                             Fill="Transparent" />
-                        <Border		
-                            x:Name="RevealBorder"		
-                            BorderBrush="{TemplateBinding BorderBrush}"		
+                        <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" >
                         </Border>
                         <Grid x:Name="ContentGrid">
@@ -1159,9 +1159,9 @@
                             x:Name="PointerRectangle" 
                             Fill="Transparent"
                             Visibility="Collapsed" />
-                        <Border		
-                            x:Name="RevealBorder"		
-                            BorderBrush="{TemplateBinding BorderBrush}"		
+                        <Border
+                            x:Name="RevealBorder"
+                            BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}" />
                         <Grid x:Name="ContentGrid">
                             <Grid.ColumnDefinitions>

--- a/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.h
+++ b/dev/PullToRefresh/RefreshVisualizer/RefreshVisualizer.h
@@ -31,7 +31,7 @@ public:
 
 private:
     //////////////////////////////////////////////////////
-    ////	OnDependencyPropertyChanged	handlers	//////
+    ////  OnDependencyPropertyChanged    handlers   //////
     //////////////////////////////////////////////////////
     void OnRefreshInfoProviderChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
@@ -71,7 +71,7 @@ private:
     bool IsPullDirectionFar();
 
     //////////////////////////////////////////////////////
-    ////	         DependencyPropertyBackers      //////
+    ////             DependencyPropertyBackers      //////
     //////////////////////////////////////////////////////
     winrt::RefreshVisualizerOrientation m_orientation{ winrt::RefreshVisualizerOrientation::Auto };
     winrt::RefreshVisualizerState m_state{ winrt::RefreshVisualizerState::Idle };
@@ -79,13 +79,13 @@ private:
     tracker_ref<winrt::UIElement> m_content{ this };
 
     ///////////////////////////////////////////////
-    /////////	Event Tokens and Sources   ////////
+    /////////   Event Tokens and Sources   ////////
     ///////////////////////////////////////////////
     winrt::event_token m_RefreshInfoProvider_InteractingForRefreshChangedToken{};
     winrt::event_token m_RefreshInfoProvider_InteractionRatioChangedToken{};
 
     ///////////////////////////////////////////////
-    /////////	Internal Reference Vars   /////////
+    /////////   Internal Reference Vars   /////////
     ///////////////////////////////////////////////
     bool m_isInteractingForRefresh{ false };
     double m_executionRatio{ 0.8f };

--- a/dev/Repeater/InspectingDataSource.h
+++ b/dev/Repeater/InspectingDataSource.h
@@ -6,7 +6,7 @@
 #include "ItemsSourceView.h"
 
 class InspectingDataSource : 
-	public winrt::implements<InspectingDataSource, ItemsSourceView>
+    public winrt::implements<InspectingDataSource, ItemsSourceView>
 {
 public:
     ForwardRefToBaseReferenceTracker(ItemsSourceView)

--- a/dev/ScrollPresenter/SnapPointWrapper.h
+++ b/dev/ScrollPresenter/SnapPointWrapper.h
@@ -48,7 +48,7 @@ public:
     static SnapPointBase* GetSnapPointFromWrapper(std::shared_ptr<SnapPointWrapper<T>> snapPointWrapper);
 
 private:
-	static SnapPointBase* GetSnapPointFromWrapper(const SnapPointWrapper<T>* snapPointWrapper);
+    static SnapPointBase* GetSnapPointFromWrapper(const SnapPointWrapper<T>* snapPointWrapper);
 
 private:
     T m_snapPoint;

--- a/dev/TeachingTip/TeachingTip.xaml
+++ b/dev/TeachingTip/TeachingTip.xaml
@@ -394,15 +394,15 @@
                                                             Command="{TemplateBinding ActionButtonCommand}"
                                                             CommandParameter="{TemplateBinding ActionButtonCommandParameter}">
                                                             <ContentPresenter TextWrapping="WrapWholeWords" Content="{TemplateBinding ActionButtonContent}"/>
-						    </Button>
+                                                    </Button>
                                                     <Button x:Name="CloseButton"
                                                             HorizontalAlignment="Stretch"
                                                             Style="{TemplateBinding CloseButtonStyle}"
                                                             Command="{TemplateBinding CloseButtonCommand}"
                                                             CommandParameter="{TemplateBinding CloseButtonCommandParameter}"
                                                             Grid.Column="1">
-					    		    <ContentPresenter TextWrapping="WrapWholeWords" Content="{TemplateBinding CloseButtonContent}"/>
-						    </Button>
+                                                        <ContentPresenter TextWrapping="WrapWholeWords" Content="{TemplateBinding CloseButtonContent}"/>
+                                                    </Button>
                                                 </Grid>
                                             </StackPanel>
                                         </ScrollViewer>

--- a/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
+++ b/dev/TeachingTip/TestUI/TeachingTipPage.xaml.cs
@@ -91,13 +91,13 @@ namespace MUXControlsTestApp
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
-            if (testWindowBounds != null && testWindowBounds.IsOpen)	
-            {	
-                testWindowBounds.IsOpen = false;	
-            }	
-            if(testScreenBounds != null && testScreenBounds.IsOpen)	
-            {	
-                testScreenBounds.IsOpen = false;	
+            if (testWindowBounds != null && testWindowBounds.IsOpen)
+            {
+                testWindowBounds.IsOpen = false;
+            }
+            if(testScreenBounds != null && testScreenBounds.IsOpen)
+            {
+                testScreenBounds.IsOpen = false;
             }
             base.OnNavigatedFrom(e);
         }

--- a/dev/dll/WinRtType.tt
+++ b/dev/dll/WinRtType.tt
@@ -42,7 +42,7 @@
             var winRtTypeName = MapToWinRtName(winmdType);
             CppAbiName = MapToAbiName(winmdType);
             CppAbiInterfaceName = MapToAbiInterfaceName(winmdType);
-			var cppFullTypeName = (CppNamespace != null ? (CppNamespace + "::" ) : "") + winRtTypeName;
+            var cppFullTypeName = (CppNamespace != null ? (CppNamespace + "::" ) : "") + winRtTypeName;
             WinRtFullName = string.Join(".", winRtNamespace, winRtTypeName).TrimStart('.');
             MetadataFullName = GetMetadataFullName(WinRtFullName);
             CppWinRtName = winmdType.IsPrimitive ? GetPrimitiveTypeName(winRtTypeName) : string.Format("winrt::{0}", cppFullTypeName);

--- a/docs/communitycalls/WinUICommunityCall.ics
+++ b/docs/communitycalls/WinUICommunityCall.ics
@@ -22,9 +22,9 @@ BEGIN:VEVENT
 CLASS:PUBLIC
 CREATED:20210618T141625Z
 DESCRIPTION:Join us for the June 2021 edition of the WinUI Community Call\,
-	 where the WinUI team welcomes community members\, ecosystem partners\, an
-	d folks all across our team to answer all of your questions about WinUI.\n
-	\n \n\nWatch on YouTube: https://youtu.be/9EOKxjFyY68\n\n
+     where the WinUI team welcomes community members\, ecosystem partners\, an
+    d folks all across our team to answer all of your questions about WinUI.\n
+    \n \n\nWatch on YouTube: https://youtu.be/9EOKxjFyY68\n\n
 DTEND;TZID="Eastern Standard Time":20210630T130000
 DTSTAMP:20210618T141625Z
 DTSTART;TZID="Eastern Standard Time":20210630T120000
@@ -34,33 +34,33 @@ SEQUENCE:0
 SUMMARY;LANGUAGE=en-us:WinUI Community Call - June 2021
 TRANSP:OPAQUE
 UID:040000008200E00074C5B7101A82E00800000000CB0BF2074B64D701000000000000000
-	01000000027E29D01A99C924DBD5CF1594EC24150
+    01000000027E29D01A99C924DBD5CF1594EC24150
 X-ALT-DESC;FMTTYPE=text/html:<html xmlns:v="urn:schemas-microsoft-com:vml" 
-	xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-mic
-	rosoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/
-	12/omml" xmlns="http://www.w3.org/TR/REC-html40">\n<head>\n\n<meta name="G
-	enerator" content="Microsoft Word 15 (filtered medium)">\n<style><!--\n/* 
-	Font Definitions */\n@font-face\n	{font-family:"Cambria Math"\;\n	panose-1
-	:2 4 5 3 5 4 6 3 2 4\;}\n@font-face\n	{font-family:Calibri\;\n	panose-1:2 
-	15 5 2 2 2 4 3 2 4\;}\n/* Style Definitions */\np.MsoNormal\, li.MsoNormal
-	\, div.MsoNormal\n	{margin:0in\;\n	font-size:11.0pt\;\n	font-family:"Calib
-	ri"\,sans-serif\;}\na:link\, span.MsoHyperlink\n	{mso-style-priority:99\;\
-	n	color:#0563C1\;\n	text-decoration:underline\;}\nspan.EmailStyle18\n	{mso
-	-style-type:personal-compose\;\n	font-family:"Calibri"\,sans-serif\;\n	col
-	or:windowtext\;}\n.MsoChpDefault\n	{mso-style-type:export-only\;\n	font-si
-	ze:10.0pt\;}\n@page WordSection1\n	{size:8.5in 11.0in\;\n	margin:1.0in 1.0
-	in 1.0in 1.0in\;}\ndiv.WordSection1\n	{page:WordSection1\;}\n--></style><!
-	--[if gte mso 9]><xml>\n<o:shapedefaults v:ext="edit" spidmax="1026" />\n<
-	/xml><![endif]--><!--[if gte mso 9]><xml>\n<o:shapelayout v:ext="edit">\n<
-	o:idmap v:ext="edit" data="1" />\n</o:shapelayout></xml><![endif]-->\n</he
-	ad>\n<body lang="EN-US" link="#0563C1" vlink="#954F72" style="word-wrap:br
-	eak-word">\n<div class="WordSection1">\n<p class="MsoNormal">Join us for t
-	he June 2021 edition of the WinUI Community Call\, where the WinUI team we
-	lcomes community members\, ecosystem partners\, and folks all across our t
-	eam to answer all of your questions about WinUI.<o:p></o:p></p>\n<p class=
-	"MsoNormal"><o:p>&nbsp\;</o:p></p>\n<p class="MsoNormal">Watch on YouTube:
-	 <a href="https://youtu.be/9EOKxjFyY68">https://youtu.be/9EOKxjFyY68</a><o
-	:p></o:p></p>\n</div>\n</body>\n</html>\n
+    xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-mic
+    rosoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/
+    12/omml" xmlns="http://www.w3.org/TR/REC-html40">\n<head>\n\n<meta name="G
+    enerator" content="Microsoft Word 15 (filtered medium)">\n<style><!--\n/* 
+    Font Definitions */\n@font-face\n    {font-family:"Cambria Math"\;\n    panose-1
+    :2 4 5 3 5 4 6 3 2 4\;}\n@font-face\n    {font-family:Calibri\;\n    panose-1:2 
+    15 5 2 2 2 4 3 2 4\;}\n/* Style Definitions */\np.MsoNormal\, li.MsoNormal
+    \, div.MsoNormal\n    {margin:0in\;\n    font-size:11.0pt\;\n    font-family:"Calib
+    ri"\,sans-serif\;}\na:link\, span.MsoHyperlink\n    {mso-style-priority:99\;\
+    n    color:#0563C1\;\n    text-decoration:underline\;}\nspan.EmailStyle18\n    {mso
+    -style-type:personal-compose\;\n    font-family:"Calibri"\,sans-serif\;\n    col
+    or:windowtext\;}\n.MsoChpDefault\n    {mso-style-type:export-only\;\n    font-si
+    ze:10.0pt\;}\n@page WordSection1\n    {size:8.5in 11.0in\;\n    margin:1.0in 1.0
+    in 1.0in 1.0in\;}\ndiv.WordSection1\n    {page:WordSection1\;}\n--></style><!
+    --[if gte mso 9]><xml>\n<o:shapedefaults v:ext="edit" spidmax="1026" />\n<
+    /xml><![endif]--><!--[if gte mso 9]><xml>\n<o:shapelayout v:ext="edit">\n<
+    o:idmap v:ext="edit" data="1" />\n</o:shapelayout></xml><![endif]-->\n</he
+    ad>\n<body lang="EN-US" link="#0563C1" vlink="#954F72" style="word-wrap:br
+    eak-word">\n<div class="WordSection1">\n<p class="MsoNormal">Join us for t
+    he June 2021 edition of the WinUI Community Call\, where the WinUI team we
+    lcomes community members\, ecosystem partners\, and folks all across our t
+    eam to answer all of your questions about WinUI.<o:p></o:p></p>\n<p class=
+    "MsoNormal"><o:p>&nbsp\;</o:p></p>\n<p class="MsoNormal">Watch on YouTube:
+     <a href="https://youtu.be/9EOKxjFyY68">https://youtu.be/9EOKxjFyY68</a><o
+    :p></o:p></p>\n</div>\n</body>\n</html>\n
 X-MICROSOFT-CDO-BUSYSTATUS:BUSY
 X-MICROSOFT-CDO-IMPORTANCE:1
 X-MICROSOFT-DISALLOW-COUNTER:FALSE

--- a/docs/contribution_workflow.md
+++ b/docs/contribution_workflow.md
@@ -4,7 +4,9 @@ You can contribute to WinUI with issues and PRs. Simply filing issues for
 problems you encounter is a great way to contribute. Contributing 
 implementations is greatly appreciated.
 
-Good issues to work on are issues tagged with [help wanted](https://github.com/microsoft/microsoft-ui-xaml/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [good first issue](https://github.com/microsoft/microsoft-ui-xaml/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+Good issues to work on are issues tagged with 
+[help wanted](https://github.com/microsoft/microsoft-ui-xaml/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or 
+[good first issue](https://github.com/microsoft/microsoft-ui-xaml/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
 ## Suggested Workflow
 
@@ -89,7 +91,8 @@ bot will then trigger the build.
 
 In order to have PRs automatically merge once all checks have passed (including optional 
 checks), maintainers can apply the [auto merge](https://github.com/Microsoft/microsoft-ui-xaml/labels/auto%20merge) 
-label. It will take effect after an 8 hour delay, [more info here (internal link)](https://microsoft.sharepoint.com/teams/FabricBot/SitePages/AutoMerge,-Bot-Templates-and.aspx).
+label. It will take effect after an 8 hour delay, 
+[more info here (internal link)](https://microsoft.sharepoint.com/teams/FabricBot/SitePages/AutoMerge,-Bot-Templates-and.aspx).
 
 ### Other Pipelines
 
@@ -108,12 +111,12 @@ Please format commit messages as follows (based on [A Note About Git Commit Mess
 
 ```
 Summarize change in 50 characters or less
-	
+
 Provide more detail after the first line. Leave one blank line below the 
 summary and wrap all lines at 72 characters or less.
-	
+
 If the change fixes an issue, leave another blank line after the final 
 paragraph and indicate which issue is fixed in the specific format below.
-	
+
 Fix #42
 ```

--- a/mux.controls.props
+++ b/mux.controls.props
@@ -4,7 +4,7 @@
   <Import Project="SdkVersion.props" />
 
   <Import Project="$(MSBuildThisFileDirectory)local.props" Condition="Exists('$(MSBuildThisFileDirectory)local.props')"/>
-  
+
   <!-- Since RS3, each release should define a min version which is required to build the theme resource. eg: MinSDKVersionRequiredForRS3ThemeResource -->
   <!-- When add page to PagesRequireCustomCompile, a MinSDKVersionRequired property should be attached to this page -->
   <!-- CustomCompile would use MinSDKVersionRequired to set TargetPlatformMinVersion for CompileXaml -->
@@ -19,11 +19,11 @@
 
   <PropertyGroup>
     <CSLangVersion>7</CSLangVersion>
-    
+
     <!-- Surface as errors the warnings that a XAML file is using a type defined in a later version of XAML than the min version for which we're compiling. -->
     <MSBuildWarningsAsErrors>WMC0151;XLS1105</MSBuildWarningsAsErrors>
   </PropertyGroup>
-  
+
   <!-- MUXControls Project-specific Properties -->
   <PropertyGroup Label="MUXControls" Condition="'$(MSBuildProjectName)' == 'MUXControls'">
   </PropertyGroup>
@@ -39,7 +39,7 @@
   <!-- MUXControlsTestApp Project-specific Properties -->
   <PropertyGroup Label="MUXControlsTestApp" Condition="'$(MSBuildProjectName)' == 'MUXControlsTestApp'">
   </PropertyGroup>
-    
+
   <!-- IXMPTestApp Project-specific Properties -->
   <PropertyGroup Label="IXMPTestApp" Condition="'$(MSBuildProjectName)' == 'IXMPTestApp'">
   </PropertyGroup>
@@ -50,7 +50,7 @@
   <!-- MUXControlsSampleApp Project-specific Properties -->
   <PropertyGroup Label="MUXControlsSampleApp" Condition="'$(MSBuildProjectName)' == 'MUXControlsSampleApp'">
   </PropertyGroup>
-  
+
   <!-- CustomTasks Project-specific Properties -->
   <PropertyGroup Label="CustomTasks" Condition="'$(MSBuildProjectName)' == 'CustomTasks'">
   </PropertyGroup>

--- a/test/MUXControlsReleaseTest/LibraryThatUsesMUX/Properties/LibraryThatUsesMUX.rd.xml
+++ b/test/MUXControlsReleaseTest/LibraryThatUsesMUX/Properties/LibraryThatUsesMUX.rd.xml
@@ -27,7 +27,7 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="LibraryThatUsesMUX">
 
-  	<!-- add directives for your library here -->
+    <!-- add directives for your library here -->
 
   </Library>
 </Directives>

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/Properties/MUXControls.ReleaseTest.rd.xml
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/Properties/MUXControls.ReleaseTest.rd.xml
@@ -27,7 +27,7 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="MUXControls.ReleaseTest">
 
-  	<!-- add directives for your library here -->
+    <!-- add directives for your library here -->
 
   </Library>
 </Directives>

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/App.xaml.h
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/App.xaml.h
@@ -12,19 +12,19 @@
 
 namespace NugetPackageTestAppCX
 {
-	/// <summary>
-	/// Provides application-specific behavior to supplement the default Application class.
-	/// </summary>
-	ref class App sealed
-	{
-	protected:
-		virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
+    /// <summary>
+    /// Provides application-specific behavior to supplement the default Application class.
+    /// </summary>
+    ref class App sealed
+    {
+    protected:
+        virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
 
-	internal:
-		App();
+    internal:
+        App();
 
-	private:
-		void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
-		void OnNavigationFailed(Platform::Object ^sender, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs ^e);
-	};
+    private:
+        void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
+        void OnNavigationFailed(Platform::Object ^sender, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs ^e);
+    };
 }

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/MainPage.xaml.cpp
@@ -23,10 +23,10 @@ using namespace Windows::UI::Xaml::Shapes;
 MainPage::MainPage() :
     mItems(ref new Vector<String^>())
 {
-	InitializeComponent();
+    InitializeComponent();
 
     AutomationProperties::SetName(this, L"MainPage");
-        
+
     Repeater->ItemsSource = mItems;
 }
 

--- a/test/MUXExperimentalTest/MUXExperimental.Test/Properties/MUXExperimental.Test.rd.xml
+++ b/test/MUXExperimentalTest/MUXExperimental.Test/Properties/MUXExperimental.Test.rd.xml
@@ -27,7 +27,7 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="MUXExperimental.Test">
 
-  	<!-- add directives for your library here -->
+    <!-- add directives for your library here -->
 
   </Library>
 </Directives>

--- a/test/TestAppCX/BackdropMaterialTestPage.xaml.cpp
+++ b/test/TestAppCX/BackdropMaterialTestPage.xaml.cpp
@@ -27,7 +27,7 @@ using namespace Windows::UI::Xaml::Navigation;
 
 BackdropMaterialTestPage::BackdropMaterialTestPage()
 {
-	InitializeComponent();
+    InitializeComponent();
 
     Loaded += ref new RoutedEventHandler(this, &BackdropMaterialTestPage::OnLoaded);
 

--- a/test/TestAppCX/BackdropMaterialTestPage.xaml.h
+++ b/test/TestAppCX/BackdropMaterialTestPage.xaml.h
@@ -23,13 +23,13 @@ using namespace Windows::UI::Xaml::Navigation;
 
 namespace TestAppCX
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	[Windows::Foundation::Metadata::WebHostHidden]
-	public ref class BackdropMaterialTestPage sealed
-	{
-	public:
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Windows::Foundation::Metadata::WebHostHidden]
+    public ref class BackdropMaterialTestPage sealed
+    {
+    public:
         BackdropMaterialTestPage();
         
         void OnNavigatedTo(NavigationEventArgs^ e) override;

--- a/test/TestAppCX/CornerRadiusTestPage.xaml.cpp
+++ b/test/TestAppCX/CornerRadiusTestPage.xaml.cpp
@@ -23,5 +23,5 @@ using namespace Windows::UI::Xaml::Navigation;
 
 CornerRadiusTestPage::CornerRadiusTestPage()
 {
-	InitializeComponent();
+    InitializeComponent();
 }

--- a/test/TestAppCX/CornerRadiusTestPage.xaml.h
+++ b/test/TestAppCX/CornerRadiusTestPage.xaml.h
@@ -9,13 +9,13 @@
 
 namespace TestAppCX
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	[Windows::Foundation::Metadata::WebHostHidden]
-	public ref class CornerRadiusTestPage sealed
-	{
-	public:
-		CornerRadiusTestPage();
-	};
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Windows::Foundation::Metadata::WebHostHidden]
+    public ref class CornerRadiusTestPage sealed
+    {
+    public:
+        CornerRadiusTestPage();
+    };
 }

--- a/test/TestAppCX/MenuBarTestPage.xaml.cpp
+++ b/test/TestAppCX/MenuBarTestPage.xaml.cpp
@@ -24,5 +24,5 @@ using namespace Windows::UI::Xaml::Navigation;
 
 MenuBarTestPage::MenuBarTestPage()
 {
-	InitializeComponent();
+    InitializeComponent();
 }

--- a/test/TestAppCX/MenuBarTestPage.xaml.h
+++ b/test/TestAppCX/MenuBarTestPage.xaml.h
@@ -12,13 +12,13 @@
 
 namespace TestAppCX
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	[Windows::Foundation::Metadata::WebHostHidden]
-	public ref class MenuBarTestPage sealed
-	{
-	public:
-		MenuBarTestPage();
-	};
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Windows::Foundation::Metadata::WebHostHidden]
+    public ref class MenuBarTestPage sealed
+    {
+    public:
+        MenuBarTestPage();
+    };
 }

--- a/test/TestAppCX/TreeViewTestPage.xaml.h
+++ b/test/TestAppCX/TreeViewTestPage.xaml.h
@@ -47,7 +47,7 @@ namespace TestAppCX
         TreeViewTestPage();
     private:
         void ReplaceAll_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-		void Clear_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-	};
+        void Clear_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+    };
 
 }

--- a/test/TestAppCX/WebView2TestPage.xaml.cpp
+++ b/test/TestAppCX/WebView2TestPage.xaml.cpp
@@ -27,7 +27,7 @@ using namespace Windows::UI::Xaml::Navigation;
 
 WebView2TestPage::WebView2TestPage()
 {
-	InitializeComponent();
+    InitializeComponent();
 }
 
 void WebView2TestPage::OnGo(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)

--- a/test/TestAppCX/WebView2TestPage.xaml.h
+++ b/test/TestAppCX/WebView2TestPage.xaml.h
@@ -23,13 +23,13 @@ using namespace Windows::UI::Xaml::Navigation;
 
 namespace TestAppCX
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	[Windows::Foundation::Metadata::WebHostHidden]
-	public ref class WebView2TestPage sealed
-	{
-	public:
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Windows::Foundation::Metadata::WebHostHidden]
+    public ref class WebView2TestPage sealed
+    {
+    public:
         WebView2TestPage();
         
         void OnGo(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/test/testinfra/MUXTestInfra/Infra/TestHelpers.cs
+++ b/test/testinfra/MUXTestInfra/Infra/TestHelpers.cs
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
                 {
                     ComboBox languageChooserComboBox = new ComboBox(languageChooser);
 
-					languageChooserComboBox.SelectItemById(Options.LanguageOverride);
+                    languageChooserComboBox.SelectItemById(Options.LanguageOverride);
                 }
             }
         }
@@ -293,7 +293,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.Infra
             TestEnvironment.LogVerbose("TestSetupHelper.Dispose()");
             TestCleanupHelper.TestSetupHelperPendingDisposals--;
 
-            while(OpenedTestPages > 0)
+            while (OpenedTestPages > 0)
             {
                 GoBack();
                 OpenedTestPages--;

--- a/tools/GenerateNewControlProject.ps1
+++ b/tools/GenerateNewControlProject.ps1
@@ -153,7 +153,7 @@ $cleanMuxControlsDir = $muxControlsDir.Replace("\","\\") + "\\"
 Write-Output "$cleanMuxControlsDir"
 
 $assemblies=(
-	"System","EnvDTE","EnvDTE80"
+    "System","EnvDTE","EnvDTE80"
 )
 
 $source=@"

--- a/tools/GenerateVisualVerificationUpdates.ps1
+++ b/tools/GenerateVisualVerificationUpdates.ps1
@@ -83,7 +83,7 @@ if($BuildId)
     if($baseNameList.Count -lt 1)
     {
         Write-Host "No verification files were found, did you call the script on the correct directory?"
-	}
+    }
     
     $staging = New-TemporaryDirectory
     foreach($baseName in $baseNameList)
@@ -125,11 +125,11 @@ if($BuildId)
                 {
                     $currentVersionedVerificationFileIndexForI = $currentVerificationFilesIndexesLessThanI[0]
                     $currentVersionedVerificationFileForI = $currentVersionedVerificationFiles | Where {$_.Name.StartsWith("$baseName-$currentVersionedVerificationFileIndexForI.")}
-                    $finalVersionedVerificationFiles += $currentVersionedVerificationFileForI        
+                    $finalVersionedVerificationFiles += $currentVersionedVerificationFileForI
                 }
                 else
                 {
-                    $finalVersionedVerificationFiles += $currentBaseVerificationFile				
+                    $finalVersionedVerificationFiles += $currentBaseVerificationFile
                 }
             }
         }

--- a/tools/MakeAppxHelper.cmd
+++ b/tools/MakeAppxHelper.cmd
@@ -18,24 +18,24 @@ if "%2" NEQ "" (
 )
 
 if "%TFS_PLATFORM%" EQU "" (
-	echo Expecting TFS_PLATFORM to be set
-	exit /b 1
+    echo Expecting TFS_PLATFORM to be set
+    exit /b 1
 )
 
 if "%TFS_BUILDCONFIGURATION%" EQU "" (
-	echo Expecting TFS_BUILDCONFIGURATION to be set
-	exit /b 1
+    echo Expecting TFS_BUILDCONFIGURATION to be set
+    exit /b 1
 )
 
 set BasePackageName=Microsoft.UI.Xaml
 
 echo BUILDOUTPUT_OVERRIDE = %BUILDOUTPUT_OVERRIDE%
 if "%BUILDOUTPUT_OVERRIDE%" == "" (
-	set InputDirectory=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\Microsoft.UI.Xaml
-	set OutputDirectory=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\FrameworkPackage
+    set InputDirectory=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\Microsoft.UI.Xaml
+    set OutputDirectory=%CD%\..\BuildOutput\%TFS_BUILDCONFIGURATION%\%TFS_PLATFORM%\FrameworkPackage
 ) else (
-	set InputDirectory=%BUILDOUTPUT_OVERRIDE%\Microsoft.UI.Xaml
-	set OutputDirectory=%BUILDOUTPUT_OVERRIDE%\FrameworkPackage
+    set InputDirectory=%BUILDOUTPUT_OVERRIDE%\Microsoft.UI.Xaml
+    set OutputDirectory=%BUILDOUTPUT_OVERRIDE%\FrameworkPackage
 )
 
 call ..\build\FrameworkPackage\MakeFrameworkPackage.cmd -InputDirectory '%InputDirectory%' ^
@@ -44,8 +44,8 @@ call ..\build\FrameworkPackage\MakeFrameworkPackage.cmd -InputDirectory '%InputD
  %3 %4 %5 %6 %7 %8 %9
 
 if %ERRORLEVEL% NEQ 0 (
-	@echo ##vso[task.logissue type=error;] MakeFrameworkPackage failed with exit code %ERRORLEVEL%
-	goto END
+    @echo ##vso[task.logissue type=error;] MakeFrameworkPackage failed with exit code %ERRORLEVEL%
+    goto END
 )
 
 :END


### PR DESCRIPTION
Fixes a few inconsistencies where there were tabs in the code instead of spaces. Didn't change .sln files, since those are created by Visual Studio. Also removed some unnecessary trailing whitespace.

There should be no functional changes, only whitespace.