### PR TITLE
Cherry-pick fixes for CBS drop

### DIFF
--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -364,6 +364,8 @@
         <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
         <Setter Property="Width" Value="{ThemeResource TabViewItemAddButtonWidth}"/>
         <Setter Property="Height" Value="{ThemeResource TabViewItemAddButtonHeight}"/>
+        <Setter Property="BorderThickness" Value="{ThemeResource TabViewButtonBorderThickness}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource TabViewButtonBorderBrush}"/>
         <Setter Property="FocusVisualMargin" Value="-3"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -371,6 +373,8 @@
                     <ContentPresenter x:Name="ContentPresenter"
                         Background="{TemplateBinding Background}"
                         contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
                         ContentTransitions="{TemplateBinding ContentTransitions}"
@@ -393,6 +397,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewButtonForegroundPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewButtonBorderBrushPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
@@ -403,6 +410,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewButtonForegroundPressed}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewButtonBorderBrushPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
@@ -412,6 +422,9 @@
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewButtonForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewButtonBorderBrushDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
@@ -827,12 +840,16 @@
         <Setter Property="Width" Value="{ThemeResource TabViewItemScrollButtonWidth}"/>
         <Setter Property="Height" Value="{ThemeResource TabViewItemScrollButtonHeight}"/>
         <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
+        <Setter Property="BorderThickness" Value="{ThemeResource TabViewButtonBorderThickness}"/>
+        <Setter Property="BorderBrush" Value="{ThemeResource TabViewScrollButtonBorderBrush}"/>
         <Setter Property="FocusVisualMargin" Value="-3"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="RepeatButton">
                     <ContentPresenter x:Name="ContentPresenter"
                         Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
                         contract7Present:BackgroundSizing="{TemplateBinding BackgroundSizing}"
                         Content="{TemplateBinding Content}"
                         ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -857,6 +874,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewScrollButtonForegroundPointerOver}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewScrollButtonBorderBrushPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
 
@@ -868,6 +888,9 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewScrollButtonForegroundPressed}" />
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewScrollButtonBorderBrushPressed}" />
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
 
@@ -878,6 +901,9 @@
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewScrollButtonForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewScrollButtonBorderBrushDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -480,7 +480,7 @@
                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible"/>
                                         <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible"/>
                                         <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
-                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackground}" />
                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}"/>
                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}"/>
                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}"/>
@@ -501,7 +501,7 @@
                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible"/>
                                         <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible"/>
                                         <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
-                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackground}" />
                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}"/>
                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}"/>
                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}"/>
@@ -510,7 +510,6 @@
                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
                                         <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonBackground}" />
                                         <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonForeground}" />
-
                                         <Setter Target="LayoutRoot.Background" Value="Transparent"/>
                                         <Setter Target="ContentPresenter.FontWeight" Value="SemiBold"/>
                                     </VisualState.Setters>
@@ -523,7 +522,7 @@
                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible"/>
                                         <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible"/>
                                         <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}"/>
-                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackground}" />
                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}"/>
                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}"/>
                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}"/>

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -30,7 +30,30 @@ TabViewItem::TabViewItem()
 
 void TabViewItem::OnApplyTemplate()
 {
+    __super::OnApplyTemplate();
+
     winrt::IControlProtected controlProtected{ *this };
+
+    m_selectedBackgroundPathSizeChangedRevoker.revoke();
+    m_closeButtonClickRevoker.revoke();
+    m_tabDragStartingRevoker.revoke();
+    m_tabDragCompletedRevoker.revoke();
+
+    if (SharedHelpers::Is19H1OrHigher()) // UIElement.ActualOffset introduced in Win10 1903.
+    {
+        m_selectedBackgroundPath.set(GetTemplateChildT<winrt::Path>(L"SelectedBackgroundPath", controlProtected));
+
+        if (const auto selectedBackgroundPath = m_selectedBackgroundPath.get())
+        {
+            m_selectedBackgroundPathSizeChangedRevoker = selectedBackgroundPath.SizeChanged(winrt::auto_revoke,
+            {
+                [this](auto const&, auto const&)
+                {
+                    UpdateSelectedBackgroundPathTranslateTransform();
+                }
+            });
+        }
+    }
 
     m_headerContentPresenter.set(GetTemplateChildT<winrt::ContentPresenter>(L"ContentPresenter", controlProtected));
 
@@ -115,14 +138,14 @@ void TabViewItem::UpdateTabGeometry()
 
     // Assumes 4px curving-out corners, which are hardcoded in the markup
     auto data = L"<Geometry xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>F1 M0,%f  a 4,4 0 0 0 4,-4  L 4,%f  a %f,%f 0 0 1 %f,-%f  l %f,0  a %f,%f 0 0 1 %f,%f  l 0,%f  a 4,4 0 0 0 4,4 Z</Geometry>";
-    
+
     WCHAR strOut[1024];
     StringCchPrintf(strOut, ARRAYSIZE(strOut), data,
-        height - 1.0f / scaleFactor,
+        height - 1.0,
         leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
         ActualWidth() - (leftCorner + rightCorner + 1.0f / scaleFactor),
         rightCorner, rightCorner, rightCorner, rightCorner,
-        height - (4 + rightCorner + 1.0f / scaleFactor));
+        height - (5.0 + rightCorner));
 
     const auto geometry = winrt::XamlReader::Load(strOut).try_as<winrt::Geometry>();
 
