### PR TITLE
NavigationViewItemRevokers use WeakRef this pointers

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3418,17 +3418,33 @@ void NavigationView::SetNavigationViewItemRevokers(const winrt::NavigationViewIt
 
 void NavigationView::ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi)
 {
+    RevokeNavigationViewItemRevokers(nvi);
     nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
     m_itemsWithRevokerObjects.erase(nvi);
 }
 
-void NavigationView::ClearAllNavigationViewItemRevokers()
+void NavigationView::ClearAllNavigationViewItemRevokers() noexcept
 {
     for (const auto& nvi : m_itemsWithRevokerObjects)
     {
-        nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+        try
+        {
+            RevokeNavigationViewItemRevokers(nvi);
+            nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+        }
+        catch (...) {}
     }
     m_itemsWithRevokerObjects.clear();
+}
+
+void NavigationView::RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi)
+{
+    if (auto const revokers = nvi.GetValue(s_NavigationViewItemRevokersProperty))
+    {
+        if (auto const revokersAsNVIR = revokers.try_as<NavigationViewItemRevokers>()) {
+            revokersAsNVIR->RevokeAll();
+        }
+    }
 }
 
 void NavigationView::InvalidateTopNavPrimaryLayout()

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -187,7 +187,8 @@ private:
     inline static GlobalDependencyProperty s_NavigationViewItemRevokersProperty{ nullptr };
     void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    void ClearAllNavigationViewItemRevokers();
+    void ClearAllNavigationViewItemRevokers() noexcept;
+    void RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects;
 
     void InvalidateTopNavPrimaryLayout();

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -186,10 +186,6 @@ private:
     // the item gets cleaned up
     inline static GlobalDependencyProperty s_NavigationViewItemRevokersProperty{ nullptr };
     void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    void ClearAllNavigationViewItemRevokers() noexcept;
-    void RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects;
 
     void InvalidateTopNavPrimaryLayout();
     // Measure functions for top navigation   

--- a/dev/NavigationView/NavigationViewItemRevokers.h
+++ b/dev/NavigationView/NavigationViewItemRevokers.h
@@ -11,4 +11,12 @@ public:
     winrt::UIElement::GotFocus_revoker gotFocusRevoker{};
     PropertyChanged_revoker isSelectedRevoker{};
     PropertyChanged_revoker isExpandedRevoker{};
+
+    void RevokeAll() {
+        if (tappedRevoker) tappedRevoker.revoke();
+        if (keyDownRevoker) keyDownRevoker.revoke();
+        if (gotFocusRevoker) gotFocusRevoker.revoke();
+        if (isSelectedRevoker) isSelectedRevoker.revoke();
+        if (isExpandedRevoker) isExpandedRevoker.revoke();
+    }
 };

--- a/dev/NavigationView/NavigationViewItemRevokers.h
+++ b/dev/NavigationView/NavigationViewItemRevokers.h
@@ -11,12 +11,4 @@ public:
     winrt::UIElement::GotFocus_revoker gotFocusRevoker{};
     PropertyChanged_revoker isSelectedRevoker{};
     PropertyChanged_revoker isExpandedRevoker{};
-
-    void RevokeAll() {
-        if (tappedRevoker) tappedRevoker.revoke();
-        if (keyDownRevoker) keyDownRevoker.revoke();
-        if (gotFocusRevoker) gotFocusRevoker.revoke();
-        if (isSelectedRevoker) isSelectedRevoker.revoke();
-        if (isExpandedRevoker) isExpandedRevoker.revoke();
-    }
 };

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -31,6 +31,7 @@ using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Composition;
 using Windows.UI.Xaml.Markup;
 using System.Collections.Generic;
+using System.Runtime;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -1261,6 +1262,40 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                     Verify.AreEqual(expectedDefaultToolTip, ToolTipService.GetToolTip(menuItem1), $"Item 1's tooltip should have been \"{expectedDefaultToolTip ?? "null"}\".");
                     Verify.AreEqual(expectedCustomToolTip, ToolTipService.GetToolTip(menuItem2), $"Item 2's tooltip should have been {expectedCustomToolTip}.");
                 }
+            });
+        }
+
+        [TestMethod]
+        public void VerifyNVIOutlivingNVDoesNotCrash2()
+        {
+            NavigationViewItem menuItem1 = null;
+            RunOnUIThread.Execute(() =>
+            {
+                var navView = new NavigationView();
+                menuItem1 = new NavigationViewItem();
+
+                navView.MenuItems.Add(menuItem1);
+                Content = navView;
+                Content.UpdateLayout();
+
+                navView.MenuItems.Clear();
+                Content = menuItem1;
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                GC.Collect();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                // NavigationView has a handler on NVI's IsSelected DependencyPropertyChangedEvent.
+                menuItem1.IsSelected = !menuItem1.IsSelected;
             });
         }
     }

--- a/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -1266,7 +1266,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
-        public void VerifyNVIOutlivingNVDoesNotCrash2()
+        public void VerifyNVIOutlivingNVDoesNotCrash()
         {
             NavigationViewItem menuItem1 = null;
             RunOnUIThread.Execute(() =>


### PR DESCRIPTION
Rather than having navigation view track which items have revoker objects attached to them and ensure those get cleared during navigation view's destructor, we can simply have the callback object keep a weak ref to the navigation view rather than a raw pointer.