### PR TITLE
Revoke the items source view changed event if there is one irrespective of the oldValue

### DIFF
--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -540,12 +540,12 @@ void ItemsRepeater::OnDataSourcePropertyChanged(const winrt::ItemsSourceView& ol
         throw winrt::hresult_error(E_FAIL, L"Cannot set ItemsSourceView during layout.");
     }
 
-    m_itemsSourceView.set(newValue);
-
-    if (oldValue)
+    if (m_itemsSourceViewChanged)
     {
         m_itemsSourceViewChanged.revoke();
     }
+
+    m_itemsSourceView.set(newValue);
 
     if (newValue)
     {


### PR DESCRIPTION
We sometimes seem to end up with handler that is not revoked because setting a new value for m_itemsSourceView before revoking causes the referenced value (pointed to by oldValue) becoming null. If the handler is not revoked, then we can end up in a crash if the events are being fired on a collection that is not the ItemsSource of repeater anymore. To avoid this completely, we can revoke the handler if there is one irrespective of the oldValue and also do it before saving the newValue.