@@ -202,6 +225,33 @@ void TabViewItem::UpdateShadow()
         else
         {
             Shadow(nullptr);
+        }
+    }
+}
+
+void TabViewItem::UpdateSelectedBackgroundPathTranslateTransform()
+{
+    MUX_ASSERT(SharedHelpers::Is19H1OrHigher());
+
+    if (const auto selectedBackgroundPath = m_selectedBackgroundPath.get())
+    {
+        const auto selectedBackgroundPathActualOffset = selectedBackgroundPath.ActualOffset();
+        const auto roundedSelectedBackgroundPathActualOffsetY = std::round(selectedBackgroundPathActualOffset.y);
+
+        if (roundedSelectedBackgroundPathActualOffsetY > selectedBackgroundPathActualOffset.y)
+        {
+            // Move the SelectedBackgroundPath element down by a fraction of a pixel to avoid a faint gap line
+            // between the selected TabViewItem and its content.
+            winrt::TranslateTransform translateTransform;
+
+            translateTransform.Y(roundedSelectedBackgroundPathActualOffsetY - selectedBackgroundPathActualOffset.y);
+
+            selectedBackgroundPath.RenderTransform(translateTransform);
+        }
+        else if (selectedBackgroundPath.RenderTransform())
+        {
+            // Reset any TranslateTransform that may have been set above.
+            selectedBackgroundPath.RenderTransform(nullptr);
         }
     }
 }
@@ -427,7 +477,6 @@ void TabViewItem::HideLeftAdjacentTabSeparator()
         const auto index = internalTabView->IndexFromContainer(*this);
         internalTabView->SetTabSeparatorOpacity(index - 1, 0);
     }
-
 }
 
 void TabViewItem::RestoreLeftAdjacentTabSeparatorVisibility()

--- a/dev/TabView/TabViewItem.h
+++ b/dev/TabView/TabViewItem.h
@@ -48,12 +48,6 @@ public:
     void StartBringTabIntoView();
 
 private:
-    tracker_ref<winrt::Button> m_closeButton{ this };
-    tracker_ref<winrt::ToolTip> m_toolTip{ this };
-    tracker_ref<winrt::ContentPresenter> m_headerContentPresenter{ this };
-    winrt::TabViewWidthMode m_tabViewWidthMode{ winrt::TabViewWidthMode::Equal };
-    winrt::TabViewCloseButtonOverlayMode m_closeButtonOverlayMode{ winrt::TabViewCloseButtonOverlayMode::Auto };
-
     void UpdateCloseButton();
     void UpdateForeground();
     void RequestClose();
@@ -63,12 +57,6 @@ private:
 
     void OnSizeChanged(const winrt::IInspectable&, const winrt::SizeChangedEventArgs& args);
     void UpdateTabGeometry();
-
-    bool m_firstTimeSettingToolTip{ true };
-
-    winrt::ButtonBase::Click_revoker m_closeButtonClickRevoker{};
-    winrt::TabView::TabDragStarting_revoker m_tabDragStartingRevoker{};
-    winrt::TabView::TabDragCompleted_revoker m_tabDragCompletedRevoker{};
 
     void OnCloseButtonClick(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args);
 
