### PR TITLE
Add MicaBaseAlt Fallback Brushes

### DIFF
--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -85,9 +85,7 @@
             <Color x:Key="LayerFillColorAlt">#0DFFFFFF</Color>
             <Color x:Key="LayerOnAcrylicFillColorDefault">#09FFFFFF</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#09FFFFFF</Color>
-
-            <Color x:Key="MicaBaseAltFallbackColor">#202020</Color>
-            
+  
             <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#733A3A3A</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0FFFFFFF</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#2C2C2C</Color>
@@ -98,6 +96,7 @@
             <Color x:Key="SolidBackgroundFillColorTertiary">#282828</Color>
             <Color x:Key="SolidBackgroundFillColorQuarternary">#2C2C2C</Color>
             <Color x:Key="SolidBackgroundFillColorTransparent">#00202020</Color>
+            <Color x:Key="SolidBackgroundFillColorBaseAlt">#0A0A0A</Color>
 
             <Color x:Key="SystemFillColorSuccess">#6CCB5F</Color>
             <Color x:Key="SystemFillColorCaution">#FCE100</Color>
@@ -199,9 +198,7 @@
             <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource LayerFillColorAlt}" />
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
- 
-            <SolidColorBrush x:Key="MicaBaseAltFallbackColorBrush" Color="{StaticResource MicaBaseAltFallbackColor}" />
-            
+         
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
@@ -211,7 +208,8 @@
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
-
+            <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SolidBackgroundFillColorBaseAlt}" />
+            
             <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{ThemeResource SystemAccentColorLight2}" />
             <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{StaticResource SystemFillColorSuccess}" />
             <SolidColorBrush x:Key="SystemFillColorCautionBrush" Color="{StaticResource SystemFillColorCaution}" />
@@ -344,9 +342,7 @@
             <Color x:Key="LayerFillColorAlt">#FFFFFF</Color>
             <Color x:Key="LayerOnAcrylicFillColorDefault">#40FFFFFF</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#40FFFFFF</Color>
-
-            <Color x:Key="MicaBaseAltFallbackColor">#E8E8E8</Color>
-            
+       
             <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#B3FFFFFF</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0A000000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#F9F9F9</Color>
@@ -357,6 +353,7 @@
             <Color x:Key="SolidBackgroundFillColorTertiary">#F9F9F9</Color>
             <Color x:Key="SolidBackgroundFillColorQuarternary">#FFFFFF</Color>
             <Color x:Key="SolidBackgroundFillColorTransparent">#00F3F3F3</Color>
+            <Color x:Key="SolidBackgroundFillColorBaseAlt">#DADADA</Color>
 
             <Color x:Key="SystemFillColorSuccess">#0F7B0F</Color>
             <Color x:Key="SystemFillColorCaution">#9D5D00</Color>
@@ -459,8 +456,6 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
 
-            <SolidColorBrush x:Key="MicaBaseAltFallbackColorBrush" Color="{StaticResource MicaBaseAltFallbackColor}" />
-            
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
@@ -470,6 +465,7 @@
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+            <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SolidBackgroundFillColorBaseAlt}" />
 
             <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{ThemeResource SystemAccentColor}" />
             <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{StaticResource SystemFillColorSuccess}" />
@@ -612,8 +608,6 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}"/>
 
-            <SolidColorBrush x:Key="MicaBaseAltFallbackColorBrush" Color="{StaticResource SystemColorWindowColor}" />
-            
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
@@ -623,6 +617,7 @@
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SystemColorWindowColor}" />
 
             <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
             <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{ThemeResource SystemColorWindowTextColor}" />

--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -617,7 +617,7 @@
             <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{StaticResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="SolidBackgroundFillColorBaseAltBrush" Color="{ThemeResource SystemColorWindowColor}" />
 
             <SolidColorBrush x:Key="SystemFillColorAttentionBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
             <SolidColorBrush x:Key="SystemFillColorSuccessBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
@@ -697,7 +697,6 @@
             <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
-            <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTransparent">#FF0000</Color>
@@ -706,6 +705,7 @@
             <Color x:Key="SolidBackgroundFillColorTertiary">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorQuarternary">#FF0000</Color>
             <Color x:Key="SolidBackgroundFillColorTransparent">#FF0000</Color>
+            <Color x:Key="SolidBackgroundFillColorBaseAlt">#FF0000</Color>
             <Color x:Key="SystemFillColorSuccess">#FF0000</Color>
             <Color x:Key="SystemFillColorCaution">#FF0000</Color>
             <Color x:Key="SystemFillColorCritical">#FF0000</Color>

--- a/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/dev/CommonStyles/Common_themeresources_any.xaml
@@ -86,6 +86,8 @@
             <Color x:Key="LayerOnAcrylicFillColorDefault">#09FFFFFF</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#09FFFFFF</Color>
 
+            <Color x:Key="MicaBaseAltFallbackColor">#202020</Color>
+            
             <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#733A3A3A</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0FFFFFFF</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#2C2C2C</Color>
@@ -197,7 +199,9 @@
             <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource LayerFillColorAlt}" />
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
-
+ 
+            <SolidColorBrush x:Key="MicaBaseAltFallbackColorBrush" Color="{StaticResource MicaBaseAltFallbackColor}" />
+            
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
@@ -341,6 +345,8 @@
             <Color x:Key="LayerOnAcrylicFillColorDefault">#40FFFFFF</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#40FFFFFF</Color>
 
+            <Color x:Key="MicaBaseAltFallbackColor">#E8E8E8</Color>
+            
             <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#B3FFFFFF</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#0A000000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#F9F9F9</Color>
@@ -453,6 +459,8 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAcrylicFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnAccentAcrylicFillColorDefault}" />
 
+            <SolidColorBrush x:Key="MicaBaseAltFallbackColorBrush" Color="{StaticResource MicaBaseAltFallbackColor}" />
+            
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorDefault}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorSecondary}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{StaticResource LayerOnMicaBaseAltFillColorTertiary}" />
@@ -604,6 +612,8 @@
             <SolidColorBrush x:Key="LayerOnAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnAccentAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}"/>
 
+            <SolidColorBrush x:Key="MicaBaseAltFallbackColorBrush" Color="{StaticResource SystemColorWindowColor}" />
+            
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="LayerOnMicaBaseAltFillColorTertiaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
@@ -691,6 +701,7 @@
             <Color x:Key="LayerFillColorAlt">#FF0000</Color>
             <Color x:Key="LayerOnAcrylicFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnAccentAcrylicFillColorDefault">#FF0000</Color>
+            <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorDefault">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorSecondary">#FF0000</Color>
             <Color x:Key="LayerOnMicaBaseAltFillColorTertiary">#FF0000</Color>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `MicaBaseAltFallbackColor` brushes in commonresources


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

For applications that are unable to use Mica Alt, we need a brush that represents the fallback colors so controls appear as expected in the application. 