### PR TITLE
Fix issue where setting IsPaneButtonVisible on NavigationView could end up in faulty rendering of pane toggle button

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -4042,6 +4042,7 @@ void NavigationView::OnPropertyChanged(const winrt::DependencyPropertyChangedEve
         UpdatePaneTitleFrameworkElementParents();
         UpdateBackAndCloseButtonsVisibility();
         UpdatePaneToggleButtonVisibility();
+        UpdateTitleBarPadding();
         UpdateVisualState();
     }
     else if (property == s_IsSettingsVisibleProperty)

--- a/dev/NavigationView/TestUI/Common/NavigationViewMinimalPage.xaml
+++ b/dev/NavigationView/TestUI/Common/NavigationViewMinimalPage.xaml
@@ -13,7 +13,7 @@
     <StackPanel>
         <StackPanel Orientation="Horizontal">
             <muxcontrols:NavigationView x:Name="NavView" AutomationProperties.Name="NavView" AutomationProperties.AutomationId="NavView"
-                                            IsBackEnabled="True" Header="LeftMinimal" PaneDisplayMode="LeftMinimal" Margin="10,0">
+                                            IsBackEnabled="True" Header="LeftMinimal" PaneDisplayMode="LeftMinimal" Margin="10,0" IsPaneToggleButtonVisible="False">
                 <StackPanel>
                     <TextBlock x:Name="NavViewActiveVisualStatesResult" AutomationProperties.Name="NavViewActiveVisualStatesResult"/>
                     <Button x:Name="GetNavViewActiveVisualStates" AutomationProperties.Name="GetNavViewActiveVisualStates" Content="GetNavViewActiveVisualStates" Click="GetNavViewActiveVisualStates_Click"/>
@@ -43,6 +43,7 @@
                 IsChecked="{Binding IsPaneOpen, ElementName=NavViewAuto, Mode=TwoWay}"
                 x:Name="IsAutoPaneOpenCheckBox"
                 AutomationProperties.Name="IsPaneOpenCheckBox" >Toggle auto pane open</CheckBox>
+            <Button Content="Toggle pane open and button visible" Click="TogglePaneOpenButton_Click"/>
         </StackPanel>
     </StackPanel>
 </local:TestPage>

--- a/dev/NavigationView/TestUI/Common/NavigationViewMinimalPage.xaml.cs
+++ b/dev/NavigationView/TestUI/Common/NavigationViewMinimalPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 
 namespace MUXControlsTestApp
@@ -15,6 +16,20 @@ namespace MUXControlsTestApp
         {
             var visualstates = Utilities.VisualStateHelper.GetCurrentVisualStateName(NavView);
             NavViewActiveVisualStatesResult.Text = string.Join(",", visualstates);
+        }
+
+        private void TogglePaneOpenButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            if (NavView.IsPaneToggleButtonVisible)
+            {
+                NavView.PaneDisplayMode = NavigationViewPaneDisplayMode.Left;
+                NavView.IsPaneToggleButtonVisible = false;
+            }
+            else
+            {
+                NavView.PaneDisplayMode = NavigationViewPaneDisplayMode.LeftMinimal;
+                NavView.IsPaneToggleButtonVisible = true;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The margin for the pane toggle button was not correctly be updated correctly because the function updating the margin of the pane toggle button was not called. This PR fixes that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Closes #6493 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually:
![Opening and closing pane of NavigationView and hiding and showing the toggle pane button](https://user-images.githubusercontent.com/16122379/156432476-d60e6b04-85de-4565-bd1a-2005ea89b40b.gif)

Note that the header moving is because we are switching between displaymodes.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->