### PR TITLE
Sync WebView2 code with WinUI 3

### DIFF
--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -22,11 +22,11 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 using Button = Microsoft.Windows.Apps.Test.Foundation.Controls.Button;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 {
@@ -77,34 +77,49 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             // 2. Get Microsoft.Web.WebView2.Core.dll build version info.
             int sdkBuildVersion = GetSdkBuildVersion();
 
-            // 3. If a runtime isn't installed or the SDK and runtime aren't compatible, install a compatible runtime.
+            // 3. Check if a runtime is already installed, and if it's compatible.
             bool hasCompatibleRuntimeInstalled = GetHasCompatibleRuntimeInstalled(browserBuildVersion, sdkBuildVersion);
 
-            if (!hasCompatibleRuntimeInstalled)
+            // 4a. If we have a compatible runtime installed, continue on to the tests!
+            if (hasCompatibleRuntimeInstalled)
             {
-                // Print if there are any Edge processes running that might interfere with installation
-                // (specifically, MicrosoftEdge<Version> or MicrosoftEdgeUpdate).
-                foreach (var process in Process.GetProcesses())
-                {
-                    if (process.ProcessName.ToLower().ToString().Contains("edge"))
-                    {
-                        Log.Comment("Note: process '{0}' ({1}) is running", process.ProcessName, process.Id);
-                    }
-                }
+                return;
+            }
 
-                // This installation can sometimes fail, so we'll try a number of times before failing out.
-                int attemptsLeft = 5;
-                bool successfullyInstalled = false;
-                while (attemptsLeft > 0)
+            // 4b. If we don't have a compatible runtime, try to install one.
+
+            // 5. Before installing, check if Edge is already installing/updating. We can't run the standalone installer if it is.
+            bool didWait = WaitForEdgeIfAlreadyInstalling();
+
+            if (didWait && IsEdgeAlreadyInstalling())
+            {
+                Log.Error("WebView2Tests Init: Edge took more than 3 minutes to install, give up.");
+            }
+            else if (didWait)
+            {
+                // If we waited for Edge to finish installing/updating and it finished, check the versions again
+                browserBuildVersion = GetInstalledBrowserVersion();
+                hasCompatibleRuntimeInstalled = GetHasCompatibleRuntimeInstalled(browserBuildVersion, sdkBuildVersion);
+                if (hasCompatibleRuntimeInstalled)
                 {
-                    attemptsLeft--;
-                    successfullyInstalled = TryInstallingBrowser(attemptsLeft);
-                    if (successfullyInstalled) break;
+                    return;
                 }
-                if (attemptsLeft == 0 && !successfullyInstalled)
-                {
-                    Log.Error("WebView2Tests Init: Browser installation failed, out of retries.");
-                }
+            }
+
+            // 6. If Edge wasn't already installing/updating, or it was but installed something old (unlikely),
+            // run the standalone installer to install it.
+            // This installation can sometimes fail, so we'll try a number of times before failing out.
+            int attemptsLeft = 5;
+            bool successfullyInstalled = false;
+            while (attemptsLeft > 0)
+            {
+                attemptsLeft--;
+                successfullyInstalled = TryInstallingBrowser(attemptsLeft);
+                if (successfullyInstalled) break;
+            }
+            if (attemptsLeft == 0 && !successfullyInstalled)
+            {
+                Log.Error("WebView2Tests Init: Browser installation failed, out of retries.");
             }
         }
 
@@ -178,22 +193,53 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             return sdkBuildVersion;
         }
 
