### PR TITLE
Fixing dangling pointer bug in AnimatedVisualPlayer

### DIFF
--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.cpp
@@ -365,6 +365,8 @@ AnimatedVisualPlayer::AnimatedVisualPlayer()
 
 AnimatedVisualPlayer::~AnimatedVisualPlayer()
 {
+    *m_isAlive = false;
+
     // Ensure any outstanding play is stopped.
     if (m_nowPlaying)
     {
@@ -834,7 +836,12 @@ void AnimatedVisualPlayer::DestroyAnimations() {
     // Call RequestCommit to make sure that previous compositor calls complete before destroying animations.
     // RequestCommitAsync is available only for RS4+
     m_rootVisual.Compositor().RequestCommitAsync().Completed(
-        [&, createAnimationsCounter = m_createAnimationsCounter](auto, auto) {
+        [&, createAnimationsCounter = m_createAnimationsCounter, isAlive = m_isAlive](auto, auto) {
+
+            if (!*isAlive) {
+                return;
+            }
+
             // Check if there was any CreateAnimations call after DestroyAnimations.
             // We should not destroy animations in this case,
             // they will be destroyed by the following DestroyAnimations call.

--- a/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
+++ b/dev/AnimatedVisualPlayer/AnimatedVisualPlayer.h
@@ -150,4 +150,9 @@ private:
 
     bool m_isAnimationsCreated{ false };
     uint32_t m_createAnimationsCounter = 0;
+
+    // Flag that tracks that this object is alive.
+    // Needed in case if we scheduled RequestCommitAsync callback
+    // and this object was destroyed before callback is called.
+    std::shared_ptr<bool> m_isAlive = std::make_shared<bool>(true);
 };


### PR DESCRIPTION
AnimatedVisualPlayer have a bug that may cause dereferencing of invalid pointer, for instance: pointer to the deleted `AnimatedVisualPlayer` object, pointer is captured by lambda as a callback of `RequestCommitAsync` async call, but before operation is completed object may be deleted that causes the problem.

In this PR I'm proposing a solution with a boolean flag that is created as a separate object with shared_ptr pointing to it. This flag should track if the object that requested the operation is still alive.