### PR TITLE
Fix LandmarkType in InfoBar

### DIFF
--- a/dev/InfoBar/InfoBar.cpp
+++ b/dev/InfoBar/InfoBar.cpp
@@ -61,10 +61,7 @@ void InfoBar::OnApplyTemplate()
         winrt::AutomationProperties::SetName(iconTextblock, ResourceAccessor::GetLocalizedStringResource(GetIconSeverityLevelResourceName(Severity())));
     }
 
-    if (auto&& contentRoot = GetTemplateChildT<winrt::Border>(c_contentRootName, controlProtected))
-    {
-        winrt::AutomationProperties::SetLocalizedLandmarkType(contentRoot, ResourceAccessor::GetLocalizedStringResource(SR_InfoBarCustomLandmarkName));
-    }
+    winrt::AutomationProperties::SetLocalizedLandmarkType(*this, ResourceAccessor::GetLocalizedStringResource(SR_InfoBarCustomLandmarkName));
 
     UpdateVisibility(m_notifyOpen, true);
     m_notifyOpen = false;

--- a/dev/InfoBar/InfoBar.cpp
+++ b/dev/InfoBar/InfoBar.cpp
@@ -61,7 +61,7 @@ void InfoBar::OnApplyTemplate()
         winrt::AutomationProperties::SetName(iconTextblock, ResourceAccessor::GetLocalizedStringResource(GetIconSeverityLevelResourceName(Severity())));
     }
 
-    if (auto&& contentRootGrid = GetTemplateChildT<winrt::Button>(c_contentRootName, controlProtected))
+    if (auto&& contentRootGrid = GetTemplateChildT<winrt::Grid>(c_contentRootName, controlProtected))
     {
         winrt::AutomationProperties::SetLocalizedLandmarkType(contentRootGrid, ResourceAccessor::GetLocalizedStringResource(SR_InfoBarCustomLandmarkName));
     }

--- a/dev/InfoBar/InfoBar.cpp
+++ b/dev/InfoBar/InfoBar.cpp
@@ -61,9 +61,9 @@ void InfoBar::OnApplyTemplate()
         winrt::AutomationProperties::SetName(iconTextblock, ResourceAccessor::GetLocalizedStringResource(GetIconSeverityLevelResourceName(Severity())));
     }
 
-    if (auto&& contentRootGrid = GetTemplateChildT<winrt::Grid>(c_contentRootName, controlProtected))
+    if (auto&& contentRoot = GetTemplateChildT<winrt::Border>(c_contentRootName, controlProtected))
     {
-        winrt::AutomationProperties::SetLocalizedLandmarkType(contentRootGrid, ResourceAccessor::GetLocalizedStringResource(SR_InfoBarCustomLandmarkName));
+        winrt::AutomationProperties::SetLocalizedLandmarkType(contentRoot, ResourceAccessor::GetLocalizedStringResource(SR_InfoBarCustomLandmarkName));
     }
 
     UpdateVisibility(m_notifyOpen, true);

--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -17,7 +17,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:InfoBar">
-                    <Border x:Name="ContentRoot" 
+                    <Border
                         VerticalAlignment="Top"
                         Background="{ThemeResource InfoBarInformationalSeverityBackgroundBrush}"
                         BorderBrush="{TemplateBinding BorderBrush}"
@@ -106,12 +106,13 @@
                         </VisualStateManager.VisualStateGroups>
 
                         <!-- Background is used here so that it overrides the severity status color if set. -->
-                        <Grid
+                        <Grid x:Name="ContentRoot"
                             HorizontalAlignment="Stretch"
                             MinHeight="{ThemeResource InfoBarMinHeight}"
                             Background="{TemplateBinding Background}"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                            Padding="{StaticResource InfoBarContentRootPadding}">
+                            Padding="{StaticResource InfoBarContentRootPadding}"
+                            AutomationProperties.LandmarkType="Custom">
 
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/> <!-- Icon -->
@@ -168,7 +169,6 @@
                                     primitives:InfoBarPanel.HorizontalOrientationMargin="{StaticResource InfoBarTitleHorizontalOrientationMargin}"
                                     primitives:InfoBarPanel.VerticalOrientationMargin="{StaticResource InfoBarTitleVerticalOrientationMargin}"
                                     TextWrapping="WrapWholeWords"
-                                    AutomationProperties.LandmarkType="Navigation"
                                     FontWeight="{StaticResource InfoBarTitleFontWeight}"
                                     FontSize="{StaticResource InfoBarTitleFontSize}"/>
 

--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -17,12 +17,13 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:InfoBar">
-                    <Border
+                    <Border x:Name="ContentRoot"
                         VerticalAlignment="Top"
                         Background="{ThemeResource InfoBarInformationalSeverityBackgroundBrush}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}">
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+                        AutomationProperties.LandmarkType="Custom">
 
                         <VisualStateManager.VisualStateGroups>
                             
@@ -106,13 +107,12 @@
                         </VisualStateManager.VisualStateGroups>
 
                         <!-- Background is used here so that it overrides the severity status color if set. -->
-                        <Grid x:Name="ContentRoot"
+                        <Grid
                             HorizontalAlignment="Stretch"
                             MinHeight="{ThemeResource InfoBarMinHeight}"
                             Background="{TemplateBinding Background}"
                             contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                            Padding="{StaticResource InfoBarContentRootPadding}"
-                            AutomationProperties.LandmarkType="Custom">
+                            Padding="{StaticResource InfoBarContentRootPadding}">
 
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/> <!-- Icon -->

--- a/dev/InfoBar/InfoBar.xaml
+++ b/dev/InfoBar/InfoBar.xaml
@@ -12,6 +12,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="{ThemeResource InfoBarBorderBrush}" />
         <Setter Property="BorderThickness" Value="{ThemeResource InfoBarBorderThickness}" />
+        <Setter Property="AutomationProperties.LandmarkType" Value="Custom" />
         <contract7Present:Setter Property="AutomationProperties.IsDialog" Value="True"/>
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         <Setter Property="Template">
@@ -22,8 +23,7 @@
                         Background="{ThemeResource InfoBarInformationalSeverityBackgroundBrush}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
-                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                        AutomationProperties.LandmarkType="Custom">
+                        contract7Present:CornerRadius="{TemplateBinding CornerRadius}">
 
                         <VisualStateManager.VisualStateGroups>
                             


### PR DESCRIPTION
Fixes Landmark type in InfoBar:
- Fix SetLocalizedLandmarkType never being called inside if
- Sets landmark type to custom 
- Moves landmark from title to grid

Before:
![image](https://user-images.githubusercontent.com/7658216/163830541-d771b25d-1496-4293-abf8-23b983357753.png)

After:
![image](https://user-images.githubusercontent.com/7658216/163830027-f9bec7c7-1ca1-4b60-aa76-70c11cae24a0.png)


Fixes internal bug 38393708.