-        private static bool GetHasCompatibleRuntimeInstalled(int browserBuildVersion, int loaderBuildVersion)
+        private static bool GetHasCompatibleRuntimeInstalled(int browserBuildVersion, int sdkBuildVersion)
         {
             bool hasCompatibleRuntime = false;
             // The full versions of browser/runtime and WebView2 SDK are not directly comparable: 
             // Browser/Runtime version ex: 80.0.361.48
             // WebView2 SDK version ex: 0.8.355
             // Webview2Loader compares the build versions (361 and 355 in above example), we do so here as well
-            if (browserBuildVersion >= loaderBuildVersion ||
-                // [1/26/21]: Special case: For SDK 1.0.721-prerelease, can use browser 88.0.705.0
-                (loaderBuildVersion == 721 && browserBuildVersion >= 705)
-               )
+            if (browserBuildVersion >= sdkBuildVersion)
             {
                 Log.Comment("WebView2Tests Init: Installed Edge build will be used for testing... ");
                 hasCompatibleRuntime = true;
             }
             return hasCompatibleRuntime;
+        }
+
+        private static bool WaitForEdgeIfAlreadyInstalling()
+        {
+            bool didWait = false;
+            int curWait = 0;
+            int maxWait = 180; // wait for 3 minutes, should finish in 1-2
+            while (IsEdgeAlreadyInstalling() && curWait < maxWait)
+            {
+                Log.Comment("Note: Edge is updating, wait up to 180 seconds for it to finish. Waited {0} seconds so far, wait another 10...", curWait);
+                Wait.ForSeconds(10);
+                curWait += 10;
+                didWait = true;
+            }
+            return didWait;
+        }
+
+        private static bool IsEdgeAlreadyInstalling()
+        {
+            bool edgeUpdateIsRunning = false;
+            // Print if there are any Edge processes running that might interfere with installation
+            // (specifically, MicrosoftEdge<Version> or MicrosoftEdgeUpdate).
+            foreach (var process in Process.GetProcesses())
+            {
+                if (process.ProcessName.ToLower().ToString().Contains("edge"))
+                {
+                    Log.Comment("Note: process '{0}' ({1}) is running", process.ProcessName, process.Id);
+                    if (process.ProcessName.ToString().Equals("MicrosoftEdgeUpdate"))
+                    {
+                        edgeUpdateIsRunning = true;
+                    }
+                }
+            }
+            return edgeUpdateIsRunning;
         }
 
         private static bool TryInstallingBrowser(int attemptsLeft)
