### PR TITLE
Update all usage of Newtonsoft.Json to 13.0.1

### DIFF
--- a/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
+++ b/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
@@ -50,7 +50,6 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(CompactXamlFile)">

--- a/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
+++ b/dev/Microsoft.UI.Xaml.FrameworkPackagePRI/Microsoft.UI.Xaml.FrameworkPackagePRI.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(CompactXamlFile)">

--- a/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
+++ b/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
@@ -25,6 +25,7 @@
       <Version>2.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/test/IXMPTestApp/TAEF/project.json
+++ b/test/IXMPTestApp/TAEF/project.json
@@ -3,7 +3,8 @@
     "Microsoft.Net.Native.Compiler": "2.2.3",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.8",
     "MUXCustomBuildTasks": "1.0.74",
-    "TAEF.Redist.Wlk": "10.31.180822002"
+    "TAEF.Redist.Wlk": "10.31.180822002",
+    "Newtonsoft.Json": "13.0.1"
   },
   "frameworks": {
     "uap10.0.17763": {}

--- a/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
+++ b/test/MUXControls.Test/TAEF/MUXControls.Test.TAEF.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Apps.Test" Version="1.0.181205002" />
     <PackageReference Include="TAEF.Redist.Wlk" Version="10.31.180822002" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <Import Project="..\MUXControls.Test.Shared.projitems" />
   <ItemGroup>

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -34,6 +34,7 @@
       <Version>2.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/test/MUXControlsTestApp/TAEF/project.json
+++ b/test/MUXControlsTestApp/TAEF/project.json
@@ -6,7 +6,8 @@
     "Microsoft.Web.WebView2": "1.0.1264.42",
     "MUXCustomBuildTasks": "1.0.74",
     "TAEF.Redist.Wlk": "10.31.180822002",
-    "Win2D.uwp": "1.22.0"
+    "Win2D.uwp": "1.22.0",
+    "Newtonsoft.Json": "13.0.1"
   },
   "frameworks": {
     "uap10.0.17763": {}


### PR DESCRIPTION
We previously updated all explicit references to Newtonsoft.Json to 13.0.1 (#7272). However, there are a few cases where we are transitively pulling in older copies of this package. So to force always using the latest version, we explicitly add a PackageReference to the projects so that we can force the version to be resolved to 13.0.1 as a minimum.