### PR TITLE
Fix F6 unable to return from teaching tip in xaml island.

### DIFF
--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -917,24 +917,6 @@ void TeachingTip::IsOpenChangedToOpen()
                 if (auto const content = xamlRoot.Content())
                 {
                     m_previewKeyDownForF6Revoker = content.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
-                }
-
-                if (auto&& popup = m_popup.get())
-                {
-                    if (auto const popupXamlRoot = popup.XamlRoot())
-                    {
-                        if (xamlRoot != popupXamlRoot)
-                        {
-                            if (auto const content = xamlRoot.Content())
-                            {
-                                m_popupPreviewKeyDownForF6Revoker = content.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
-                            }
-                        }
-                    }
-                }
-
-                if (m_previewKeyDownForF6Revoker || m_popupPreviewKeyDownForF6Revoker)
-                {
                     return;
                 }
             }
@@ -1233,6 +1215,20 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
             m_currentXamlRootSize = xamlRoot.Size();
             m_xamlRoot.set(xamlRoot);
             m_xamlRootChangedRevoker = RegisterXamlRootChanged(xamlRoot, { this, &TeachingTip::XamlRootChanged });
+
+            if (auto&& popup = m_popup.get())
+            {
+                if (auto const popupXamlRoot = popup.XamlRoot())
+                {
+                    if (xamlRoot != popupXamlRoot)
+                    {
+                        if (auto const content = xamlRoot.Content())
+                        {
+                            m_popupPreviewKeyDownForF6Revoker = content.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
+                        }
+                    }
+                }
+            }
         }
     }
     else

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1218,16 +1218,7 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
 
             if (auto&& popup = m_popup.get())
             {
-                if (auto const popupXamlRoot = popup.XamlRoot())
-                {
-                    if (xamlRoot != popupXamlRoot)
-                    {
-                        if (auto const content = xamlRoot.Content())
-                        {
-                            m_popupPreviewKeyDownForF6Revoker = content.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
-                        }
-                    }
-                }
+                m_popupPreviewKeyDownForF6Revoker = popup.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
             }
         }
     }

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1148,9 +1148,9 @@ bool TeachingTip::HandleF6Clicked(bool fromPopup)
 
     auto const hasFocusInSubtree = [this]()
     {
-        auto current = winrt::FocusManager::GetFocusedElement().try_as<winrt::DependencyObject>();
         if (auto const rootElement = m_rootElement.get())
         {
+            auto current = winrt::FocusManager::GetFocusedElement(rootElement.XamlRoot()).try_as<winrt::DependencyObject>();
             while (current)
             {
                 if (current.try_as<winrt::UIElement>() == rootElement)
@@ -1240,9 +1240,6 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
                 if (auto const popupContent = popup.Child())
                 {
                     m_popupPreviewKeyDownForF6Revoker = popupContent.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PopupPreviewKeyDownClicked });
-
-                    m_popupPreviewKeyDownEventHandler = winrt::box_value<winrt::KeyEventHandler>({ this, &TeachingTip::OnF6PopupPreviewKeyDownClickedEvenHandled });
-                    popupContent.AddHandler(winrt::UIElement::PreviewKeyDownEvent(), m_popupPreviewKeyDownEventHandler, true /*handledEventsToo*/);
                 }
             }
         }