@@ -281,7 +327,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             using (var waiter = check.GetToggledWaiter())
             {
                 // If the web message hasn't been received, wait for it
-                if (check.ToggleState != ToggleState.On && !waiter.TryWait(TimeSpan.FromSeconds(5)))
+                if (check.ToggleState != ToggleState.On && !waiter.TryWait())
                 {
                     Log.Error("Expected web message was never received.");
                 }
@@ -298,13 +344,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             Button CompleteTestButton = new Button(FindElement.ById("CompleteTest"));
             string expectedValue = selectedTest + ": Passed []";
 
+            Log.Comment("Waiting for result...");
+            CompleteTestButton.Invoke();
+
             // If the web message hasn't been received, wait for it
             using (var waiter = check.GetToggledWaiter())
             {
-                Log.Comment("Waiting for result...");
-                CompleteTestButton.Invoke();
-
-                if (check.ToggleState != ToggleState.On && !waiter.TryWait(TimeSpan.FromSeconds(5)))
+                if (check.ToggleState != ToggleState.On && !waiter.TryWait())
                 {
                     Log.Error("Expected web message was never received.");
                 }
@@ -332,19 +378,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         private static void WaitForTextBoxValue(Edit textbox, string expectedValue, bool match = true)
         {
-            using (var waiter = new ValueChangedEventWaiter(textbox, expectedValue))
+            // if value is empty, wait for it
+            if (textbox.Value == string.Empty)
             {
-                // if value is empty, wait for it
-                if (textbox.Value == string.Empty)
+                using (var waiter = new ValueChangedEventWaiter(textbox, expectedValue))
                 {
-                    try
-                    {
-                        waiter.Wait(TimeSpan.FromSeconds(120));
-                    }
-                    catch
-                    {
-                        Log.Comment("Wait timed out, textbox value is {0}", textbox.Value);
-                    }
+                    waiter.Wait();
                 }
             }
 
@@ -450,12 +489,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void BasicRenderingTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("BasicRenderingTest");
@@ -469,12 +502,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         private static void MouseClickTestCommon(PointerButtons mouseButton)
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 string selectedTest = "Invalid";
@@ -563,12 +590,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void MouseWheelScrollTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MouseWheelScrollTest");
@@ -594,12 +615,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void CursorUpdateTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 // On ChooseTest, replace the default webview with one that exposes the ProtectedCursor member
@@ -630,12 +645,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void NavigationErrorTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("NavigationErrorTest");
@@ -652,12 +661,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void Focus_BasicTabTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("Focus_BasicTabTest");
@@ -697,12 +700,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void Focus_ReverseTabTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("Focus_ReverseTabTest");
@@ -743,12 +740,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void Focus_BackAndForthTabTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("Focus_BackAndForthTabTest");
@@ -796,18 +787,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void Focus_MouseActivateTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("Focus_MouseActivateTest");
 
                 Button x1 = new Button(FindElement.ById("TabStopButton1"));     // Xaml TabStop 1
-                UIObject webviewControl = new UIObject(FindElement.ById("MyWebView2"));
 
                 Log.Comment("Test1: Focus on x1, Click on w1, Shift+Tab w2 -> w1, Click on x2");
                 Log.Comment("Focus on x1");
@@ -817,12 +801,12 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Log.Comment("Click on w2");
 
-                Rectangle bounds = webviewControl.BoundingRectangle;
+                Rectangle bounds = FindElement.ById("MyWebView2").BoundingRectangle;
                 const int w2_offsetX = 100;
                 const int w2_offsetY = 200;
 
                 // top left coordinate (location of web button) relative from the center of webview
-                InputHelper.MoveMouse(webviewControl, -bounds.Width / 2 + w2_offsetX, -bounds.Height / 2 + w2_offsetY);
+                InputHelper.MoveMouse(FindElement.ById("MyWebView2"), -bounds.Width / 2 + w2_offsetX, -bounds.Height / 2 + w2_offsetY);
                 PointerInput.Press(PointerButtons.Primary);
                 PointerInput.Release(PointerButtons.Primary);
 
@@ -850,12 +834,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void ExecuteScriptTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ExecuteScriptTest");
@@ -867,12 +845,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "A")]
         public void MultipleWebviews_FocusTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MultipleWebviews_FocusTest");
@@ -922,12 +894,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void MultipleWebviews_BasicRenderingTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MultipleWebviews_BasicRenderingTest");
@@ -943,12 +909,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("Ignore", "True")] // TODO: Investigate why LanguageTest is failing on latest WebView2 runtime
         public void MultipleWebviews_LanguageTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MultipleWebviews_LanguageTest");
@@ -967,12 +927,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("Ignore", "True")] // Task 37000273
         public void CopyPasteTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("CopyPasteTest");
@@ -1042,12 +996,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void BasicKeyboardTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("BasicKeyboardTest");
@@ -1071,18 +1019,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 KeyboardHelper.PressKey(Key.Left);
                 KeyboardHelper.PressKey(Key.Left);
                 KeyboardHelper.PressKey(Key.Left);
-                
+
                 Log.Comment("Inject '123 '...");
                 TextInput.SendText("123 ");
-                
+
                 Log.Comment("Inject right arrow three times...");
                 KeyboardHelper.PressKey(Key.Right);
                 KeyboardHelper.PressKey(Key.Right);
                 KeyboardHelper.PressKey(Key.Right);
-                
+
                 Log.Comment("Inject 'ld'...");
                 TextInput.SendText("ld");
-                
+
                 Log.Comment("Test simultaneous keyboard inputs by injecting shift+left twice...");
                 KeyboardHelper.PressKey(Key.Left, ModifierKey.Shift);
                 KeyboardHelper.PressKey(Key.Left, ModifierKey.Shift);
