### PR TITLE
NavigationView & Repeater DisableVirtualization fixes

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -7,6 +7,7 @@
 #include "NavigationView.h"
 #include "NavigationViewItem.h"
 #include "NavigationViewItemAutomationPeer.h"
+#include "StackLayout.h"
 #include "Utils.h"
 
 static constexpr wstring_view c_navigationViewItemPresenterName = L"NavigationViewItemPresenter"sv;
@@ -155,6 +156,12 @@ void NavigationViewItem::LoadMenuItemsHost()
         if (auto repeater = GetTemplateChildT<winrt::ItemsRepeater>(c_repeater, *this))
         {
             m_repeater.set(repeater);
+
+            if (auto stackLayout = repeater.Layout().try_as<winrt::StackLayout>())
+            {
+                auto stackLayoutImpl = winrt::get_self<StackLayout>(stackLayout);
+                stackLayoutImpl->DisableVirtualization(true);
+            }
 
             // Primary element setup happens in NavigationView
             m_repeaterElementPreparedRevoker = repeater.ElementPrepared(winrt::auto_revoke, { nvImpl,  &NavigationView::OnRepeaterElementPrepared });

--- a/dev/Repeater/FlowLayoutAlgorithm.cpp
+++ b/dev/Repeater/FlowLayoutAlgorithm.cpp
@@ -58,9 +58,12 @@ winrt::Size FlowLayoutAlgorithm::Measure(
         }
     }
 
-    m_elementManager.OnBeginMeasure(orientation);
+    if(!disableVirtualization)
+    {
+        m_elementManager.OnBeginMeasure(orientation);
+    }
 
-    const int anchorIndex = GetAnchorIndex(availableSize, isWrapping, minItemSpacing, layoutId);
+    const int anchorIndex = GetAnchorIndex(availableSize, isWrapping, minItemSpacing, disableVirtualization, layoutId);
     Generate(GenerateDirection::Forward, anchorIndex, availableSize, minItemSpacing, lineSpacing, maxItemsPerLine, disableVirtualization, layoutId);
     Generate(GenerateDirection::Backward, anchorIndex, availableSize, minItemSpacing, lineSpacing, maxItemsPerLine, disableVirtualization, layoutId);
     if (isWrapping && IsReflowRequired())
@@ -147,13 +150,14 @@ int FlowLayoutAlgorithm::GetAnchorIndex(
     const winrt::Size& availableSize,
     bool isWrapping,
     double minItemSpacing,
+    const bool disableVirtualization,
     const wstring_view& layoutId)
 {
     int anchorIndex = -1;
     winrt::Point anchorPosition{};
     auto context = m_context.get();
 
-    if (!IsVirtualizingContext())
+    if (!IsVirtualizingContext() || disableVirtualization)
     {
         // Non virtualizing host, start generating from the element 0
         anchorIndex = context.ItemCountCore() > 0 ? 0 : -1;

--- a/dev/Repeater/FlowLayoutAlgorithm.h
+++ b/dev/Repeater/FlowLayoutAlgorithm.h
@@ -77,6 +77,7 @@ private:
         const winrt::Size& availableSize,
         bool isWrapping,
         double minItemSpacing,
+        const bool disableVirtualization,
         const wstring_view& layoutId);
     void Generate(
         GenerateDirection direction,


### PR DESCRIPTION
Hierarchical NavigationView was hitting multiple visual and container retrieval issues related to virtualization not being properly disabled

## Motivation and Context
Fixes internal bugs 39162477 & 39162229