### PR TITLE
Fixing NavigationView UIA set logic

### DIFF
--- a/dev/NavigationView/NavigationViewItemAutomationPeer.h
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.h
@@ -60,8 +60,7 @@ private:
     NavigationViewRepeaterPosition GetNavigationViewRepeaterPosition();
     int32_t GetNavigationViewItemCountInPrimaryList();
     int32_t GetNavigationViewItemCountInTopNav();
-    int32_t GetPositionOrSetCountInLeftNavHelper(AutomationOutput automationOutput);
-    int32_t GetPositionOrSetCountInTopNavHelper(AutomationOutput automationOutput);
+    int32_t GetPositionOrSetCountHelper(AutomationOutput automationOutput);
     void ChangeSelection(bool isSelected);
     bool HasChildren();
 };

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -882,6 +882,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
 
                     Verify.AreEqual(2, positionInSet, "Position in set, not including separator/header");
                     Verify.AreEqual(2, sizeOfSet, "Size of set");
+
+                    Log.Comment("Setting focus to HasChildItem");
+                    UIObject hasChildItem = FindElement.ByName("HasChildItem");
+                    hasChildItem.SetFocus();
+                    Wait.ForIdle();
+
+                    ae = AutomationElement.FocusedElement;
+                    positionInSet = (int)ae.GetCurrentPropertyValue(AutomationElement.PositionInSetProperty);
+                    sizeOfSet = (int)ae.GetCurrentPropertyValue(AutomationElement.SizeOfSetProperty);
+
+                    Verify.AreEqual(5, positionInSet, "Position in set, not including separator/header");
+                    Verify.AreEqual(5, sizeOfSet, "Size of set");
                 }
             }
         }

--- a/dev/NavigationView/NavigationView_InteractionTests/FocusBehaviorTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/FocusBehaviorTests.cs
@@ -373,7 +373,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                     UIObject item6 = FindElement.ByName("TV");
                     UIObject item7 = FindElement.ByName("Volume");
                     UIObject item8 = FindElement.ByName("Integer");
-                    UIObject item9 = FindElement.ByName("HasChildItem");
+                    UIObject item9 = FindElement.ByName("AcceptItem");
+                    UIObject item10 = FindElement.ByName("HasChildItem");
                     UIObject settingsItem = FindElement.ByName("Settings");
 
                     Log.Comment("Verify that tab from the TogglePaneButton goes to the search box");
@@ -419,6 +420,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                     Wait.ForIdle();
                     Verify.IsTrue(item9.HasKeyboardFocus);
 
+                    KeyboardHelper.PressKey(Key.Down);
+                    Wait.ForIdle();
+                    Verify.IsTrue(item10.HasKeyboardFocus);
+
                     Log.Comment("Verify that tab thrice from the last menu item goes to the settings item");
                     KeyboardHelper.PressKey(Key.Tab, ModifierKey.None, 3);
                     Wait.ForIdle();
@@ -427,9 +432,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                     Log.Comment("Verify that shift+tab thrice from the settings item goes to the last menu item");
                     KeyboardHelper.PressKey(Key.Tab, ModifierKey.Shift, 3);
                     Wait.ForIdle();
-                    Verify.IsTrue(item9.HasKeyboardFocus);
+                    Verify.IsTrue(item10.HasKeyboardFocus);
 
                     Log.Comment("Verify that up arrow can navigate through all items");
+                    KeyboardHelper.PressKey(Key.Up);
+                    Wait.ForIdle();
+                    Verify.IsTrue(item9.HasKeyboardFocus);
+
                     KeyboardHelper.PressKey(Key.Up);
                     Wait.ForIdle();
                     Verify.IsTrue(item8.HasKeyboardFocus);

--- a/dev/NavigationView/TestUI/Common/NavigationViewPage.xaml
+++ b/dev/NavigationView/TestUI/Common/NavigationViewPage.xaml
@@ -58,6 +58,7 @@
                 </muxcontrols:NavigationViewItem>
                 <muxcontrols:NavigationViewItem x:Name="IntegerItem" AutomationProperties.Name="Integer" Icon="Accept"/>
                 <muxcontrols:NavigationViewItemSeparator />
+                <muxcontrols:NavigationViewItem x:Name="AcceptItem" AutomationProperties.Name="AcceptItem" Icon="Accept" Content="Accept"/>
                 <muxcontrols:NavigationViewItem x:Name="HasChildItem" AutomationProperties.Name="HasChildItem" Content="Item with child">
                     <muxcontrols:NavigationViewItem.MenuItems>
                         <muxcontrols:NavigationViewItem x:Name="ChildItem" AutomationProperties.Name="ChildItem" Content="Child Item Content" Icon="Document" />


### PR DESCRIPTION
Left nav currently has faulty logic to calculate the position in set and size of set, relating to the way in which we count what element we're iterating on.  The top nav scenario has the correct logic, and there isn't anything remaining that differentiates the left and top nav here anymore, so I've consolidated both to the same logic.  I've added a test scenario to ensure that those are now calculated correctly, as well.