### PR TITLE
Fix CommandBarFlyout spacing

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutOS_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyoutOS_themeresources.xaml
@@ -17,7 +17,7 @@
         <Setter Property="ExitDisplayModeOnAccessKeyInvoked" Value="False" />
         <Setter Property="DefaultLabelPosition" Value="Collapsed" />
         <Setter Property="MaxWidth" Value="440" />
-        <Setter Property="Height" Value="48" />
+        <Setter Property="Height" Value="46" />
         <Setter Property="IsDynamicOverflowEnabled" Value="True" />
         <Setter Property="CommandBarOverflowPresenterStyle" Value="{StaticResource CommandBarFlyoutCommandBarOverflowPresenterStyle}" />
         <Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
@@ -415,6 +415,7 @@
                                     </RectangleGeometry>
                                 </Grid.Clip>
                                 <Grid x:Name="PrimaryItemsRoot"
+                                    Padding="2,0"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     CornerRadius="{TemplateBinding CornerRadius}">
@@ -423,8 +424,6 @@
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
-                                        Height="40"
-                                        Margin="3,3,0,3"
                                         Grid.Column="0"
                                         IsTabStop="False"
                                         HorizontalAlignment="Left">

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -124,8 +124,8 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Thickness x:Key="CommandBarFlyoutAppBarButtonInnerBorderMargin">2</Thickness>
-    <Thickness x:Key="CommandBarFlyoutAppBarEllipsisButtonInnerBorderMargin">2,2,6,2</Thickness>
+    <Thickness x:Key="CommandBarFlyoutAppBarButtonInnerBorderMargin">2,4</Thickness>
+    <Thickness x:Key="CommandBarFlyoutAppBarEllipsisButtonInnerBorderMargin">2,4</Thickness>
     <contract12Present:ThemeShadow x:Key="CommandBarFlyoutOverflowShadow"/>
 
     <Style x:Key="CommandBarFlyoutAppBarButtonStyleBase" TargetType="AppBarButton">
@@ -157,6 +157,7 @@
                                 <VisualState x:Name="LabelCollapsed" />
                                 <VisualState x:Name="Overflow">
                                     <VisualState.Setters>
+                                        <Setter Target="AppBarButtonInnerBorder.Margin" Value="4,2" />
                                         <Setter Target="ContentRoot.MinHeight" Value="0" />
                                         <Setter Target="ContentRoot.Width" Value="NaN" />
                                         <Setter Target="ContentViewbox.Visibility" Value="Collapsed" />
@@ -166,6 +167,7 @@
                                 </VisualState>
                                 <VisualState x:Name="OverflowWithToggleButtons">
                                     <VisualState.Setters>
+                                        <Setter Target="AppBarButtonInnerBorder.Margin" Value="4,2" />
                                         <Setter Target="ContentRoot.MinHeight" Value="0" />
                                         <Setter Target="ContentRoot.Width" Value="NaN" />
                                         <Setter Target="ContentViewbox.Visibility" Value="Collapsed" />
@@ -175,6 +177,7 @@
                                 </VisualState>
                                 <VisualState x:Name="OverflowWithMenuIcons">
                                     <VisualState.Setters>
+                                        <Setter Target="AppBarButtonInnerBorder.Margin" Value="4,2" />
                                         <Setter Target="ContentRoot.MinHeight" Value="0" />
                                         <Setter Target="ContentRoot.Width" Value="NaN" />
                                         <Setter Target="ContentViewbox.HorizontalAlignment" Value="Left" />
@@ -188,6 +191,7 @@
                                 </VisualState>
                                 <VisualState x:Name="OverflowWithToggleButtonsAndMenuIcons">
                                     <VisualState.Setters>
+                                        <Setter Target="AppBarButtonInnerBorder.Margin" Value="4,2" />
                                         <Setter Target="ContentRoot.MinHeight" Value="0" />
                                         <Setter Target="ContentRoot.Width" Value="NaN" />
                                         <Setter Target="ContentViewbox.HorizontalAlignment" Value="Left" />