@@ -1305,17 +1302,6 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
 
 void TeachingTip::OnPopupClosed(const winrt::IInspectable&, const winrt::IInspectable&)
 {
-    if (m_popupPreviewKeyDownEventHandler)
-    {
-        if (auto&& popup = m_popup.get())
-        {
-            if (auto const popupContent = popup.Child())
-            {
-                popupContent.RemoveHandler(winrt::UIElement::PreviewKeyDownEvent(), m_popupPreviewKeyDownEventHandler);
-            }
-        }
-        m_popupPreviewKeyDownEventHandler = nullptr;
-    }
     m_windowSizeChangedRevoker.revoke();
     m_xamlRootChangedRevoker.revoke();
     m_xamlRoot.set(nullptr);

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -917,10 +917,28 @@ void TeachingTip::IsOpenChangedToOpen()
                 if (auto const content = xamlRoot.Content())
                 {
                     m_previewKeyDownForF6Revoker = content.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
+                }
+
+                if (auto&& popup = m_popup.get())
+                {
+                    if (auto const popupXamlRoot = popup.XamlRoot())
+                    {
+                        if (xamlRoot != popupXamlRoot)
+                        {
+                            if (auto const content = xamlRoot.Content())
+                            {
+                                m_popupPreviewKeyDownForF6Revoker = content.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
+                            }
+                        }
+                    }
+                }
+
+                if (m_previewKeyDownForF6Revoker || m_popupPreviewKeyDownForF6Revoker)
+                {
                     return;
                 }
             }
-        };
+        }
 
         m_acceleratorKeyActivatedRevoker = Dispatcher().AcceleratorKeyActivated(winrt::auto_revoke, { this, &TeachingTip::OnF6AcceleratorKeyClicked });
         return;
@@ -953,6 +971,7 @@ void TeachingTip::IsOpenChangedToClose()
 
     m_acceleratorKeyActivatedRevoker.revoke();
     m_previewKeyDownForF6Revoker.revoke();
+    m_popupPreviewKeyDownForF6Revoker.revoke();
     m_currentEffectiveTipPlacementMode = winrt::TeachingTipPlacementMode::Auto;
     TeachingTipTestHooks::NotifyEffectivePlacementChanged(*this);
 }

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1218,7 +1218,10 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
 
             if (auto&& popup = m_popup.get())
             {
-                m_popupPreviewKeyDownForF6Revoker = popup.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
+                if (auto const popupContent = popup.Child())
+                {
+                    m_popupPreviewKeyDownForF6Revoker = popupContent.PreviewKeyDown(winrt::auto_revoke, { this, &TeachingTip::OnF6PreviewKeyDownClicked });
+                }
             }
         }
     }

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -61,9 +61,9 @@ public:
 private:
     PropertyChanged_revoker m_automationNameChangedRevoker{};
     PropertyChanged_revoker m_automationIdChangedRevoker{};
-    winrt::KeyboardAccelerator::Invoked_revoker m_keyboardAcceleratorKeyActivatedRevoker{};
-    winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_dispatcherAcceleratorKeyActivatedRevoker{};
+    winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_acceleratorKeyActivatedRevoker{};
     winrt::UIElement::PreviewKeyDown_revoker m_previewKeyDownForF6Revoker{};
+    winrt::UIElement::PreviewKeyDown_revoker m_popupPreviewKeyDownForF6Revoker{};
     winrt::Button::Click_revoker m_closeButtonClickedRevoker{};
     winrt::Button::Click_revoker m_alternateCloseButtonClickedRevoker{};
     winrt::Button::Click_revoker m_actionButtonClickedRevoker{};
@@ -116,8 +116,8 @@ private:
     void OnAutomationIdChanged(const winrt::IInspectable&, const winrt::IInspectable&);
 
     void OnContentSizeChanged(const winrt::IInspectable&, const winrt::SizeChangedEventArgs& args);
-    void OnF6KeyboardAcceleratorKeyClicked(const winrt::KeyboardAccelerator&, const winrt::KeyboardAcceleratorInvokedEventArgs& args);
-    void OnF6DispatcherAcceleratorKeyClicked(const winrt::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args);
+    void OnF6PreviewKeyDownClicked(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
+    void OnF6AcceleratorKeyClicked(const winrt::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args);
     bool HandleF6Clicked();
     void OnCloseButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);
     void OnActionButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);
@@ -210,6 +210,7 @@ private:
 
     winrt::Size m_currentXamlRootSize{ 0,0 };
 
+    bool m_ignoreNextIsOpenChanged{ false };
     bool m_isTemplateApplied{ false };
     bool m_createNewPopupOnOpen{ false };
 

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -63,6 +63,7 @@ private:
     PropertyChanged_revoker m_automationIdChangedRevoker{};
     winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_acceleratorKeyActivatedRevoker{};
     winrt::UIElement::PreviewKeyDown_revoker m_previewKeyDownForF6Revoker{};
