### PR TITLE
Fix ProgressRing Automation Name Property

### DIFF
--- a/dev/ProgressRing/ProgressRingAutomationPeer.cpp
+++ b/dev/ProgressRing/ProgressRingAutomationPeer.cpp
@@ -41,7 +41,7 @@ winrt::hstring ProgressRingAutomationPeer::GetNameCore()
         {
             if (progressRing.IsIndeterminate())
             {
-                return winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingIndeterminateStatus) + " " + name };
+                return winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingIndeterminateStatus) + L" " + name };
             }
             else
             {

--- a/dev/ProgressRing/ProgressRingAutomationPeer.cpp
+++ b/dev/ProgressRing/ProgressRingAutomationPeer.cpp
@@ -41,7 +41,7 @@ winrt::hstring ProgressRingAutomationPeer::GetNameCore()
         {
             if (progressRing.IsIndeterminate())
             {
-                return winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingIndeterminateStatus) + name };
+                return winrt::hstring{ ResourceAccessor::GetLocalizedStringResource(SR_ProgressRingIndeterminateStatus) + " " + name };
             }
             else
             {


### PR DESCRIPTION
Screen readers were reading it the status and name of progress ring as one word, since we were concatenating them without a space. 

For example, if you progress ring is called Troubleshooter it was reading "BusyTroubleshooter". 

This PR adds the missing space for correct narrator reading. 
