### PR TITLE
Fix WebView2 accessibility crash in ProviderWrapper::GetRuntimeId

### DIFF
--- a/dev/WebView2/WebView2AutomationPeer.cpp
+++ b/dev/WebView2/WebView2AutomationPeer.cpp
@@ -141,6 +141,10 @@ public:
         *pRetVal = nullptr;
 
         SAFEARRAY* psa = SafeArrayCreateVector(VT_I4, 0, 2);
+        if (psa == nullptr)
+        {
+            return E_OUTOFMEMORY;
+        }
 
         auto id = winrt::AutomationPeer::GenerateRawElementProviderRuntimeId();
 

--- a/dev/WebView2/WebView2AutomationPeer.cpp
+++ b/dev/WebView2/WebView2AutomationPeer.cpp
@@ -140,7 +140,7 @@ public:
     {
         *pRetVal = nullptr;
 
-        SAFEARRAY* psa = SafeArrayCreateVector(VT_I4, 1, 2);
+        SAFEARRAY* psa = SafeArrayCreateVector(VT_I4, 0, 2);
 
         auto id = winrt::AutomationPeer::GenerateRawElementProviderRuntimeId();
 


### PR DESCRIPTION
ProviderWrapper::GetRuntimeId used for WebView2 accessibility is reported to be consistently crashing on some machines. From inspection this appears to be due to incorrect lLBounds being passed in:
	SAFEARRAY* psa = SafeArrayCreateVector(VT_I4, 1, 2)

lLBounds specifies the lower bound for the safe array and is usually set to 0. Here it is incorrectly set to 1, presumably causing a crash in some environments when we try to set the 0’th index via SafeArrayPutElement a few lines later.

Also added check for possible out-of-memory condition from SafeArrayCreateVector.
