### PR TITLE
Enable Velocity in CBS branch

### DIFF
--- a/MUXControls.sln
+++ b/MUXControls.sln
@@ -788,7 +788,6 @@ Global
 		dev\TestHooks\TestHooks.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TreeView\TreeView.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\TwoPaneView\TwoPaneView.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
-		dev\WebView2\WebView2.vcxitems*{ad0c90b0-4845-4d4b-88f1-86f653f8171b}*SharedItemsImports = 4
 		dev\WebView2\WebView2.vcxitems*{ad144714-93fc-4281-b500-a5c2193dbc60}*SharedItemsImports = 9
 		dev\RadialGradientBrush\TestUI\RadialGradientBrush_TestUI.projitems*{ae308818-af18-48ba-bf33-89779083d297}*SharedItemsImports = 13
 		dev\TreeView\InteractionTests\TreeView_InteractionTests.projitems*{ae638a24-2bc6-4d4f-a51e-715d198f01fd}*SharedItemsImports = 13
@@ -914,7 +913,6 @@ Global
 		dev\TreeView\TestUI\TreeView_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\TwoPaneView\APITests\TwoPaneView_APITests.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\TwoPaneView\TestUI\TwoPaneView_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
-		dev\WebView2\TestUI\WebView2_TestUI.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		test\TestAppUtils\TestAppUtils.projitems*{dedc1e4f-cfa5-4443-83eb-e79d425df7e7}*SharedItemsImports = 4
 		dev\SplitButton\InteractionTests\SplitButton_InteractionTests.projitems*{e1c861e2-c4d9-41e1-aed7-5e203451bd4d}*SharedItemsImports = 13
 		dev\Materials\Backdrop\InteractionTests\BackdropMaterial_InteractionTests.projitems*{e4e384ef-7a6c-4db4-9e59-2d9b45871544}*SharedItemsImports = 13
@@ -1017,7 +1015,6 @@ Global
 		dev\TreeView\TestUI\TreeView_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\TwoPaneView\APITests\TwoPaneView_APITests.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\TwoPaneView\TestUI\TwoPaneView_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
