### PR TITLE
CommandBarFlyoutCommandBar fix - respond to size changes

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -49,8 +49,8 @@ private:
     void DetachEventHandlers();
 
     void UpdateFlowsFromAndFlowsTo();
-    void UpdateUI(bool useTransitions = true, bool isForCommandBarElementDependencyPropertyChange = false);
-    void UpdateVisualState(bool useTransitions, bool isForCommandBarElementDependencyPropertyChange = false);
+    void UpdateUI(bool useTransitions = true, bool isForSizeChange = false);
+    void UpdateVisualState(bool useTransitions, bool isForSizeChange = false);
     void UpdateTemplateSettings();
     void EnsureAutomationSetCountAndPosition();
     void EnsureLocalizedControlTypes();

--- a/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
+++ b/dev/CommandBarFlyout/InteractionTests/CommandBarFlyoutTests.cs
@@ -1006,6 +1006,174 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void VerifyDynamicSecondaryCommandVisibility()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled pre-RS2 because CommandBarFlyout is not supported pre-RS2");
+                return;
+            }
+
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Log.Comment("Retrieving FlyoutTarget6");
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with no primary commands");
+
+                Log.Comment("Retrieving IsFlyoutOpenCheckBox");
+                ToggleButton isFlyoutOpenCheckBox = FindElement.ById<ToggleButton>("IsFlyoutOpenCheckBox");
+
+                Log.Comment("Retrieving UseSecondaryCommandDynamicVisibilityCheckBox");
+                ToggleButton useSecondaryCommandDynamicVisibilityCheckBox = FindElement.ById<ToggleButton>("UseSecondaryCommandDynamicVisibilityCheckBox");
+
+                Log.Comment("SecondaryCommandDynamicVisibilityChangedCheckBox");
+                ToggleButton secondaryCommandDynamicVisibilityChangedCheckBox = FindElement.ById<ToggleButton>("SecondaryCommandDynamicVisibilityChangedCheckBox");
+
+                Log.Comment("Retrieving DynamicVisibilityTimerIntervalTextBox");
+                Edit dynamicVisibilityTimerIntervalTextBox = new Edit(FindElement.ById("DynamicVisibilityTimerIntervalTextBox"));
+
+                Log.Comment("Retrieving DynamicVisibilityChangeCountTextBox");
+                Edit dynamicVisibilityChangeCountTextBox = new Edit(FindElement.ById("DynamicVisibilityChangeCountTextBox"));
+
+                Verify.AreEqual(ToggleState.Off, isFlyoutOpenCheckBox.ToggleState);
+
+                Log.Comment("Change the fifth command bar element's Visibility property asynchronously after the command bar is opened");
+                useSecondaryCommandDynamicVisibilityCheckBox.Check();
+
+                Log.Comment("Setting DynamicVisibilityTimerIntervalTextBox to 1s");
+                dynamicVisibilityTimerIntervalTextBox.SetValue("1000");
+
+                Log.Comment("Setting DynamicVisibilityChangeCountTextBox to 1 single change");
+                dynamicVisibilityChangeCountTextBox.SetValue("1");
+                Wait.ForIdle();
+
+                Verify.AreEqual(ToggleState.Off, secondaryCommandDynamicVisibilityChangedCheckBox.ToggleState);
+
+                Log.Comment("Invoking button 'Show CommandBarFlyout with no primary commands' to show the Flyout6 command bar.");
+                showCommandBarFlyoutButton.Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual(ToggleState.On, isFlyoutOpenCheckBox.ToggleState);
+
+                FocusHelper.SetFocus(FindElement.ById("UndoButton6"));
+
+                Button undoButton6 = FindElement.ById<Button>("UndoButton6");
+                Verify.IsNotNull(undoButton6);
+
+                UIObject commandBarElementsContainer = undoButton6.Parent;
+                Verify.IsNotNull(commandBarElementsContainer);
+
+                Rectangle initialBoundingRectangle = commandBarElementsContainer.BoundingRectangle;
+
+                Log.Comment("Initial commandBarElementsContainer.BoundingRectangle.Width=" + initialBoundingRectangle.Width);
+                Log.Comment("Initial commandBarElementsContainer.BoundingRectangle.Height=" + initialBoundingRectangle.Height);
+
+                Verify.AreEqual(ToggleState.Off, secondaryCommandDynamicVisibilityChangedCheckBox.ToggleState);
+
+                Log.Comment("Waiting for SecondaryCommandDynamicVisibilityChangedCheckBox becoming checked indicating the asynchronous Visibility property change occurred");
+                secondaryCommandDynamicVisibilityChangedCheckBox.GetToggledWaiter().Wait();
+                Wait.ForIdle();
+
+                Rectangle finalBoundingRectangle = commandBarElementsContainer.BoundingRectangle;
+
+                Log.Comment("Final commandBarElementsContainer.BoundingRectangle.Width=" + finalBoundingRectangle.Width);
+                Log.Comment("Final commandBarElementsContainer.BoundingRectangle.Height=" + finalBoundingRectangle.Height);
+
+                Log.Comment("Hitting Escape key to close the command bar.");
+                KeyboardHelper.PressKey(Key.Escape);
+                Wait.ForIdle();
+
+                Verify.AreEqual(ToggleState.Off, isFlyoutOpenCheckBox.ToggleState);
+
+                Log.Comment("Verifying the command bar flyout width and height were increased to accommodate the new AppBarButton.");
+                Verify.IsGreaterThan(finalBoundingRectangle.Width, initialBoundingRectangle.Width);
+                Verify.IsGreaterThan(finalBoundingRectangle.Height, initialBoundingRectangle.Height);
+            }
+        }
+
+        [TestMethod]
+        public void VerifyDynamicOverflowContentRootWidth()
+        {
+            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))
+            {
+                Log.Warning("Test is disabled pre-RS2 because CommandBarFlyout is not supported pre-RS2");
+                return;
+            }
+
+            using (var setup = new CommandBarFlyoutTestSetupHelper())
+            {
+                Log.Comment("Retrieving FlyoutTarget6");
+                Button showCommandBarFlyoutButton = FindElement.ByName<Button>("Show CommandBarFlyout with no primary commands");
+
+                Log.Comment("Retrieving IsFlyoutOpenCheckBox");
+                ToggleButton isFlyoutOpenCheckBox = FindElement.ById<ToggleButton>("IsFlyoutOpenCheckBox");
+
+                Log.Comment("Retrieving UseOverflowContentRootDynamicWidthCheckBox");
+                ToggleButton useOverflowContentRootDynamicWidthCheckBox = FindElement.ById<ToggleButton>("UseOverflowContentRootDynamicWidthCheckBox");
+
+                Log.Comment("OverflowContentRootDynamicWidthChangedCheckBox");
+                ToggleButton overflowContentRootDynamicWidthChangedCheckBox = FindElement.ById<ToggleButton>("OverflowContentRootDynamicWidthChangedCheckBox");
+
+                Log.Comment("Retrieving DynamicWidthTimerIntervalTextBox");
+                Edit dynamicWidthTimerIntervalTextBox = new Edit(FindElement.ById("DynamicWidthTimerIntervalTextBox"));
+
+                Log.Comment("Retrieving DynamicWidthChangeCountTextBox");
+                Edit dynamicWidthChangeCountTextBox = new Edit(FindElement.ById("DynamicWidthChangeCountTextBox"));
+
+                Verify.AreEqual(ToggleState.Off, isFlyoutOpenCheckBox.ToggleState);
+
+                Log.Comment("Change the fifth command bar element's Visibility property asynchronously after the command bar is opened");
+                useOverflowContentRootDynamicWidthCheckBox.Check();
+
+                Log.Comment("Setting DynamicWidthTimerIntervalTextBox to 1s");
+                dynamicWidthTimerIntervalTextBox.SetValue("1000");
+
+                Log.Comment("Setting DynamicWidthChangeCountTextBox to 1 single change");
+                dynamicWidthChangeCountTextBox.SetValue("1");
+                Wait.ForIdle();
+
+                Verify.AreEqual(ToggleState.Off, overflowContentRootDynamicWidthChangedCheckBox.ToggleState);
+
+                Log.Comment("Invoking button 'Show CommandBarFlyout with no primary commands' to show the Flyout6 command bar.");
+                showCommandBarFlyoutButton.Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual(ToggleState.On, isFlyoutOpenCheckBox.ToggleState);
+
+                FocusHelper.SetFocus(FindElement.ById("UndoButton6"));
+
+                Button undoButton6 = FindElement.ById<Button>("UndoButton6");
+                Verify.IsNotNull(undoButton6);
+
+                UIObject commandBarElementsContainer = undoButton6.Parent;
+                Verify.IsNotNull(commandBarElementsContainer);
+
+                Rectangle initialBoundingRectangle = commandBarElementsContainer.BoundingRectangle;
+
+                Log.Comment("Initial commandBarElementsContainer.BoundingRectangle.Width=" + initialBoundingRectangle.Width);
+                Log.Comment("Initial commandBarElementsContainer.BoundingRectangle.Height=" + initialBoundingRectangle.Height);
+
+                Verify.AreEqual(ToggleState.Off, overflowContentRootDynamicWidthChangedCheckBox.ToggleState);
+
+                Log.Comment("Waiting for OverflowContentRootDynamicWidthChangedCheckBox becoming checked indicating the asynchronous Visibility property change occurred");
+                overflowContentRootDynamicWidthChangedCheckBox.GetToggledWaiter().Wait();
+                Wait.ForIdle();
+
+                Rectangle finalBoundingRectangle = commandBarElementsContainer.BoundingRectangle;
+
+                Log.Comment("Final commandBarElementsContainer.BoundingRectangle.Width=" + finalBoundingRectangle.Width);
+                Log.Comment("Final commandBarElementsContainer.BoundingRectangle.Height=" + finalBoundingRectangle.Height);
+
+                Log.Comment("Hitting Escape key to close the command bar.");
+                KeyboardHelper.PressKey(Key.Escape);
+                Wait.ForIdle();
+
+                Verify.AreEqual(ToggleState.Off, isFlyoutOpenCheckBox.ToggleState);
+
+                Log.Comment("Verifying the command bar flyout width was increased to accommodate the OverflowContentRoot's larger Width.");
+                Verify.IsGreaterThan(finalBoundingRectangle.Width, initialBoundingRectangle.Width);
+                Verify.AreEqual(finalBoundingRectangle.Height, initialBoundingRectangle.Height);
+            }
+        }
+
+        [TestMethod]
         public void VerifyIsFlyoutKeyboardAccessibleWithNoPrimaryCommands()
         {
             if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone2))

