### PR TITLE
Fixing TabView null ref crash

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -702,20 +702,23 @@ void TabView::OnItemsPresenterSizeChanged(const winrt::IInspectable& sender, con
 
 void TabView::BringSelectedTabIntoView()
 {
-    if(SelectedItem())
+    if (SelectedItem())
     {
         auto tvi = SelectedItem().try_as<winrt::TabViewItem>();
         if (!tvi)
         {
             tvi = ContainerFromItem(SelectedItem()).try_as<winrt::TabViewItem>();
         }
-        winrt::get_self<TabViewItem>(tvi)->StartBringTabIntoView();
+        if (tvi)
+        {
+            winrt::get_self<TabViewItem>(tvi)->StartBringTabIntoView();
+        }
     }
 }
 
 void TabView::OnItemsChanged(winrt::IInspectable const& item)
 {
-    if(m_isDragging)
+    if (m_isDragging)
     {
         return;
     }


### PR DESCRIPTION
Just adding a null-ref check to avoid an occasional crash.

Internal bug is 38531928. We have had a few crashes where tvi is null.  ContainerFromItem(SelectedItem()).try_as<winrt::TabViewItem>() must be returning null. I don't know the exact circumstances, so do not have a new regression test. I just confirmed while debugging MuxControlsTestApp that using a null tvi results in the kind of crash reported.

This code was introduced recently with https://github.com/microsoft/microsoft-ui-xaml/pull/6632. 