### PR TITLE
Fix bugs in WebView2 cursor updating

### DIFF
--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -643,6 +643,43 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "A")]
+        public void CursorClickUpdateTest()
+        {
+            using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))
+            {
+                // On ChooseTest, replace the default webview with one that exposes the ProtectedCursor member
+                ChooseTest("CursorClickUpdateTest");
+
+                // Clear the cache so we can find the new webview
+                ElementCache.Clear();
+                var webview = FindElement.ById("MyWebView2");
+                Rectangle bounds = webview.BoundingRectangle;
+                Log.Comment("Bounds = X:{0}, Y:{1}, Width:{2}, Height:{3}", bounds.X, bounds.Y, bounds.Width, bounds.Height);
+
+                // Click somewhere in the webview that's not the button a few times
+                var centerOfWebView = new Point(bounds.X + bounds.Width / 2, bounds.Y + bounds.Height / 2);
+                PointerInput.Move(centerOfWebView);
+
+                PointerInput.Press(PointerButtons.Primary);
+                PointerInput.Release(PointerButtons.Primary);
+
+                PointerInput.Press(PointerButtons.Primary);
+                PointerInput.Release(PointerButtons.Primary);
+
+                PointerInput.Press(PointerButtons.Primary);
+                PointerInput.Release(PointerButtons.Primary);
+
+                var insideButton = new Point(bounds.X + 20, bounds.Y + 20);
+                PointerInput.Move(insideButton);
+                Wait.ForIdle();
+
+                // Checks that the ProtectedCursor type has changed to the one we expect
+                CompleteTestAndWaitForResult("CursorClickUpdateTest");
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("TestSuite", "A")]
         public void NavigationErrorTest()
         {
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToBasicWebView2" }))

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml
@@ -36,6 +36,7 @@
                             <ComboBoxItem AutomationProperties.Name="CoreWebView2InitializedTest">CoreWebView2InitializedTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="CoreWebView2Initialized_FailedTest">CoreWebView2Initialized_FailedTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="CursorUpdateTest">CursorUpdateTest</ComboBoxItem>
+                            <ComboBoxItem AutomationProperties.Name="CursorClickUpdateTest">CursorClickUpdateTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="ExecuteScriptTest">ExecuteScriptTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="Focus_BackAndForthTabTest">Focus_BackAndForthTabTest</ComboBoxItem>
                             <ComboBoxItem AutomationProperties.Name="Focus_BasicTabTest">Focus_BasicTabTest</ComboBoxItem>

--- a/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
+++ b/dev/WebView2/TestUI/WebView2BasicPage.xaml.cs
@@ -181,6 +181,7 @@ namespace MUXControlsTestApp
             ParentVisibilityTurnedOnTest,
             SpecificTouchTest,
             CursorUpdateTest,
+            CursorClickUpdateTest,
             WebView2CleanedUpTest,
             QueryCoreWebView2BasicTest,
             CoreWebView2InitializedTest,
@@ -208,18 +209,18 @@ namespace MUXControlsTestApp
             { TestList.BasicRenderingTest, 0 },
             { TestList.MouseLeftClickTest, 1 },
             { TestList.MouseMiddleClickTest, 1 },
-            { TestList.MouseRightClickTest, 1},
-            { TestList.MouseXButton1ClickTest, 1},
-            { TestList.MouseXButton2ClickTest, 1},
-            { TestList.MouseWheelScrollTest, 2},
-            { TestList.NavigationErrorTest, 0},
-            { TestList.Focus_BasicTabTest, 3},
-            { TestList.Focus_ReverseTabTest, 3},
-            { TestList.Focus_BackAndForthTabTest, 3},
-            { TestList.Focus_MouseActivateTest, 3},
-            { TestList.ExecuteScriptTest, 4},
-            { TestList.MultipleWebviews_BasicRenderingTest, 0},
-            { TestList.MultipleWebviews_FocusTest, 3},
+            { TestList.MouseRightClickTest, 1 },
+            { TestList.MouseXButton1ClickTest, 1 },
+            { TestList.MouseXButton2ClickTest, 1 },
+            { TestList.MouseWheelScrollTest, 2 },
+            { TestList.NavigationErrorTest, 0 },
+            { TestList.Focus_BasicTabTest, 3 },
+            { TestList.Focus_ReverseTabTest, 3 },
+            { TestList.Focus_BackAndForthTabTest, 3 },
+            { TestList.Focus_MouseActivateTest, 3 },
+            { TestList.ExecuteScriptTest, 4 },
+            { TestList.MultipleWebviews_BasicRenderingTest, 0 },
+            { TestList.MultipleWebviews_FocusTest, 3 },
             { TestList.MultipleWebviews_LanguageTest, 0 },
             { TestList.CopyPasteTest, 3 },
             { TestList.BasicKeyboardTest, 5 },
@@ -246,14 +247,15 @@ namespace MUXControlsTestApp
             { TestList.ParentVisibilityHiddenTest, 3 },
             { TestList.ParentVisibilityTurnedOnTest, 3 },
             { TestList.SpecificTouchTest, 6 },
-            { TestList.CursorUpdateTest, 1},
+            { TestList.CursorUpdateTest, 1 },
+            { TestList.CursorClickUpdateTest, 1 },
             { TestList.WebView2CleanedUpTest, 1 },
             { TestList.QueryCoreWebView2BasicTest, 0 },
             { TestList.CoreWebView2InitializedTest, 0 },
-            { TestList.CoreWebView2Initialized_FailedTest, 0},
+            { TestList.CoreWebView2Initialized_FailedTest, 0 },
             { TestList.WindowHiddenTest, 3 },
             { TestList.WindowlessPopupTest, 1 },
-            { TestList.PointerReleaseWithoutPressTest, 1},
+            { TestList.PointerReleaseWithoutPressTest, 1 },
             { TestList.HostNameToFolderMappingTest, 0 },
             { TestList.NavigateToVideoTest, 4 },
             { TestList.NavigateToLocalImageTest, 0 },
@@ -662,6 +664,7 @@ namespace MUXControlsTestApp
                     }
                     break;
                 case TestList.CursorUpdateTest:
