### PR TITLE
Fix issue with exception being thrown during cleanup of NavigationView.

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3418,17 +3418,33 @@ void NavigationView::SetNavigationViewItemRevokers(const winrt::NavigationViewIt
 
 void NavigationView::ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi)
 {
+    RevokeNavigationViewItemRevokers(nvi);
     nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
     m_itemsWithRevokerObjects.erase(nvi);
 }
 
-void NavigationView::ClearAllNavigationViewItemRevokers()
+void NavigationView::ClearAllNavigationViewItemRevokers() noexcept
 {
     for (const auto& nvi : m_itemsWithRevokerObjects)
     {
-        nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+        try
+        {
+            RevokeNavigationViewItemRevokers(nvi);
+            nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+        }
+        catch (...) {}
     }
     m_itemsWithRevokerObjects.clear();
+}
+
+void NavigationView::RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi)
+{
+    if (auto const revokers = nvi.GetValue(s_NavigationViewItemRevokersProperty))
+    {
+        if (auto const revokersAsNVIR = revokers.try_as<NavigationViewItemRevokers>()) {
+            revokersAsNVIR->RevokeAll();
+        }
+    }
 }
 
 void NavigationView::InvalidateTopNavPrimaryLayout()

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3427,6 +3427,10 @@ void NavigationView::ClearAllNavigationViewItemRevokers() noexcept
 {
     for (const auto& nvi : m_itemsWithRevokerObjects)
     {
+        // ClearAllNavigationViewItemRevokers is only called in the destructor, where exceptions cannot be thrown.
+        // If the associated NV has not yet been cleaned up, we must detach these revokers or risk a call into freed
+        // memory being made.  However if they have been cleaned up these calls will throw. In this case we can ignore
+        // those exceptions.
         try
         {
             RevokeNavigationViewItemRevokers(nvi);

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -187,7 +187,8 @@ private:
     inline static GlobalDependencyProperty s_NavigationViewItemRevokersProperty{ nullptr };
     void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    void ClearAllNavigationViewItemRevokers();
+    void ClearAllNavigationViewItemRevokers() noexcept;
+    void RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects;
 
     void InvalidateTopNavPrimaryLayout();

--- a/dev/NavigationView/NavigationViewItemRevokers.h
+++ b/dev/NavigationView/NavigationViewItemRevokers.h
@@ -11,4 +11,12 @@ public:
     winrt::UIElement::GotFocus_revoker gotFocusRevoker{};
     PropertyChanged_revoker isSelectedRevoker{};
     PropertyChanged_revoker isExpandedRevoker{};
+
+    void RevokeAll() {
+        if (tappedRevoker) tappedRevoker.revoke();
+        if (keyDownRevoker) keyDownRevoker.revoke();
+        if (gotFocusRevoker) gotFocusRevoker.revoke();
+        if (isSelectedRevoker) isSelectedRevoker.revoke();
+        if (isExpandedRevoker) isExpandedRevoker.revoke();
+    }
 };

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -1263,5 +1263,39 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 }
             });
         }
+
+        [TestMethod]
+        public void VerifyNVIOutlivingNVDoesNotCrash()
+        {
+            NavigationViewItem menuItem1 = null;
+            RunOnUIThread.Execute(() =>
+            {
+                var navView = new NavigationView();
+                menuItem1 = new NavigationViewItem();
+
+                navView.MenuItems.Add(menuItem1);
+                Content = navView;
+                Content.UpdateLayout();
+
+                navView.MenuItems.Clear();
+                Content = menuItem1;
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                GC.Collect();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                // NavigationView has a handler on NVI's IsSelected DependencyPropertyChangedEvent.
+                menuItem1.IsSelected = !menuItem1.IsSelected;
+            });
+        }
     }
 }


### PR DESCRIPTION
When NavigationView is being cleaned up in needs to detatch the event handlers on its children NVI's that are still alive, however if those NVI's have already been cleaned up they can be in a state that SetValue(nullptr) throws an exception, which are not allowed during the NavigationView's destructor.