### PR TITLE
Add SwipeControlOpenState #7015

### DIFF
--- a/dev/Generated/SwipeControl.properties.cpp
+++ b/dev/Generated/SwipeControl.properties.cpp
@@ -15,6 +15,7 @@ namespace winrt::Microsoft::UI::Xaml::Controls
 
 GlobalDependencyProperty SwipeControlProperties::s_BottomItemsProperty{ nullptr };
 GlobalDependencyProperty SwipeControlProperties::s_LeftItemsProperty{ nullptr };
+GlobalDependencyProperty SwipeControlProperties::s_OpenStateProperty{ nullptr };
 GlobalDependencyProperty SwipeControlProperties::s_RightItemsProperty{ nullptr };
 GlobalDependencyProperty SwipeControlProperties::s_TopItemsProperty{ nullptr };
 
@@ -47,6 +48,17 @@ void SwipeControlProperties::EnsureProperties()
                 ValueHelper<winrt::SwipeItems>::BoxedDefaultValue(),
                 winrt::PropertyChangedCallback(&OnLeftItemsPropertyChanged));
     }
+    if (!s_OpenStateProperty)
+    {
+        s_OpenStateProperty =
+            InitializeDependencyProperty(
+                L"OpenState",
+                winrt::name_of<winrt::SwipeControlOpenState>(),
+                winrt::name_of<winrt::SwipeControl>(),
+                false /* isAttached */,
+                ValueHelper<winrt::SwipeControlOpenState>::BoxedDefaultValue(),
+                winrt::PropertyChangedCallback(&OnOpenStatePropertyChanged));
+    }
     if (!s_RightItemsProperty)
     {
         s_RightItemsProperty =
@@ -75,6 +87,7 @@ void SwipeControlProperties::ClearProperties()
 {
     s_BottomItemsProperty = nullptr;
     s_LeftItemsProperty = nullptr;
+    s_OpenStateProperty = nullptr;
     s_RightItemsProperty = nullptr;
     s_TopItemsProperty = nullptr;
 }
@@ -88,6 +101,14 @@ void SwipeControlProperties::OnBottomItemsPropertyChanged(
 }
 
 void SwipeControlProperties::OnLeftItemsPropertyChanged(
+    winrt::DependencyObject const& sender,
+    winrt::DependencyPropertyChangedEventArgs const& args)
+{
+    auto owner = sender.as<winrt::SwipeControl>();
+    winrt::get_self<SwipeControl>(owner)->OnPropertyChanged(args);
+}
+
+void SwipeControlProperties::OnOpenStatePropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& args)
 {
@@ -135,6 +156,19 @@ void SwipeControlProperties::LeftItems(winrt::SwipeItems const& value)
 winrt::SwipeItems SwipeControlProperties::LeftItems()
 {
     return ValueHelper<winrt::SwipeItems>::CastOrUnbox(static_cast<SwipeControl*>(this)->GetValue(s_LeftItemsProperty));
+}
+
+void SwipeControlProperties::OpenState(winrt::SwipeControlOpenState const& value)
+{
+    [[gsl::suppress(con)]]
+    {
+    static_cast<SwipeControl*>(this)->SetValue(s_OpenStateProperty, ValueHelper<winrt::SwipeControlOpenState>::BoxValueIfNecessary(value));
+    }
+}
+
+winrt::SwipeControlOpenState SwipeControlProperties::OpenState()
+{
+    return ValueHelper<winrt::SwipeControlOpenState>::CastOrUnbox(static_cast<SwipeControl*>(this)->GetValue(s_OpenStateProperty));
 }
 
 void SwipeControlProperties::RightItems(winrt::SwipeItems const& value)

--- a/dev/Generated/SwipeControl.properties.h
+++ b/dev/Generated/SwipeControl.properties.h
@@ -15,6 +15,9 @@ public:
     void LeftItems(winrt::SwipeItems const& value);
     winrt::SwipeItems LeftItems();
 
+    void OpenState(winrt::SwipeControlOpenState const& value);
+    winrt::SwipeControlOpenState OpenState();
+
     void RightItems(winrt::SwipeItems const& value);
     winrt::SwipeItems RightItems();
 
@@ -23,11 +26,13 @@ public:
 
     static winrt::DependencyProperty BottomItemsProperty() { return s_BottomItemsProperty; }
     static winrt::DependencyProperty LeftItemsProperty() { return s_LeftItemsProperty; }
+    static winrt::DependencyProperty OpenStateProperty() { return s_OpenStateProperty; }
     static winrt::DependencyProperty RightItemsProperty() { return s_RightItemsProperty; }
     static winrt::DependencyProperty TopItemsProperty() { return s_TopItemsProperty; }
 
     static GlobalDependencyProperty s_BottomItemsProperty;
     static GlobalDependencyProperty s_LeftItemsProperty;
+    static GlobalDependencyProperty s_OpenStateProperty;
     static GlobalDependencyProperty s_RightItemsProperty;
     static GlobalDependencyProperty s_TopItemsProperty;
 
@@ -39,6 +44,10 @@ public:
         winrt::DependencyPropertyChangedEventArgs const& args);
 
     static void OnLeftItemsPropertyChanged(
+        winrt::DependencyObject const& sender,
+        winrt::DependencyPropertyChangedEventArgs const& args);
+
+    static void OnOpenStatePropertyChanged(
         winrt::DependencyObject const& sender,
         winrt::DependencyPropertyChangedEventArgs const& args);
 

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -363,6 +363,13 @@ void SwipeControl::ValuesChanged(
             CreateBottomContent();
         }
     }
