### PR TITLE
Fix WebView2 focus getting stuck

### DIFF
--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -149,6 +149,7 @@ private:
     void HandleKeyDown(const winrt::Windows::Foundation::IInspectable&, const winrt::KeyRoutedEventArgs& e);
     void HandleGettingFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::GettingFocusEventArgs& args) noexcept;
     void HandleGotFocus(const winrt::Windows::Foundation::IInspectable&, const winrt::RoutedEventArgs&);
+    void MoveFocusIntoCoreWebView(winrt::CoreWebView2MoveFocusReason reason);
     void HandleAcceleratorKeyActivated(const winrt::Windows::UI::Core::CoreDispatcher&, const winrt::AcceleratorKeyEventArgs& args) noexcept;
     void HandleXamlRootChanged();
     void HandleSizeChanged(const winrt::IInspectable& /*sender*/, const winrt::SizeChangedEventArgs& args);


### PR DESCRIPTION
There was an issue where when a WebView2 was the only focusable element and the user tabbed through the content, the focus would get stuck at the end (or beginning) of the WebView2. This change prevents the issue by putting focus back in the webview.

<!--- Provide a general summary of your changes in the Title above -->

## Description
After moving focus all the way through a webview, at the end XAML will receive a MoveFocusRequested message where we would normally put focus on the next XAML element. However, in the case where the webview is the ONLY focusable element, focus did not go back to the webview. Instead, we should check if the next focusable element is the same webview that we're leaving, and if it is, put focus back in the WebView2 with a call to CoreWebView2Controller.MoveFocus(). This results in the focus moving from the end back up to the top, or when moving backwards, from the top back down to the end.

## How Has This Been Tested?
This has been tested in a standalone app.