### PR TITLE
Fixing SplitButtonAutomationPeer's Invoke implementation

### DIFF
--- a/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -97,11 +97,15 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 ClickPrimaryButtonWithKey(splitButton, "ENTER");
                 Verify.AreEqual("3", executeCountTextBlock.DocumentText);
 
+                Log.Comment("Use invoke pattern to execute command");
+                splitButton.InvokeAndWait();
+                Verify.AreEqual("4", executeCountTextBlock.DocumentText);
+
                 Log.Comment("Verify that setting CanExecute to false disables the primary button");
                 canExecuteCheckBox.Uncheck();
                 Wait.ForIdle();
                 ClickPrimaryButton(splitButton);
-                Verify.AreEqual("3", executeCountTextBlock.DocumentText);
+                Verify.AreEqual("4", executeCountTextBlock.DocumentText);
             }
         }
 

--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -290,6 +290,26 @@ void SplitButton::OnClickSecondary(const winrt::IInspectable& sender, const winr
     OpenFlyout();
 }
 
+void SplitButton::Invoke()
+{
+    bool invoked = false;
+
+    if (winrt::AutomationPeer peer = winrt::FrameworkElementAutomationPeer::FromElement(m_primaryButton.get()))
+    {
+        if (winrt::IInvokeProvider invokeProvider = peer.GetPattern(winrt::PatternInterface::Invoke).try_as<winrt::IInvokeProvider>())
+        {
+            invokeProvider.Invoke();
+            invoked = true;
+        }
+    }
+
+    // If we don't have a primary button that provides an invoke provider, we'll fall back to calling OnClickPrimary manually.
+    if (!invoked)
+    {
+        OnClickPrimary(nullptr, nullptr);
+    }
+}
+
 void SplitButton::OnPointerEvent(const winrt::IInspectable& sender, const winrt::PointerRoutedEventArgs& args)
 {
     winrt::PointerDeviceType pointerDeviceType = args.Pointer().PointerDeviceType();

--- a/dev/SplitButton/SplitButton.h
+++ b/dev/SplitButton/SplitButton.h
@@ -27,14 +27,17 @@ public:
     bool IsFlyoutOpen() { return m_isFlyoutOpen; };
     void OpenFlyout();
     void CloseFlyout();
-    virtual void OnClickPrimary(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
     virtual bool InternalIsChecked() { return false; }
 
     void UpdateVisualStates(bool useTransitions = true);
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
+    void Invoke();
+
 protected:
+    virtual void OnClickPrimary(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
+
     bool m_hasLoaded{ false };
 
 private:

--- a/dev/SplitButton/SplitButtonAutomationPeer.cpp
+++ b/dev/SplitButton/SplitButtonAutomationPeer.cpp
@@ -86,6 +86,6 @@ void SplitButtonAutomationPeer::Invoke()
 {
     if (auto splitButton = GetImpl())
     {
-        splitButton->OnClickPrimary(nullptr, nullptr);
+        splitButton->Invoke();
     }
 }

--- a/dev/SplitButton/TestUI/SplitButtonPage.xaml.cs
+++ b/dev/SplitButton/TestUI/SplitButtonPage.xaml.cs
@@ -150,6 +150,11 @@ namespace MUXControlsTestApp
         {
             ToggleStateOnClickTextBlock.Text = ToggleSplitButton.IsChecked ? "Checked" : "Unchecked";
         }
+
+        private void SplitButtonCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+        {
+
+        }
     }
 
     public class MyCommand : ICommand

--- a/dev/SplitButton/TestUI/SplitButtonPage.xaml.cs
+++ b/dev/SplitButton/TestUI/SplitButtonPage.xaml.cs
@@ -150,11 +150,6 @@ namespace MUXControlsTestApp
         {
             ToggleStateOnClickTextBlock.Text = ToggleSplitButton.IsChecked ? "Checked" : "Unchecked";
         }
-
-        private void SplitButtonCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
-        {
-
-        }
     }
 
     public class MyCommand : ICommand


### PR DESCRIPTION
SplitButtonAutomationPeer's Invoke implementation currently just directly calls the Click event handler, which misses the fact that we also have the option of assigning a command to execute.  Instead of that, I've made it so we just forward the Invoke implementation to the primary button's automation peer, which will ensure that we do everything a button should do in this case.

I also edited the test case using the SplitButton with a command to use Invoke() to test that case as well.