### PR TITLE
Update min supported version to RS5

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ You don't need version checks or conditional XAML markup to use WinUI controls o
 
 ### Version support
 
-The Microsoft.UI.Xaml 2.7 NuGet package requires your project to have TargetPlatformVersion &gt;= 10.0.18362.0 and TargetPlatformMinVersion &gt;= 10.0.15063.0 when building. 
+The Microsoft.UI.Xaml 2.7 NuGet package requires your project to have TargetPlatformVersion &gt;= 10.0.18362.0 and TargetPlatformMinVersion &gt;= 10.0.17763.0 when building. 
 
 Your app's users can be on any of the following supported Windows 10 versions:
 
-* Windows 10 1703 - Build 15063 (Creators Update aka "Redstone 2") and newer (including Windows Insider Previews)
+* Windows 10 1809 - Build 17763 (Creators Update aka "Redstone 5") and newer (including Windows Insider Previews)
 
 Some features may have a reduced or slightly different user experience on older versions.
 

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -19,7 +19,7 @@ steps:
     displayName: 'Use .NET Core sdk'
     inputs:
       packageType: sdk
-      version: 3.1.419
+      version: 3.1.415
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - template: MUX-InstallWindowsSDK-Steps.yml

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -19,7 +19,7 @@ steps:
     displayName: 'Use .NET Core sdk'
     inputs:
       packageType: sdk
-      version: 3.1.415
+      version: 3.1.419
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
   - template: MUX-InstallWindowsSDK-Steps.yml

--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -107,7 +107,7 @@ jobs:
     parameters:
       condition: and(succeeded(),ne('${{ parameters.testSuite }}','NugetTestSuite'))
       testBinaryDirectoryPath: '$(Build.SourcesDirectory)\HelixPayload\$(buildConfiguration)\$(buildPlatform)'
-      testFilePattern: 'MUXControlsTestApp.appx'
+      testFilePattern: 'MUXControlsTestApp.msix'
       outputProjFileName: 'RunTestsInHelix-ApiTests.proj'
       taefQuery: ${{ parameters.taefQuery }}
 
@@ -115,7 +115,7 @@ jobs:
     parameters:
       condition: and(succeeded(),ne('${{ parameters.testSuite }}','NugetTestSuite'))
       testBinaryDirectoryPath: '$(Build.SourcesDirectory)\HelixPayload\$(buildConfiguration)\$(buildPlatform)'
-      testFilePattern: 'IXMPTestApp.appx'
+      testFilePattern: 'IXMPTestApp.msix'
       outputProjFileName: 'RunTestsInHelix-IXMPTestAppTests.proj'
       taefQuery: ${{ parameters.taefQuery }}
 

--- a/build/FrameworkPackage/FrameworkPackageContents/AppxManifest.xml
+++ b/build/FrameworkPackage/FrameworkPackageContents/AppxManifest.xml
@@ -12,7 +12,7 @@
     <Resource Language="en-US" />
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.15063.0" MaxVersionTested="10.0.18362.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0" />
   </Dependencies>
   <mp:PhoneIdentity PhoneProductId="3F0E3E5D-C663-407a-9187-9A5F47398F11" PhonePublisherId="1AC97219-40D1-4c98-B175-2BFCD96578C3" />
   <Extensions>

--- a/build/Helix/scripts/TestPass-PreRun.ps1
+++ b/build/Helix/scripts/TestPass-PreRun.ps1
@@ -53,6 +53,11 @@ $versionMajor = $versionData.GetElementsByTagName("MUXVersionMajor").'#text'
 $versionMinor = $versionData.GetElementsByTagName("MUXVersionMinor").'#text'
 UninstallTestApps("Microsoft.UI.Xaml.$versionMajor.$versionMinor")
 
+$certs = Get-ChildItem *.cer
+foreach($cert in $certs)
+{
+    certutil -addstore TrustedPeople $cert.Name
+}
 
 .\InstallTestAppDependencies.ps1
 