+    // In some cases, `IdleStateEntered` alone isn't enough to maintain a consistent IsOpen state.
+    // E.g. m_interactionTracker.TryUpdatePosition(Vector3) isn't synchronous in CloseWithoutAnimation
+    // Updating IsOpen here guarantee the state is consistent across all interaction tracker state.
+    if (m_interactionTracker && !m_isInteracting)
+    {
+        UpdateIsOpen(m_interactionTracker.get().Position() != winrt::float3::zero());
+    }
     UpdateThresholdReached(value);
 }
 

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -191,7 +191,7 @@ void SwipeControl::IdleStateEntered(
 
     if (IsOpen())
     {
-        if (m_currentItems && m_currentItems.get().Mode() == winrt::SwipeMode::Execute && m_currentItems.get().Size() > 0)
+        if (!m_isIdle && m_currentItems && m_currentItems.get().Mode() == winrt::SwipeMode::Execute && m_currentItems.get().Size() > 0)
         {
             auto swipeItem = static_cast<winrt::SwipeItem>(m_currentItems.get().GetAt(0));
             winrt::get_self<SwipeItem>(swipeItem)->InvokeSwipe(*this);

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -185,9 +185,13 @@ void SwipeControl::IdleStateEntered(
     winrt::InteractionTrackerIdleStateEnteredArgs const& /*args*/)
 {
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
+    DoIdleStateEntered(m_interactionTracker.get().Position());
+}
 
+void SwipeControl::DoIdleStateEntered(winrt::float3 const& position)
+{
     m_isInteracting = false;
-    UpdateIsOpen(m_interactionTracker.get().Position() != winrt::float3::zero());
+    UpdateIsOpen(position != winrt::float3::zero());
 
     if (IsOpen())
     {
@@ -362,13 +366,6 @@ void SwipeControl::ValuesChanged(
         {
             CreateBottomContent();
         }
-    }
-    // In some cases, `IdleStateEntered` alone isn't enough to maintain a consistent IsOpen state.
-    // E.g. m_interactionTracker.TryUpdatePosition(Vector3) isn't synchronous in CloseWithoutAnimation
-    // Updating IsOpen here guarantee the state is consistent across all interaction tracker state.
-    if (m_interactionTracker && !m_isInteracting)
-    {
-        UpdateIsOpen(m_interactionTracker.get().Position() != winrt::float3::zero());
     }
     UpdateThresholdReached(value);
 }
@@ -1047,10 +1044,10 @@ void SwipeControl::CloseWithoutAnimation()
     SWIPECONTROL_TRACE_INFO(*this, TRACE_MSG_METH, METH_NAME, this);
 
     const bool wasIdle = m_isIdle;
-    m_interactionTracker.get().TryUpdatePosition({ 0.0f, 0.0f, 0.0f });
+    m_interactionTracker.get().TryUpdatePosition(winrt::float3::zero());
     if (wasIdle)
     {
-        IdleStateEntered(nullptr);
+        DoIdleStateEntered(winrt::float3::zero());
     }
 }
 

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -53,7 +53,6 @@ public:
 
 #pragma region TestHookHelpers
     static winrt::SwipeControl GetLastInteractedWithSwipeControl();
-    bool GetIsOpen();
     bool GetIsIdle();
 #pragma endregion
 
@@ -126,6 +125,8 @@ private:
 
     void ThrowIfHasVerticalAndHorizontalContent(bool IsHorizontal = false);
 
+    inline bool IsOpen() { return OpenState() == winrt::Microsoft::UI::Xaml::Controls::SwipeControlOpenState::Opened; }
+
     std::wstring GetAnimationTarget(winrt::UIElement child);
 
     winrt::SwipeControl GetThis();
@@ -187,7 +188,6 @@ private:
     bool m_lastActionWasOpening{ false };
     bool m_isInteracting{ false };
     bool m_isIdle{ true };
-    bool m_isOpen{ false };
     bool m_thresholdReached{ false };
     //Near content = left or top
     //Far content = right or bottom

--- a/dev/SwipeControl/SwipeControl.h
+++ b/dev/SwipeControl/SwipeControl.h
@@ -40,6 +40,8 @@ public:
     void IdleStateEntered(
         winrt::InteractionTrackerIdleStateEnteredArgs const& args);
 
+    void DoIdleStateEntered(winrt::float3 const& position);
+
     void InteractingStateEntered(
         winrt::InteractionTrackerInteractingStateEnteredArgs const& args);
 

--- a/dev/SwipeControl/SwipeControl.idl
+++ b/dev/SwipeControl/SwipeControl.idl
@@ -25,6 +25,14 @@ enum SwipeMode
 
 [MUX_PUBLIC]
 [webhosthidden]
+enum SwipeControlOpenState
+{
+    Closed,
+    Opened
+};
+
+[MUX_PUBLIC]
+[webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
 unsealed runtimeclass SwipeItems : Windows.UI.Xaml.DependencyObject, Windows.Foundation.Collections.IVector<SwipeItem>
 {
@@ -49,12 +57,14 @@ unsealed runtimeclass SwipeControl : Windows.UI.Xaml.Controls.ContentControl
     SwipeItems RightItems { get; set; };
     SwipeItems TopItems { get; set; };
     SwipeItems BottomItems { get; set; };
+    SwipeControlOpenState OpenState{ get; };
     void Close();
 
     static Windows.UI.Xaml.DependencyProperty LeftItemsProperty { get; };
     static Windows.UI.Xaml.DependencyProperty RightItemsProperty { get; };
     static Windows.UI.Xaml.DependencyProperty TopItemsProperty { get; };
     static Windows.UI.Xaml.DependencyProperty BottomItemsProperty { get; };
+    static Windows.UI.Xaml.DependencyProperty OpenStateProperty{ get; };
 }
 
 [MUX_PUBLIC]

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml
@@ -12,7 +12,7 @@
     <muxc:SwipeControl x:Name="sc">
         <muxc:SwipeControl.LeftItems>
             <muxc:SwipeItems Mode="Execute">
-                <muxc:SwipeItem Text="You shouldn't see me when navigating to this page" BehaviorOnInvoked="RemainOpen" Invoked="SwipeItem_Invoked">
+                <muxc:SwipeItem x:Name="si" Text="You shouldn't see me when navigating to this page" BehaviorOnInvoked="RemainOpen" Invoked="SwipeItem_Invoked">
                     <muxc:SwipeItem.IconSource>
                         <muxc:SymbolIconSource Symbol="Accept"/>
                     </muxc:SwipeItem.IconSource>
@@ -23,16 +23,21 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <muxc:RadioButtons>
+            <!-- selected index must sync with si.BehaviorOnInvoked -->
+            <ComboBox x:Name="behaviorOnInvoked" AutomationProperties.Name="behaviorOnInvoked" SelectedIndex="2" SelectionChanged="ComboBox_SelectionChanged">
+                <ComboBoxItem>Auto</ComboBoxItem>
+                <ComboBoxItem>Close</ComboBoxItem>
+                <ComboBoxItem>RemainOpen</ComboBoxItem>
+            </ComboBox>
+            <muxc:RadioButtons Grid.Row="1">
                 <RadioButton x:Name="backOnOpen" AutomationProperties.Name="backOnOpen" Content="Back on open" IsChecked="True"/>
                 <RadioButton x:Name="backOnInvoked" AutomationProperties.Name="backOnInvoked" Content="Back on invoked"/>
             </muxc:RadioButtons>
-            <CheckBox Grid.Row="1" Content="IsOpen" IsChecked="{x:Bind local:SwipeControlLoadedAlwaysClosedPage.IsOpen(sc.OpenState), Mode=OneWay}" IsEnabled="False"/>
-            <Border Grid.Row="2">
-                <TextBlock TextWrapping="WrapWholeWords" Text="Swipe to navigate back, and come back to this page slowly, or rapidly. Expected result: the swipe control is in closed state, and you can swipt it. In some rare cases, this swipe control would stay open and slowly close with animation instead. Or, this swipe control would remain closed and refuse to be swiped."/>
-            </Border>
+            <CheckBox Grid.Row="2" Content="IsOpen" IsChecked="{x:Bind local:SwipeControlLoadedAlwaysClosedPage.IsOpen(sc.OpenState), Mode=OneWay}" IsEnabled="False"/>
+            <TextBlock Grid.Row="3" TextWrapping="WrapWholeWords" Text="Swipe to navigate back, and come back to this page slowly, or rapidly. Expected result: the swipe control is in closed state, and you can swipt it. In some rare cases, this swipe control would stay open and slowly close with animation instead. Or, this swipe control would remain closed and refuse to be swiped."/>
         </Grid>
     </muxc:SwipeControl>
 </local:TestPage>

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml
@@ -1,0 +1,38 @@
+﻿<local:TestPage
+    x:Class="MUXControlsTestApp.SwipeControlLoadedAlwaysClosedPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    NavigationCacheMode="Required">
+    <muxc:SwipeControl x:Name="sc">
+        <muxc:SwipeControl.LeftItems>
+            <muxc:SwipeItems Mode="Execute">
+                <muxc:SwipeItem Text="You shouldn't see me when navigating to this page" BehaviorOnInvoked="RemainOpen" Invoked="SwipeItem_Invoked">
+                    <muxc:SwipeItem.IconSource>
+                        <muxc:SymbolIconSource Symbol="Accept"/>
+                    </muxc:SwipeItem.IconSource>
+                </muxc:SwipeItem>
+            </muxc:SwipeItems>
+        </muxc:SwipeControl.LeftItems>
+        <Grid Padding="16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <muxc:RadioButtons>
+                <RadioButton x:Name="backOnOpen" AutomationProperties.Name="backOnOpen" Content="Back on open" IsChecked="True"/>
+                <RadioButton x:Name="backOnInvoked" AutomationProperties.Name="backOnInvoked" Content="Back on invoked"/>
+            </muxc:RadioButtons>
+            <CheckBox Grid.Row="1" Content="IsOpen" IsChecked="{x:Bind local:SwipeControlLoadedAlwaysClosedPage.IsOpen(sc.OpenState), Mode=OneWay}" IsEnabled="False"/>
+            <Border Grid.Row="2">
+                <TextBlock TextWrapping="WrapWholeWords" Text="Swipe to navigate back, and come back to this page slowly, or rapidly. Expected result: the swipe control is in closed state, and you can swipt it. In some rare cases, this swipe control would stay open and slowly close with animation instead. Or, this swipe control would remain closed and refuse to be swiped."/>
+            </Border>
+        </Grid>
+    </muxc:SwipeControl>
+</local:TestPage>

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml.cs
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml.cs
@@ -1,0 +1,41 @@
+﻿using Windows.UI.Xaml;
+
+using SwipeControlOpenState = Microsoft.UI.Xaml.Controls.SwipeControlOpenState;
+using SwipeControl = Microsoft.UI.Xaml.Controls.SwipeControl;
+using SwipeItem = Microsoft.UI.Xaml.Controls.SwipeItem;
+using SwipeItemInvokedEventArgs = Microsoft.UI.Xaml.Controls.SwipeItemInvokedEventArgs;
+
+namespace MUXControlsTestApp
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class SwipeControlLoadedAlwaysClosedPage : TestPage
+    {
+        public static bool IsOpen(SwipeControlOpenState state)
+        {
+            return state == SwipeControlOpenState.Opened;
+        }
+
+        public SwipeControlLoadedAlwaysClosedPage()
+        {
+            this.InitializeComponent();
+            sc.RegisterPropertyChangedCallback(SwipeControl.OpenStateProperty, SwipeControl_PropertyChanged);
+        }
+
+        void SwipeControl_PropertyChanged(DependencyObject obj, DependencyProperty dp)
+        {
+            if (backOnOpen.IsChecked != true) return;
+            if (sc.OpenState == SwipeControlOpenState.Opened)
+            {
+                Frame.GoBack();
+            }
+        }
+
+        void SwipeItem_Invoked(SwipeItem sender, SwipeItemInvokedEventArgs e)
+        {
+            if (backOnInvoked.IsChecked != true) return;
+            Frame.GoBack();
+        }
+    }
+}

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml.cs
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlLoadedAlwaysClosedPage.xaml.cs
@@ -3,6 +3,7 @@
 using SwipeControlOpenState = Microsoft.UI.Xaml.Controls.SwipeControlOpenState;
 using SwipeControl = Microsoft.UI.Xaml.Controls.SwipeControl;
 using SwipeItem = Microsoft.UI.Xaml.Controls.SwipeItem;
+using SwipeBehaviorOnInvoked = Microsoft.UI.Xaml.Controls.SwipeBehaviorOnInvoked;
 using SwipeItemInvokedEventArgs = Microsoft.UI.Xaml.Controls.SwipeItemInvokedEventArgs;
 
 namespace MUXControlsTestApp
@@ -26,7 +27,8 @@ namespace MUXControlsTestApp
         void SwipeControl_PropertyChanged(DependencyObject obj, DependencyProperty dp)
         {
             if (backOnOpen.IsChecked != true) return;
-            if (sc.OpenState == SwipeControlOpenState.Opened)
+            var isOpen = sc.OpenState == SwipeControlOpenState.Opened;
+            if (isOpen)
             {
                 Frame.GoBack();
             }
@@ -36,6 +38,11 @@ namespace MUXControlsTestApp
         {
             if (backOnInvoked.IsChecked != true) return;
             Frame.GoBack();
+        }
+
+        private void ComboBox_SelectionChanged(object sender, Windows.UI.Xaml.Controls.SelectionChangedEventArgs e)
+        {
+            si.BehaviorOnInvoked = (SwipeBehaviorOnInvoked) behaviorOnInvoked.SelectedIndex;
         }
     }
 }

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml
@@ -98,13 +98,13 @@
             <StackPanel Orientation="Horizontal">
                 <StackPanel Orientation="Vertical" Width="118">
                     <TextBlock VerticalAlignment="Center" Text="O:"/>
-                    <CheckBox x:Name="SwipeItem8OpenCheckBox" AutomationProperties.Name="SwipeItem8OpenCheckBox" IsChecked="false" IsEnabled="false" Width="40"/>
+                    <CheckBox x:Name="SwipeItem8OpenCheckBox" AutomationProperties.Name="SwipeItem8OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc8.OpenState), Mode=OneWay}" IsEnabled="false" Width="40"/>
                     <TextBlock VerticalAlignment="Center" Text="I:"/>
                     <CheckBox x:Name="SwipeItem8IdleCheckBox" AutomationProperties.Name="SwipeItem8IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Width="118">
                     <TextBlock VerticalAlignment="Center" Text="O:"/>
-                    <CheckBox x:Name="SwipeItem9OpenCheckBox" AutomationProperties.Name="SwipeItem9OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                    <CheckBox x:Name="SwipeItem9OpenCheckBox" AutomationProperties.Name="SwipeItem9OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc9.OpenState), Mode=OneWay}" IsEnabled="false"/>
                     <TextBlock VerticalAlignment="Center" Text="I:"/>
                     <CheckBox x:Name="SwipeItem9IdleCheckBox" AutomationProperties.Name="SwipeItem9IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                 </StackPanel>
