### PR TITLE
Fix for WACK tests after change from appx to msix

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-WACKTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-WACKTests-Job.yml
@@ -42,7 +42,7 @@ jobs:
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
-      PackageFilePath: '$(appxPackagesPath)\NugetPackageTestApp_Test\NugetPackageTestApp.appx'
+      PackageFilePath: '$(appxPackagesPath)\NugetPackageTestApp_Test\NugetPackageTestApp.msix'
   - task: CopyFiles@2
     displayName: 'Copy results for NugetPackageTestApp'
     condition: succeededOrFailed()
@@ -57,7 +57,7 @@ jobs:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     condition: succeededOrFailed()
     inputs:
-      PackageFilePath: '$(appxPackagesPath)\AppThatUsesMUXIndirectly_Test\AppThatUsesMUXIndirectly.appx'
+      PackageFilePath: '$(appxPackagesPath)\AppThatUsesMUXIndirectly_Test\AppThatUsesMUXIndirectly.msix'
   - task: CopyFiles@2
     displayName: 'Copy results for AppThatUsesMUXIndirectly'
     condition: succeededOrFailed()


### PR DESCRIPTION
#7195 had the effect of changing the test app packages from .appx to .msix. So we need to update any references to these files.
I missed the updates for the yml file that runs the WACK tests which results in that pipeline failing.

Running the ReleaseTest pipeline with these changes here:
https://microsoft.visualstudio.com/WinUI/_build/results?buildId=50674100&view=results

