### PR TITLE
Reverting product change made for 'TabView gap between active tab and active content fix #6644'

### DIFF
--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -115,11 +115,11 @@ void TabViewItem::UpdateTabGeometry()
     
     WCHAR strOut[1024];
     StringCchPrintf(strOut, ARRAYSIZE(strOut), data,
-        height,
+        height - 1,
         leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
         ActualWidth() - (leftCorner + rightCorner),
         rightCorner, rightCorner, rightCorner, rightCorner,
-        height - (4 + rightCorner));
+        height - (4 + rightCorner + 1));
 
     const auto geometry = winrt::XamlReader::Load(strOut).try_as<winrt::Geometry>();
 


### PR DESCRIPTION
The TabViewItem change made in https://github.com/microsoft/microsoft-ui-xaml/pull/6644 introduced a regression worse than the pbm it fixed. So reverting it & we will be working on finding a better fix. 

The regression was that in some cases the TabViewItem would constantly grow incrementally by 0.5px.

Internal bug 37332027 will be reactivated.