@@ -81,12 +69,27 @@ private:
     void HideLeftAdjacentTabSeparator();
     void RestoreLeftAdjacentTabSeparatorVisibility();
 
+    void UpdateShadow();
+    void UpdateSelectedBackgroundPathTranslateTransform();
+
     bool m_hasPointerCapture = false;
     bool m_isMiddlePointerButtonPressed = false;
     bool m_isDragging = false;
     bool m_isPointerOver = false;
+    bool m_firstTimeSettingToolTip{ true };
 
-    void UpdateShadow();
+    tracker_ref<winrt::Path> m_selectedBackgroundPath{ this };
+    tracker_ref<winrt::Button> m_closeButton{ this };
+    tracker_ref<winrt::ToolTip> m_toolTip{ this };
+    tracker_ref<winrt::ContentPresenter> m_headerContentPresenter{ this };
+    winrt::TabViewWidthMode m_tabViewWidthMode{ winrt::TabViewWidthMode::Equal };
+    winrt::TabViewCloseButtonOverlayMode m_closeButtonOverlayMode{ winrt::TabViewCloseButtonOverlayMode::Auto };
+
+    winrt::FrameworkElement::SizeChanged_revoker m_selectedBackgroundPathSizeChangedRevoker{};
+    winrt::ButtonBase::Click_revoker m_closeButtonClickRevoker{};
+    winrt::TabView::TabDragStarting_revoker m_tabDragStartingRevoker{};
+    winrt::TabView::TabDragCompleted_revoker m_tabDragCompletedRevoker{};
+
     winrt::IInspectable m_shadow{ nullptr };
 
     winrt::weak_ref<winrt::TabView> m_parentTabView{ nullptr };

--- a/dev/TabView/TabView_themeresources.xaml
+++ b/dev/TabView/TabView_themeresources.xaml
@@ -30,6 +30,10 @@
             <StaticResource x:Key="TabViewButtonForegroundPressed"                          ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewButtonForegroundPointerOver"                      ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TabViewButtonForegroundDisabled"                         ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrush"                                ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPressed"                         ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPointerOver"                     ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushDisabled"                        ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackground"                           ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundPressed"                    ResourceKey="SubtleFillColorTertiaryBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver"                ResourceKey="SubtleFillColorSecondaryBrush" />
@@ -38,6 +42,10 @@
             <StaticResource x:Key="TabViewScrollButtonForegroundPressed"                    ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver"                ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundDisabled"                   ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrush"                          ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPressed"                   ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPointerOver"               ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushDisabled"                  ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewItemSeparator"                                    ResourceKey="DividerStrokeColorDefaultBrush" />
             <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground"                  ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed"           ResourceKey="SubtleFillColorTertiaryBrush" />
@@ -65,6 +73,7 @@
 
             <StaticResource x:Key="TabViewBorderBrush"                                      ResourceKey="CardStrokeColorDefault" />
             <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
+            <Thickness x:Key="TabViewButtonBorderThickness">0</Thickness>
             <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">0</Thickness>
             <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,4">
                 <LinearGradientBrush.RelativeTransform>
@@ -102,6 +111,10 @@
             <StaticResource x:Key="TabViewButtonForegroundPressed"                          ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewButtonForegroundPointerOver"                      ResourceKey="TextFillColorPrimaryBrush" />
             <StaticResource x:Key="TabViewButtonForegroundDisabled"                         ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrush"                                ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPressed"                         ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPointerOver"                     ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushDisabled"                        ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackground"                           ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundPressed"                    ResourceKey="SubtleFillColorTertiaryBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver"                ResourceKey="SubtleFillColorSecondaryBrush" />
@@ -110,6 +123,10 @@
             <StaticResource x:Key="TabViewScrollButtonForegroundPressed"                    ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver"                ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundDisabled"                   ResourceKey="TextFillColorDisabledBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrush"                          ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPressed"                   ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPointerOver"               ResourceKey="SubtleFillColorTransparentBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushDisabled"                  ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewItemSeparator"                                    ResourceKey="DividerStrokeColorDefaultBrush" />
             <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground"                  ResourceKey="SubtleFillColorTransparentBrush" />
             <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed"           ResourceKey="SubtleFillColorTertiaryBrush" />
@@ -137,6 +154,7 @@
 
             <StaticResource x:Key="TabViewBorderBrush"                                      ResourceKey="CardStrokeColorDefault" />
             <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
