### PR TITLE
Keyboard text alignment

### DIFF
--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -334,6 +334,7 @@
                                 Foreground="{ThemeResource CommandBarFlyoutAppBarButtonKeyboardTextLabelForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                             <FontIcon x:Name="SubItemChevron"
@@ -588,6 +589,7 @@
                                 Foreground="{ThemeResource CommandBarFlyoutAppBarButtonKeyboardTextLabelForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                         </Grid>

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:contract6NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
@@ -334,7 +335,7 @@
                                 Foreground="{ThemeResource CommandBarFlyoutAppBarButtonKeyboardTextLabelForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
-                                HorizontalTextAlignment="Right"
+                                contract5Present:HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                             <FontIcon x:Name="SubItemChevron"
@@ -589,7 +590,7 @@
                                 Foreground="{ThemeResource CommandBarFlyoutAppBarButtonKeyboardTextLabelForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
-                                HorizontalTextAlignment="Right"
+                                contract5Present:HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                         </Grid>

--- a/dev/CommandBarFlyout/CommandBarFlyout_themeresources_v1.xaml
+++ b/dev/CommandBarFlyout/CommandBarFlyout_themeresources_v1.xaml
@@ -494,6 +494,7 @@
                                 Foreground="{ThemeResource SystemControlBackgroundBaseMediumBrush}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                         </Grid>

--- a/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -447,6 +447,7 @@
                                 Foreground="{ThemeResource AppBarButtonKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                             <Grid x:Name="SubItemChevronPanel"

--- a/dev/CommonStyles/AppBarButton_themeresources_v1.xaml
+++ b/dev/CommonStyles/AppBarButton_themeresources_v1.xaml
@@ -413,6 +413,7 @@
                                 Foreground="{ThemeResource AppBarButtonKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                             <FontIcon x:Name="SubItemChevron"

--- a/dev/CommonStyles/AppBarToggleButton_themeresources.xaml
+++ b/dev/CommonStyles/AppBarToggleButton_themeresources.xaml
@@ -599,6 +599,7 @@
                                 Foreground="{ThemeResource AppBarToggleButtonKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/CommonStyles/AppBarToggleButton_themeresources_v1.xaml
+++ b/dev/CommonStyles/AppBarToggleButton_themeresources_v1.xaml
@@ -594,6 +594,7 @@
                                 Foreground="{ThemeResource AppBarToggleButtonKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/CommonStyles/MediaTransportControls_themeresources_v1.xaml
+++ b/dev/CommonStyles/MediaTransportControls_themeresources_v1.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)">
@@ -583,7 +584,7 @@
                                                             Foreground="{ThemeResource AppBarButtonKeyboardAcceleratorTextForeground}"
                                                             HorizontalAlignment="Right"
                                                             VerticalAlignment="Center"
-                                                            HorizontalTextAlignment="Right"
+                                                            contract5Present:HorizontalTextAlignment="Right"
                                                             Visibility="Collapsed"
                                                             AutomationProperties.AccessibilityView="Raw" />
                                                     <Border

--- a/dev/CommonStyles/MediaTransportControls_themeresources_v1.xaml
+++ b/dev/CommonStyles/MediaTransportControls_themeresources_v1.xaml
@@ -583,6 +583,7 @@
                                                             Foreground="{ThemeResource AppBarButtonKeyboardAcceleratorTextForeground}"
                                                             HorizontalAlignment="Right"
                                                             VerticalAlignment="Center"
+                                                            HorizontalTextAlignment="Right"
                                                             Visibility="Collapsed"
                                                             AutomationProperties.AccessibilityView="Raw" />
                                                     <Border

--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -467,6 +467,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
@@ -609,6 +610,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
@@ -892,6 +894,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
 
@@ -1035,6 +1038,7 @@
                             Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>

--- a/dev/CommonStyles/MenuFlyout_themeresources.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:media="using:Microsoft.UI.Xaml.Media"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
@@ -467,7 +468,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            HorizontalTextAlignment="Right"
+                            contract5Present:HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
@@ -610,7 +611,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                HorizontalTextAlignment="Right"
+                                contract5Present:HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
@@ -894,7 +895,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            HorizontalTextAlignment="Right"
+                            contract5Present:HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
 
