### PR TITLE
Ensure selection indicator moves correctly in minimal mode

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1054,6 +1054,21 @@ void NavigationView::OnNavigationViewItemInvoked(const winrt::NavigationViewItem
 
     if (updateSelection)
     {
+        auto indicatorTarget = nvi;
+
+        // Move indicator to topmost collapsed parent
+        auto parent = GetParentNavigationViewItemForContainer(nvi);
+        while (parent)
+        {
+            if (!parent.IsExpanded())
+            {
+                indicatorTarget = parent;
+            }
+            parent = GetParentNavigationViewItemForContainer(parent);
+        }
+
+        AnimateSelectionChanged(indicatorTarget);
+
         CloseFlyoutIfRequired(nvi);
     }
 }


### PR DESCRIPTION
## Description

In `NavigationView` minimal mode the selection indicator position was not updated properly in some edge cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->

Fixes #6837

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->