### PR TITLE
Update WebView2 SDK to 1.0.1264.42

### DIFF
--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -38,6 +38,7 @@ PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\Generic.xaml $FullPubli
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml.Design\Microsoft.UI.Xaml.Design.dll $FullPublishDir\Microsoft.UI.Xaml.Design\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\Microsoft.UI.Xaml.FrameworkPackagePRI\Microsoft.UI.Xaml.pri $FullPublishDir\Microsoft.UI.Xaml.FrameworkPackagePRI\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\*.dll $FullPublishDir\Test\
+PublishFile -IfExists $BuildOutputDir\$Configuration\$Platform\MUXControlsTestApp.TAEF\WebView2Loader.dll $FullPublishDir\Test\
 PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\WebView2Loader.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.ReleaseTest.TAEF\MUXControls.ReleaseTest.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.ReleaseTest.TAEF\WebView2Loader.dll $FullPublishDir\Test\

--- a/build/CopyFilesToStagingDir.ps1
+++ b/build/CopyFilesToStagingDir.ps1
@@ -39,10 +39,8 @@ PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml.Design\Microsoft.UI.Xam
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\Microsoft.UI.Xaml.FrameworkPackagePRI\Microsoft.UI.Xaml.pri $FullPublishDir\Microsoft.UI.Xaml.FrameworkPackagePRI\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.Test.TAEF\*.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\$Platform\MUXControlsTestApp.TAEF\WebView2Loader.dll $FullPublishDir\Test\
-PublishFile -IfExists $FullBuildOutput\Microsoft.UI.Xaml\WebView2Loader.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.ReleaseTest.TAEF\MUXControls.ReleaseTest.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXControls.ReleaseTest.TAEF\WebView2Loader.dll $FullPublishDir\Test\
-PublishFile -IfExists $FullBuildOutput\NugetPackageTestApp\WebView2Loader.dll $FullPublishDir\Test\
 PublishFile -IfExists $BuildOutputDir\$Configuration\AnyCPU\MUXExperimental.Test.TAEF\MUXExperimental.Test.dll $FullPublishDir\Test\
 
 PublishFile -IfExists $FullBuildOutput\Microsoft.Experimental.UI.Xaml\Microsoft.Experimental.UI.Xaml.dll $FullPublishDir\Microsoft.Experimental.UI.Xaml\

--- a/build/NuSpecs/MUXControls.nuspec
+++ b/build/NuSpecs/MUXControls.nuspec
@@ -15,7 +15,7 @@
     <iconUrl>https://aka.ms/winui_icon</iconUrl>
 
     <dependencies>
-      <dependency id="Microsoft.Web.WebView2" version="[1.0.1020.30,)" />
+      <dependency id="Microsoft.Web.WebView2" version="[1.0.1264.42,)" />
     </dependencies>  
   </metadata>
   <files>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -15,7 +15,7 @@
     <iconUrl>https://aka.ms/winui_icon</iconUrl>
 
     <dependencies>
-      <dependency id="Microsoft.Web.WebView2" version="[1.0.1020.30,)" />
+      <dependency id="Microsoft.Web.WebView2" version="[1.0.1264.42,)" />
     </dependencies>  
   </metadata>
   <files>

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1428,7 +1428,7 @@ winrt::IUnknown WebView2::GetWebView2Provider()
     if (m_coreWebViewCompositionController)
     {
         auto coreWebView2CompositionControllerInterop = m_coreWebViewCompositionController.as<ICoreWebView2CompositionControllerInterop>();
-        winrt::check_hresult(coreWebView2CompositionControllerInterop->get_UIAProvider(provider.put()));
+        winrt::check_hresult(coreWebView2CompositionControllerInterop->get_AutomationProvider(provider.put()));
     }
     return provider.as<winrt::IUnknown>();
 }
@@ -1441,7 +1441,7 @@ winrt::IUnknown WebView2::GetProviderForHwnd(HWND hwnd)
         // If there is no provider for the given HWND, CoreWebview2 will return UIA_E_ELEMENTNOTAVAILABLE,
         // and we should just return an empty provider
         auto coreWebView2EnvironmentInterop = m_coreWebViewEnvironment.as<ICoreWebView2EnvironmentInterop>();