@@ -387,6 +391,7 @@
                                 <VisualState x:Name="LabelCollapsed" />
                                 <VisualState x:Name="Overflow">
                                     <VisualState.Setters>
+                                        <Setter Target="AppBarButtonInnerBorder.Margin" Value="4,2" />
                                         <Setter Target="ContentRoot.MinHeight" Value="0" />
                                         <Setter Target="ContentRoot.Width" Value="NaN" />
                                         <Setter Target="ContentViewbox.Visibility" Value="Collapsed" />
@@ -396,6 +401,7 @@
                                 </VisualState>
                                 <VisualState x:Name="OverflowWithMenuIcons">
                                     <VisualState.Setters>
+                                        <Setter Target="AppBarButtonInnerBorder.Margin" Value="4,2" />
                                         <Setter Target="ContentRoot.MinHeight" Value="0" />
                                         <Setter Target="ContentRoot.Width" Value="NaN" />
                                         <Setter Target="ContentViewbox.Visibility" Value="Visible" />
@@ -648,7 +654,7 @@
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             AutomationProperties.AccessibilityView="Raw">
                             <ItemsPresenter x:Name="ItemsPresenter"
-                                Margin="3"/>
+                                Margin="0,2"/>
                         </ScrollViewer>
                     </Grid>
                 </ControlTemplate>
@@ -682,7 +688,7 @@
                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
                             AutomationProperties.AccessibilityView="Raw">
                             <ItemsPresenter x:Name="ItemsPresenter"
-                                Margin="3"/>
+                                Margin="0,2"/>
                         </ScrollViewer>
                     </Grid>
                 </ControlTemplate>
@@ -695,8 +701,8 @@
         <Setter Property="Foreground" Value="{ThemeResource CommandBarFlyoutAppBarButtonForeground}" />
         <Setter Property="BorderBrush" Value="{ThemeResource CommandBarFlyoutAppBarButtonBorderBrush}" />
         <Setter Property="Padding" Value="0" />
-        <Setter Property="Width" Value="44" />
-        <Setter Property="Height" Value="40" />
+        <Setter Property="Width" Value="40" />
+        <Setter Property="Height" Value="44" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -778,7 +784,7 @@
         <Setter Property="ExitDisplayModeOnAccessKeyInvoked" Value="False" />
         <Setter Property="DefaultLabelPosition" Value="Collapsed" />
         <Setter Property="MaxWidth" Value="440" />
-        <Setter Property="Height" Value="48" />
+        <Setter Property="Height" Value="46" />
         <Setter Property="IsDynamicOverflowEnabled" Value="True" />
         <contract7Present:Setter Property="CommandBarOverflowPresenterStyle" Value="{StaticResource CommandBarFlyoutCommandBarOverflowPresenterStyle}" />
         <contract7NotPresent:Setter Property="CommandBarOverflowPresenterStyle" Value="{StaticResource CommandBarFlyoutCommandBarOverflowPresenterStyleRS4}" />
@@ -1265,6 +1271,7 @@
                                     </RectangleGeometry>
                                 </Grid.Clip>
                                 <Grid x:Name="PrimaryItemsRoot"
+                                    Padding="2,0"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
@@ -1274,8 +1281,6 @@
                                         <ColumnDefinition Width="Auto" MinWidth="3" />
                                     </Grid.ColumnDefinitions>
                                     <ItemsControl x:Name="PrimaryItemsControl"
-                                        Height="40"
-                                        Margin="3,3,0,3"
                                         Grid.Column="0"
                                         IsTabStop="False"
                                         HorizontalAlignment="Left">

--- a/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
@@ -34,17 +34,17 @@
         <Grid.Resources>
             <muxc:CommandBarFlyout Placement="Right" x:Name="Flyout1" AutomationProperties.AutomationId="Flyout1" Opened="OnFlyoutOpened" Closed="OnFlyoutClosed">
                 <AppBarButton x:Name="CutButton1" AutomationProperties.AutomationId="CutButton1" Label="Cut" Icon="Cut" Click="OnElementClicked"/>
