### PR TITLE
Add an Opened event to TeachingTip

### DIFF
--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -8,6 +8,7 @@
 #include "ResourceAccessor.h"
 #include "TeachingTipClosingEventArgs.h"
 #include "TeachingTipClosedEventArgs.h"
+#include "TeachingTipOpenedEventArgs.h"
 #include "TeachingTipTestHooks.h"
 #include "TeachingTipAutomationPeer.h"
 #include "../ResourceHelper/Utils.h"

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1259,6 +1259,10 @@ void TeachingTip::OnPopupOpened(const winrt::IInspectable&, const winrt::IInspec
     {
         // We won't be playing an animation so we're immediately idle.
         SetIsIdle(true);
+
+        // Since we immediately opened, just immediately fire off the Opened event.
+        auto const myArgs = winrt::make_self<TeachingTipOpenedEventArgs>();
+        m_openedEventSource(*this, *myArgs);
     }
 
     if (auto const teachingTipPeer = winrt::FrameworkElementAutomationPeer::FromElement(*this).try_as<winrt::TeachingTipAutomationPeer>())
@@ -1727,6 +1731,9 @@ void TeachingTip::StartExpandToOpen()
         {
             strongThis->SetIsIdle(true);
         }
+
+        auto const myArgs = winrt::make_self<TeachingTipOpenedEventArgs>();
+        strongThis->m_openedEventSource(*strongThis, *myArgs);
     });
 
     // Under normal circumstances we would have launched an animation just now, if we did not then we should make sure that the idle state is correct

--- a/dev/TeachingTip/TeachingTip.idl
+++ b/dev/TeachingTip/TeachingTip.idl
@@ -66,6 +66,7 @@ runtimeclass TeachingTipClosingEventArgs
 
 
 [MUX_PUBLIC]
+[default_interface]
 [webhosthidden]
 runtimeclass TeachingTipOpenedEventArgs
 {

--- a/dev/TeachingTip/TeachingTip.idl
+++ b/dev/TeachingTip/TeachingTip.idl
@@ -64,6 +64,13 @@ runtimeclass TeachingTipClosingEventArgs
     Windows.Foundation.Deferral GetDeferral();
 };
 
+
+[MUX_PUBLIC]
+[webhosthidden]
+runtimeclass TeachingTipOpenedEventArgs
+{
+};
+
 [MUX_PUBLIC]
 [webhosthidden]
 unsealed runtimeclass TeachingTipTemplateSettings : Windows.UI.Xaml.DependencyObject
@@ -128,6 +135,7 @@ unsealed runtimeclass TeachingTip : Windows.UI.Xaml.Controls.ContentControl
     event Windows.Foundation.TypedEventHandler<TeachingTip, Object> CloseButtonClick;
     event Windows.Foundation.TypedEventHandler<TeachingTip, TeachingTipClosingEventArgs> Closing;
     event Windows.Foundation.TypedEventHandler<TeachingTip, TeachingTipClosedEventArgs> Closed;
+    event Windows.Foundation.TypedEventHandler<TeachingTip, TeachingTipOpenedEventArgs> Opened;
 
     static Windows.UI.Xaml.DependencyProperty IsOpenProperty{ get; };
 

--- a/dev/TeachingTip/TeachingTip.vcxitems
+++ b/dev/TeachingTip/TeachingTip.vcxitems
@@ -20,6 +20,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)TeachingTipAutomationPeer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TeachingTipClosedEventArgs.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TeachingTipClosingEventArgs.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)TeachingTipOpenedEventArgs.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TeachingTipTemplateSettings.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)TeachingTipTestHooks.cpp" />
   </ItemGroup>
@@ -68,6 +69,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipAutomationPeer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipClosedEventArgs.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipClosingEventArgs.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipOpenedEventArgs.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipTemplateSettings.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TeachingTipTestHooks.h" />
   </ItemGroup>

--- a/dev/TeachingTip/TeachingTipOpenedEventArgs.cpp
+++ b/dev/TeachingTip/TeachingTipOpenedEventArgs.cpp
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "TeachingTipOpenedEventArgs.h"

--- a/dev/TeachingTip/TeachingTipOpenedEventArgs.h
+++ b/dev/TeachingTip/TeachingTipOpenedEventArgs.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "TeachingTipOpenedEventArgs.g.h"
+
+class TeachingTipOpenedEventArgs :
+    public winrt::implementation::TeachingTipOpenedEventArgsT<TeachingTipOpenedEventArgs>
+{
+};


### PR DESCRIPTION
Filed to prompt discussion. I understand API changes are temporarily locked down. This is to prompt discussion for inclusion in MUX 2.8+ (and also make sure I don't forget to actually submit the code as a PR)


## Description
Adds an `Opened` event to `TeachingTip`, like the `Closed` event. The payload is a `TeachingTipOpenedEventArgs`, but I didn't know if there was anything reasonable to put in there.

Arguably, there should also be an `Opening` event. I was trying to scope the changes to the smallest ones needed for the Terminal, but since we'll need to pursue another solution, we can likely increase the scope of this change if need be.

## Motivation and Context
* Relevant to #1607. 
* Downstream bug: https://github.com/microsoft/terminal/issues/12021 - P1 a11y bug that prompted this
* See also #3257 and #3545 - what could have likely been another acceptable workaround for us. 
  
## How Has This Been Tested?

Tested only manually, by building a nuget package and ingesting that into the Terminal. Terminal side, I added a handler for the `Opened` event and used that to manually focus a `TextBox` in the `TeachingTip`. This proved that the event was fired _after_ the `TextBox` was successfully added to the visual tree. Subsequent opening of the `TeachingTip` continued to successfully focus the `TextBox`.