@@ -188,55 +188,55 @@
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem1OpenCheckBox" AutomationProperties.Name="SwipeItem1OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem1OpenCheckBox" AutomationProperties.Name="SwipeItem1OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc1.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem1IdleCheckBox" AutomationProperties.Name="SwipeItem1IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem2OpenCheckBox" AutomationProperties.Name="SwipeItem2OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem2OpenCheckBox" AutomationProperties.Name="SwipeItem2OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc2.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem2IdleCheckBox" AutomationProperties.Name="SwipeItem2IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="44">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem3OpenCheckBox" AutomationProperties.Name="SwipeItem3OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem3OpenCheckBox" AutomationProperties.Name="SwipeItem3OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc3.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem3IdleCheckBox" AutomationProperties.Name="SwipeItem3IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem4OpenCheckBox" AutomationProperties.Name="SwipeItem4OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem4OpenCheckBox" AutomationProperties.Name="SwipeItem4OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc4.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem4IdleCheckBox" AutomationProperties.Name="SwipeItem4IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem5OpenCheckBox" AutomationProperties.Name="SwipeItem5OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem5OpenCheckBox" AutomationProperties.Name="SwipeItem5OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc5.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem5IdleCheckBox" AutomationProperties.Name="SwipeItem5IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem10OpenCheckBox" AutomationProperties.Name="SwipeItem10OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem10OpenCheckBox" AutomationProperties.Name="SwipeItem10OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc10.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem10IdleCheckBox" AutomationProperties.Name="SwipeItem10IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="40">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem11OpenCheckBox" AutomationProperties.Name="SwipeItem11OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem11OpenCheckBox" AutomationProperties.Name="SwipeItem11OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc11.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem11IdleCheckBox" AutomationProperties.Name="SwipeItem11IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="60">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem6OpenCheckBox" AutomationProperties.Name="SwipeItem6OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem6OpenCheckBox" AutomationProperties.Name="SwipeItem6OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc6.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem6IdleCheckBox" AutomationProperties.Name="SwipeItem6IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Height="60">
                         <TextBlock VerticalAlignment="Center" Text="O:"/>