@@ -1038,7 +1039,7 @@
                             Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            HorizontalTextAlignment="Right"
+                            contract5Present:HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>

--- a/dev/CommonStyles/MenuFlyout_themeresources_v1.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources_v1.xaml
@@ -446,6 +446,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     
@@ -589,6 +590,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
@@ -749,6 +751,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/CommonStyles/MenuFlyout_themeresources_v1.xaml
+++ b/dev/CommonStyles/MenuFlyout_themeresources_v1.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:media="using:Microsoft.UI.Xaml.Media"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
@@ -446,7 +447,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            HorizontalTextAlignment="Right"
+                            contract5Present:HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     
@@ -590,7 +591,7 @@
                             Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            HorizontalTextAlignment="Right"
+                            contract5Present:HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>
@@ -751,7 +752,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                HorizontalTextAlignment="Right"
+                                contract5Present:HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
     <Style TargetType="local:RadioMenuFlyoutItem" BasedOn="{StaticResource DefaultRadioMenuFlyoutItemStyle}" />
@@ -171,6 +172,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                contract5Present:HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                         </Grid>

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
@@ -171,6 +171,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                         </Grid>

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs4_themeresources_v1.xaml
@@ -171,7 +171,6 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
                         </Grid>

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
 
     <Style TargetType="local:RadioMenuFlyoutItem" BasedOn="{StaticResource DefaultRadioMenuFlyoutItemStyle}" />
@@ -159,6 +160,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                contract5Present:HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
@@ -159,7 +159,6 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_rs5_themeresources_v1.xaml
@@ -159,6 +159,7 @@
                                 Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                HorizontalTextAlignment="Right"
                                 Visibility="Collapsed"
                                 AutomationProperties.AccessibilityView="Raw" />
 

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
@@ -2,6 +2,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
     xmlns:local="using:Microsoft.UI.Xaml.Controls">
@@ -148,7 +149,7 @@
                             Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            HorizontalTextAlignment="Right"
+                            contract5Present:HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>

--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem_themeresources.xaml
@@ -148,6 +148,7 @@
                             Foreground="{ThemeResource ToggleMenuFlyoutItemKeyboardAcceleratorTextForeground}"
                             HorizontalAlignment="Right"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            HorizontalTextAlignment="Right"
                             Visibility="Collapsed"
                             AutomationProperties.AccessibilityView="Raw" />
                     </Grid>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add HorizontalTextAlignment="Right" in the style of KeyboardAcceleratorTextLabel for CommandBarFlyoutAppBarButtonStyleBase, CommandBarFlyoutAppBarToggleButtonStyleBase, DefaultAppBarButtonStyle, DefaultAppBarToggleButtonStyle, MediaControlAppBarButtonStyle and their uses cases.

Add HorizontalTextAlignment="Right" in the style of KeyboardAcceleratorTextBlock for DefaultMenuFlyoutItemStyle, DefaultToggleMenuFlyoutItemStyle, MenuFlyoutItemRevealStyle, ToggleMenuFlyoutItemRevealStyle, DefaultRadioMenuFlyoutItemStyle and theiruse cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
The text alignment of the keyboard accelerator text would switch to center even if the HorizontalAlignment has been set to "Right". 
Expected:
![image](https://user-images.githubusercontent.com/14192280/186749534-c1921600-bed4-40ef-ac1c-a905ce0ddeab.png)
Actual:
![image](https://user-images.githubusercontent.com/14192280/186749660-d46f1ec5-13bc-4310-9a41-ac25fa0974a2.png)
This is because the HorizontalAlignment of the textblock is right, but the HorizontalTextAlignment is not aligned to right.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested with rtl and ltr by [tashatitova](https://github.com/tashatitova) as we can observe below:
![0a4e8a2d-3783-4c35-803c-2485d571462d](https://user-images.githubusercontent.com/14192280/186748565-3d776684-aefe-4af2-8db8-a9fc949afdd4.jpg)
![ef0d5034-2288-4fe5-99de-aed8226d862f](https://user-images.githubusercontent.com/14192280/186748578-d0519e64-7ed4-465d-9a30-2c77a6c41816.jpg)




## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->