### PR TITLE
Fix PGO Pipeline

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -48,6 +48,7 @@ steps:
       targetType: filePath
       workingDirectory: $(Build.SourcesDirectory)\tools\MUXPGODatabase
       filePath: $(Build.SourcesDirectory)\tools\MUXPGODatabase\restore-pgodb.ps1
+      arguments: -NuGetConfigPath $(Build.SourcesDirectory)\nuget.config
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore ${{ parameters.solutionPath }}'

--- a/tools/MUXPGODatabase/config.ps1
+++ b/tools/MUXPGODatabase/config.ps1
@@ -1,5 +1,5 @@
 $pgoBranch           = "main"
-$packageId           = "MUXPGODatabase-test"
+$packageId           = "MUXPGODatabase"
 
 # Get release version
 [xml] $customProps   = ( Get-Content "..\..\version.props" )

--- a/tools/MUXPGODatabase/config.ps1
+++ b/tools/MUXPGODatabase/config.ps1
@@ -1,7 +1,9 @@
 $pgoBranch           = "main"
-$packageId           = "MUXPGODatabase"
+$packageId           = "MUXPGODatabase-test"
 
 # Get release version
 [xml] $customProps   = ( Get-Content "..\..\version.props" )
-$releaseVersionMajor = ( [int]::Parse( $customProps.GetElementsByTagName("MUXVersionMajor").'#text' ) )
-$releaseVersionMinor = ( [int]::Parse( $customProps.GetElementsByTagName("MUXVersionMinor").'#text' ) )
+$releaseVersionMajor      = ( [int64]::Parse( $customProps.GetElementsByTagName("MUXVersionMajor").'#text' ) )
+$releaseVersionMinor      = ( [int64]::Parse( $customProps.GetElementsByTagName("MUXVersionMinor").'#text' ) )
+$releaseVersionPatch      = [int64] 0
+$releaseVersionPrerelease = $null