--- a/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
+++ b/dev/CommandBarFlyout/TestUI/CommandBarFlyoutPage.xaml
@@ -130,6 +130,7 @@
                     <AppBarButton x:Name="UndoButton5" AutomationProperties.AutomationId="UndoButton5" Label="Undo" Icon="Undo" Click="OnElementClicked" />
                     <AppBarButton x:Name="RedoButton5" AutomationProperties.AutomationId="RedoButton5" Label="Redo" Icon="Redo" Click="OnElementClicked" />
                     <AppBarButton x:Name="SelectAllButton5" AutomationProperties.AutomationId="SelectAllButton5" Label="Select all" Click="OnElementClicked" />
+                    <AppBarButton x:Name="LongLabelButton5" AutomationProperties.AutomationId="LongLabelButton5" Label="AppBarButton with long label" Visibility="Collapsed" Click="OnElementClicked" />
                 </muxc:CommandBarFlyout.SecondaryCommands>
             </muxc:CommandBarFlyout>
             <muxc:CommandBarFlyout Placement="Right" x:Name="Flyout6" AutomationProperties.AutomationId="Flyout6" Opened="OnFlyoutOpened" Closed="OnFlyoutClosed">
@@ -138,6 +139,7 @@
                     <AppBarButton x:Name="RedoButton6" AutomationProperties.AutomationId="RedoButton6" Label="Redo" Icon="Redo" Click="OnElementClicked" />
                     <AppBarButton x:Name="SelectAllButton6" AutomationProperties.AutomationId="SelectAllButton6" Label="Select all" Click="OnElementClicked" />
                     <AppBarToggleButton x:Name="FavoriteToggleButton6" AutomationProperties.AutomationId="FavoriteToggleButton6" Label="Favorite" Icon="Favorite" Checked="OnElementChecked" Unchecked="OnElementUnchecked" />
