### PR TITLE
Set IsTabStop=False on scroll buttons in TabView

### DIFF
--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -257,6 +257,7 @@
                                 VerticalAlignment="Bottom">
                                 <RepeatButton x:Name="ScrollDecreaseButton"
                                     AutomationProperties.AccessibilityView="Raw"
+                                    IsTabStop="False"
                                     Delay="50"
                                     Interval="100"
                                     HighContrastAdjustment="None"
@@ -276,6 +277,7 @@
                                 VerticalAlignment="Bottom">
                                 <RepeatButton x:Name="ScrollIncreaseButton"
                                     AutomationProperties.AccessibilityView="Raw"
+                                    IsTabStop="False"
                                     Delay="50"
                                     Interval="100"
                                     HighContrastAdjustment="None"


### PR DESCRIPTION
The Scroll Left/Right buttons in TabView are removed from the UIA tree. But they are still keyboard focusable. This gives a very bad experience when using Narrator. If you tab to these buttons, Narrator has no info about them and remains silent. This is very confusing.

It is not necessary for these buttons to be keyboard focusable. You can navigate and scroll through the tab list using the left and right arrows, so there is no reason to invoke these scroll buttons when using keyboard navigation.

Ideally, in addition to removing these buttons from the tab order, we would also add these buttons back to the UIA tree. This would enable them to be invoked by tools such as Voice Access. However, these buttons are inside the ListView template, and ListView has custom logic for creating its UIA children - it only shows the listview items, so other general UI under the ListView template does not show up. Hence these buttons do not appear even if they are not in the 'Raw' tree. The tab strip is still navigable with Voice Access using the "press right" and "press left" commands, even if it is not ideal.