--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -8,8 +8,8 @@
       <MicrosoftUIXamlTargetPlatformMinCheckValue>$([System.Version]::Parse('$(TargetPlatformMinVersion)').Build)</MicrosoftUIXamlTargetPlatformMinCheckValue>
     </PropertyGroup>
     <Error 
-        Text="Microsoft.UI.Xaml nuget package requires TargetPlatformMinVersion &gt;= 10.0.15063.0 (current project is $(MicrosoftUIXamlTargetPlatformMinCheckValue))" 
-        Condition="$(MicrosoftUIXamlTargetPlatformMinCheckValue) &lt; 15063" />
+        Text="Microsoft.UI.Xaml nuget package requires TargetPlatformMinVersion &gt;= 10.0.17763.0 (current project is $(MicrosoftUIXamlTargetPlatformMinCheckValue))" 
+        Condition="$(MicrosoftUIXamlTargetPlatformMinCheckValue) &lt; 17763" />
     <PropertyGroup>
       <MicrosoftUIXamlTargetPlatformCheckValue>$([System.Version]::Parse('$(TargetPlatformVersion)').Build)</MicrosoftUIXamlTargetPlatformCheckValue>
     </PropertyGroup>

--- a/dev/InfoBadge/APITests/InfoBadgeTests.cs
+++ b/dev/InfoBadge/APITests/InfoBadgeTests.cs
@@ -172,7 +172,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 
             RunOnUIThread.Execute(() =>
             {
-                Verify.Throws<COMException>(() => { infoBadge.Value = -10; });
+                Verify.Throws<Exception>(() => { infoBadge.Value = -10; });
             });
         }
     }

--- a/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
+++ b/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
@@ -15,7 +15,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/dev/dll/Microsoft.UI.Xaml.Common.props
+++ b/dev/dll/Microsoft.UI.Xaml.Common.props
@@ -17,7 +17,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <!-- Use 64-bit compilers because 32-bit compilers run out of heap space -->
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>