+    // This handler is not required for Winui3 because the framework bug this works around has been fixed.
     winrt::UIElement::PreviewKeyDown_revoker m_popupPreviewKeyDownForF6Revoker{};
     winrt::Button::Click_revoker m_closeButtonClickedRevoker{};
     winrt::Button::Click_revoker m_alternateCloseButtonClickedRevoker{};
@@ -118,7 +119,6 @@ private:
     void OnContentSizeChanged(const winrt::IInspectable&, const winrt::SizeChangedEventArgs& args);
     void OnF6PreviewKeyDownClicked(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
     void OnF6PopupPreviewKeyDownClicked(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
-    void OnF6PopupPreviewKeyDownClickedEvenHandled(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
     void OnF6AcceleratorKeyClicked(const winrt::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args);
     bool HandleF6Clicked(bool fromPopup = false);
     void OnCloseButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -63,6 +63,7 @@ private:
     PropertyChanged_revoker m_automationIdChangedRevoker{};
     winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_acceleratorKeyActivatedRevoker{};
     winrt::UIElement::PreviewKeyDown_revoker m_previewKeyDownForF6Revoker{};
+    winrt::UIElement::PreviewKeyDown_revoker m_popupPreviewKeyDownForF6Revoker{};
     winrt::Button::Click_revoker m_closeButtonClickedRevoker{};
     winrt::Button::Click_revoker m_alternateCloseButtonClickedRevoker{};
     winrt::Button::Click_revoker m_actionButtonClickedRevoker{};

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -59,6 +59,7 @@ public:
     friend class TeachingTipTestHooks;
 
 private:
+    winrt::IInspectable m_popupPreviewKeyDownEventHandler{nullptr};
     PropertyChanged_revoker m_automationNameChangedRevoker{};
     PropertyChanged_revoker m_automationIdChangedRevoker{};
     winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_acceleratorKeyActivatedRevoker{};
@@ -117,8 +118,10 @@ private:
 
     void OnContentSizeChanged(const winrt::IInspectable&, const winrt::SizeChangedEventArgs& args);
     void OnF6PreviewKeyDownClicked(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
+    void OnF6PopupPreviewKeyDownClicked(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
+    void OnF6PopupPreviewKeyDownClickedEvenHandled(const winrt::IInspectable&, const winrt::KeyRoutedEventArgs& args);
     void OnF6AcceleratorKeyClicked(const winrt::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args);
-    bool HandleF6Clicked();
+    bool HandleF6Clicked(bool fromPopup = false);
     void OnCloseButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);
     void OnActionButtonClicked(const winrt::IInspectable&, const winrt::RoutedEventArgs&);
     void OnPopupOpened(const winrt::IInspectable&, const winrt::IInspectable&);

--- a/dev/TeachingTip/TeachingTip.h
+++ b/dev/TeachingTip/TeachingTip.h
@@ -59,7 +59,6 @@ public:
     friend class TeachingTipTestHooks;
 
 private:
-    winrt::IInspectable m_popupPreviewKeyDownEventHandler{nullptr};
     PropertyChanged_revoker m_automationNameChangedRevoker{};
     PropertyChanged_revoker m_automationIdChangedRevoker{};
     winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_acceleratorKeyActivatedRevoker{};


### PR DESCRIPTION
There were two issues blocking this functionality in islands scenarios. 

First there is a platform bug which caused the PreviewKeyDown event handler to not be hit when focus was in a popup.  This issue was fixed in winui3 recently but we will not be porting that fix to system xaml. To work around this we need to attach the handler to the root element in the popup as well as the XamlRoot.Content.

Second, we were using the FocusManager.GetFocusedElement method in the handler which doesn't work in xaml island scenarios.  There we need to use the 19h1+ version of the API with the XamlRoot parameter.

I've validated the fix with our test suite for non-islands scenarios. and with a custom WPF app for the island case.