+                    <AppBarButton x:Name="LongLabelButton6" AutomationProperties.AutomationId="LongLabelButton6" Label="AppBarButton with long label" Visibility="Collapsed" Click="OnElementClicked" />
                 </muxc:CommandBarFlyout.SecondaryCommands>
             </muxc:CommandBarFlyout>
             <muxc:CommandBarFlyout Placement="Right" x:Name="Flyout7" AutomationProperties.AutomationId="Flyout7" Opened="OnFlyoutOpened" Closed="OnFlyoutClosed">
@@ -235,6 +237,22 @@
                     <TextBox x:Name="DynamicLabelTimerIntervalTextBox" Text="1500" Margin="5,0,0,0" AutomationProperties.AutomationId="DynamicLabelTimerIntervalTextBox"/>
                     <TextBlock Text="Change Count:" Margin="5,0,0,0" VerticalAlignment="Center"/>
                     <TextBox x:Name="DynamicLabelChangeCountTextBox" Text="4" Margin="5,0,0,0" AutomationProperties.AutomationId="DynamicLabelChangeCountTextBox"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="10,0,10,2">
+                    <CheckBox x:Name="UseSecondaryCommandDynamicVisibilityCheckBox" Content="Use Secondary Command with Dynamic Visibility?" AutomationProperties.AutomationId="UseSecondaryCommandDynamicVisibilityCheckBox" />
+                    <CheckBox x:Name="SecondaryCommandDynamicVisibilityChangedCheckBox" Content="Visibility Changed?" AutomationProperties.AutomationId="SecondaryCommandDynamicVisibilityChangedCheckBox" Margin="5,0,0,0" />
+                    <TextBlock Text="Timer Interval (ms):" Margin="5,0,0,0" VerticalAlignment="Center"/>
+                    <TextBox x:Name="DynamicVisibilityTimerIntervalTextBox" Text="1500" Margin="5,0,0,0" AutomationProperties.AutomationId="DynamicVisibilityTimerIntervalTextBox"/>
+                    <TextBlock Text="Change Count:" Margin="5,0,0,0" VerticalAlignment="Center"/>
+                    <TextBox x:Name="DynamicVisibilityChangeCountTextBox" Text="4" Margin="5,0,0,0" AutomationProperties.AutomationId="DynamicVisibilityChangeCountTextBox"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="10,0,10,2">
+                    <CheckBox x:Name="UseOverflowContentRootDynamicWidthCheckBox" Content="Use OverflowContentRoot with Dynamic Width?" AutomationProperties.AutomationId="UseOverflowContentRootDynamicWidthCheckBox" />
+                    <CheckBox x:Name="OverflowContentRootDynamicWidthChangedCheckBox" Content="Width Changed?" AutomationProperties.AutomationId="OverflowContentRootDynamicWidthChangedCheckBox" Margin="5,0,0,0" />
+                    <TextBlock Text="Timer Interval (ms):" Margin="5,0,0,0" VerticalAlignment="Center"/>
+                    <TextBox x:Name="DynamicWidthTimerIntervalTextBox" Text="1500" Margin="5,0,0,0" AutomationProperties.AutomationId="DynamicWidthTimerIntervalTextBox"/>
+                    <TextBlock Text="Change Count:" Margin="5,0,0,0" VerticalAlignment="Center"/>
+                    <TextBox x:Name="DynamicWidthChangeCountTextBox" Text="4" Margin="5,0,0,0" AutomationProperties.AutomationId="DynamicWidthChangeCountTextBox"/>
                 </StackPanel>
                 <CheckBox x:Name="ClearSecondaryCommandsCheckBox" Content="Clear Secondary Commands Asynchronously?" AutomationProperties.AutomationId="ClearSecondaryCommandsCheckBox" Margin="10,0,10,2" />
             </StackPanel>

