### PR TITLE
ColorPicker misc fixes

### DIFF
--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -15,7 +15,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:ColorPicker">
-                    <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" Padding="0,4"
+                    <Grid x:Name="RootGrid" Background="{TemplateBinding Background}"
                         MaxWidth="{StaticResource ColorPickerVerticalOrientationMaxWidth}"
                         MinWidth="{StaticResource ColorPickerVerticalOrientationMinWidth}">
                         <Grid.Resources>
@@ -174,7 +174,7 @@
 
                                         <Setter Target="AlphaSliderGrid.(Grid.Column)" Value="2"/>
                                         <Setter Target="AlphaSliderGrid.(Grid.Row)" Value="0"/>
-                                        <Setter Target="AlphaSliderGrid.Margin" Value="0,0,16,0"/>
+                                        <Setter Target="AlphaSliderGrid.Margin" Value="0,0,6,0"/>
                                         <Setter Target="AlphaSlider.Orientation" Value="Vertical"/>
                                         <Setter Target="AlphaSliderCheckeredBackgroundRectangle.Height" Value="Auto"/>
                                         <Setter Target="AlphaSliderCheckeredBackgroundRectangle.Width" Value="12"/>
@@ -192,7 +192,7 @@
                                     
                                         <Setter Target="MoreEntriesPanel.(Grid.Column)" Value="3"/>
                                         <Setter Target="MoreEntriesPanel.(Grid.Row)" Value="0"/>
-                                        <Setter Target="MoreEntriesPanel.Margin" Value="0"/>
+                                        <Setter Target="MoreEntriesPanel.Margin" Value="10,0,0,0"/>
                                         <Setter Target="MoreButton.Margin" Value="0"/>
 
                                         <Setter Target="ColorRepresentationComboBox.(Grid.Row)" Value="1"/>
@@ -247,35 +247,19 @@
                                     Components="{TemplateBinding ColorSpectrumComponents}"
                                     contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
                                     TabIndex="0"/>
-                                <Grid x:Name="ColorPreviewRectangleGrid" Grid.Column="1" Grid.Row="0" Width="44" Margin="12,0,0,0">
+                                <Grid x:Name="ColorPreviewRectangleGrid" Grid.Column="1" Grid.Row="0" Width="44" Margin="12,0,0,0" CornerRadius="{ThemeResource ControlCornerRadius}">
                                     <Grid.RowDefinitions>
                                         <RowDefinition />
                                         <RowDefinition />
                                     </Grid.RowDefinitions>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition />
-                                        <ColumnDefinition />
-                                    </Grid.ColumnDefinitions>
-                                    <Rectangle VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2"
-                                               contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
+                                    <Rectangle VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2">
                                         <Rectangle.Fill>
                                             <ImageBrush x:Name="ColorPreviewRectangleCheckeredBackgroundImageBrush" />
                                         </Rectangle.Fill>
                                     </Rectangle>
-                                    <Rectangle x:Name="ColorPreviewRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.RowSpan="2"
-                                               contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
-                                    <Rectangle x:Name="PreviousColorRectangle" VerticalAlignment="Stretch" Grid.ColumnSpan="2" Grid.Row="1" Visibility="Collapsed"
-                                               contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
-                                               contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
-                                    <Rectangle x:Name="BorderRectangle" Style="{StaticResource ColorPickerBorderStyle}" Grid.RowSpan="2" Grid.ColumnSpan="2"
+                                    <Rectangle x:Name="ColorPreviewRectangle" VerticalAlignment="Stretch" Grid.RowSpan="2" />
+                                    <Rectangle x:Name="PreviousColorRectangle" VerticalAlignment="Stretch" Grid.Row="1" Visibility="Collapsed" />
+                                    <Rectangle x:Name="BorderRectangle" Style="{StaticResource ColorPickerBorderStyle}" Grid.RowSpan="2"
                                                contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                                contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
                                                contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
@@ -294,7 +278,7 @@
                                 </Rectangle>
                                 <primitives:ColorPickerSlider x:Name="ThirdDimensionSlider" Minimum="0" Maximum="100" ColorChannel="Value" Orientation="Horizontal" Style="{StaticResource ColorPickerSliderStyle}" IsThumbToolTipEnabled="False" TabIndex="1"/>
                             </Grid>
-                            <Grid Margin="0,0,0,16" x:Name="AlphaSliderGrid" Grid.Row="2">
+                            <Grid Margin="0,0,0,6" x:Name="AlphaSliderGrid" Grid.Row="2">
                                 <Rectangle x:Name="AlphaSliderCheckeredBackgroundRectangle" RenderTransformOrigin="0.5, 0.5" Height="12" VerticalAlignment="Center"
                                            contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                            contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
