### PR TITLE
Fixes Narrator not reading Name of tab when drag is starting

### DIFF
--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -19,7 +19,7 @@ TabViewItemAutomationPeer::TabViewItemAutomationPeer(winrt::TabViewItem const& o
 // IAutomationPeerOverrides
 winrt::IInspectable TabViewItemAutomationPeer::GetPatternCore(winrt::PatternInterface const& patternInterface)
 {
-    if (patternInterface == winrt::PatternInterface::SelectionItem)
+    if (patternInterface == winrt::PatternInterface::SelectionItem || patternInterface == winrt::PatternInterface::Drag)
     {
         return *this;
     }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7658216/162811624-ec31a771-7a34-4f67-8fce-45517c09b8ec.png)

After:
![image](https://user-images.githubusercontent.com/7658216/162811743-982c2d35-7127-4fe9-87dd-f0b456e51201.png)
*notice the "grabbed <tab name>" being read by narrator


Fixes internal issue 36431796