--- a/tools/MUXPGODatabase/generate-nuspec.ps1
+++ b/tools/MUXPGODatabase/generate-nuspec.ps1
@@ -6,6 +6,7 @@ Param(
 . .\template.ps1
 . .\config.ps1
 
-$version = FormatVersion ( MakeVersion $releaseVersionMajor $releaseVersionMinor ( GetDatetimeStamp $pgoBranch ) )
-Write-Host ( "PGO INSTRUMENT: generating {0} version {1}" -f $packageId, $version )
+$forkPoint = ( GetForkPoint $pgoBranch )
+$version = FormatVersion ( MakeVersion $releaseVersionMajor $releaseVersionMinor $releaseVersionPatch $releaseVersionPrerelease $forkPoint.DateString $forkPoint.BranchString )
+Write-Host ( "PGO INSTRUMENT: generating {0} version {1} ({2})" -f $packageId, $version, $forkPoint.SHA )
 FillOut-Template $templatePath $outputPath @{ "version" = $version; "id" = $packageId }

--- a/tools/MUXPGODatabase/restore-pgodb.ps1
+++ b/tools/MUXPGODatabase/restore-pgodb.ps1
@@ -1,47 +1,95 @@
+# Param(
+#     [Parameter(Position=0, Mandatory=$true)]
+#     [string] $NuGetConfigPath
+# )
+# TODO: fix
+
+$repoRoot = $script:MyInvocation.MyCommand.Path | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent
+$NuGetConfigPath = Join-Path $repoRoot "nuget.config"
+
 . .\version.ps1
 . .\template.ps1
 . .\config.ps1
 
-$feedUri = "https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v2"
-
-$currentVersion = MakeVersion $releaseVersionMajor $releaseVersionMinor ( GetDatetimeStamp $pgoBranch )
-
-Write-Host ( "PGO OPTIMIZE: requesting {0} version {1}" -f $packageId, ( FormatVersion $currentVersion ) )
-
-$packageSource = Register-PackageSource -ForceBootstrap -Name MUX_Dependencies -Location $feedUri -ProviderName NuGet -Trusted
-$packages = ( Find-Package $packageId -Source MUX_Dependencies -AllowPrereleaseVersions -AllVersions ) | Sort-Object -Property Version -Descending
-
-$best = $null
-
-foreach ( $existing in $packages )
+function Get-AvailablePackages ( $package )
 {
-    $existingVersion = MakeVersionFromString $existing.Version
+    $result = @()
 
-    if ( ( CompareBranches $existingVersion $currentVersion ) -eq $False -or
-         ( CompareReleases $existingVersion $currentVersion ) -ne 0 )
+    $output = ( & nuget.exe list $package -prerelease -allversions -configfile $NuGetConfigPath )
+
+
+
+    if ( $LastExitCode -ne 0 )
     {
-        # If this is different release or branch, then skip it.
+        throw "FAILED: nuget.exe list"
+    }
+
+    foreach ( $line in $output )
+    {
+        $name, $version = $line.Split(" ")
+
+        # TODO: fix
+        if(($version -ne "2.0.0") -and  ($version -ne "0.0.3"))
+        {
+            if ( $name -eq $package )
+            {
+                $result += ( MakeVersionFromString $version )
+            }
+        }
+    }
+
+    return $result
+}
+
+function Install-Package ( $package, $version )
+{
+    & nuget.exe install $package -prerelease -version $version -configfile $NuGetConfigPath
+
+    if ( $LastExitCode -ne 0 )
+    {
+        throw "FAILED: nuget.exe install"
+    }
+}
+
+$forkPoint = ( GetForkPoint $pgoBranch )
+
+$requestedVersion = MakeVersion $releaseVersionMajor $releaseVersionMinor $releaseVersionPatch $releaseVersionPrerelease $forkPoint.DateString $forkPoint.BranchString
+
+Write-Host ( "PGO OPTIMIZE: requesting {0} version {1} ({2})" -f $packageId, ( FormatVersion $requestedVersion ), $forkPoint.SHA )
+
+$packageVersions = ( Get-AvailablePackages $packageId ) | Sort-Object -Descending -Property Major, Minor, Patch, Prerelease, Branch, Revision
+
+$bestVersion = $null
+
+foreach ( $existingVersion in $packageVersions )
+{
+    if ( ( CompareReleaseAndBranch $existingVersion $requestedVersion ) -eq $False )
+    {
+        # If this is different release number, pre-release tag or branch, then skip it.
         continue
     }
 
-    if ( ( CompareRevisions $existingVersion $currentVersion ) -le 0 )
+    # Sorting guarantees that all eligible entries are consecutive and sorted according to decreasing revision time stamp.
+    # Revisions are fixed, 10 character strings containing numbers (YYMMHHhhmm).  Sorting will arrange them reverse-chronologically.
+    # Once we are here, we are beginning of that segment.
+
+    if ( ( CompareRevisions $existingVersion $requestedVersion ) -le 0 )
     {
-        # Version are sorted in descending order, the first one less than or equal to the current is the one we want.
-        # NOTE: at this point the only difference between versions will be revision (date-time stamp)
-        # which is formatted as a fixed-length string, so string comparison WILL sort it correctly.
-        $best = $existing
+        # Revisions are sorted in descending order, the first one less than or equal to the current is the one we want.
+        $bestVersion = $existingVersion
         break
     }
 }
 
-if ( $best -eq $null )
+if ( $bestVersion -eq $null )
 {
     throw "Appropriate database cannot be found"
 }
 
-Write-Host ( "PGO OPTIMIZE: picked {0} version {1}" -f $packageId, $best.Version )
+$bestVersionAsString = ( FormatVersion $bestVersion )
 
-$best | Install-Package -Destination ..\..\packages -Force
-$packageSource | Unregister-PackageSource
+Write-Host ( "PGO OPTIMIZE: picked {0} version {1}" -f $packageId, $bestVersionAsString )
 
-FillOut-Template "PGO.version.props.template" "PGO.version.props" @{ "version" = $best.Version; "id" = $packageId }
+Install-Package $packageId $bestVersionAsString
+
+FillOut-Template "PGO.version.props.template" "PGO.version.props" @{ "version" = $bestVersionAsString; "id" = $packageId }

--- a/tools/MUXPGODatabase/restore-pgodb.ps1
+++ b/tools/MUXPGODatabase/restore-pgodb.ps1
@@ -29,7 +29,7 @@ function Get-AvailablePackages ( $package )
         $name, $version = $line.Split(" ")
 
         # TODO: fix
-        if(($version -ne "2.0.0") -and  ($version -ne "0.0.3"))
+        if($version.Contains("-"))
         {
             if ( $name -eq $package )
             {

--- a/tools/MUXPGODatabase/restore-pgodb.ps1
+++ b/tools/MUXPGODatabase/restore-pgodb.ps1
@@ -22,13 +22,9 @@ function Get-AvailablePackages ( $package )
     {
         $name, $version = $line.Split(" ")
 
-        # Some packages on the feed use an old versioning scheme. Skip the package if it does not include a -foo portion in the version.
-        if($version.Contains("-"))
+        if ( $name -eq $package )
         {
-            if ( $name -eq $package )
-            {
-                $result += ( MakeVersionFromString $version )
-            }
+            $result += ( MakeVersionFromString $version )
         }
     }
 

--- a/tools/MUXPGODatabase/restore-pgodb.ps1
+++ b/tools/MUXPGODatabase/restore-pgodb.ps1
@@ -1,11 +1,7 @@
-# Param(
-#     [Parameter(Position=0, Mandatory=$true)]
-#     [string] $NuGetConfigPath
-# )
-# TODO: fix
-
-$repoRoot = $script:MyInvocation.MyCommand.Path | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent
-$NuGetConfigPath = Join-Path $repoRoot "nuget.config"
+Param(
+    [Parameter(Position=0, Mandatory=$true)]
+    [string] $NuGetConfigPath
+)
 
 . .\version.ps1
 . .\template.ps1
@@ -17,8 +13,6 @@ function Get-AvailablePackages ( $package )
 
     $output = ( & nuget.exe list $package -prerelease -allversions -configfile $NuGetConfigPath )
 
-
-
     if ( $LastExitCode -ne 0 )
     {
         throw "FAILED: nuget.exe list"
@@ -28,7 +22,7 @@ function Get-AvailablePackages ( $package )
     {
         $name, $version = $line.Split(" ")
 
-        # TODO: fix
+        # Some packages on the feed use an old versioning scheme. Skip the package if it does not include a -foo portion in the version.
         if($version.Contains("-"))
         {
             if ( $name -eq $package )


### PR DESCRIPTION
The existing PGO versioning logic hit an issue at the start of this year, since it used a YYMMDDhhmm format for part of the version of the nuget package which hit an overflow issue once the year became "22".

This is primarily a port of the corresponding fix from WinUI3.