--- a/test/IXMPTestApp/IXMPTestApp.Shared.projitems
+++ b/test/IXMPTestApp/IXMPTestApp.Shared.projitems
@@ -23,7 +23,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/IXMPTestApp/Package.appxmanifest
+++ b/test/IXMPTestApp/Package.appxmanifest
@@ -9,7 +9,7 @@
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.15063.0" MaxVersionTested="10.0.18362.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.18362.0" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/test/IXMPTestApp/TAEF/project.json
+++ b/test/IXMPTestApp/TAEF/project.json
@@ -6,7 +6,7 @@
     "TAEF.Redist.Wlk": "10.31.180822002"
   },
   "frameworks": {
-    "uap10.0.15063": {}
+    "uap10.0.17763": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/MUXControlsReleaseTest/AppThatUsesMUXIndirectly/AppThatUsesMUXIndirectly.csproj
+++ b/test/MUXControlsReleaseTest/AppThatUsesMUXIndirectly/AppThatUsesMUXIndirectly.csproj
@@ -15,9 +15,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.17763.0</TargetPlatformMinVersion>
-    <!-- arm64 build is supported only after 16299 -->
-    <TargetPlatformMinVersion Condition="'$(Platform)' == 'ARM64'">$(SDKVersionRS3)</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsReleaseTest/AppThatUsesMUXIndirectly/AppThatUsesMUXIndirectly.csproj
+++ b/test/MUXControlsReleaseTest/AppThatUsesMUXIndirectly/AppThatUsesMUXIndirectly.csproj
@@ -15,7 +15,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.17763.0</TargetPlatformMinVersion>
     <!-- arm64 build is supported only after 16299 -->
     <TargetPlatformMinVersion Condition="'$(Platform)' == 'ARM64'">$(SDKVersionRS3)</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>

--- a/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
+++ b/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
@@ -13,7 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.17763.0</TargetPlatformMinVersion>
     <!-- arm64 build is supported only after 16299 -->
     <TargetPlatformMinVersion Condition="'$(Platform)' == 'ARM64'">$(SDKVersionRS3)</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>

--- a/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
+++ b/test/MUXControlsReleaseTest/LibraryThatUsesMUX/LibraryThatUsesMUX.csproj
@@ -13,9 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.17763.0</TargetPlatformMinVersion>
-    <!-- arm64 build is supported only after 16299 -->
-    <TargetPlatformMinVersion Condition="'$(Platform)' == 'ARM64'">$(SDKVersionRS3)</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/MUXControls.ReleaseTest.Shared.projitems
+++ b/test/MUXControlsReleaseTest/MUXControls.ReleaseTest/MUXControls.ReleaseTest.Shared.projitems
@@ -21,7 +21,7 @@
     <RootNamespace>MUXControls.ReleaseTest</RootNamespace>
     <AssemblyName>MUXControls.ReleaseTest</AssemblyName>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(ReleaseTestSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -15,9 +15,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.17763.0</TargetPlatformMinVersion>
-    <!-- arm64 build is supported only after 16299 -->
-    <TargetPlatformMinVersion Condition="'$(Platform)' == 'ARM64'">$(SDKVersionRS3)</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestApp/NugetPackageTestApp.csproj
@@ -15,7 +15,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion Condition="'$(Platform)' != 'ARM64'">10.0.17763.0</TargetPlatformMinVersion>
     <!-- arm64 build is supported only after 16299 -->
     <TargetPlatformMinVersion Condition="'$(Platform)' == 'ARM64'">$(SDKVersionRS3)</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>

--- a/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
+++ b/test/MUXControlsReleaseTest/NugetPackageTestAppCX/NugetPackageTestAppCX.vcxproj
@@ -12,7 +12,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ConvertedPlatformName>$(Platform)</ConvertedPlatformName>
     <ConvertedPlatformName Condition="'$(Platform)' == 'Win32'">x86</ConvertedPlatformName>

--- a/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.nuspec
+++ b/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.nuspec
@@ -10,7 +10,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <group targetFramework="UAP10.0.15063">
+      <group targetFramework="UAP10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.8" exclude="Build,Analyzers" />
         <dependency id="Microsoft.UI.Xaml" version="2.6.1" exclude="Build,Analyzers" />
       </group>

--- a/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
+++ b/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
@@ -15,7 +15,7 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
+++ b/test/MUXControlsTestApp/MUXControlsTestApp.Shared.projitems
@@ -25,7 +25,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXControlsTestApp/TAEF/project.json
+++ b/test/MUXControlsTestApp/TAEF/project.json
@@ -9,7 +9,7 @@
     "Win2D.uwp": "1.22.0"
   },
   "frameworks": {
-    "uap10.0.15063": {}
+    "uap10.0.17763": {}
   },
   "runtimes": {
     "win10-x86": {},

--- a/test/MUXExperimentalTest/MUXExperimental.Test/MUXExperimental.Test.Shared.projitems
+++ b/test/MUXExperimentalTest/MUXExperimental.Test/MUXExperimental.Test.Shared.projitems
@@ -20,7 +20,7 @@
     <RootNamespace>MUXExperimental.Test</RootNamespace>
     <AssemblyName>MUXExperimental.Test</AssemblyName>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(ReleaseTestSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/MUXExperimentalTest/MUXExperimentalTestApp/MUXExperimentalTestApp.csproj
+++ b/test/MUXExperimentalTest/MUXExperimentalTestApp/MUXExperimentalTestApp.csproj
@@ -14,7 +14,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">$(MuxSdkVersion)</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -12,7 +12,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">$(MuxSdkVersion)</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <PackageCertificateKeyFile>..\..\build\WinUITest.pfx</PackageCertificateKeyFile>
   </PropertyGroup>

--- a/test/testinfra/AppTestAutomationHelpers/AppTestAutomationHelpers.vcxproj
+++ b/test/testinfra/AppTestAutomationHelpers/AppTestAutomationHelpers.vcxproj
@@ -15,7 +15,7 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.15063.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
We no longer run tests on RS2 - RS4 as those versions are out of support for Windows. RS5 is still supported as LTSB so we continue to test there. 

We update the min supported version from RS2 to RS5 and update the test apps to target RS5 as min version.