### PR TITLE
MenuBar: Sets Automation Size of Set and Position in Set

### DIFF
--- a/dev/MenuBar/MenuBar.cpp
+++ b/dev/MenuBar/MenuBar.cpp
@@ -15,6 +15,15 @@ MenuBar::MenuBar()
 
     auto items = winrt::make<ObservableVector<winrt::MenuBarItem>>();
     SetValue(s_ItemsProperty, items);
+
+    auto observableVector = Items().try_as<winrt::IObservableVector<winrt::MenuBarItem>>();
+    m_itemsVectorChangedRevoker = observableVector.VectorChanged(winrt::auto_revoke,
+    {
+        [this](auto const&, auto const&)
+        {
+            UpdateAutomationSizeAndPosition();
+        }
+    });
 }
 
 // IUIElement / IUIElementOverridesHelper
@@ -60,3 +69,31 @@ void MenuBar::IsFlyoutOpen(bool state)
     m_isFlyoutOpen = state;
 }
 
+// Automation Properties
+void MenuBar::UpdateAutomationSizeAndPosition()
+{
+    int sizeOfSet = 0;
+
+    for (const auto& item : Items())
+    {
+        if (auto itemAsUIElement = item.try_as<winrt::UIElement>())
+        {
+            if (itemAsUIElement.Visibility() == winrt::Visibility::Visible)
+            {
+                sizeOfSet++;
+                winrt::AutomationProperties::SetPositionInSet(itemAsUIElement, sizeOfSet);
+            }
+        }
+    }
+
+    for (const auto& item : Items())
+    {
+        if (auto itemAsUIElement = item.try_as<winrt::UIElement>())
+        {
+            if (itemAsUIElement.Visibility() == winrt::Visibility::Visible)
+            {
+                winrt::AutomationProperties::SetSizeOfSet(itemAsUIElement, sizeOfSet);
+            }
+        }
+    }
+}

--- a/dev/MenuBar/MenuBar.h
+++ b/dev/MenuBar/MenuBar.h
@@ -27,8 +27,10 @@ public:
 private:
 
     void SetUpTemplateParts();
+    void UpdateAutomationSizeAndPosition();
 
     bool m_isFlyoutOpen{ false };
+    winrt::IObservableVector<winrt::MenuBarItem>::VectorChanged_revoker m_itemsVectorChangedRevoker{};
 
     // Visual components
     tracker_ref<winrt::ItemsControl> m_contentRoot{ this };


### PR DESCRIPTION
Narrator was not reading how many items there where in the menu, for example:
"MenuBarItem 1of 3"

This PR sets the missing Automation Properties in MenuBar:
- PositionInSet
- SizeOfSet