### PR TITLE
Fix building with Visual Studio 2022

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,5 +25,7 @@
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
     <GeneratedFilesDir>$(BaseIntermediateOutputPath)Generated Files\</GeneratedFilesDir>
     <GenerateProjectSpecificOutputFolder>True</GenerateProjectSpecificOutputFolder>
+    
+    <UwpUnitTestSdkPkgVersion>16.7.1</UwpUnitTestSdkPkgVersion>
   </PropertyGroup>
 </Project>

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1352,7 +1352,7 @@ bool TabView::MoveFocus(bool moveForward)
 
     // At this point, we know that the focused control is indeed in the focus list, so we'll move focus to the next or previous control in the list.
 
-    int sourceIndex = static_cast<int>(position - focusOrderList.begin());
+    const int sourceIndex = static_cast<int>(position - focusOrderList.begin());
     const int listSize = static_cast<int>(focusOrderList.size());
     const int increment = moveForward ? 1 : -1;
     int nextIndex = sourceIndex + increment;

--- a/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
+++ b/test/IXMPTestApp/MSTest/IXMPTestApp.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.1.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(UwpUnitTestSdkPkgVersion)" Condition="'$(VisualStudioVersion)' &lt;= '16.0'" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/test/MUXControls.Test/MUXControls.Test.Shared.targets
+++ b/test/MUXControls.Test/MUXControls.Test.Shared.targets
@@ -44,7 +44,6 @@
   <Import Project="..\..\dev\PagerControl\InteractionTests\PagerControl_InteractionTests.projitems" Label="Shared" Condition="$(FeaturePagerControlEnabled) == 'true'" />
   <Import Project="..\..\dev\PipsPager\InteractionTests\PipsPager_InteractionTests.projitems" Label="Shared" Condition="$(FeaturePipsPagerEnabled) == 'true'" />
   <Import Project="..\..\dev\ImageIcon\InteractionTests\ImageIcon_InteractionTests.projitems" Label="Shared" Condition="$(FeatureImageIconEnabled) == 'true'" />
-  <Import Project="..\..\dev\PipsPager\InteractionTests\PipsPager_InteractionTests.projitems" Label="Shared" Condition="$(FeatureNumberBoxEnabled) == 'true'" />
   <Import Project="..\..\dev\Breadcrumb\InteractionTests\Breadcrumb_InteractionTests.projitems" Label="Shared" Condition="$(FeatureBreadcrumbEnabled) == 'true'" />
   <Import Project="..\..\dev\InfoBadge\InteractionTests\InfoBadge_InteractionTests.projitems" Label="Shared" Condition="$(FeatureInfoBadgeEnabled) == 'true'" />
   <Import Project="..\..\dev\WebView2\InteractionTests\WebView2_InteractionTests.projitems" Label="Shared" Condition="$(FeatureWebView2Enabled) == 'true'" />

--- a/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
+++ b/test/MUXControlsTestApp/MSTest/MUXControlsTestApp.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.1.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(UwpUnitTestSdkPkgVersion)" Condition="'$(VisualStudioVersion)' &lt;= '16.0'" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Visual Studio 2022 added implicit includes of the Microsoft.NET.Test.Sdk package, which broke the WinUI 2 build there.  I've fixed that by adding a define for `UwpUnitTestSdkPkgVersion`, which is what VS 2022 uses to know what version of the package to pick up, and have made us explicitly add Microsoft.NET.Test.Sdk only in pre-2022 versions of VS.

I also fixed a couple warnings that were also preventing a clean build.