### PR TITLE
Update community call in WinUI website

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,11 +226,11 @@
           <p class="subtext">Get connected with us on <a href="https://twitter.com/WindowsUI" class="inline-link" >Twitter</a> and <a href="https://discord.gg/PF8FCHZ" class="inline-link" >Discord</a>, and file issues or feature requests on our <a href="https://github.com/microsoft/microsoft-ui-xaml" class="inline-link" >Github repository</a>.</h4>
           <br/><br/>
           <p class="subtext">Our next community call is on:</h4>
-          <p class="subtext"><span style="font-weight: 600; margin-top: 5px;"> October 20, 2021 at 9AM PT <span style="vertical-align: text-top;"> | </span> </span><i class="icon-calendar m-auto text-icon"></i><span id="add-to-cal"><a href="./WinUICommunityCall-October.ics"> Add to calendar</a></span></h4> 
+          <p class="subtext"><span style="font-weight: 600; margin-top: 5px;"> April 20, 2022 at 9AM PT <span style="vertical-align: text-top;">
           <br/><br/>
         </div>
         <div class="col-sm-9 col-md-6 embed-responsive embed-responsive-16by9" id="video-wrapper">
-          <iframe id="video-content" width="560" height="349" src="https://www.youtube.com/embed/h4apI79wt4o" class="embed-responsive-item"" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; fullscreen" aria-label="Community Call Video"></iframe>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLI_J2v67C23ZqsolUDaHoFkF1GKvGrttB" aria-label="Community call video" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Updated 'next' community call date
- Fixed broken link and updated to show playlist instead of a single video
- Removed .ics invite