--- a/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
+++ b/test/MUXControlsTestApp/Utilities/VisualTreeUtils.cs
@@ -71,5 +71,20 @@ namespace MUXControlsTestApp.Utilities
                 ? elementAsT 
                 : VisualTreeHelper.GetParent(element).FindVisualParentByType<T>();
         }
+
+        public static FrameworkElement FindVisualParentByName(this DependencyObject element, string name)
+        {
+            if (element is null || string.IsNullOrWhiteSpace(name))
+            {
+                return null;
+            }
+
+            if (element is FrameworkElement elementAsFE && elementAsFE.Name == name)
+            {
+                return elementAsFE;
+            }
+
+            return VisualTreeHelper.GetParent(element).FindVisualParentByName(name);
+        }
     }
 }


### PR DESCRIPTION
Instead of just reacting to AppBarButton / AppBarToggleButton dependency property changes that might affect the owning CommandBarFlyout size, react to size changes in general to account for CommandBarFlyoutCommandBar visibility changes (addresses issue #6864) and OverflowContentRoot size changes. 

The changes involve expanding the use of the internal parameter 'isForCommandBarElementDependencyPropertyChange' to size changes in general. I thus changed its name to 'isForSizeChange'.

I added a new test for the case where an AppBarButton visibility changes, and a test for the case where the OverflowContentRoot size changes. 