### PR TITLE
Fixing UIA names surrounding Value from HSV

### DIFF
--- a/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
+++ b/dev/ColorPicker/InteractionTests/ColorPickerTests.cs
@@ -1187,7 +1187,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var setup = SetupColorPickerTest(TestOptions.EnableAlpha | TestOptions.DisableColorSpectrumLoadWait))
             {
                 Verify.AreEqual("Color picker", FindElement.ById(ColorSpectrumAutomationId).Name);
-                Verify.AreEqual("Brightness", FindElement.ById(ThirdDimensionAutomationId).Name);
+                Verify.AreEqual("Value (Brightness)", FindElement.ById(ThirdDimensionAutomationId).Name);
                 Verify.AreEqual("Opacity", FindElement.ById(AlphaSliderAutomationId).Name);
                 Verify.AreEqual("Color model", FindElement.ById(ColorRepresentationComboBoxAutomationId).Name);
                 Verify.AreEqual("Red", FindElement.ById(RedTextBoxAutomationId).Name);
@@ -1197,7 +1197,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 SelectTextBoxes(ColorChannels.HSV);
                 Verify.AreEqual("Hue", FindElement.ById(HueTextBoxAutomationId).Name);
                 Verify.AreEqual("Saturation", FindElement.ById(SaturationTextBoxAutomationId).Name);
-                Verify.AreEqual("Brightness", FindElement.ById(ValueTextBoxAutomationId).Name);
+                Verify.AreEqual("Value (Brightness)", FindElement.ById(ValueTextBoxAutomationId).Name);
             }
         }
 
@@ -1231,11 +1231,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 bool colorNamesAvailable = ApiInformation.IsMethodPresent("Windows.UI.ColorHelper", "ToDisplayName");
 
-                Verify.AreEqual(colorNamesAvailable ? "Red, Hue 0, Saturation 100, Brightness 100" : "Hue 0, Saturation 100, Brightness 100", colorSpectrum.Value);
+                Verify.AreEqual(colorNamesAvailable ? "Red, Hue 0, Saturation 100, Value 100" : "Hue 0, Saturation 100, Value 100", colorSpectrum.Value);
                 KeyboardHelper.PressKey(Key.Right);
-                Verify.AreEqual(colorNamesAvailable ? "Red, Hue 1, Saturation 100, Brightness 100" : "Hue 1, Saturation 100, Brightness 100", colorSpectrum.Value);
+                Verify.AreEqual(colorNamesAvailable ? "Red, Hue 1, Saturation 100, Value 100" : "Hue 1, Saturation 100, Value 100", colorSpectrum.Value);
                 KeyboardHelper.PressKey(Key.Right, ModifierKey.Control);
-                Verify.AreEqual(colorNamesAvailable ? "Orange, Hue 28, Saturation 100, Brightness 100" : "Hue 31, Saturation 100, Brightness 100", colorSpectrum.Value);
+                Verify.AreEqual(colorNamesAvailable ? "Orange, Hue 28, Saturation 100, Value 100" : "Hue 31, Saturation 100, Value 100", colorSpectrum.Value);
             }
         }
 

--- a/dev/ColorPicker/Strings/en-us/Resources.resw
+++ b/dev/ColorPicker/Strings/en-us/Resources.resw
@@ -138,7 +138,7 @@
     <comment>The automation name for the third-dimension slider when it's controlling saturation.</comment>
   </data>
   <data name="AutomationNameValueSlider" xml:space="preserve">
-    <value>Brightness</value>
+    <value>Value (Brightness)</value>
     <comment>The automation name for the third-dimension slider when it's controlling value.</comment>
   </data>
   <data name="TextBlueLabel" xml:space="preserve">
@@ -214,11 +214,11 @@
     <comment>The label for the text box to edit the value component of the current HSV color.</comment>
   </data>
   <data name="ValueStringColorSpectrumWithColorName" xml:space="preserve">
-    <value>%1!s!, Hue %2!u!, Saturation %3!u!, Brightness %4!u!</value>
+    <value>%1!s!, Hue %2!u!, Saturation %3!u!, Value %4!u!</value>
     <comment>The string to provide as the UIA value of the ColorSpectrum when we're including the friendly color name. %1 is the friendly name of the color; %2, %3, and %4 are the HSV values for the color between 0 and 359 (for hue) or 0 and 100 (for saturation or value).</comment>
   </data>
   <data name="ValueStringColorSpectrumWithoutColorName" xml:space="preserve">
-    <value>Hue %1!u!, Saturation %2!u!, Brightness %3!u!</value>
+    <value>Hue %1!u!, Saturation %2!u!, Value %3!u!</value>
     <comment>The string to provide as the UIA value of the ColorSpectrum when we aren't including the friendly color name. %1, %2, and %3 are the HSV values for the color between 0 and 359 (for hue) or 0 and 100 (for saturation or value).</comment>
   </data>
   <data name="ValueStringHueSliderWithColorName" xml:space="preserve">
@@ -246,7 +246,7 @@
     <comment>The string to provide as the UIA value of the third-dimension slider when it's controlling value and we're not including the friendly color name. %1 is the brightness value between 0 and 100.</comment>
   </data>
   <data name="AutomationNameValueTextBox" xml:space="preserve">
-    <value>Brightness</value>
+    <value>Value (Brightness)</value>
     <comment>The automation name for the text box to edit the value component of the current HSV color.</comment>
   </data>
   <data name="ToolTipStringAlphaSlider" xml:space="preserve">


### PR DESCRIPTION
"Value" wasn't used as the UIA name associated with HSV since the concern was that "value" could be considered confusing by low-vision accessible users since without the broader context, it wasn't clear it meant the V in HSV rather than just any old value, so we used the equivalent "Brightness" instead.  However, UIA names need to contain the full string of any attached label, so I've updated things to read "Value (Brightness)" instead.  Also, in cases where there's the context of hue and saturation being present as well, I updated things to just read "Value", for consistency.