### PR TITLE
Fix issue with cancelled touch pointers not resetting state correctly

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -1070,7 +1070,8 @@ void NavigationViewItem::ProcessPointerCanceled(const winrt::PointerRoutedEventA
     // What this flag tracks is complicated because of the NavigationView sub items and the m_capturedPointers that are being tracked..
     // We do this check because PointerCaptureLost can sometimes take the place of PointerReleased events.
     // In these cases we need to test if the pointer is over the item to maintain the proper state.
-    if (IsOutOfControlBounds(args.GetCurrentPoint(*this).Position()))
+    // In the case of touch input, we want to cancel anyway since there is not pointer exited for touch events.
+    if (IsOutOfControlBounds(args.GetCurrentPoint(*this).Position()) || args.Pointer().PointerDeviceType() == winrt::PointerDeviceType::Touch)
     {
         m_isPointerOver = false;
     }

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -1070,7 +1070,7 @@ void NavigationViewItem::ProcessPointerCanceled(const winrt::PointerRoutedEventA
     // What this flag tracks is complicated because of the NavigationView sub items and the m_capturedPointers that are being tracked..
     // We do this check because PointerCaptureLost can sometimes take the place of PointerReleased events.
     // In these cases we need to test if the pointer is over the item to maintain the proper state.
-    // In the case of touch input, we want to cancel anyway since there is not pointer exited for touch events.
+    // In the case of touch input, we want to cancel anyway since there will be no pointer exited due to the pointer being cancelled.
     if (IsOutOfControlBounds(args.GetCurrentPoint(*this).Position()) || args.Pointer().PointerDeviceType() == winrt::PointerDeviceType::Touch)
     {
         m_isPointerOver = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a touch pointer gets cancelled, we expect that there still would be a pointer exited event, however that does not occur. Because of that, when we get pointer cancelled for touch pointers, we should treat this also as a pointer-exited event.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
Fixes #6863 
## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested manually.
## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->