### PR TITLE
Ensure correct .props and .targets order in nuget package

### DIFF
--- a/build/NuSpecs/MUXControls-Nuget-Common.targets
+++ b/build/NuSpecs/MUXControls-Nuget-Common.targets
@@ -33,7 +33,6 @@
   <PropertyGroup>
     <XamlWinmdName>Microsoft.UI.Xaml.winmd</XamlWinmdName>
     <XamlCompactXbfName>Microsoft.UI.Xaml\DensityStyles\Compact.xbf</XamlCompactXbfName>
-    <WebView2UseWinRT Condition="'$(WebView2UseWinRT)' ==''">true</WebView2UseWinRT>
   </PropertyGroup>
   <Target Name="_FixWinmdCopyLocal" AfterTargets="ResolveNuGetPackageAssets">
     <ItemGroup>

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage-Native.props
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage-Native.props
@@ -1,0 +1,7 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.UI.Xaml.props"/>
+  <PropertyGroup>
+    <WebView2UseWinRT Condition="'$(WebView2UseWinRT)' ==''">true</WebView2UseWinRT>
+  </PropertyGroup>
+</Project>

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.targets
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.targets
@@ -8,5 +8,4 @@
     <ItemGroup>
         <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.UI.Xaml.winmd"/>
     </ItemGroup>
-  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.UI.Xaml.props"/>
 </Project>

--- a/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.targets
+++ b/build/NuSpecs/MUXControls-Nuget-FrameworkPackage.targets
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
-        <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.UI.Xaml.winmd"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <Native-Platform Condition="'$(Platform)' == 'Win32'">x86</Native-Platform>
+    <Native-Platform Condition="'$(Platform)' != 'Win32'">$(Platform)</Native-Platform>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.UI.Xaml.winmd"/>
+  </ItemGroup>
 </Project>

--- a/build/NuSpecs/MUXControls-Nuget-Native.props
+++ b/build/NuSpecs/MUXControls-Nuget-Native.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.UI.Xaml.props"/>
   <PropertyGroup>
     <WebView2UseWinRT Condition="'$(WebView2UseWinRT)' ==''">true</WebView2UseWinRT>
   </PropertyGroup>

--- a/build/NuSpecs/MUXControls-Nuget-Native.props
+++ b/build/NuSpecs/MUXControls-Nuget-Native.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)..\Microsoft.UI.Xaml.props"/>
+  <PropertyGroup>
+    <WebView2UseWinRT Condition="'$(WebView2UseWinRT)' ==''">true</WebView2UseWinRT>
+  </PropertyGroup>
+</Project>

--- a/build/NuSpecs/MUXControls.nuspec
+++ b/build/NuSpecs/MUXControls.nuspec
@@ -36,8 +36,10 @@
     <file target="build\$ID$.targets" src="MUXControls-Nuget-Common.targets"/>
     <file target="buildTransitive\$ID$.targets" src="MUXControls-Nuget-Common.targets"/>
 
-    <!-- This is here for C++ based projects, see http://nugetdocsbeta.azurewebsites.net/ndocs/guides/create-uwp-packages -->
+    <!-- This is here for C++ based projects, see https://docs.microsoft.com/en-us/nuget/guides/create-uwp-packages -->
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-Native.targets"/>
+    <file target="build\native\$ID$.props" src="MUXControls-Nuget-Native.props"/>
     <file target="buildTransitive\native\$ID$.targets" src="MUXControls-Nuget-Native.targets"/>
+    <file target="buildTransitive\native\$ID$.props" src="MUXControls-Nuget-Native.props"/>
   </files>
 </package>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -40,7 +40,7 @@
     <file target="buildTransitive\Common.targets" src="MUXControls-Nuget-Common.targets"/>
     <file target="build\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
     <file target="buildTransitive\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
-    <file target="build\native\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
+    <file target="build\native\$ID$.props" src="MUXControls-Nuget-FrameworkPackage-Native.props"/>
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-FrameworkPackage.targets"/>
   </files>
 </package>

--- a/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
+++ b/build/NuSpecs/MUXControlsFrameworkPackage.nuspec
@@ -40,6 +40,7 @@
     <file target="buildTransitive\Common.targets" src="MUXControls-Nuget-Common.targets"/>
     <file target="build\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
     <file target="buildTransitive\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
+    <file target="build\native\$ID$.props" src="MUXControls-Nuget-FrameworkPackage.props"/>
     <file target="build\native\$ID$.targets" src="MUXControls-Nuget-FrameworkPackage.targets"/>
   </files>
 </package>


### PR DESCRIPTION
Fix an issue where WinUI 2.8 couldn't be used in XAML islands apps.

## Description
When you add a nuget package reference, VS will add imports for the package’s props and targets. Props go at the top, targets at the bottom. WinUI didn't have a props file in the right location in the package (in build\native), only targets. The WinUI targets import a props file from a directory above. This means that it’s possible for WebView2’s targets to be imported before WinUI's targets (and therefore the WinUI props), rendering the project unbuildable. This change moves the props file to the build/native directory, and removes the unnecessary import.

http://task.ms/40798730