+                case TestList.CursorClickUpdateTest:
                     {
                         // Remove existing WebView, we're going to replace it
                         Border parentBorder = RemoveExistingWebViewControl(MyWebView2);
@@ -1650,6 +1653,7 @@ namespace MUXControlsTestApp
                         break;
 
                     case TestList.CursorUpdateTest:
+                    case TestList.CursorClickUpdateTest:
                         {
                             WebView2WithCursor webviewWithCursor = MyWebView2 as WebView2WithCursor;
                             Windows.UI.Core.CoreCursor cursor = webviewWithCursor.WrappedProtectedCursor;

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -325,6 +325,13 @@ void WebView2::HandlePointerExited(const winrt::Windows::Foundation::IInspectabl
     winrt::PointerDeviceType deviceType{ args.Pointer().PointerDeviceType() };
     UINT message;
 
+    if (m_isPointerOver)
+    {
+        m_isPointerOver = false;
+        winrt::CoreWindow::GetForCurrentThread().PointerCursor(m_oldCursor);
+        m_oldCursor = nullptr;
+    }
+
     if (deviceType == winrt::PointerDeviceType::Mouse)
     {
         message = WM_MOUSELEAVE;
@@ -365,13 +372,6 @@ void WebView2::HandlePointerCaptureLost(const winrt::Windows::Foundation::IInspe
 void WebView2::ResetPointerHelper(const winrt::PointerRoutedEventArgs& args)
 {
     winrt::PointerDeviceType deviceType{ args.Pointer().PointerDeviceType() };
-
-    if (m_isPointerOver)
-    {
-        m_isPointerOver = false;
-        winrt::CoreWindow::GetForCurrentThread().PointerCursor(m_oldCursor);
-        m_oldCursor = nullptr;
-    }
 
     if (deviceType == winrt::PointerDeviceType::Mouse)
     {
@@ -614,8 +614,6 @@ void WebView2::RegisterCoreEventHandlers()
     m_cursorChangedRevoker = m_coreWebViewCompositionController.CursorChanged(winrt::auto_revoke, {
         [this](auto const& controller, auto const& obj)
         {
-            m_requestedCursor = controller.Cursor();
-
             UpdateCoreWindowCursor();
         }});
 }
@@ -1034,9 +1032,9 @@ void WebView2::FillPointerInfo(const winrt::PointerPoint& inputPt, winrt::CoreWe
 
 void WebView2::UpdateCoreWindowCursor()
 {
-    if (m_isPointerOver)
+    if (m_coreWebViewCompositionController && m_isPointerOver)
     {
-        winrt::CoreWindow::GetForCurrentThread().PointerCursor(m_requestedCursor);
+        winrt::CoreWindow::GetForCurrentThread().PointerCursor(m_coreWebViewCompositionController.Cursor());
     }
 }
 

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -85,7 +85,6 @@ public:
     winrt::IUnknown GetProviderForHwnd(HWND hwnd);
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
-    void ResetPointerHelper(const winrt::PointerRoutedEventArgs& args);
     void OnLoaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnUnloaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
 
@@ -246,9 +245,9 @@ private:
     winrt::AccessibilitySettings::HighContrastChanged_revoker m_highContrastChangedRevoker{};
 
     // Pointer handling for CoreWindow
+    void ResetPointerHelper(const winrt::PointerRoutedEventArgs& args);
     bool m_isPointerOver{};
     winrt::CoreCursor m_oldCursor{ nullptr };
-    winrt::CoreCursor m_requestedCursor{ nullptr };
 
     XamlFocusChangeInfo m_xamlFocusChangeInfo{};
 

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -110,7 +110,6 @@ private:
     void FillPointerInfo(const winrt::PointerPoint& inputPt, winrt::CoreWebView2PointerInfo outputPt, const winrt::PointerRoutedEventArgs& args);
 
     winrt::float4x4 GetMatrixFromTransform();
-    void ResetMouseInputState();
     void OnManipulationModePropertyChanged(const winrt::DependencyObject& /*sender*/, const winrt::DependencyProperty& /*args*/);
     void OnVisibilityPropertyChanged(const winrt::DependencyObject& /*sender*/, const winrt::DependencyProperty& /*args*/);
 


### PR DESCRIPTION
This change updates three areas:
- There was a bug where if a user clicked in the webview, the cursor would no longer update. For example, when moved over a button, we expect the cursor to change from an arrow to a hand. This was because on pointer up, we release pointer capture. Doing so would change m_isPointerOver to false, and we would no longer apply cursor updates in UpdateCoreWindowCursor. By moving that logic to HandlePointerExited, we get the expected behavior.
- This change also removes m_requestedCursor. Instead of caching the cursor, we get it from the core controller in UpdateCoreWindowCursor. In addition to not needing to cache it, this also means we won't set the cursor to null the first time the pointer enters the webview.
- Lastly, we used to cache which button was pressed on PointerPressed, and expected that to be the button released on PointerReleased. By getting the PointerUpdateKind at the time of press or release, we don't have to cache the button, and we don't have an instance where one button is released but we send a message with a different button to the core webview. If multiple buttons are pressed or released, we only get the first PointerPressed or last PointerReleased message, so we don't have to worry about releasing pointer capture while another button still has capture.

https://task.ms/40563051
https://task.ms/40563093

## How Has This Been Tested?
Verified manually. Added CursorClickUpdateTest in addition to CursorUpdateTest.