### PR TITLE
NavView: Navigation does not work when using Narrator in Scan Mode

### DIFF
--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -47,6 +47,7 @@ winrt::hstring NavigationViewItemAutomationPeer::GetNameCore()
 winrt::IInspectable NavigationViewItemAutomationPeer::GetPatternCore(winrt::PatternInterface const& pattern)
 {
     if (pattern == winrt::PatternInterface::SelectionItem ||
+        pattern == winrt::PatternInterface::Invoke ||
         // Only provide expand collapse pattern if we have children!
         (pattern == winrt::PatternInterface::ExpandCollapse && HasChildren()))
     {

--- a/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
+++ b/dev/NavigationView/NavigationViewItemAutomationPeer.cpp
@@ -46,8 +46,10 @@ winrt::hstring NavigationViewItemAutomationPeer::GetNameCore()
 
 winrt::IInspectable NavigationViewItemAutomationPeer::GetPatternCore(winrt::PatternInterface const& pattern)
 {
+    // Note: We are intentionally not supporting Invoke Pattern, since supporting both SelectionItem and Invoke was
+    // causing problems. 
+    // See this Issue for more details: https://github.com/microsoft/microsoft-ui-xaml/issues/2702
     if (pattern == winrt::PatternInterface::SelectionItem ||
-        pattern == winrt::PatternInterface::Invoke ||
         // Only provide expand collapse pattern if we have children!
         (pattern == winrt::PatternInterface::ExpandCollapse && HasChildren()))
     {
@@ -366,6 +368,11 @@ void NavigationViewItemAutomationPeer::RemoveFromSelection()
 
 void NavigationViewItemAutomationPeer::ChangeSelection(bool isSelected)
 {
+    // If the item is being selected, we trigger an invoke as if the user had clicked on the item:
+    if(isSelected)
+    {
+        Invoke();
+    }
     if (auto nvi = Owner().try_as<winrt::NavigationViewItem>())
     {
         nvi.IsSelected(isSelected);

--- a/dev/NavigationView/NavigationView_InteractionTests/SelectionTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/SelectionTests.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using Microsoft.Windows.Apps.Test.Automation;
 using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
+using Microsoft.Windows.Apps.Test.Foundation.Patterns;
 using Microsoft.Windows.Apps.Test.Foundation.Waiters;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
@@ -331,23 +332,26 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
             {
-                var invokedItem = FindElement.ByName("Music");
+                var musicItem = FindElement.ByName("Music");
+                var musicItemInvoker= new InvokeImplementation(musicItem);
 
-                invokedItem.Click();
+                musicItemInvoker.Invoke();
 
                 Wait.ForIdle();
 
                 var result = new TextBlock(FindElement.ByName("InvokedItemState"));
                 Log.Comment("Verify item is selected when Invoked event got raised");
                 Verify.AreEqual("ItemWasSelectedInItemInvoked", result.GetText());
+                Verify.IsTrue(Convert.ToBoolean(musicItem.GetProperty(UIProperty.Get("SelectionItem.IsSelected"))));
 
-                invokedItem.Click();
+                musicItemInvoker.Invoke();
 
                 Wait.ForIdle();
 
                 Log.Comment("Verify item invoked was raised despite item already selected");
                 result = new TextBlock(FindElement.ByName("InvokedItemState"));
                 Verify.AreEqual("ItemWasInvokedSecomdTimeWithCorrectSelection", result.GetText());
+                Verify.IsTrue(Convert.ToBoolean(musicItem.GetProperty(UIProperty.Get("SelectionItem.IsSelected"))));
             }
         }
 

--- a/dev/NavigationView/NavigationView_InteractionTests/SelectionTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/SelectionTests.cs
@@ -21,7 +21,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using Microsoft.Windows.Apps.Test.Automation;
 using Microsoft.Windows.Apps.Test.Foundation;
 using Microsoft.Windows.Apps.Test.Foundation.Controls;
-using Microsoft.Windows.Apps.Test.Foundation.Patterns;
 using Microsoft.Windows.Apps.Test.Foundation.Waiters;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
@@ -332,25 +331,44 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
             {
-                var musicItem = FindElement.ByName("Music");
-                var musicItemInvoker= new InvokeImplementation(musicItem);
+                var invokedItem = FindElement.ByName("Music");
 
-                musicItemInvoker.Invoke();
+                invokedItem.Click();
 
                 Wait.ForIdle();
 
                 var result = new TextBlock(FindElement.ByName("InvokedItemState"));
                 Log.Comment("Verify item is selected when Invoked event got raised");
                 Verify.AreEqual("ItemWasSelectedInItemInvoked", result.GetText());
-                Verify.IsTrue(Convert.ToBoolean(musicItem.GetProperty(UIProperty.Get("SelectionItem.IsSelected"))));
 
-                musicItemInvoker.Invoke();
+                invokedItem.Click();
 
                 Wait.ForIdle();
 
                 Log.Comment("Verify item invoked was raised despite item already selected");
                 result = new TextBlock(FindElement.ByName("InvokedItemState"));
                 Verify.AreEqual("ItemWasInvokedSecomdTimeWithCorrectSelection", result.GetText());
+            }
+        }
+		
+        [TestMethod]
+        public void VerifySelectionItemPatternDoesInvoke()
+        {
+            // When using UIA SelectionItem pattern to select a navview item, this should also trigger an
+            // invoke on the item.
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationView Test" }))
+            {
+                var musicItem = FindElement.ByName("Music");
+                var lvi = new ListViewItem(musicItem);
+
+                lvi.Select();
+                Wait.ForIdle();
+
+                Log.Comment("Verify item was invoked");
+                var result = new TextBlock(FindElement.ByName("InvokedItemState"));
+                Verify.AreEqual("ItemWasSelectedInItemInvoked", result.GetText());
+
+                Log.Comment("Verify item got selected");
                 Verify.IsTrue(Convert.ToBoolean(musicItem.GetProperty(UIProperty.Get("SelectionItem.IsSelected"))));
             }
         }


### PR DESCRIPTION
NavViewItem AutomationPeer was intended to support Invoke Pattern, but didn't return correctly for GetPatternCore.
Not supporting Invoke causes problems when interacting with NavView via UIA, particularly when using Scan Mode in Narrator.

Closes #5998