@@ -1108,12 +1056,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void WebMessageReceivedTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("WebMessageReceivedTest");
@@ -1135,16 +1077,9 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("Ignore", "True")] // Task 32016751: [WebView2] Re-enable Focus_MouseActivateTest and MouseCaptureTest
         [TestProperty("TestSuite", "B")]
         public void MouseCaptureTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MouseCaptureTest");
@@ -1196,12 +1131,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void ReloadTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ReloadTest");
@@ -1213,12 +1142,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void NavigateToStringTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("NavigateToStringTest");
@@ -1239,12 +1162,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void SourceBindingTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("SourceBindingTest");
@@ -1281,12 +1198,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void GoBackAndForwardTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("GoBackAndForwardTest");
@@ -1296,15 +1207,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "B")]
-        [TestProperty("Ignore", "True")] // TODO: Investigate why this test is not completing on 19H1
         public void NavigationStartingTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("NavigationStartingTest");
@@ -1327,12 +1231,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "B")]
         public void ResizeTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ResizeTest");
@@ -1397,7 +1295,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 InputHelper.Flick(webview, 250, Direction.West);
                 */
                 Point center = new Point(bounds.Width / 2, bounds.Height / 2);
-                //InputHelper.Flick(webview, center, 300, Direction.West);
+                InputHelper.Flick(webview, 300, Direction.West);
                 WaitForWebMessageResult("BasicFlingTouchTest");
             }
         }
@@ -1436,7 +1334,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Log.Warning("This test requires RS5+ functionality");
                 return;
             }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("BasicPanTouchTest");
@@ -1487,12 +1384,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void ScaledTouchTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (IDisposable page1 = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ScaledTouchTest");
@@ -1522,12 +1413,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void MoveTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("MoveTest");
@@ -1539,12 +1424,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void ReparentElementTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ReparentElementTest");
@@ -1563,12 +1442,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void SourceBeforeLoadTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("SourceBeforeLoadTest");
@@ -1580,12 +1453,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void VisibilityHiddenTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("VisibilityHiddenTest");
@@ -1597,12 +1464,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void VisibilityTurnedOnTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("VisibilityTurnedOnTest");
@@ -1619,12 +1480,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void ParentVisibilityHiddenTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ParentVisibilityHiddenTest");
@@ -1636,12 +1491,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void ParentVisibilityTurnedOnTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("ParentVisibilityTurnedOnTest");
@@ -1659,12 +1508,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void SpecificTouchTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("SpecificTouchTest");
@@ -1696,12 +1539,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void QueryCoreWebView2BasicTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("QueryCoreWebView2BasicTest", false /* waitForLoadCompleted */);
@@ -1713,12 +1550,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void CoreWebView2InitializedTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("CoreWebView2InitializedTest", false /* waitForLoadCompleted */);
@@ -1730,12 +1561,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void CoreWebView2Initialized_FailedTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("CoreWebView2Initialized_FailedTest", false /* waitForLoadCompleted */);
@@ -1768,12 +1593,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("Ignore", "True")] // Task 31425073: Unreliable tests: MenuBarTests.KeyboardNavigationWithArrowKeysTest and WebView2CleanedUpTest
         public void WebView2CleanedUpTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 // Go back a page (WebView2 should be cleaned up)
@@ -1818,16 +1637,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void WindowHiddenTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("WindowHiddenTest");
 
+                var appFrameWindow = new Microsoft.Windows.Apps.Test.Foundation.Controls.Window(TestEnvironment.Application.ApplicationFrameWindow);
                 // If we got a visibility message when the web view first appeared, make sure we get it again
                 var check = new CheckBox(FindElement.ById("MessageReceived"));
                 check.Uncheck();
@@ -1835,8 +1649,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 // Minimize and restore the app to trigger the XamlRootChanged event. The CoreWebView2
                 // should be hidden and unhidden as well, each of which will send a web message. We 
                 // then listen for the second message.