-		dev\WebView2\TestUI\WebView2_TestUI.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		test\TestAppUtils\TestAppUtils.projitems*{fbc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\CommonManaged\CommonManaged.projitems*{fcc396f5-26dd-4ca3-981e-c7bc9fea4546}*SharedItemsImports = 4
 		dev\LayoutPanel\LayoutPanel.vcxitems*{fd3c1a00-0d07-4849-a3b9-646f0ff21d7b}*SharedItemsImports = 9

--- a/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildProject-Steps.yml
@@ -48,7 +48,7 @@ steps:
       targetType: filePath
       workingDirectory: $(Build.SourcesDirectory)\tools\MUXPGODatabase
       filePath: $(Build.SourcesDirectory)\tools\MUXPGODatabase\restore-pgodb.ps1
-      arguments: -NuGetConfigPath $(Build.SourcesDirectory)\nuget.config
+      arguments: -NuGetConfigPath $(Build.SourcesDirectory)\nuget-pgo.config
 
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: 'NuGet restore ${{ parameters.solutionPath }}'

--- a/build/AzurePipelinesTemplates/MUX-InstallNuget-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-InstallNuget-Steps.yml
@@ -6,3 +6,5 @@ steps:
     displayName: 'Use NuGet ${{ parameters.nugetVersion }}'
     inputs:
       versionSpec: ${{ parameters.nugetVersion }}
+      
+  - task: NuGetAuthenticate@0

--- a/dev/Effects/microsoft.ui.private.composition.effects_impl.h
+++ b/dev/Effects/microsoft.ui.private.composition.effects_impl.h
@@ -167,7 +167,7 @@ namespace Microsoft { namespace UI { namespace Private { namespace Composition {
             auto ret = func();
             auto propertyValue = ret.as<winrt::IPropertyValue>();
             to_winrt(*value) = propertyValue;
-            CATCH_RETURN;
+            MUX_CATCH_RETURN;
         }
 
         template<UINT32 ComponentCount>
@@ -251,7 +251,7 @@ namespace Microsoft { namespace UI { namespace Private { namespace Composition {
     { \
         if (index == 0) to_winrt(*source) = m_##Name; \
         else throw winrt::hresult_invalid_argument(); \
-        CATCH_RETURN; \
+        MUX_CATCH_RETURN; \
     }
 
 #pragma push_macro("DECLARE_DUAL_SOURCES")
@@ -265,7 +265,7 @@ namespace Microsoft { namespace UI { namespace Private { namespace Composition {
         if (index == 0) to_winrt(*source) = m_##Name1; \
         else if (index == 1) to_winrt(*source) = m_##Name2; \
         else throw winrt::hresult_invalid_argument(); \
-        CATCH_RETURN; \
+        MUX_CATCH_RETURN; \
     }
 
 #pragma push_macro("DECLARE_NAMED_PROPERTY_MAPPING")

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -11,6 +11,7 @@
 #include "ResourceAccessor.h"
 #include "SharedHelpers.h"
 #include <Vector.h>
+#include "velocity.h"
 
 static constexpr double c_tabMinimumWidth = 48.0;
 static constexpr double c_tabMaximumWidth = 200.0;

--- a/dev/dll/Microsoft.UI.Xaml.Common.props
+++ b/dev/dll/Microsoft.UI.Xaml.Common.props
@@ -6,6 +6,7 @@
   <Import Project="..\..\packages\Microsoft.SourceLink.GitHub.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\..\packages\Microsoft.SourceLink.GitHub.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="..\..\packages\Microsoft.SourceLink.Common.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\..\packages\Microsoft.SourceLink.Common.1.0.0-beta2-18618-05\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\..\packages\Microsoft.Build.Tasks.Git.1.0.0-beta2-18618-05\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="..\..\packages\Microsoft.Windows.Wil.Internal.0.2.105\build\native\Microsoft.Windows.Wil.Internal.targets" Condition="Exists('..\..\packages\Microsoft.Windows.Wil.Internal.0.2.105\build\native\Microsoft.Windows.Wil.Internal.targets')" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\mux.controls.props" Condition="Exists('$(MSBuildProjectDirectory)\..\..\mux.controls.props')" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\environment.props" />
   <Import Project="$(MSBuildProjectDirectory)\..\..\ProjectConfigurations.props" />

--- a/dev/dll/Microsoft.UI.Xaml.Common.targets
+++ b/dev/dll/Microsoft.UI.Xaml.Common.targets
@@ -727,6 +727,7 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.Wil.Internal.0.2.105\build\native\Microsoft.Windows.Wil.Internal.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.Wil.Internal.0.2.105\build\native\Microsoft.Windows.Wil.Internal.targets'))" />
   </Target>
   <!-- We want to generate SourceLink urls to GitHub even if we build against the AzDO repo -->
   <Target Name="_TranslateAzureDevOpsUrlToGitHubUrl"

--- a/dev/dll/packages.config
+++ b/dev/dll/packages.config
@@ -8,5 +8,6 @@
   <package id="Microsoft.UI.Xaml" version="2.6.1" targetFramework="native" />
   <package id="Microsoft.Web.WebView2" version="1.0.1020.30" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
+  <package id="Microsoft.Windows.Wil.Internal" version="0.2.105" targetFramework="native" />
   <package id="MUXCustomBuildTasks" version="1.0.74" targetFramework="native" />
 </packages>

--- a/dev/inc/ErrorHandling.h
+++ b/dev/inc/ErrorHandling.h
@@ -10,15 +10,15 @@
 #define E_INVALID_OPERATION HRESULT_FROM_WIN32(ERROR_INVALID_OPERATION)
 #endif
 
-// CATCH_RETURN macro should be used in all ABI methods like this:
+// MUX_CATCH_RETURN macro should be used in all ABI methods like this:
 // IFACEMETHODIMP CFoo::Bar(...) try
 // {
 //     ...
-//     CATCH_RETURN
+//     MUX_CATCH_RETURN
 // } 
 //
 
-#define CATCH_RETURN \
+#define MUX_CATCH_RETURN \
         return S_OK; \
     } catch (...) { \
         auto hr = winrt::to_hresult(); \

--- a/dev/inc/velocity.h
+++ b/dev/inc/velocity.h
@@ -1,0 +1,35 @@
+#ifndef __features_FeatureStaging_SampleFeature
+#define __features_FeatureStaging_SampleFeature
+#endif
+
+#ifndef WIL_STAGING_DLL
+#define WIL_STAGING_DLL
+#endif
+
+// wil does not work well with code analysis enabled so we disable some warnings:
+#pragma warning(push) 
+#pragma warning(disable : 6001)
+#pragma warning(disable : 6319)
+#pragma warning(disable : 6387)
+#pragma warning(disable : 26460)
+#pragma warning(disable : 26461)
+#pragma warning(disable : 26462)
+#pragma warning(disable : 26495)
+#pragma warning(disable : 26496)
+#pragma warning(disable : 26497)
+#pragma warning(disable : 26812)
+
+#include <wil/Staging.h>
+
+WI_DEFINE_FEATURE(
+    Feature_NWMTest1, 39145991, DisabledByDefault,
+    WilStagingChangeTime(OnReboot),
+    WilStagingGroup("", R"()"));
+
+WI_DEFINE_FEATURE(
+    Feature_Tabs, 37634385, DisabledByDefault,
+    WilStagingChangeTime(OnReboot),
+    WilStagingRequiresFeature(Feature_NWMTest1),
+    WilStagingGroup("", R"()"));
+
+#pragma warning(pop)

--- a/nuget-pgo.config
+++ b/nuget-pgo.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- PGO looks for an appropriate pgo database package by listing the packages on the feed. -->
+    <!-- It needs to query directly from the feed that hosts the packages and not a feed that has it as an upstream. -->
+    <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
+
+    <add key="localpackages" value="localpackages" />
+  </packageSources>
+  <config>
+    <add key="repositoryPath" value="$\..\packages" />
+  </config>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,7 +4,7 @@
     <clear />
 
     <!-- do not add new sources to this file. If new packages are required, push them to this feed. -->
-    <add key="MUX-Dependencies" value="https://pkgs.dev.azure.com/ms/microsoft-ui-xaml/_packaging/MUX-Dependencies/nuget/v3/index.json" />
+    <add key="WinUI2-Dependencies" value="https://pkgs.dev.azure.com/microsoft/WinUI/_packaging/WinUI2-Dependencies/nuget/v3/index.json" />
 
     <add key="localpackages" value="localpackages" />
   </packageSources>

--- a/tools/GenerateNewProperty.ps1
+++ b/tools/GenerateNewProperty.ps1
@@ -41,5 +41,5 @@ Write-Host "Factory.cpp methods";
 Write-Host "IFACEMETHODIMP RatingControlFactory::get_$($propertyName)Property(abi::IDependencyProperty** value) try
 {
     winrt::copy_to(getAsABI(s_$($propertyName)Property), value);
-    CATCH_RETURN;
+    MUX_CATCH_RETURN;
 }"

--- a/tools/MUXPGODatabase/restore-pgodb.ps1
+++ b/tools/MUXPGODatabase/restore-pgodb.ps1
@@ -11,7 +11,7 @@ function Get-AvailablePackages ( $package )
 {
     $result = @()
 
-    $output = ( & nuget.exe list $package -prerelease -allversions -configfile $NuGetConfigPath )
+    $output = ( & nuget.exe list $package -prerelease -allversions -configfile $NuGetConfigPath -NonInteractive )
 
     if ( $LastExitCode -ne 0 )
     {
@@ -33,7 +33,7 @@ function Get-AvailablePackages ( $package )
 
 function Install-Package ( $package, $version )
 {
-    & nuget.exe install $package -prerelease -version $version -configfile $NuGetConfigPath
+    & nuget.exe install $package -prerelease -version $version -configfile $NuGetConfigPath -NonInteractive
 
     if ( $LastExitCode -ne 0 )
     {


### PR DESCRIPTION
This enables velocity to be used in the cbs branch. Nothing is using it yet, but this sets up things so that it can be used.

Notes:
Updates nuget.config to point to an internal feed which has the public feed as an upstream feed.
PGO needs to directly query the main feed, so I needed to duplicate the nuget.config to have a special version for pgo.

wil defines a macro CATCH_RETURN which conflicts with our own definition of CATCH_RETURN. So we rename ours to MUX_CATCH_RETURN.