-                        <CheckBox x:Name="SwipeItem7OpenCheckBox" AutomationProperties.Name="SwipeItem7OpenCheckBox" IsChecked="false" IsEnabled="false"/>
+                        <CheckBox x:Name="SwipeItem7OpenCheckBox" AutomationProperties.Name="SwipeItem7OpenCheckBox" IsChecked="{x:Bind local:SwipeControlPage.IsOpen(sc7.OpenState), Mode=OneWay}" IsEnabled="false"/>
                         <TextBlock VerticalAlignment="Center" Text="I:"/>
                         <CheckBox x:Name="SwipeItem7IdleCheckBox" AutomationProperties.Name="SwipeItem7IdleCheckBox" IsChecked="true" IsEnabled="false"/>
                     </StackPanel>

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml.cs
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml.cs
@@ -29,6 +29,11 @@ namespace MUXControlsTestApp
 {
     public sealed partial class SwipeControlPage : TestPage
     {
+        static bool IsOpen(SwipeControlOpenState state)
+        {
+            return state == SwipeControlOpenState.Opened;
+        }
+
         object asyncEventReportingLock = new object();
         List<string> lstAsyncEventMessage = new List<string>();
         List<string> fullLogs = new List<string>();
@@ -37,8 +42,6 @@ namespace MUXControlsTestApp
         SwipeItem pastSender;
         UIElement animatedSwipe;
         DispatcherTimer _dt;
-        List<SwipeControl> swipeControls;
-        List<long> swipeControlOpenStateChangedTokens = new List<long>();
 
         public SwipeControlPage()
         {
@@ -74,7 +77,6 @@ namespace MUXControlsTestApp
                 MUXControlsTestHooks.LoggingMessage += MUXControlsTestHooks_LoggingMessage;
             }
 
-            swipeControls = new List<SwipeControl> { sc1, sc2, sc3, sc4, sc5, sc6, sc7, sc8, sc9, sc10, sc11 };
         }
 
         private void SwipeTestHooks_LastInteractedWithSwipeControlChanged(object sender, object args)
@@ -253,24 +255,11 @@ namespace MUXControlsTestApp
 
             SetupAnimatedValuesSpy();
             SpyAnimatedValues();
-            foreach (var swipeControl in swipeControls)
-            {
-                swipeControlOpenStateChangedTokens.Add(swipeControl.RegisterPropertyChangedCallback(SwipeControl.OpenStateProperty, SwipeControl_PropertyChanged));
-            }
             SwipeTestHooks.IdleStatusChanged += SwipeTestHooks_IdleStatusChanged;
         }
 
         private void TestSwipeControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            var swipeControlCount = swipeControls.Count;
