### PR TITLE
Revoke HandleAcceleratorKeyActivated when a WebView2 is closed

### DIFF
--- a/build/Helix/global.json
+++ b/build/Helix/global.json
@@ -3,6 +3,6 @@
     "version": "3.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.20529.1"
+    "Microsoft.DotNet.Helix.Sdk": "7.0.0-beta.22275.2"
   }
 }

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -2209,8 +2209,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "D")]
-        public void LifetimeStatesTabTest()
+        [TestProperty("TestSuite", "A")]
+        public void LifetimeTabTest()
         {
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
@@ -2230,8 +2230,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Part 3: Tab with closed core webview
 
                 Log.Comment("Part 3: Tab with closed core webview");
-                ChooseTest("LifetimeStatesTabTest" /* waitForLoadCompleted */);
-                CompleteTestAndWaitForResult("LifetimeStatesTabTest");  // Closes the CoreWebView2
+                ChooseTest("LifetimeTabTest" /* waitForLoadCompleted */);
+                CompleteTestAndWaitForResult("LifetimeTabTest");  // Closes the CoreWebView2
                 TabTwicePastWebView2();
             }
         }

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -402,6 +402,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             WaitForTextBoxValue(status2, string.Empty, false /* match = false for not match */);
         }
 
+        private static void WaitForEnsureCompleted()
+        {
+            var status1 = new Edit(FindElement.ById("Status1"));
+            WaitForTextBoxValue(status1, "EnsureCoreWebView2Async() completed", true);
+        }
+
         private static void ChooseTest(string testName, bool waitForLoadCompleted = true)
         {
             WaitForCopyCompleted();
@@ -2208,64 +2214,46 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         {
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
-                Button x1 = new Button(FindElement.ById("TabStopButton1"));     // Xaml TabStop 1
-                Button x2 = new Button(FindElement.ById("TabStopButton2"));     // Xaml TabStop 2
-
                 // Part 1: Tab with no core webview
 
                 Log.Comment("Part 1: Tab with no core webview");
-                Log.Comment("Focus on x1");
-                x1.SetFocus();
-                Wait.ForIdle();
-                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
-
-                Log.Comment("Tab x1 -> webview -> x2");
-                using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
-                {
-                    KeyboardHelper.PressKey(Key.Tab);
-                    KeyboardHelper.PressKey(Key.Tab);
-                    xamlFocusWaiter.Wait();
-                    Log.Comment("Focus is on " + UIObject.Focused);
-                    Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
-                }
+                TabTwicePastWebView2();
 
                 // Part 2: Tab with core webview, ensured but not navigated
 
                 Log.Comment("Part 2: Tab with core webview, not navigated");
-                Log.Comment("Focus on x1");
-                x1.SetFocus();
-                Wait.ForIdle();
-                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
-
-                Log.Comment("Tab x1 -> webview -> x2");
-                using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
-                {
-                    KeyboardHelper.PressKey(Key.Tab);
-                    KeyboardHelper.PressKey(Key.Tab);
-                    xamlFocusWaiter.Wait();
-                    Log.Comment("Focus is on " + UIObject.Focused);
-                    Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
-                }
+                Button ensureButton = new Button(FindElement.ById("EnsureCWV2Button"));
+                ensureButton.Invoke();
+                WaitForEnsureCompleted();
+                TabTwicePastWebView2();
 
                 // Part 3: Tab with closed core webview
 
                 Log.Comment("Part 3: Tab with closed core webview");
-                ChooseTest("LifetimeStatesTabTest");  // Creates the CoreWebView2
+                ChooseTest("LifetimeStatesTabTest" /* waitForLoadCompleted */);
                 CompleteTestAndWaitForResult("LifetimeStatesTabTest");  // Closes the CoreWebView2
-                Log.Comment("Focus on x1");
-                x1.SetFocus();
-                Wait.ForIdle();
-                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
+                TabTwicePastWebView2();
+            }
+        }
 
