### PR TITLE
Update CopyFilesToStagingDir.ps1 to fix wrong file location

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -80,7 +80,7 @@ $symbolsOutputDir = "$($FullPublishDir)\Symbols\"
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\Microsoft.UI.Xaml.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\Microsoft.Experimental.UI.Xaml\Microsoft.Experimental.UI.Xaml.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\IXMPTestApp.TAEF\IXMPTestApp.pdb $symbolsOutputDir
-PublishFile -IfExists $FullBuildOutput\MUXControls.Test\MUXControls.Test.pdb $symbolsOutputDir
+PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test\MUXControls.Test.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestApp.TAEF\MUXControlsTestApp.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppForIslands\MUXControlsTestAppForIslands.pdb $symbolsOutputDir
 PublishFile -IfExists $FullBuildOutput\MUXControlsTestAppWPF\MUXControlsTestAppWPF.pdb $symbolsOutputDir


### PR DESCRIPTION
CopyFilesToStagingDir.ps1 was referencing the wrong location for MUXControls.Test.pdb file, causing it to not be added in the artifacts of the pipeline making it difficult to debug tests. This PR updates the location of mentioned file.