-            if (swipeControlCount != swipeControlOpenStateChangedTokens.Count)
-            {
-                throw new InvalidOperationException("swipeControls.Count != swipeControlOpenStateChangedTokens.Count");
-            }
-            for (var i = 0; i < swipeControlCount; ++i)
-            {
-                swipeControls[i].UnregisterPropertyChangedCallback(SwipeControl.OpenStateProperty, swipeControlOpenStateChangedTokens[i]);
-            }
             SwipeTestHooks.IdleStatusChanged -= SwipeTestHooks_IdleStatusChanged;
         }
 
@@ -424,137 +413,6 @@ namespace MUXControlsTestApp
                 else
                 {
                     this.SwipeItem11IdleCheckBox.IsChecked = false;
-                }
-            }
-        }
-
-        private void SwipeControl_PropertyChanged(DependencyObject obj, DependencyProperty dp)
-        {
-            SwipeControl sender = (SwipeControl) obj;
-            if (chkLogSwipeControlEvents.IsChecked == true)
-            {
-                AppendAsyncEventMessage("SwipeControl_PropertyChanged sender.Name=" + sender.Name);
-            }
-
-            if (sender.Name == this.sc1.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem1OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem1OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc2.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem2OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem2OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc3.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem3OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem3OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc4.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem4OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem4OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc5.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem5OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem5OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc6.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem6OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem6OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc7.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem7OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem7OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc8.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem8OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem8OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc9.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem9OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem9OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc10.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem10OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem10OpenCheckBox.IsChecked = false;
-                }
-            }
-            if (sender.Name == this.sc11.Name)
-            {
-                if (sender.OpenState == SwipeControlOpenState.Opened)
-                {
-                    this.SwipeItem11OpenCheckBox.IsChecked = true;
-                }
-                else
-                {
-                    this.SwipeItem11OpenCheckBox.IsChecked = false;
                 }
             }
         }

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml.cs
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControlPage.xaml.cs
@@ -18,6 +18,7 @@ using SwipeControl_TestUI;
 using IconSource = Microsoft.UI.Xaml.Controls.IconSource;
 using SwipeItem = Microsoft.UI.Xaml.Controls.SwipeItem;
 using SwipeControl = Microsoft.UI.Xaml.Controls.SwipeControl;
