### PR TITLE
NavigationView deep nesting crash fix

### DIFF
--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -130,14 +130,11 @@ void NavigationViewItemsFactory::RecycleElementCore(winrt::ElementFactoryRecycle
 
         // Do not recycle SettingsItem
         bool isSettingsItem = m_settingsItem && m_settingsItem == args.Element();
-
+        
+        UnlinkElementFromParent(args);
         if (m_itemTemplateWrapper && !isSettingsItem)
         {
             m_itemTemplateWrapper.RecycleElement(args);
-        }
-        else
-        {
-            UnlinkElementFromParent(args);
         }
     }
 }
@@ -153,6 +150,7 @@ void NavigationViewItemsFactory::UnlinkElementFromParent(winrt::ElementFactoryRe
         if (children.IndexOf(args.Element(), childIndex))
         {
             children.RemoveAt(childIndex);
+            args.Parent(nullptr);
         }
     }
 }


### PR DESCRIPTION
## Description
NavigationView uses nested ItemRepeaters for nesting menu functionality. To improve performance, ItemRepeater doesn't unlink recycled elements. This is valuable for single level lists however Hierarchical NavView may move elements between multiple repeaters. Keeping the link is causing issues, so updating NavigationViewItemsFactory to unlink all recycled NavigationViewItems.

## Motivation and Context
Fixes internal bug 38374267