### PR TITLE
Ensure `BringIntoView` request is not skipped for direct content of `ScrollView`

### DIFF
--- a/dev/ScrollPresenter/APITests/ScrollPresenterBringIntoViewTests.cs
+++ b/dev/ScrollPresenter/APITests/ScrollPresenterBringIntoViewTests.cs
@@ -30,6 +30,7 @@ using ScrollingScrollCompletedEventArgs = Microsoft.UI.Xaml.Controls.ScrollingSc
 using ScrollingBringingIntoViewEventArgs = Microsoft.UI.Xaml.Controls.ScrollingBringingIntoViewEventArgs;
 using ScrollPresenterTestHooks = Microsoft.UI.Private.Controls.ScrollPresenterTestHooks;
 using ScrollPresenterViewChangeResult = Microsoft.UI.Private.Controls.ScrollPresenterViewChangeResult;
+using Windows.UI.Xaml.Shapes;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -741,6 +742,43 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
                 0.0 /*expectedInnerHorizontalOffset*/,
                 1103.0 /*expectedInnerVerticalOffset*/,
                 options);
+        }
+
+        [TestMethod]
+        [TestProperty("Description", "ScrollPresenter should handle BringIntoView for its direct content.")]
+        public void BringContentWithMarginIntoView()
+        {
+            ScrollPresenter scrollPresenter = null;
+            Rectangle rectangleScrollPresenterContent = null;
+            AutoResetEvent scrollPresenterViewChangedEvent = new AutoResetEvent(false);
+            AutoResetEvent scrollPresenterLoadedEvent = new AutoResetEvent(false);
+
+            RunOnUIThread.Execute(() =>
+            {
+                rectangleScrollPresenterContent = new Rectangle() { Margin = new Thickness(0, 500, 0, 0) };
+                scrollPresenter = new ScrollPresenter();
+
+                SetupDefaultUI(scrollPresenter, rectangleScrollPresenterContent, scrollPresenterLoadedEvent);
+            });
+
+            WaitForEvent("Waiting for Loaded event", scrollPresenterLoadedEvent);
+
+            RunOnUIThread.Execute(() =>
+            {
+                scrollPresenter.ViewChanged += (s, e) =>
+                {
+                    scrollPresenterViewChangedEvent.Set();
+                };
+
+                rectangleScrollPresenterContent.StartBringIntoView(new BringIntoViewOptions() { AnimationDesired = false });
+            });
+
+            WaitForEvent("Waiting for ViewChanged event", scrollPresenterViewChangedEvent);
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual(500.0, scrollPresenter.VerticalOffset);
+            });
         }
 
         private void BringElementIntoViewWithAlignment(

--- a/dev/ScrollPresenter/APITests/ScrollPresenterTests.cs
+++ b/dev/ScrollPresenter/APITests/ScrollPresenterTests.cs
@@ -879,6 +879,44 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
+        [TestMethod]
+        [TestProperty("Description", "ScrollPresenter should handle BringIntoView for its direct content.")]
+        public void HandleContentBringIntoView()
+        {
+            ScrollPresenter scrollPresenter = null;
+            Rectangle rectangleScrollPresenterContent = null;
+            AutoResetEvent scrollPresenterViewChangedEvent = new AutoResetEvent(false);
+            AutoResetEvent scrollPresenterLoadedEvent = new AutoResetEvent(false);
+
+            RunOnUIThread.Execute(() =>
+            {
+                rectangleScrollPresenterContent = new Rectangle() { Margin = new Thickness(0, 500, 0, 0) };
+                scrollPresenter = new ScrollPresenter();
+
+                SetupDefaultUI(scrollPresenter, rectangleScrollPresenterContent, scrollPresenterLoadedEvent);
+
+            });
+
+            WaitForEvent("Waiting for Loaded event", scrollPresenterLoadedEvent);
+            
+            RunOnUIThread.Execute(() =>
+            {
+                scrollPresenter.ViewChanged += (s, e) =>
+                {
+                    scrollPresenterViewChangedEvent.Set();
+                };
+
+                rectangleScrollPresenterContent.StartBringIntoView(new BringIntoViewOptions() { AnimationDesired = false });
+            });
+            
+            WaitForEvent("Waiting for ViewChanged event", scrollPresenterViewChangedEvent);
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual(500.0, scrollPresenter.VerticalOffset);
+            });
+        }
+
         private void SetupDefaultUI(
             ScrollPresenter scrollPresenter,
             Rectangle rectangleScrollPresenterContent,

--- a/dev/ScrollPresenter/APITests/ScrollPresenterTests.cs
+++ b/dev/ScrollPresenter/APITests/ScrollPresenterTests.cs
@@ -879,44 +879,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
-        [TestMethod]
-        [TestProperty("Description", "ScrollPresenter should handle BringIntoView for its direct content.")]
-        public void HandleContentBringIntoView()
-        {
-            ScrollPresenter scrollPresenter = null;
-            Rectangle rectangleScrollPresenterContent = null;
-            AutoResetEvent scrollPresenterViewChangedEvent = new AutoResetEvent(false);
-            AutoResetEvent scrollPresenterLoadedEvent = new AutoResetEvent(false);
-
-            RunOnUIThread.Execute(() =>
-            {
-                rectangleScrollPresenterContent = new Rectangle() { Margin = new Thickness(0, 500, 0, 0) };
-                scrollPresenter = new ScrollPresenter();
-
-                SetupDefaultUI(scrollPresenter, rectangleScrollPresenterContent, scrollPresenterLoadedEvent);
-
-            });
-
-            WaitForEvent("Waiting for Loaded event", scrollPresenterLoadedEvent);
-            
-            RunOnUIThread.Execute(() =>
-            {
-                scrollPresenter.ViewChanged += (s, e) =>
-                {
-                    scrollPresenterViewChangedEvent.Set();
-                };
-
-                rectangleScrollPresenterContent.StartBringIntoView(new BringIntoViewOptions() { AnimationDesired = false });
-            });
-            
-            WaitForEvent("Waiting for ViewChanged event", scrollPresenterViewChangedEvent);
-
-            RunOnUIThread.Execute(() =>
-            {
-                Verify.AreEqual(500.0, scrollPresenter.VerticalOffset);
-            });
-        }
-
         private void SetupDefaultUI(
             ScrollPresenter scrollPresenter,
             Rectangle rectangleScrollPresenterContent,

--- a/dev/ScrollPresenter/ScrollPresenter.cpp
+++ b/dev/ScrollPresenter/ScrollPresenter.cpp
@@ -4472,7 +4472,7 @@ void ScrollPresenter::OnBringIntoViewRequestedHandler(
         args.Handled() ||
         args.TargetElement() == static_cast<winrt::UIElement>(*this) ||
         (args.TargetElement() == content && content.Visibility() == winrt::Visibility::Collapsed) ||
-        !SharedHelpers::IsAncestor(args.TargetElement(), content, true /*checkVisibility*/))
+        (args.TargetElement() != content && !SharedHelpers::IsAncestor(args.TargetElement(), content, true /*checkVisibility*/)))
     {
         // Ignore the request when:
         // - There is no InteractionTracker to fulfill it.
@@ -4525,7 +4525,7 @@ void ScrollPresenter::OnBringIntoViewRequestedHandler(
             args.Handled() ||
             args.TargetElement() == static_cast<winrt::UIElement>(*this) ||
             (args.TargetElement() == content && content.Visibility() == winrt::Visibility::Collapsed) ||
-            !SharedHelpers::IsAncestor(args.TargetElement(), content, true /*checkVisibility*/))
+            (args.TargetElement() != content && !SharedHelpers::IsAncestor(args.TargetElement(), content, true /*checkVisibility*/)))
         {
             // Again, ignore the request when:
             // - There is no Content anymore.


### PR DESCRIPTION
## Description

The logic in `ScrollPresenter` skips `BringIntoView` request if it is called for its direct content (even though it may be relevant if it has high `Margin`.

## Motivation and Context

Fixes #6888 

## How Has This Been Tested?

Manually, added API test

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->