+using SwipeControlOpenState = Microsoft.UI.Xaml.Controls.SwipeControlOpenState;
 using SwipeItemInvokedEventArgs = Microsoft.UI.Xaml.Controls.SwipeItemInvokedEventArgs;
 using MaterialHelperTestApi = Microsoft.UI.Private.Media.MaterialHelperTestApi;
 using SwipeTestHooks = Microsoft.UI.Private.Controls.SwipeTestHooks;
@@ -36,6 +37,8 @@ namespace MUXControlsTestApp
         SwipeItem pastSender;
         UIElement animatedSwipe;
         DispatcherTimer _dt;
+        List<SwipeControl> swipeControls;
+        List<long> swipeControlOpenStateChangedTokens = new List<long>();
 
         public SwipeControlPage()
         {
@@ -70,6 +73,8 @@ namespace MUXControlsTestApp
                 MUXControlsTestHooks.SetLoggingLevelForType("SwipeControl", isLoggingInfoLevel: true, isLoggingVerboseLevel: true);
                 MUXControlsTestHooks.LoggingMessage += MUXControlsTestHooks_LoggingMessage;
             }
+
+            swipeControls = new List<SwipeControl> { sc1, sc2, sc3, sc4, sc5, sc6, sc7, sc8, sc9, sc10, sc11 };
         }
 
         private void SwipeTestHooks_LastInteractedWithSwipeControlChanged(object sender, object args)
@@ -248,13 +253,24 @@ namespace MUXControlsTestApp
 
             SetupAnimatedValuesSpy();
             SpyAnimatedValues();
-            SwipeTestHooks.OpenedStatusChanged += SwipeTestHooks_OpenedStatusChanged;
+            foreach (var swipeControl in swipeControls)
+            {
+                swipeControlOpenStateChangedTokens.Add(swipeControl.RegisterPropertyChangedCallback(SwipeControl.OpenStateProperty, SwipeControl_PropertyChanged));
+            }
             SwipeTestHooks.IdleStatusChanged += SwipeTestHooks_IdleStatusChanged;
         }
 
         private void TestSwipeControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            SwipeTestHooks.OpenedStatusChanged -= SwipeTestHooks_OpenedStatusChanged;
+            var swipeControlCount = swipeControls.Count;
+            if (swipeControlCount != swipeControlOpenStateChangedTokens.Count)
+            {
+                throw new InvalidOperationException("swipeControls.Count != swipeControlOpenStateChangedTokens.Count");
+            }
+            for (var i = 0; i < swipeControlCount; ++i)
+            {
+                swipeControls[i].UnregisterPropertyChangedCallback(SwipeControl.OpenStateProperty, swipeControlOpenStateChangedTokens[i]);
+            }
             SwipeTestHooks.IdleStatusChanged -= SwipeTestHooks_IdleStatusChanged;
         }
 