-
-                var appFrameWindow = new Microsoft.Windows.Apps.Test.Foundation.Controls.Window(TestEnvironment.Application.ApplicationFrameWindow);
                 Log.Comment("Minimize window");
                 appFrameWindow.SetWindowVisualState(WindowVisualState.Minimized);
                 Wait.ForMilliseconds(1000);
@@ -1853,12 +1665,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void WindowlessPopupTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 // Insert popup with empty webview
@@ -1896,12 +1702,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void PointerReleaseWithoutPressTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("PointerReleaseWithoutPressTest");
@@ -1928,12 +1728,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void HostNameToFolderMappingTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("HostNameToFolderMappingTest");
@@ -1960,12 +1754,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void NavigateToVideoTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("NavigateToVideoTest");
@@ -1977,12 +1765,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void NavigateToLocalImageTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("NavigateToLocalImageTest");
@@ -1995,12 +1777,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void CloseThenDPIChangeTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("CloseThenDPIChangeTest");
@@ -2012,17 +1788,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
             }
         }
 
-        [TestMethod] // Test fails because .NET UWP doesn't support Object -> VARIANT marshalling.
+        [TestMethod]
         [TestProperty("TestSuite", "D")]
-        [TestProperty("Ignore", "True")]
+        [TestProperty("Ignore", "True")] // Test fails because .NET UWP doesn't support Object -> VARIANT marshalling.
         public void AddHostObjectToScriptTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("AddHostObjectToScriptTest");