-                Log.Comment("Tab x1 -> webview -> x2");
-                using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
-                {
-                    KeyboardHelper.PressKey(Key.Tab);
-                    KeyboardHelper.PressKey(Key.Tab);
-                    xamlFocusWaiter.Wait();
-                    Log.Comment("Focus is on " + UIObject.Focused);
-                    Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
-                }
+        private static void TabTwicePastWebView2()
+        {
+            Button x1 = new Button(FindElement.ById("TabStopButton1"));     // Xaml TabStop 1
+            Button x2 = new Button(FindElement.ById("TabStopButton2"));     // Xaml TabStop 2
+
+            Log.Comment("Focus on x1");
+            x1.SetFocus();
+            Wait.ForIdle();
+            Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
+
+            Log.Comment("Tab x1 -> webview -> x2");
+            using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
+            {
+                KeyboardHelper.PressKey(Key.Tab);
+                KeyboardHelper.PressKey(Key.Tab);
+                xamlFocusWaiter.Wait();
+                Log.Comment("Focus is on " + UIObject.Focused);
+                Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
             }
         }
 

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -2202,6 +2202,73 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        public void LifetimeStatesTabTest()
+        {
+            using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
+            {
+                Button x1 = new Button(FindElement.ById("TabStopButton1"));     // Xaml TabStop 1
+                Button x2 = new Button(FindElement.ById("TabStopButton2"));     // Xaml TabStop 2
+
+                // Part 1: Tab with no core webview
+
+                Log.Comment("Part 1: Tab with no core webview");
+                Log.Comment("Focus on x1");
+                x1.SetFocus();
+                Wait.ForIdle();
+                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
+
+                Log.Comment("Tab x1 -> webview -> x2");
+                using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
+                {
+                    KeyboardHelper.PressKey(Key.Tab);
+                    KeyboardHelper.PressKey(Key.Tab);
+                    xamlFocusWaiter.Wait();
+                    Log.Comment("Focus is on " + UIObject.Focused);
+                    Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
+                }
+
+                // Part 2: Tab with core webview, ensured but not navigated
+
+                Log.Comment("Part 2: Tab with core webview, not navigated");
+                Log.Comment("Focus on x1");
+                x1.SetFocus();
+                Wait.ForIdle();
+                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
+
+                Log.Comment("Tab x1 -> webview -> x2");
+                using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
+                {
+                    KeyboardHelper.PressKey(Key.Tab);
+                    KeyboardHelper.PressKey(Key.Tab);
+                    xamlFocusWaiter.Wait();
+                    Log.Comment("Focus is on " + UIObject.Focused);
+                    Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
+                }
+
+                // Part 3: Tab with closed core webview
+
+                Log.Comment("Part 3: Tab with closed core webview");
+                ChooseTest("LifetimeStatesTabTest");  // Creates the CoreWebView2
+                CompleteTestAndWaitForResult("LifetimeStatesTabTest");  // Closes the CoreWebView2
+                Log.Comment("Focus on x1");
+                x1.SetFocus();
+                Wait.ForIdle();
+                Verify.IsTrue(x1.HasKeyboardFocus, "TabStopButton1 has keyboard focus");
+
+                Log.Comment("Tab x1 -> webview -> x2");
+                using (var xamlFocusWaiter = new FocusAcquiredWaiter("TabStopButton2"))
+                {
+                    KeyboardHelper.PressKey(Key.Tab);
+                    KeyboardHelper.PressKey(Key.Tab);
+                    xamlFocusWaiter.Wait();
+                    Log.Comment("Focus is on " + UIObject.Focused);
+                    Verify.IsTrue(x2.HasKeyboardFocus, "TabStopButton2 has keyboard focus");
+                }
+            }
+        }
+
         private static void BeginSubTest(string testName, string testDescription)
         {
             Log.Comment(Environment.NewLine + testName + ": " + testDescription);

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml
@@ -45,6 +45,7 @@
                             <ComboBoxItem AutomationProperties.Name="HiddenThenVisibleTest">HiddenThenVisibleTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="HostNameToFolderMappingTest">HostNameToFolderMappingTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="HtmlDropdownTest">HtmlDropdownTest</ComboBoxItem>
+                            <ComboBoxItem AutomationProperties.Name="LifetimeStatesTabTest">LifetimeStatesTabTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseCaptureTest">MouseCaptureTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseLeftClickTest">MouseLeftClickTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseMiddleClickTest">MouseMiddleClickTest</ComboBoxItem>

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml
@@ -45,7 +45,7 @@
                             <ComboBoxItem AutomationProperties.Name="HiddenThenVisibleTest">HiddenThenVisibleTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="HostNameToFolderMappingTest">HostNameToFolderMappingTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="HtmlDropdownTest">HtmlDropdownTest</ComboBoxItem>
-                            <ComboBoxItem AutomationProperties.Name="LifetimeStatesTabTest">LifetimeStatesTabTest</ComboBoxItem>
+                            <ComboBoxItem AutomationProperties.Name="LifetimeTabTest">LifetimeTabTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseCaptureTest">MouseCaptureTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseLeftClickTest">MouseLeftClickTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="MouseMiddleClickTest">MouseMiddleClickTest</ComboBoxItem>

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -199,7 +199,7 @@ namespace MUXControlsTestApp
             HtmlDropdownTest,
             HiddenThenVisibleTest,
             ParentHiddenThenVisibleTest,
-            LifetimeStatesTabTest,
+            LifetimeTabTest,
         };
 
         // Map of TestList entry to its webpage (index in TestPageNames[])
