### PR TITLE
Cherry-picking a NavigationView crash fix to 2.7

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -3,6 +3,8 @@
 
 #include "pch.h"
 #include "common.h"
+#include <mutex>
+#include <thread>
 
 #include "NavigationView.h"
 #include "Vector.h"
@@ -179,6 +181,7 @@ void NavigationView::UnhookEventsAndClearFields(bool isFromDestructor)
     {
         m_selectionChangedRevoker.revoke();
         m_autoSuggestBoxQuerySubmittedRevoker.revoke();
+        ClearAllNavigationViewItemRevokers();
     }
 }
 
@@ -220,13 +223,15 @@ NavigationView::NavigationView()
 
     m_navigationViewItemsFactory = winrt::make_self<NavigationViewItemsFactory>();
 
-    s_NavigationViewItemRevokersProperty =
-        InitializeDependencyProperty(
-            L"NavigationViewItemRevokers",
-            winrt::name_of<winrt::IInspectable>(),
-            winrt::name_of<winrt::NavigationViewItem>(),
-            true /* isAttached */,
-            nullptr /* defaultValue */);
+    std::call_once(s_NavigationViewItemRevokersPropertySet, [this]() {
+        s_NavigationViewItemRevokersProperty =
+            InitializeDependencyProperty(
+                L"NavigationViewItemRevokers",
+                winrt::name_of<winrt::IInspectable>(),
+                winrt::name_of<winrt::NavigationViewItem>(),
+                true /* isAttached */,
+                nullptr /* defaultValue */);
+        });
 }
 
 void NavigationView::OnSelectionModelChildrenRequested(const winrt::SelectionModel& selectionModel, const winrt::SelectionModelChildrenRequestedEventArgs& e)
@@ -1253,14 +1258,7 @@ void NavigationView::OnRepeaterElementPrepared(const winrt::ItemsRepeater& ir, c
             }();
             winrt::get_self<NavigationViewItem>(nvi)->PropagateDepthToChildren(childDepth);
 
-            // Register for item events
-            auto nviRevokers = winrt::make_self<NavigationViewItemRevokers>();
-            nviRevokers->tappedRevoker = nvi.Tapped(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemTapped });
-            nviRevokers->keyDownRevoker = nvi.KeyDown(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemKeyDown });
-            nviRevokers->gotFocusRevoker = nvi.GotFocus(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemOnGotFocus });
-            nviRevokers->isSelectedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItemBase::IsSelectedProperty(), { this, &NavigationView::OnNavigationViewItemIsSelectedPropertyChanged });
-            nviRevokers->isExpandedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItem::IsExpandedProperty(), { this, &NavigationView::OnNavigationViewItemExpandedPropertyChanged });
-            nvi.SetValue(s_NavigationViewItemRevokersProperty, nviRevokers.as<winrt::IInspectable>());
+            SetNavigationViewItemRevokers(nvi);
         }
     }
 }
@@ -1295,8 +1293,7 @@ void NavigationView::OnRepeaterElementClearing(const winrt::ItemsRepeater& ir, c
         nvibImpl->IsTopLevelItem(false);
         if (auto nvi = nvib.try_as<winrt::NavigationViewItem>())
         {
-            // Revoke all the events that we were listing to on the item
-            nvi.SetValue(s_NavigationViewItemRevokersProperty, nullptr);
+            ClearNavigationViewItemRevokers(nvi);
         }
     }
 }

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -190,6 +190,11 @@ private:
     void ClearAllNavigationViewItemRevokers() noexcept;
     void RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects;
+    void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
+    void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
+    void ClearAllNavigationViewItemRevokers();
+    std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects{};
+    std::once_flag s_NavigationViewItemRevokersPropertySet;
 
     void InvalidateTopNavPrimaryLayout();
     // Measure functions for top navigation   

--- a/dev/NavigationView/NavigationView.h
+++ b/dev/NavigationView/NavigationView.h
@@ -189,10 +189,6 @@ private:
     void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
     void ClearAllNavigationViewItemRevokers() noexcept;
     void RevokeNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects;
-    void SetNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    void ClearNavigationViewItemRevokers(const winrt::NavigationViewItem& nvi);
-    void ClearAllNavigationViewItemRevokers();
     std::set<winrt::NavigationViewItem> m_itemsWithRevokerObjects{};
     std::once_flag s_NavigationViewItemRevokersPropertySet;
 

--- a/test/testinfra/AppTestAutomationHelpers/AppTestAutomationHelpers.vcxproj
+++ b/test/testinfra/AppTestAutomationHelpers/AppTestAutomationHelpers.vcxproj
@@ -10,7 +10,7 @@
     <ProjectName>AppTestAutomationHelpers</ProjectName>
     <RootNamespace>AppTestAutomationHelpers</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
@@ -58,6 +58,7 @@
     <PlatformToolset>v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>


### PR DESCRIPTION
This cherry-picks #6240 to 2.7, which is needed to fix a crash related to NavigationView.