### PR TITLE
Update areaPath in tsaoptions.json. Add token to PkgESVPack

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,7 +1,7 @@
 {
     "instanceUrl": "https://microsoft.visualstudio.com",
     "projectName": "os",
-    "areaPath": "OS\\WDX\\DXP\\WinDev\\Controls",
+    "areaPath": "OS\\WDX\\DXP\\OWL (Open Windows pLatform)\\Controls",
     "iterationPath": "OS",
     "notificationAliases": [ "uxpct@microsoft.com" ],
     "ignoreBranchName": true,

--- a/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-PushCBSVpack-Job.yml
@@ -73,6 +73,8 @@ jobs:
   - task: PkgESVPack@12
     displayName: 'Push VPack Microsoft.UI.Xaml'
     condition: eq(variables['PublishVpack'], 'true')
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       sourceDirectory: '$(publishDir)\WinUIVpack'
       githubToken: $(WinUI2GitHubToken)
@@ -82,6 +84,8 @@ jobs:
   - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_x64'
     condition: eq(variables['PublishVpack'], 'true')
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       sourceDirectory: '$(publishDir)\CBS\x64'
       githubToken: $(WinUI2GitHubToken)
@@ -91,6 +95,8 @@ jobs:
   - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_x86'
     condition: eq(variables['PublishVpack'], 'true')
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       sourceDirectory: '$(publishDir)\CBS\x86'
       githubToken: $(WinUI2GitHubToken)
@@ -100,6 +106,8 @@ jobs:
   - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_arm'
     condition: eq(variables['PublishVpack'], 'true')
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       sourceDirectory: '$(publishDir)\CBS\arm'
       githubToken: $(WinUI2GitHubToken)
@@ -109,6 +117,8 @@ jobs:
   - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInbox_arm64'
     condition: eq(variables['PublishVpack'], 'true')
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       sourceDirectory: '$(publishDir)\CBS\arm64'
       githubToken: $(WinUI2GitHubToken)
@@ -118,6 +128,8 @@ jobs:
   - task: PkgESVPack@12
     displayName: 'Push VPack MicrosoftUIXamlInboxWinmd'
     condition: eq(variables['PublishVpack'], 'true')
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
       sourceDirectory: '$(publishDir)\CBS\winmd'
       githubToken: $(WinUI2GitHubToken)


### PR DESCRIPTION
tsaoptions.json configures automated bug filing for issues found by scanning tools running in the Pipeline.
The AzDO areapath we use has been updated recently, so we update the file to reflect that.

Also update PkgESVPack to include a token that is now required for this task to work.