-                <AppBarSeparator />
                 <AppBarButton x:Name="CopyButton1" AutomationProperties.AutomationId="CopyButton1" Label="Copy" Icon="Copy" Click="OnElementClicked" />
                 <AppBarButton x:Name="PasteButton1" AutomationProperties.AutomationId="PasteButton1" Label="Paste" Icon="Paste" Click="OnElementClicked" />
-                <AppBarButton x:Name="BoldButton1" AutomationProperties.AutomationId="BoldButton1" Label="Bold" Icon="Bold" Click="OnElementClicked" />
-                <AppBarButton x:Name="ItalicButton1" AutomationProperties.AutomationId="ItalicButton1" Label="Italic" Icon="Italic" Click="OnElementClicked" />
+                <AppBarSeparator />
+                <AppBarToggleButton x:Name="BoldButton1" AutomationProperties.AutomationId="BoldButton1" Label="Bold" Icon="Bold" Click="OnElementClicked" />
+                <AppBarToggleButton x:Name="ItalicButton1" AutomationProperties.AutomationId="ItalicButton1" Label="Italic" Icon="Italic" Click="OnElementClicked" />
                 <AppBarToggleButton x:Name="UnderlineButton1" AutomationProperties.AutomationId="UnderlineButton1" Label="Underline" Icon="Underline" Click="OnElementClicked" />
                 <muxc:CommandBarFlyout.SecondaryCommands>
                     <AppBarButton x:Name="UndoButton1" AutomationProperties.AutomationId="UndoButton1" Label="Undo" Icon="Undo" Click="OnElementClicked" />
-                    <AppBarSeparator IsTabStop="False" />
                     <AppBarButton x:Name="RedoButton1" AutomationProperties.AutomationId="RedoButton1" Label="Redo" Icon="Redo" Click="OnElementClicked" />
                     <AppBarButton x:Name="SelectAllButton1" AutomationProperties.AutomationId="SelectAllButton1" Label="Select all" Click="OnElementClicked" />
+                    <AppBarSeparator />
                     <AppBarToggleButton x:Name="FavoriteToggleButton1" AutomationProperties.AutomationId="FavoriteToggleButton1" Label="Favorite" Icon="Favorite" Checked="OnElementChecked" Unchecked="OnElementUnchecked" />
                 </muxc:CommandBarFlyout.SecondaryCommands>
             </muxc:CommandBarFlyout>
@@ -196,13 +196,15 @@
                 <AppBarButton x:Name="CutButton10" AutomationProperties.AutomationId="CutButton10" Label="Cut" Icon="Cut" Click="OnElementClicked" />
                 <AppBarButton x:Name="CopyButton10" AutomationProperties.AutomationId="CopyButton10" Label="Copy" Icon="Copy" Click="OnElementClicked" />
                 <AppBarButton x:Name="PasteButton10" AutomationProperties.AutomationId="PasteButton10" Label="Paste" Icon="Paste" Click="OnElementClicked" />