@@ -412,16 +428,17 @@ namespace MUXControlsTestApp
             }
         }
 
-        private void SwipeTestHooks_OpenedStatusChanged(SwipeControl sender, object args)
+        private void SwipeControl_PropertyChanged(DependencyObject obj, DependencyProperty dp)
         {
+            SwipeControl sender = (SwipeControl) obj;
             if (chkLogSwipeControlEvents.IsChecked == true)
             {
-                AppendAsyncEventMessage("SwipeTestHooks_OpenedStatusChanged sender.Name=" + sender.Name);
+                AppendAsyncEventMessage("SwipeControl_PropertyChanged sender.Name=" + sender.Name);
             }
 
             if (sender.Name == this.sc1.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc1))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem1OpenCheckBox.IsChecked = true;
                 }
@@ -432,7 +449,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc2.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc2))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem2OpenCheckBox.IsChecked = true;
                 }
@@ -443,7 +460,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc3.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc3))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem3OpenCheckBox.IsChecked = true;
                 }
@@ -454,7 +471,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc4.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc4))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem4OpenCheckBox.IsChecked = true;
                 }
@@ -465,7 +482,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc5.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc5))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem5OpenCheckBox.IsChecked = true;
                 }
@@ -476,7 +493,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc6.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc6))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem6OpenCheckBox.IsChecked = true;
                 }
@@ -487,7 +504,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc7.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc7))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem7OpenCheckBox.IsChecked = true;
                 }
@@ -498,7 +515,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc8.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc8))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem8OpenCheckBox.IsChecked = true;
                 }
@@ -509,7 +526,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc9.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc9))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem9OpenCheckBox.IsChecked = true;
                 }
@@ -520,7 +537,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc10.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc10))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem10OpenCheckBox.IsChecked = true;
                 }
@@ -531,7 +548,7 @@ namespace MUXControlsTestApp
             }
             if (sender.Name == this.sc11.Name)
             {
-                if (SwipeTestHooks.GetIsOpen(this.sc11))
+                if (sender.OpenState == SwipeControlOpenState.Opened)
                 {
                     this.SwipeItem11OpenCheckBox.IsChecked = true;
                 }

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipeControl_TestUI.projitems
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipeControl_TestUI.projitems
@@ -10,8 +10,11 @@
     <Import_RootNamespace>SwipeControl_TestUI</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)SwipeControlClearPage.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)SwipeControlClearPage.xaml.cs">
       <DependentUpon>SwipeControlClearPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)SwipeControlLoadedAlwaysClosedPage.xaml.cs">
+      <DependentUpon>SwipeControlLoadedAlwaysClosedPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)SwipeControlPage2.xaml.cs">
       <DependentUpon>SwipeControlPage2.xaml</DependentUpon>
@@ -26,6 +29,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)SwipeControlClearPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)SwipeControlLoadedAlwaysClosedPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipePage.xaml
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipePage.xaml
@@ -19,6 +19,7 @@
             <Button x:Name="navigateToSimpleContents" AutomationProperties.Name="navigateToSimpleContents" Margin="2" HorizontalAlignment="Stretch">List Items with simple swipe items.</Button>
             <Button x:Name="navigateToDynamic" AutomationProperties.Name="navigateToDynamic" Margin="2" HorizontalAlignment="Stretch">Exercise Swipe API</Button>
             <Button x:Name="navigateToClear" AutomationProperties.Name="navigateToClear" Margin="2" HorizontalAlignment="Stretch">Clear items page</Button>
+            <Button x:Name="navigateToLoadedAlwaysClosed" AutomationProperties.Name="navigateToLoadedAlwaysClosed" Margin="2" HorizontalAlignment="Stretch">Loaded always stay in close state</Button>
         </StackPanel>
 
         <StackPanel Grid.Column="1" Margin="2">

--- a/dev/SwipeControl/SwipeControl_TestUI/SwipePage.xaml.cs
+++ b/dev/SwipeControl/SwipeControl_TestUI/SwipePage.xaml.cs
@@ -31,6 +31,7 @@ namespace MUXControlsTestApp
             navigateToSimpleContents.Click += delegate { Frame.NavigateWithoutAnimation(typeof(SwipeControlPage), 0); };
             navigateToDynamic.Click += delegate { Frame.NavigateWithoutAnimation(typeof(SwipeControlPage2), 0); };
             navigateToClear.Click += delegate { Frame.NavigateWithoutAnimation(typeof(SwipeControlClearPage), 0); };
+            navigateToLoadedAlwaysClosed.Click += delegate { Frame.NavigateWithoutAnimation(typeof(SwipeControlLoadedAlwaysClosedPage), 0); };
         }
 
         private void CmbSwipeControlOutputDebugStringLevel_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/dev/SwipeControl/SwipeTestHooks.cpp
+++ b/dev/SwipeControl/SwipeTestHooks.cpp
@@ -21,22 +21,6 @@ winrt::SwipeControl SwipeTestHooks::GetLastInteractedWithSwipeControl()
     return SwipeControl::GetLastInteractedWithSwipeControl();
 }
 