@@ -315,7 +299,7 @@
                                 </Rectangle>
                                 <primitives:ColorPickerSlider x:Name="AlphaSlider" Minimum="0" Maximum="100" ColorChannel="Alpha" Orientation="Horizontal" Style="{StaticResource ColorPickerSliderStyle}" IsThumbToolTipEnabled="False" TabIndex="2"/>
                             </Grid>
-                            <StackPanel x:Name="MoreEntriesPanel" Grid.Row="3" Margin="0,0,0,12">
+                            <StackPanel x:Name="MoreEntriesPanel" Grid.Row="3" Margin="0,10,0,0">
                                 <ToggleButton
                                     x:Name="MoreButton"
                                     MinHeight="32"

--- a/dev/ColorPicker/ColorPicker.xaml
+++ b/dev/ColorPicker/ColorPicker.xaml
@@ -156,11 +156,11 @@
                                         <Setter Target="RootGrid.MinWidth" Value="0"/>
                                         <Setter Target="RootGrid.MaxWidth" Value="10000"/>
                                         <Setter Target="ColorSpectrumGrid.Margin" Value="0"/>
-                                        <Setter Target="ColorPreviewRectangleGrid.Margin" Value="12,0,16,0"/>
+                                        <Setter Target="ColorPreviewRectangleGrid.Margin" Value="12,0,14,0"/>
 
                                         <Setter Target="ThirdDimensionSliderGrid.(Grid.Column)" Value="1"/>
                                         <Setter Target="ThirdDimensionSliderGrid.(Grid.Row)" Value="0"/>
-                                        <Setter Target="ThirdDimensionSliderGrid.Margin" Value="0,0,6,0" />
+                                        <Setter Target="ThirdDimensionSliderGrid.Margin" Value="0,0,4,0" />
                                         <Setter Target="ThirdDimensionSlider.Orientation" Value="Vertical"/>
                                         <Setter Target="ThirdDimensionBackgroundRectangle.Height" Value="Auto"/>
                                         <Setter Target="ThirdDimensionBackgroundRectangle.Width" Value="12"/>
@@ -174,7 +174,7 @@
 
                                         <Setter Target="AlphaSliderGrid.(Grid.Column)" Value="2"/>
                                         <Setter Target="AlphaSliderGrid.(Grid.Row)" Value="0"/>
-                                        <Setter Target="AlphaSliderGrid.Margin" Value="0,0,6,0"/>
+                                        <Setter Target="AlphaSliderGrid.Margin" Value="0,0,4,0"/>
                                         <Setter Target="AlphaSlider.Orientation" Value="Vertical"/>
                                         <Setter Target="AlphaSliderCheckeredBackgroundRectangle.Height" Value="Auto"/>
                                         <Setter Target="AlphaSliderCheckeredBackgroundRectangle.Width" Value="12"/>
@@ -227,7 +227,7 @@
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
 
-                            <Grid x:Name="ColorSpectrumGrid" Margin="0,0,0,16">
+                            <Grid x:Name="ColorSpectrumGrid" Margin="0,0,0,14">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition />
                                     <ColumnDefinition Width="Auto" />
@@ -266,7 +266,7 @@
                                                contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
                                 </Grid>
                             </Grid>
-                            <Grid Margin="0,0,0,6" x:Name="ThirdDimensionSliderGrid" Grid.Row="1">
+                            <Grid Margin="0,0,0,4" x:Name="ThirdDimensionSliderGrid" Grid.Row="1">
                                 <Rectangle x:Name="ThirdDimensionBackgroundRectangle" RenderTransformOrigin="0.5, 0.5" Height="12" VerticalAlignment="Center"
                                            contract7Present:RadiusX="{Binding Source={ThemeResource ColorPickerSliderCornerRadius}, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                            contract7Present:RadiusY="{Binding Source={ThemeResource ColorPickerSliderCornerRadius}, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
@@ -278,7 +278,7 @@
                                 </Rectangle>
                                 <primitives:ColorPickerSlider x:Name="ThirdDimensionSlider" Minimum="0" Maximum="100" ColorChannel="Value" Orientation="Horizontal" Style="{StaticResource ColorPickerSliderStyle}" IsThumbToolTipEnabled="False" TabIndex="1"/>
                             </Grid>
-                            <Grid Margin="0,0,0,6" x:Name="AlphaSliderGrid" Grid.Row="2">
+                            <Grid Margin="0,0,0,4" x:Name="AlphaSliderGrid" Grid.Row="2">
                                 <Rectangle x:Name="AlphaSliderCheckeredBackgroundRectangle" RenderTransformOrigin="0.5, 0.5" Height="12" VerticalAlignment="Center"
                                            contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                            contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"

--- a/dev/ColorPicker/ColorPicker_themeresources.xaml
+++ b/dev/ColorPicker/ColorPicker_themeresources.xaml
@@ -37,12 +37,12 @@
     <x:Double x:Key="ColorPickerSliderInnerThumbHeight">10</x:Double>
     <x:Double x:Key="ColorPickerVerticalOrientationMinWidth">312</x:Double>
     <x:Double x:Key="ColorPickerVerticalOrientationMaxWidth">392</x:Double>
-    <x:Double x:Key="ColorPickerVerticalOrientationMinHeight">312</x:Double>
-    <x:Double x:Key="ColorPickerVerticalOrientationMaxHeight">392</x:Double>
+    <x:Double x:Key="ColorPickerVerticalOrientationMinHeight">256</x:Double>
+    <x:Double x:Key="ColorPickerVerticalOrientationMaxHeight">336</x:Double>
     <x:Double x:Key="ColorPickerTextInputHorizontalOrientationMargin">122</x:Double>
 
     <Style x:Key="ColorPickerBorderStyle" TargetType="Shape">
         <Setter Property="Stroke" Value="{ThemeResource ColorPickerBorderBrush}" />
-        <Setter Property="StrokeThickness" Value="2" />
+        <Setter Property="StrokeThickness" Value="1" />
     </Style>
 </ResourceDictionary>

--- a/dev/ColorPicker/TestUI/ColorPickerPage.xaml
+++ b/dev/ColorPicker/TestUI/ColorPickerPage.xaml
@@ -25,9 +25,9 @@
             </Grid.RowDefinitions>
 
             <TextBlock Text="Sample" Style="{ThemeResource StandardGroupHeader}"/>
-            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}" Padding="4"
+            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}"
                           AutomationProperties.AutomationId="ColorPickerScrollViewer">
