### PR TITLE
Changes MenuBar default TabNavigation to "Once"

### DIFF
--- a/dev/MenuBar/MenuBar.xaml
+++ b/dev/MenuBar/MenuBar.xaml
@@ -10,11 +10,12 @@
         <Setter Property="Background" Value="{ThemeResource MenuBarBackground}"/>
         <Setter Property="IsTabStop" Value="False"/>
         <Setter Property="Height" Value="{StaticResource MenuBarHeight}"/>
+        <Setter Property="TabNavigation" Value="Once"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:MenuBar">
                     <Grid x:Name="LayoutRoot" Background="{TemplateBinding Background}" HorizontalAlignment="Stretch">
-                        <ItemsControl x:Name="ContentRoot" VerticalAlignment="Stretch" HorizontalAlignment="Left" IsTabStop="False">
+                        <ItemsControl x:Name="ContentRoot" VerticalAlignment="Stretch" HorizontalAlignment="Left" IsTabStop="False" TabNavigation="{TemplateBinding TabNavigation}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal"/>


### PR DESCRIPTION
Currently on menu bar you can tab through all menu bar items, which is not the recommended behavior looking at the accessibility side. 

Changing the default to only tabbing to first element and arrow keys between the items, so the next tab is going out of menu bar.
Also adds binding to menu bar's tab navigation in case we want users to be able to tab in each item.