### PR TITLE
Explicitly revoke event handlers on WebView2 Close()

### DIFF
--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -134,7 +134,8 @@ private:
     winrt::IAsyncAction CreateCoreWebViewFromEnvironment(HWND hwndParent);
     void CreateMissingAnaheimWarning();
 
-    void RegisterXamlHandlers();
+    void RegisterXamlEventHandlers();
+    void UnregisterXamlEventHandlers();
     void RegisterCoreEventHandlers();
     void UnregisterCoreEventHandlers();
 


### PR DESCRIPTION
This change revokes most WebView2 event handlers when WebView2.Close() is called. These handlers would not do anything useful after close, and could even cause rendering issues. This doesn't m_actualThemeChangedRevoker and m_highContrastChangedRevoker, which will be looked at in a future change.

Also renamed RegisterXamlHandlers to RegisterXamlEventHandlers, to match RegisterCoreEventHandlers.