-                <StackPanel>
+                <StackPanel  Padding="4">
                     <controls:ColorPicker x:Name="ColorPicker" IsAlphaEnabled="True" ColorChanged="ColorPicker_ColorChanged" />
                     <TextBlock Text="Text"/>
                 </StackPanel>
@@ -41,9 +41,9 @@
             </Grid.RowDefinitions>
 
             <TextBlock Text="Options" Style="{ThemeResource StandardGroupHeader}"/>
-            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}" Padding="4">
+            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}">
                 <!-- Place options below -->
-                <StackPanel Width="400">
+                <StackPanel Width="400"  Padding="4">
                     <TextBlock Text="Set theme to..." />
                     <StackPanel Orientation="Horizontal">
                         <Button AutomationProperties.AutomationId="ThemeLightButton" Content="Light" Click="ThemeLightButton_Click" />
@@ -109,8 +109,8 @@
             </Grid.RowDefinitions>
 
             <TextBlock Text="Properties" Style="{ThemeResource StandardGroupHeader}"/>
-            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}" Padding="4">
-                <StackPanel Width="400" >
+            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}">
+                <StackPanel Width="400" Padding="4">
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="Currently focused element:" Margin="0,0,5,0" />
                         <TextBlock AutomationProperties.AutomationId="CurrentlyFocusedElementTextBlock" x:Name="CurrentlyFocusedElementTextBlock" />

--- a/dev/ColorPicker/TestUI/ColorPickerPage.xaml
+++ b/dev/ColorPicker/TestUI/ColorPickerPage.xaml
@@ -18,14 +18,21 @@
         </Grid.ColumnDefinitions>
 
         <!-- Sample control -->
-        <ScrollViewer AutomationProperties.AutomationId="ColorPickerScrollViewer" Height="500"
-            HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Visible" IsVerticalRailEnabled="True">
-            <StackPanel>
-                <controls:ColorPicker x:Name="ColorPicker" IsAlphaEnabled="True" ColorChanged="ColorPicker_ColorChanged" />
-                <TextBlock Text="Text"/>
-            </StackPanel>
-        </ScrollViewer>
-        
+        <Grid  Margin="8,0,8,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Text="Sample" Style="{ThemeResource StandardGroupHeader}"/>
+            <ScrollViewer Grid.Row="1" BorderThickness="1" BorderBrush="{ThemeResource SystemChromeHighColor}" Padding="4"
+                          AutomationProperties.AutomationId="ColorPickerScrollViewer">
+                <StackPanel>
+                    <controls:ColorPicker x:Name="ColorPicker" IsAlphaEnabled="True" ColorChanged="ColorPicker_ColorChanged" />
+                    <TextBlock Text="Text"/>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
         <!-- Options -->
         <Grid Grid.Column="1" Margin="8,0,8,0">
             <Grid.RowDefinitions>


### PR DESCRIPTION
Various small ColorPicker fixes:

- Removed weird padding at the top
- Fixed min/max heights for horizontal mode
- Made spacing around the sliders always be the same
- Fixed preview corner radius
- Made color spectrum and preview have a 1px border, matching Figma
- Tweaked test page

Before/after:
![image](https://user-images.githubusercontent.com/101892345/159530443-e185d0aa-7c35-4037-9747-2f23c4d859a9.png)
![image](https://user-images.githubusercontent.com/101892345/159530470-1e24fffd-aee9-453a-95ed-468ee3974c65.png)