-bool SwipeTestHooks::GetIsOpen(const winrt::SwipeControl& swipeControl)
-{
-    if (swipeControl)
-    {
-        return winrt::get_self<SwipeControl>(swipeControl)->GetIsOpen();
-    }
-    else
-    {
-        if (auto lastInteractedWithSwipeControl = SwipeControl::GetLastInteractedWithSwipeControl())
-        {
-            return winrt::get_self<SwipeControl>(lastInteractedWithSwipeControl)->GetIsOpen();
-        }
-        return false;
-    }
-}
-
 bool SwipeTestHooks::GetIsIdle(const winrt::SwipeControl& swipeControl)
 {
     if (swipeControl)
@@ -72,27 +56,6 @@ void SwipeTestHooks::LastInteractedWithSwipeControlChanged(winrt::event_token co
 {
     auto hooks = EnsureGlobalTestHooks();
     hooks->m_lastInteractedWithSwipeControlChangedEventSource.remove(token);
-}
-
-void SwipeTestHooks::NotifyOpenedStatusChanged(const winrt::SwipeControl& sender)
-{
-    auto hooks = EnsureGlobalTestHooks();
-    if (hooks->m_openedStatusChangedEventSource)
-    {
-        hooks->m_openedStatusChangedEventSource(sender, nullptr);
-    }
-}
-
-winrt::event_token SwipeTestHooks::OpenedStatusChanged(winrt::TypedEventHandler<winrt::SwipeControl, winrt::IInspectable> const& value)
-{
-    auto hooks = EnsureGlobalTestHooks();
-    return hooks->m_openedStatusChangedEventSource.add(value);
-}
-
-void SwipeTestHooks::OpenedStatusChanged(winrt::event_token const& token)
-{
-    auto hooks = EnsureGlobalTestHooks();
-    hooks->m_openedStatusChangedEventSource.remove(token);
 }
 
 void SwipeTestHooks::NotifyIdleStatusChanged(const winrt::SwipeControl& sender)

--- a/dev/SwipeControl/SwipeTestHooks.h
+++ b/dev/SwipeControl/SwipeTestHooks.h
@@ -19,16 +19,11 @@ public:
     static com_ptr<SwipeTestHooks> EnsureGlobalTestHooks();
 
     static winrt::SwipeControl GetLastInteractedWithSwipeControl();
-    static bool GetIsOpen(const winrt::SwipeControl& swipeControl);
     static bool GetIsIdle(const winrt::SwipeControl& swipeControl);
 
     static void NotifyLastInteractedWithSwipeControlChanged();
     static winrt::event_token LastInteractedWithSwipeControlChanged(winrt::TypedEventHandler<winrt::IInspectable, winrt::IInspectable> const& value);
     static void LastInteractedWithSwipeControlChanged(winrt::event_token const& token);
-
-    static void NotifyOpenedStatusChanged(const winrt::SwipeControl& sender);
-    static winrt::event_token OpenedStatusChanged(winrt::TypedEventHandler<winrt::SwipeControl, winrt::IInspectable> const& value);
-    static void OpenedStatusChanged(winrt::event_token const& token);
 
     static void NotifyIdleStatusChanged(const winrt::SwipeControl& sender);
     static winrt::event_token IdleStatusChanged(winrt::TypedEventHandler<winrt::SwipeControl, winrt::IInspectable> const& value);

--- a/dev/SwipeControl/SwipeTestHooks.idl
+++ b/dev/SwipeControl/SwipeTestHooks.idl
@@ -1,4 +1,4 @@
-namespace MU_PRIVATE_CONTROLS_NAMESPACE
+﻿namespace MU_PRIVATE_CONTROLS_NAMESPACE
 {
 
 [MUX_INTERNAL]
@@ -7,10 +7,8 @@ namespace MU_PRIVATE_CONTROLS_NAMESPACE
 runtimeclass SwipeTestHooks
 {
     static MU_XC_NAMESPACE.SwipeControl GetLastInteractedWithSwipeControl();
-    static Boolean GetIsOpen(MU_XC_NAMESPACE.SwipeControl swipeControl);
     static Boolean GetIsIdle(MU_XC_NAMESPACE.SwipeControl swipeControl);
     static event Windows.Foundation.TypedEventHandler<Object, Object> LastInteractedWithSwipeControlChanged;
-    static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.SwipeControl, Object> OpenedStatusChanged;
     static event Windows.Foundation.TypedEventHandler<MU_XC_NAMESPACE.SwipeControl, Object> IdleStatusChanged;
 }
 


### PR DESCRIPTION
## Description
Add `SwipeControlOpenState` to `SwipeControl`

Note that this PR only implement the basic `Closed` and `Opened` state, which exactly maps to the previously internal state. If `Closed`, `Opening`, and `Opened`, or event `OpendLeft/Right` is desirable as described in the issue, I can update in this PR.

## Motivation and Context
Implement #7015
Fix #7021 
Fix #7022

## How Has This Been Tested?
Manually in test app.

## Note
The fix doesn't depend on #7015, although with `OpenState` the test page is easier to implement and reason about. Can submit a separate PR only for the fix.