### PR TITLE
Fix issue with ProgressRing not animating after being unloaded

### DIFF
--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -31,6 +31,7 @@ ProgressRing::ProgressRing()
     SetValue(s_TemplateSettingsProperty, winrt::make<::ProgressRingTemplateSettings>());
 
     SizeChanged({ this, &ProgressRing::OnSizeChanged });
+    Loaded({ this, &ProgressRing::OnLoaded });
 }
 
 winrt::AutomationPeer ProgressRing::OnCreateAutomationPeer()
@@ -63,6 +64,11 @@ void ProgressRing::OnIndeterminateSourcePropertyChanged(winrt::DependencyPropert
 void ProgressRing::OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&)
 {
     ApplyTemplateSettings();
+}
+
+void ProgressRing::OnLoaded(const winrt::IInspectable&, const winrt::IInspectable&)
+{
+    UpdateStates();
 }
 
 void ProgressRing::OnForegroundPropertyChanged(const winrt::DependencyObject&, const winrt::DependencyProperty&)

--- a/dev/ProgressRing/ProgressRing.h
+++ b/dev/ProgressRing/ProgressRing.h
@@ -43,6 +43,7 @@ private:
     void SetLottieForegroundColor(const winrt::IAnimatedVisualSource);
     void SetLottieBackgroundColor(const winrt::IAnimatedVisualSource);
     void OnSizeChanged(const winrt::IInspectable&, const winrt::IInspectable&);
+    void OnLoaded(const winrt::IInspectable&, const winrt::IInspectable&);
     void UpdateStates();
     void ApplyTemplateSettings();
     void UpdateLottieProgress();

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -180,6 +180,7 @@
                         <StackPanel Padding="16" Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
                             <TextBlock>Shop text</TextBlock>
                             <Button Content="SecondTabButton" AutomationProperties.Name="SecondTabButton"/>
+                            <controls:ProgressRing IsActive="True"/>
                         </StackPanel>
                     </controls:TabViewItem>
 
@@ -187,6 +188,7 @@
                         <StackPanel Padding="16" Background="{ThemeResource TabViewItemHeaderBackgroundSelected}">
                             <TextBlock >Emoji text</TextBlock>
                             <Button Content="Button 3"/>
+                            <controls:ProgressRing IsActive="True"/>
                         </StackPanel>
                     </controls:TabViewItem>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the ProgressRing control is being unloaded, the underlying AnimatedVisualPlayer unloads its content. This results in the animation not rendering anymore.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #6354 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->