-                <AppBarButton x:Name="BoldButton10" AutomationProperties.AutomationId="BoldButton10" Label="Bold" Icon="Bold" Click="OnElementClicked" />
-                <AppBarButton x:Name="ItalicButton10" AutomationProperties.AutomationId="ItalicButton10" Label="Italic" Icon="Italic" Click="OnElementClicked" />
-                <AppBarButton x:Name="UnderlineButton10" AutomationProperties.AutomationId="UnderlineButton10" Label="Underline" Icon="Underline" Click="OnElementClicked" />
+                <AppBarSeparator />
+                <AppBarToggleButton x:Name="BoldButton10" AutomationProperties.AutomationId="BoldButton10" Label="Bold" Icon="Bold" Click="OnElementClicked" />
+                <AppBarToggleButton x:Name="ItalicButton10" AutomationProperties.AutomationId="ItalicButton10" Label="Italic" Icon="Italic" Click="OnElementClicked" />
+                <AppBarToggleButton x:Name="UnderlineButton10" AutomationProperties.AutomationId="UnderlineButton10" Label="Underline" Icon="Underline" Click="OnElementClicked" />
                 <contract13Present:CommandBarFlyout.SecondaryCommands>
                     <AppBarButton x:Name="UndoButton10" AutomationProperties.AutomationId="UndoButton10" Label="Undo" Icon="Undo" Click="OnElementClicked" />
                     <AppBarButton x:Name="RedoButton10" AutomationProperties.AutomationId="RedoButton10" Label="Redo" Icon="Redo" Click="OnElementClicked" />
                     <AppBarButton x:Name="SelectAllButton10" AutomationProperties.AutomationId="SelectAllButton10" Label="Select all" Click="OnElementClicked" />
+                    <AppBarSeparator />
                     <AppBarToggleButton x:Name="FavoriteToggleButton10" AutomationProperties.AutomationId="FavoriteToggleButton10" Label="Favorite" Icon="Favorite" Checked="OnElementChecked" Unchecked="OnElementUnchecked" />
                 </contract13Present:CommandBarFlyout.SecondaryCommands>
             </contract13Present:CommandBarFlyout>

--- a/dev/CommonStyles/AppBarSeparator_themeresources.xaml
+++ b/dev/CommonStyles/AppBarSeparator_themeresources.xaml
@@ -14,7 +14,7 @@
     </ResourceDictionary.ThemeDictionaries>
 
     <Thickness x:Key="AppBarSeparatorMargin">2,8,2,8</Thickness>
-    <Thickness x:Key="AppBarOverflowSeparatorMargin">0,4,0,4</Thickness>
+    <Thickness x:Key="AppBarOverflowSeparatorMargin">0,2</Thickness>
     <x:Double x:Key="AppBarSeparatorWidth">1</x:Double>
     <x:Double x:Key="AppBarOverflowSeparatorHeight">1</x:Double>
     <x:Double x:Key="AppBarSeparatorCornerRadius">0.5</x:Double>
@@ -34,12 +34,7 @@
                                 <!-- FullSize is used when we are in landscape or filled mode -->
                                 <VisualState x:Name="FullSize"/>
                                 <!-- Compact is used when we are in portrait or snapped mode -->
-                                <VisualState x:Name="Compact">
-                                    <VisualState.Setters>
-                                        <Setter Target="RootGrid.Height" Value="{ThemeResource AppBarThemeCompactHeight}"/>
-                                        <Setter Target="RootGrid.VerticalAlignment" Value="Top"/>
-                                    </VisualState.Setters>
-                                </VisualState>
+                                <VisualState x:Name="Compact"/>
                                 <VisualState x:Name="Overflow">
                                     <VisualState.Setters>
                                         <Setter Target="SeparatorRectangle.Width" Value="NaN"/>


### PR DESCRIPTION
* Made all items spaced consistently with other menus
* Made separator span the entire width of the menu, matching spec and other menus
* Fixed AppBarSeparator from having a fixed height in collapsed mode (see before pics)
* Updated two base tests to have more toggle buttons and separators

Before:
![oldcollapsed](https://user-images.githubusercontent.com/101892345/159071189-7ae1d626-2bf5-44c1-ad65-51e23dff1d5d.png)
![oldexpanded](https://user-images.githubusercontent.com/101892345/159071188-440b0d54-c3ed-42ef-a860-ed2c7367cecb.png)
After:
![newcollapsed](https://user-images.githubusercontent.com/101892345/159071220-f9bf3859-f74c-47f6-bdbd-a72f349647a9.png)
![newexpanded](https://user-images.githubusercontent.com/101892345/159071215-54ba6c63-845b-4b62-9b64-236867b199db.png)

