### PR TITLE
MenuBar Keyboard Accessibility Fixes

### DIFF
--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -170,6 +170,7 @@ void MenuBarItem::OnMenuBarItemKeyDown( winrt::IInspectable const& sender, winrt
         {
             MoveFocusTo(FlyoutLocation::Right);
         }
+        args.Handled(TRUE);
     }
     else if (key == winrt::VirtualKey::Left)
     {
@@ -181,9 +182,8 @@ void MenuBarItem::OnMenuBarItemKeyDown( winrt::IInspectable const& sender, winrt
         {
             MoveFocusTo(FlyoutLocation::Left);
         }
+        args.Handled(TRUE);
     }
-
-    args.Handled(TRUE);
 }
 
 void MenuBarItem::OnPresenterKeyDown( winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)

--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -160,6 +160,30 @@ void MenuBarItem::OnMenuBarItemKeyDown( winrt::IInspectable const& sender, winrt
     {
         ShowMenuFlyout();
     }
+    else if (key == winrt::VirtualKey::Right)
+    {
+        if (FlowDirection() == winrt::FlowDirection::RightToLeft)
+        {
+            MoveFocusTo(FlyoutLocation::Left);
+        }
+        else
+        {
+            MoveFocusTo(FlyoutLocation::Right);
+        }
+    }
+    else if (key == winrt::VirtualKey::Left)
+    {
+        if (FlowDirection() == winrt::FlowDirection::RightToLeft)
+        {
+            MoveFocusTo(FlyoutLocation::Right);
+        }
+        else
+        {
+            MoveFocusTo(FlyoutLocation::Left);
+        }
+    }
+
+    args.Handled(TRUE);
 }
 
 void MenuBarItem::OnPresenterKeyDown( winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)
@@ -273,6 +297,23 @@ void MenuBarItem::OpenFlyoutFrom(FlyoutLocation location)
         else
         {
             winrt::get_self<MenuBarItem>(menuBar.Items().GetAt((index + 1) % menuBar.Items().Size()))->ShowMenuFlyout();
+        }
+    }
+}
+
+void MenuBarItem::MoveFocusTo(FlyoutLocation location)
+{
+    if (auto menuBar = m_menuBar.get())
+    {
+        uint32_t index = 0;
+        menuBar.Items().IndexOf(*this, index);
+        if (location == FlyoutLocation::Left)
+        {
+            winrt::get_self<MenuBarItem>(menuBar.Items().GetAt(((index - 1) + menuBar.Items().Size()) % menuBar.Items().Size()))->Focus(winrt::FocusState::Programmatic);
+        }
+        else
+        {
+            winrt::get_self<MenuBarItem>(menuBar.Items().GetAt((index + 1) % menuBar.Items().Size()))->Focus(winrt::FocusState::Programmatic);
         }
     }
 }

--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -164,6 +164,11 @@ void MenuBarItem::OnMenuBarItemKeyDown( winrt::IInspectable const& sender, winrt
 
 void MenuBarItem::OnPresenterKeyDown( winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)
 {
+    if (auto const& sourceAsUIElement = args.OriginalSource().try_as<winrt::MenuFlyoutSubItem>())
+    {
+        return;
+    }
+
     const auto key = args.Key();
     if (key == winrt::VirtualKey::Right)
     {

--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -164,9 +164,12 @@ void MenuBarItem::OnMenuBarItemKeyDown( winrt::IInspectable const& sender, winrt
 
 void MenuBarItem::OnPresenterKeyDown( winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)
 {
-    if (auto const& sourceAsUIElement = args.OriginalSource().try_as<winrt::MenuFlyoutSubItem>())
+    if (auto const& subitem = args.OriginalSource().try_as<winrt::MenuFlyoutSubItem>())
     {
-        return;
+        if (subitem.Items().GetAt(0))
+        {
+            return;
+        }
     }
 
     const auto key = args.Key();
@@ -311,7 +314,7 @@ void MenuBarItem::OnFlyoutClosed( winrt::IInspectable const& sender, winrt::IIns
 
 void MenuBarItem::OnFlyoutOpening( winrt::IInspectable const& sender, winrt::IInspectable const& args)
 {
-    Focus(winrt::FocusState::Pointer);
+    Focus(winrt::FocusState::Programmatic);
 
     m_isFlyoutOpen = true;
 

--- a/dev/MenuBar/MenuBarItem.cpp
+++ b/dev/MenuBar/MenuBarItem.cpp
@@ -188,6 +188,7 @@ void MenuBarItem::OnMenuBarItemKeyDown( winrt::IInspectable const& sender, winrt
 
 void MenuBarItem::OnPresenterKeyDown( winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)
 {
+    // If the event came from a MenuFlyoutSubItem it means right/left arrow will open it, so we should not handle them to not override default behaviour
     if (auto const& subitem = args.OriginalSource().try_as<winrt::MenuFlyoutSubItem>())
     {
         if (subitem.Items().GetAt(0))

--- a/dev/MenuBar/MenuBarItem.h
+++ b/dev/MenuBar/MenuBarItem.h
@@ -39,6 +39,7 @@ private:
     void AttachEventHandlers();
     void DetachEventHandlers(bool useSafeGet = false);
     void OpenFlyoutFrom(FlyoutLocation location);
+    void MoveFocusTo(FlyoutLocation location);
 
     void OnVisualPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void UpdateVisualStates();

--- a/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
+++ b/dev/MenuBar/MenuBar_InteractionTests/MenuBarTests.cs
@@ -158,11 +158,31 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 if (ApiInformation.IsTypePresent("Windows.UI.Xaml.IUIElement5")) // XYFocusNavigation is only availabe from IUElement5 foward
                 {
+                    KeyboardHelper.PressKey(Key.Left);
+                    VerifyElement.NotFound("Word Wrap", FindBy.Name);
+
+                    KeyboardHelper.PressKey(Key.Enter);
+                    VerifyElement.Found("Word Wrap", FindBy.Name);
+
+                    KeyboardHelper.PressKey(Key.Escape);
+                    KeyboardHelper.PressKey(Key.Right);
+
                     KeyboardHelper.PressKey(Key.Right);
                     VerifyElement.NotFound("Undo", FindBy.Name);
 
                     KeyboardHelper.PressKey(Key.Enter);
                     VerifyElement.Found("Undo", FindBy.Name);
+
+                    KeyboardHelper.PressKey(Key.Down);
+                    KeyboardHelper.PressKey(Key.Down);
+                    KeyboardHelper.PressKey(Key.Down);
+                    KeyboardHelper.PressKey(Key.Down);
+                    KeyboardHelper.PressKey(Key.Down);
+                    VerifyElement.NotFound("Item 1", FindBy.Name);
+
+                    KeyboardHelper.PressKey(Key.Right);
+                    VerifyElement.Found("Item 1", FindBy.Name);
+
                 }
             }
         }


### PR DESCRIPTION
Fixes 3 issues with keyboard in MenuBar:
- Enable opening a submenu in the MenuFlyout with the arrow keys.
- Fixes keyboard focus from pointer to programmatic.
- Changes MenuBarItems to be able to cycle through using arrow keys.

Fixes internal issues: 36685596, 36629906 and 38190286