-        winrt::hresult hr = coreWebView2EnvironmentInterop->GetProviderForHwnd(hwnd, provider.put());
+        winrt::hresult hr = coreWebView2EnvironmentInterop->GetAutomationProviderForWindow(hwnd, provider.put());
         if (hr != UIA_E_ELEMENTNOTAVAILABLE)
         {
             winrt::check_hresult(hr);

--- a/dev/WebView2/WebView2.idl
+++ b/dev/WebView2/WebView2.idl
@@ -4,7 +4,7 @@ namespace MU_XC_NAMESPACE
 {
 
 [webhosthidden]
-[MUX_PREVIEW]
+[MUX_PUBLIC]
 runtimeclass CoreWebView2InitializedEventArgs
 {
     HRESULT Exception{ get; };
@@ -13,7 +13,7 @@ runtimeclass CoreWebView2InitializedEventArgs
 [webhosthidden]
 [MUX_PROPERTY_CHANGED_CALLBACK(TRUE)]
 [MUX_PROPERTY_CHANGED_CALLBACK_METHODNAME("OnPropertyChanged")]
-[MUX_PREVIEW]
+[MUX_PUBLIC]
 unsealed runtimeclass WebView2 : Windows.UI.Xaml.Controls.Control
 {
     WebView2();

--- a/dev/dll/Microsoft.UI.Xaml.Common.targets
+++ b/dev/dll/Microsoft.UI.Xaml.Common.targets
@@ -427,7 +427,7 @@
     <Import Condition="'$(PGOBuildMode)' == 'Optimize' and '$(DisablePGO)' != 'True'" Project="..\..\packages\$(PGODatabaseId).$(PGODatabaseVersion)\build\PGO.targets" />
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\packages\MUXCustomBuildTasks.1.0.74\build\native\MUXCustomBuildTasks.targets" Condition="Exists('..\..\packages\MUXCustomBuildTasks.1.0.74\build\native\MUXCustomBuildTasks.targets')" />
-    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <PropertyGroup>
     <MergedWinmdDirectory>$(OutDir)Merged</MergedWinmdDirectory>
@@ -726,7 +726,7 @@
     <Error Condition="!Exists('..\..\packages\MUXCustomBuildTasks.1.0.74\build\native\MUXCustomBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MUXCustomBuildTasks.1.0.74\build\native\MUXCustomBuildTasks.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.210309.3\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
   <!-- We want to generate SourceLink urls to GitHub even if we build against the AzDO repo -->
   <Target Name="_TranslateAzureDevOpsUrlToGitHubUrl"

--- a/dev/dll/packages.config
+++ b/dev/dll/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.SourceLink.Common" version="1.0.0-beta2-18618-05" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0-beta2-18618-05" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.UI.Xaml" version="2.6.1" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.1020.30" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1264.42" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210309.3" targetFramework="native" />
   <package id="MUXCustomBuildTasks" version="1.0.74" targetFramework="native" />
 </packages>

--- a/test/MUXControls.Test/MSTest/MUXControls.Test.csproj
+++ b/test/MUXControls.Test/MSTest/MUXControls.Test.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.1020.30</Version>
+      <Version>1.0.1264.42</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/MUXControls.Test/MSTest/MUXControls.Test.csproj
+++ b/test/MUXControls.Test/MSTest/MUXControls.Test.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Axe.Windows" Version="1.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Apps.Test" Version="1.0.181205002" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
@@ -20,11 +21,6 @@
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.1264.42</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\testinfra\MUXTestInfra\MSTest\MUXTestInfra.MSTest.csproj" />

--- a/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
+++ b/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
@@ -17,7 +17,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1020.30" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1264.42" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="TE.Managed">

--- a/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
+++ b/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
@@ -35,7 +35,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Axe.Windows" Version="1.0.4" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1018-prerelease" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Apps.Test" Version="1.0.181205002" />
     <PackageReference Include="TAEF.Redist.Wlk" Version="10.31.180822002" />

--- a/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
+++ b/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/RuntimeComponentThatUsesMUX.vcxproj
@@ -145,7 +145,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\..\packages\Microsoft.UI.Xaml.2.6.1\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\packages\Microsoft.UI.Xaml.2.6.1\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -154,7 +154,7 @@
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.UI.Xaml.2.6.1\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.UI.Xaml.2.6.1\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
   <Target Name="AfterBuild">
     <PropertyGroup>

--- a/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/packages.config
+++ b/test/MUXControlsReleaseTest/RuntimeComponentThatUsesMUX/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.6.1" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.1020.30" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1264.42" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
 </packages>

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2">
-      <Version>1.0.1020.30</Version>
+      <Version>1.0.1264.42</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="..\MUXControlsTestApp.Shared.projitems" />

--- a/test/MUXControlsTestApp/TAEF/MUXControlsTestApp.TAEF.csproj
+++ b/test/MUXControlsTestApp/TAEF/MUXControlsTestApp.TAEF.csproj
@@ -19,10 +19,4 @@
   </ItemGroup>
   <Import Project="..\MUXControlsTestApp.Shared.projitems" />
   <Import Project="..\MUXControlsTestApp.Shared.targets" />
-  <Target Name="Binplace" AfterTargets="Build">
-    <ItemGroup>
-      <BinplaceItem Include="$(PkgMicrosoft_Web_WebView2)\runtimes\win-$(Platform)\native\WebView2Loader.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BinplaceItem)" DestinationFiles="@(BinplaceItem -> '$(OutDir)\%(Filename)%(Extension)')" />
-  </Target>
 </Project>

--- a/test/MUXControlsTestApp/TAEF/MUXControlsTestApp.TAEF.csproj
+++ b/test/MUXControlsTestApp/TAEF/MUXControlsTestApp.TAEF.csproj
@@ -19,4 +19,10 @@
   </ItemGroup>
   <Import Project="..\MUXControlsTestApp.Shared.projitems" />
   <Import Project="..\MUXControlsTestApp.Shared.targets" />
+  <Target Name="Binplace" AfterTargets="Build">
+    <ItemGroup>
+      <BinplaceItem Include="$(PkgMicrosoft_Web_WebView2)\runtimes\win-$(Platform)\native\WebView2Loader.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BinplaceItem)" DestinationFiles="@(BinplaceItem -> '$(OutDir)\%(Filename)%(Extension)')" />
+  </Target>
 </Project>

--- a/test/MUXControlsTestApp/TAEF/project.json
+++ b/test/MUXControlsTestApp/TAEF/project.json
@@ -3,7 +3,7 @@
     "DiffPlex": "1.2.1",
     "Microsoft.Net.Native.Compiler": "2.2.3",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.8",
-    "Microsoft.Web.WebView2": "1.0.1020.30",
+    "Microsoft.Web.WebView2": "1.0.1264.42",
     "MUXCustomBuildTasks": "1.0.74",
     "TAEF.Redist.Wlk": "10.31.180822002",
     "Win2D.uwp": "1.22.0"

--- a/test/TestAppCX/TestAppCX.vcxproj
+++ b/test/TestAppCX/TestAppCX.vcxproj
@@ -306,12 +306,12 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="..\RetargetCopyLocalFiles.targets" />
   <ImportGroup Label="ExtensionTargets" Condition="$(FeatureWebView2Enabled) == 'true'">
-    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="$(FeatureWebView2Enabled) == 'true' And !Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.1020.30\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="$(FeatureWebView2Enabled) == 'true' And !Exists('..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Web.WebView2.1.0.1264.42\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
 </Project>

--- a/test/TestAppCX/packages.config
+++ b/test/TestAppCX/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Web.WebView2" version="1.0.1020.30" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.1264.42" targetFramework="native" />
 </packages>


### PR DESCRIPTION
* Update the WebView2 SDK used from 1.0.1020.30 to 1.0.1264.42
* Update two API calls to new names
* WebView2 is no longer experimental
* Change the way we get SDK version to use Microsoft.Web.WebView2.Core.dll.
  * In the future, we should change getting the browser version to use the environment's static method, rather than the loader dll