@@ -2034,12 +1804,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void UserAgentTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 ChooseTest("UserAgentTest");
@@ -2051,12 +1815,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void NonAsciiUriTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
             {
                 // Navigate to a uri with a non-ascii characters
@@ -2209,7 +1967,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        [TestProperty("TestSuite", "A")]
+        [TestProperty("TestSuite", "D")]
         public void LifetimeTabTest()
         {
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
@@ -2330,12 +2088,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void BasicCoreObjectCreationAndDestructionTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToCoreObjectsWebView2" }))
             {
                 ChooseTest("BasicCoreObjectCreationAndDestructionTest", false /* waitForLoadCompleted */);
@@ -2732,12 +2484,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void ConcurrentCreationRequestsTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             // Use two sources to test that concurrent creations/navigations end up in the expected state
             string source1_filename = "SimplePage.html";
             string source2_filename = "SimplePageWithButton.html";
@@ -2893,12 +2639,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "D")]
         public void EdgeProcessFailedTest()
         {
-            if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone5))
-            {
-                Log.Warning("CoreWebView2 doesn't work RS2-RS4 yet");
-                return;
-            }
-
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToCoreObjectsWebView2" }))
             {
                 ChooseTest("EdgeProcessFailedTest", false /* waitForLoadCompleted */);

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -1105,6 +1105,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 var outsidePoint = new Point(bounds.X + w2_offsetX + bounds.Width, bounds.Y + w2_offsetY);
 
                 PointerInput.Move(startPoint);
+
+                // Click once in edit box - this helps selection work in MITA, but is not necessary in manual testing
+                PointerInput.Press(PointerButtons.Primary);
+                PointerInput.Release(PointerButtons.Primary);
+
                 PointerInput.Press(PointerButtons.Primary);
                 PointerInput.Move(outsidePoint);
                 PointerInput.Release(PointerButtons.Primary);

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -1,15 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Windows.UI;
-using Windows.UI.Text;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Automation;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Controls;
 
 using System;
 using System.Collections.Generic;
@@ -19,7 +11,15 @@ using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Globalization;
 using Windows.System;
-using Microsoft.UI.Xaml.Controls;
+using Windows.UI;
+using Windows.UI.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
 
 #if !BUILD_WINDOWS
 using Popup = Windows.UI.Xaml.Controls.Primitives.Popup;
@@ -690,7 +690,6 @@ namespace MUXControlsTestApp
                     break;
                 case TestList.OffTreeWebViewInputTest:
                     {
-                        // Remove existing webview
                         Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
                         parentBorder.BorderBrush = new SolidColorBrush(Colors.Pink);
                     }
@@ -703,14 +702,16 @@ namespace MUXControlsTestApp
                         parentStackPanel.Children.Remove(parentBorder);
 
                         // Create a new border that gets its size from the webview
-                        var newBorder = new Border() {
+                        var newBorder = new Border()
+                        {
                             BorderBrush = new SolidColorBrush(Colors.Red),
                             BorderThickness = new Thickness(5)
                         };
 
                         // Add a new, collapsed WebView2 into the tree
                         var uri = WebView2Common.GetTestPageUri(TestPageNames[TestInfoDictionary[test]]);
-                        var newWebView2 = new WebView2() {
+                        var newWebView2 = new WebView2()
+                        {
                             Name = "MyWebView2",
                             Margin = new Thickness(8, 8, 8, 8),
                             Width = 670,
@@ -732,7 +733,8 @@ namespace MUXControlsTestApp
                         parentStackPanel.Children.Remove(parentBorder);
 
                         // Create a new, collapsed border that gets its size from the webview
-                        var newBorder = new Border() {
+                        var newBorder = new Border()
+                        {
                             BorderBrush = new SolidColorBrush(Colors.Red),
                             BorderThickness = new Thickness(5),
                             Visibility = Visibility.Collapsed
@@ -740,7 +742,8 @@ namespace MUXControlsTestApp
 
                         // Add a new WebView2 into the tree
                         var uri = WebView2Common.GetTestPageUri(TestPageNames[TestInfoDictionary[test]]);
-                        var newWebView2 = new WebView2() {
+                        var newWebView2 = new WebView2()
+                        {
                             Name = "MyWebView2",
                             Margin = new Thickness(8, 8, 8, 8),
                             Width = 670,
@@ -963,6 +966,7 @@ namespace MUXControlsTestApp
         Border RemoveExistingWebViewControl(WebView2 webview)
         {
             RemoveWebViewEventHandlers(webview);
+            webview.Close();
             Border parentBorder = webview.Parent as Border;
             parentBorder.Child = null;
             return parentBorder;
@@ -1317,6 +1321,10 @@ namespace MUXControlsTestApp
                                                          selectedTest.ToString(), wv2_name, wv2_language, wv2_expectedLanguage));
                         }
                         break;
+
+                    /*
+                        TestList.BasicKeyboardTest: Validated on testrunner side
+                    */
 
                     case TestList.MouseCaptureTest:
                         {
@@ -1788,7 +1796,7 @@ namespace MUXControlsTestApp
                                 "Test {0}: Expected NotImplementedException but did not receive it.", selectedTest.ToString()));
 
                             // There is a interop we can use to access the method
-                            var interop = (ICoreWebView2Interop)(object)core_wv2;//core_wv2.As<ICoreWebView2Interop>();
+                            var interop = (ICoreWebView2Interop)(object)core_wv2;
                             try
                             {
                                 interop.AddHostObjectToScript("bridge", new Bridge());
@@ -1869,6 +1877,7 @@ namespace MUXControlsTestApp
                             border.Child = webView2;
                         }
                         break;
+
                     case TestList.HtmlDropdownTest:
                         {
                             var selctedOption = await MyWebView2.ExecuteScriptAsync("getSelectedOption();");
@@ -1877,6 +1886,7 @@ namespace MUXControlsTestApp
                                     selectedTest, selctedOption));;
                         }
                         break;
+
                     case TestList.HiddenThenVisibleTest:
                         {
                             logger.Verify(MyWebView2.Visibility == Visibility.Collapsed,
@@ -1891,12 +1901,13 @@ namespace MUXControlsTestApp
                                     selectedTest, MyWebView2.IsHitTestVisible));
                         }
                         break;
+
                     case TestList.ParentHiddenThenVisibleTest:
                         {
                             var parentBorder = MyWebView2.Parent as Border;
 
                             logger.Verify(parentBorder.Visibility == Visibility.Collapsed,
-                                 string.Format("Test {0}: Incorrect setup, Expected MyWebView2.Visibility to be Collapsed, was {1}",
+                                 string.Format("Test {0}: Incorrect setup, Expected parentBorder.Visibility to be Collapsed, was {1}",
                                     selectedTest, parentBorder.Visibility));
 
                             // Make WebView2's parent Border visible
@@ -1907,6 +1918,7 @@ namespace MUXControlsTestApp
                                     selectedTest, MyWebView2.IsHitTestVisible));
                         }
                         break;
+
                     case TestList.LifetimeTabTest:
                         {
                             MyWebView2.Close();
@@ -1915,7 +1927,6 @@ namespace MUXControlsTestApp
 
                     default:
                         break;
-
                 }
             }
         }