@@ -265,7 +265,7 @@ namespace MUXControlsTestApp
             { TestList.HtmlDropdownTest, 5 },
             { TestList.HiddenThenVisibleTest, 1 },
             { TestList.ParentHiddenThenVisibleTest, 1 },
-            { TestList.LifetimeStatesTabTest, 0 },
+            { TestList.LifetimeTabTest, 0 },
         };
 
         readonly string[] TestPageNames =
@@ -1907,7 +1907,7 @@ namespace MUXControlsTestApp
                                     selectedTest, MyWebView2.IsHitTestVisible));
                         }
                         break;
-                    case TestList.LifetimeStatesTabTest:
+                    case TestList.LifetimeTabTest:
                         {
                             MyWebView2.Close();
                         }

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -198,7 +198,8 @@ namespace MUXControlsTestApp
             OffTreeWebViewInputTest,
             HtmlDropdownTest,
             HiddenThenVisibleTest,
-            ParentHiddenThenVisibleTest
+            ParentHiddenThenVisibleTest,
+            LifetimeStatesTabTest,
         };
 
         // Map of TestList entry to its webpage (index in TestPageNames[])
@@ -264,6 +265,7 @@ namespace MUXControlsTestApp
             { TestList.HtmlDropdownTest, 5 },
             { TestList.HiddenThenVisibleTest, 1 },
             { TestList.ParentHiddenThenVisibleTest, 1 },
+            { TestList.LifetimeStatesTabTest, 0 },
         };
 
         readonly string[] TestPageNames =
@@ -1903,6 +1905,11 @@ namespace MUXControlsTestApp
                             logger.Verify(MyWebView2.IsHitTestVisible,
                                  string.Format("Test {0}: Failed, Expected MyWebView2.IsHitTestVisible to be true, was {1}",
                                     selectedTest, MyWebView2.IsHitTestVisible));
+                        }
+                        break;
+                    case TestList.LifetimeStatesTabTest:
+                        {
+                            MyWebView2.Close();
                         }
                         break;
 

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -101,6 +101,13 @@ void WebView2::CloseInternal(bool inShutdownPath)
         m_visibilityChangedToken.value = 0;
     }
 
+    // TODO: We do not have direct analogue for AcceleratorKeyActivated with DispatcherQueue in Islands/ win32. Please refer Task# 30013704 for  more details.
+    if (auto coreWindow = winrt::CoreWindow::GetForCurrentThread())
+    {
+        m_inputWindowHwnd = nullptr;
+        m_acceleratorKeyActivatedRevoker.revoke();
+    }
+
     if (m_coreWebView)
     {
         m_coreWebView = nullptr;

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1334,9 +1334,10 @@ void WebView2::MoveFocusIntoCoreWebView(winrt::CoreWebView2MoveFocusReason reaso
 // Xaml control and force HWND focus back to itself, popping Xaml focus out of the
 // WebView2 control. We mark TAB handled in our KeyDown handler so that it is ignored
 // by XamlRoot's tab processing.
+// If the WebView2 has been closed, then we should let Xaml's tab processing handle it.
 void WebView2::HandleKeyDown(const winrt::Windows::Foundation::IInspectable&, const winrt::KeyRoutedEventArgs& e)
 {
-    if (e.Key() == winrt::VirtualKey::Tab)
+    if (e.Key() == winrt::VirtualKey::Tab && !m_isClosed)
     {
         e.Handled(true);
     }


### PR DESCRIPTION
## Description
When a WebView2 is closed, we no longer need to forward tab messages to the CoreWebView2. However, the event handler will still try even when the WebView2 is closed if it has not been destroyed, since the auto-revoker won't have kicked in. We should explicitly revoke this handler when Close() is called on the WebView2. Once the webview has been closed, when we get a KeyDown event, we should no longer mark it handled, and instead let normal Xaml tab handling happen.

I also moved some code so some registering and revoking was closer together, and in matching order. (First commit)

## Motivation and Context
Without this change, a closed WebView2 will still try to forward the tab to a no-longer-existing hwnd owned by the CoreWebView2, and the app will crash.

## How Has This Been Tested?
Added LifetimeStatesTabTest, which tabs past the webview 1) before a core webview is created, 2) after a core webview is created but before any navigation, and 3) after the webview has been closed. I've also verified manually.