+            <Thickness x:Key="TabViewButtonBorderThickness">0</Thickness>
             <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">0</Thickness>
             <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,4">
                 <LinearGradientBrush.RelativeTransform>
@@ -169,19 +187,27 @@
             <StaticResource x:Key="TabViewButtonBackground"                                 ResourceKey="SystemColorButtonFaceColorBrush" />
             <StaticResource x:Key="TabViewButtonBackgroundPressed"                          ResourceKey="SystemColorHighlightColorBrush" />
             <StaticResource x:Key="TabViewButtonBackgroundPointerOver"                      ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="TabViewButtonBackgroundDisabled"                         ResourceKey="SystemColorButtonFaceColorBrush" />
-            <StaticResource x:Key="TabViewButtonForeground"                                 ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewButtonBackgroundDisabled"                         ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="TabViewButtonForeground"                                 ResourceKey="SystemColorButtonTextColorBrush" />
             <StaticResource x:Key="TabViewButtonForegroundPressed"                          ResourceKey="SystemColorHighlightTextColorBrush" />
             <StaticResource x:Key="TabViewButtonForegroundPointerOver"                      ResourceKey="SystemColorHighlightTextColorBrush" />
             <StaticResource x:Key="TabViewButtonForegroundDisabled"                         ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrush"                                ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPressed"                         ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushPointerOver"                     ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewButtonBorderBrushDisabled"                        ResourceKey="SystemColorGrayTextColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackground"                           ResourceKey="SystemColorButtonFaceColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundPressed"                    ResourceKey="SystemColorHighlightColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundPointerOver"                ResourceKey="SystemColorHighlightColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonBackgroundDisabled"                   ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="TabViewScrollButtonForeground"                           ResourceKey="SystemColorButtonFaceColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonForeground"                           ResourceKey="SystemColorButtonTextColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundPressed"                    ResourceKey="SystemColorHighlightTextColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundPointerOver"                ResourceKey="SystemColorHighlightTextColorBrush" />
             <StaticResource x:Key="TabViewScrollButtonForegroundDisabled"                   ResourceKey="SystemColorGrayTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrush"                          ResourceKey="SystemColorButtonTextColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPressed"                   ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushPointerOver"               ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="TabViewScrollButtonBorderBrushDisabled"                  ResourceKey="SystemColorGrayTextColorBrush" />
             <StaticResource x:Key="TabViewItemSeparator"                                    ResourceKey="SystemColorWindowTextColorBrush" />
             <StaticResource x:Key="TabViewItemHeaderCloseButtonBackground"                  ResourceKey="SystemColorButtonFaceColorBrush" />
             <StaticResource x:Key="TabViewItemHeaderCloseButtonBackgroundPressed"           ResourceKey="SystemColorButtonFaceColorBrush" />
@@ -209,7 +235,8 @@
 
             <SolidColorBrush x:Key="TabViewBorderBrush"                                     Color="{ThemeResource SystemColorHighlightColor}" />
             <StaticResource x:Key="TabViewItemBorderBrush"                                  ResourceKey="SubtleFillColorTransparentBrush" />
-            <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">1</Thickness>                
+            <Thickness x:Key="TabViewButtonBorderThickness">1</Thickness>
+            <Thickness x:Key="TabViewItemHeaderCloseButtonBorderThickness">1</Thickness>
             <LinearGradientBrush x:Key="TabViewSelectedItemBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,4">
                 <LinearGradientBrush.RelativeTransform>
                     <ScaleTransform ScaleY="-1" CenterY="0.5"/>


### PR DESCRIPTION
Cherry-pick these commits to the cbs branch:
*[set TabContainer to Transparent on selected \(\#7110\)](https://github.com/microsoft/microsoft-ui-xaml/commit/85167636224a1f1f0cdc0843cde84d4065adceb9)
*[Fixing TabViewItem sub\-pixel bugs \(\#7174\)](https://github.com/microsoft/microsoft-ui-xaml/commit/76d8ebe458f99556ef51ab262e6f39250206737b)
*[\[TabView\] High contrast scroll buttons fix \(\#7205\)](https://github.com/microsoft/microsoft-ui-xaml/commit/8e41f536c0baa22f4a5d23bf20cfa82202c50452)