@@ -1969,18 +1980,24 @@ namespace MUXControlsTestApp
     }
 
     // Example classes from public documentation of CoreWebView2's AddHostObjectToScript
-    //[ClassInterface(ClassInterfaceType.AutoDual)]
+#pragma warning disable CS0618
+    // The.NET version of CoreWebView2.AddHostObjectToScript currently relies on the host object
+    // implementing IDispatch and so uses the deprecated ClassInterfaceType.AutoDual feature of.NET.
+    // This may change in the future, see https://github.com/MicrosoftEdge/WebView2Feedback/issues/517
+    // for more information
+    [ClassInterface(ClassInterfaceType.AutoDual)]
+#pragma warning restore CS0618
     [ComVisible(true)]
-    //[Obsolete]
     public class BridgeAnotherClass
     {
         // Sample property.
         public string Prop { get; set; } = "Example property from host object";
     }
 
-    //[ClassInterface(ClassInterfaceType.AutoDual)]
+#pragma warning disable CS0618
+    [ClassInterface(ClassInterfaceType.AutoDual)]
+#pragma warning restore CS0618
     [ComVisible(true)]
-    //[Obsolete]
     public class Bridge
     {
         public string Func(string param)

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -21,7 +21,7 @@ namespace winrt
 #pragma warning( disable : 28251 26812)   // warning C28251: Inconsistent annotation for function: this instance has an error
 #include <webview2.h>
 #include <WebView2EnvironmentOptions.h>
-#pragma warning( pop ) 
+#pragma warning( pop )
 
  // for making async/await possible
 struct AsyncWebViewOperations final : public Awaitable
@@ -122,7 +122,7 @@ private:
     void FireCoreProcessFailedEvent(const winrt::CoreWebView2ProcessFailedEventArgs& args);
     void FireCoreWebView2Initialized(winrt::hresult exception);
 
-    void UpdateDefaultBackgroundColor();
+    void UpdateDefaultVisualBackgroundColor();
 
     HWND GetHostHwnd() noexcept;
     HWND GetActiveInputWindowHwnd() noexcept;
@@ -175,6 +175,7 @@ private:
     void ResetProperties();
     void CloseInternal(bool inShutdownPath);
 
+    winrt::AccessibilitySettings GetAccessibilitySettings();
     bool SafeIsLoaded();
 
     void UpdateCoreWindowCursor();
@@ -208,9 +209,6 @@ private:
     HWND m_inputWindowHwnd{ nullptr };
     winrt::hstring m_stopNavigateOnUriChanged{};
     bool m_canGoPropSetInternally{};
-#if WINUI3
-    winrt::IExpSystemVisualBridge m_systemVisualBridge;
-#endif
     winrt::Windows::UI::Composition::SpriteVisual m_visual{ nullptr };
 
     winrt::UIElement::GettingFocus_revoker m_gettingFocusRevoker;


### PR DESCRIPTION
Remove "#ifdef WinUI3" that doesn't run. Align sections of code that were in different places in the different code bases. Run all WebView2 tests down-level.

Fix issue where we were revoking m_pointerPressedRevoker twice, and revoke m_pointerReleasedRevoker instead.