### PR TITLE
New api spec : Window.AppWindow api

### DIFF
--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -70,7 +70,7 @@ New subclassing order with this new feature change:
   &darr;
 * AppWindow  
   &darr;
-* Xaml DesktopWindow (WinUI's main WndProc)  
+* Xaml Window
 &darr;
 * DefaultWndProc
 

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -14,7 +14,7 @@ You can get an AppWindow from a Xaml Window by calling a COM API to get Xaml and
 
 ## Window.AppWindow property
 
-This newly introduced api will allow developers to use appwindow object directly within WinUI code.
+Gets the `AppWindow` associated with this `Window`.
 ```c#
 public Microsoft.UI.Windowing.AppWindow Window.AppWindow { get; }
 ```

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -1,26 +1,23 @@
 Window.AppWindow api
 ===
-New api to simplify accessing [appwindow](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/windowing/windowing-overview) functionality through WinUI code
+New api to simplify accessing [appwindow](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/windowing/windowing-overview)
+functionality through WinUI code
 
 # Background
-Xaml has a [Window](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Window) API that internally wraps an hwnd. Windows has an [AppWindow](https://docs.microsoft.com/uwp/api/Windows.UI.WindowManagement.AppWindow) class that similarly wraps an hwnd in UWP. WinAppSDK has a new [AppWindow](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Windowing.AppWindow) which wraps an hwnd and works on Desktop.
+Xaml has a [Window](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Window) API that
+internally wraps an hwnd. Windows has an [AppWindow](https://docs.microsoft.com/uwp/api/Windows.UI.WindowManagement.AppWindow) class
+that similarly wraps an hwnd in UWP. WinAppSDK has a new [AppWindow](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Windowing.AppWindow) which wraps an hwnd and works on Desktop.
 
-You can get an AppWindow from a Xaml Window by calling a COM API to get Xaml and then a DLL export API to convert the hwnd to an AppWindow. This spec adds a simple `Window.AppWindow` property to make this much easier and more discoverable.
+You can get an AppWindow from a Xaml Window by calling a COM API to get Xaml and then
+a DLL export API to convert the hwnd to an AppWindow. This spec adds a simple `Window.AppWindow`
+property to make this much easier and more discoverable.
 
-[Xaml Window](https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window) will expose AppWindow object directly to app developer through an api. Instead of writing a lot of boiler plate code everywhere, app developer can use this api, reducing code bloat, and making appwindow apis easily accessible from winui code.
+[Xaml Window](https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window) will
+expose AppWindow object directly to app developer through an api. Instead of writing a lot of boiler plate
+code everywhere, app developer can use this api, reducing code bloat, and making appwindow apis easily
+accessible from winui code.
 
-
-# API Pages
-
-## Window.AppWindow property
-
-Gets the `AppWindow` associated with this `Window`.
-```c#
-public Microsoft.UI.Windowing.AppWindow Window.AppWindow { get; }
-```
-_Spec note: Mapping an hwnd to an AppWindow causes the hwnd to be subclassed, meaning that the timing of when [AppWindow.GetFromWindowId](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Windowing.AppWindow.GetFromWindowId) is first called can potentially have a behavioral side effect. To ensure this is predictable, the AppWindow for Xaml's hwnd will be created during the Xaml Window's construction. Note that this could potentially be an observable behavior change from the behavior before the introduction of this API._
 These *before* and *after* C# code examples illustrate how this api simplifies integrating appwindow apis in winui codebase.
-
 
 ### Before
 ```c#
@@ -45,6 +42,27 @@ xamlWindow.AppWindow.foo();
 ```
 Notice how `xamlWindow.AppWindow.foo()` doesn't require additional steps to call the function `foo`.
 
+
+# API Pages
+
+## Window.AppWindow property
+
+Gets the `AppWindow` associated with this `Window`.
+```c#
+public Microsoft.UI.Windowing.AppWindow Window.AppWindow { get; }
+```
+_Spec note: Mapping an hwnd to an AppWindow causes the hwnd to be subclassed, meaning that the timing of
+when [AppWindow.GetFromWindowId](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Windowing.AppWindow.GetFromWindowId)
+is first called can potentially have a behavioral side effect. To ensure this is predictable, the AppWindow
+for Xaml's hwnd will be created during the Xaml Window's construction. Note that this could potentially be
+an observable behavior change from the behavior before the introduction of this API.
+
+### Sample example
+```c#
+var xamlWindow = WindowHelper.GetWindowForElement(this);   
+auto windowSize = xamlWindow.AppWindow.Size;  
+```
+
 # API Details
 
 ```c# (but really MIDL3)
@@ -59,12 +77,16 @@ namespace Microsoft.UI.Xaml
 ```
 
 # Appendix
-- Window.AppWindow api returns reference to the same appwindow object every time. It gets created during xaml window object's creation.
+- Window.AppWindow api returns reference to the same appwindow object every time. It gets created
+  during xaml window object's creation.
 
+- Since AppWindow is just an abstraction for HWND, its lifetime will be same as that of HWND. The
+  api cannot return null as AppWindow will always be present if Window object is there. If called after
+  window has been closed, it will fail similarly to other winui apis and return a failure HRESULT. 
 
-- Since AppWindow is just an abstraction for HWND, its lifetime will be same as that of HWND. The api cannot return null as AppWindow will always be present if Window object is there. If called after window has been closed, it will fail similarly to other winui apis and return a failure HRESULT. 
+- There will be just one appwindow object per top level HWND, created during Window object creation.
+  No new appwindow objects are created for child windows. 
 
-- There will be just one appwindow object per top level HWND, created during Window object creation. No new appwindow objects are created for child windows. 
-
-- Future scope : Since this api is limited to top level HWND, there should be a way to get app window object for top level HWND from one of its nested children HWND which doesn’t require app developer writing a lot of code. 
+- Future scope : Since this api is limited to top level HWND, there should be a way to get app window object
+  for top level HWND from one of its nested children HWND which doesn’t require app developer writing a lot of code. 
 

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -70,11 +70,10 @@ New subclassing order with this new feature change:
   &darr;
 * AppWindow  
   &darr;
-* Xaml Window
+* Xaml Window  
 &darr;
 * DefaultWndProc
 
-This order can change later.
 
 # API Details
 

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -1,11 +1,11 @@
 Window.AppWindow api
 ===
-New api to simplify accessing appwindow through WinUI code
+New api to simplify accessing [appwindow](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/windowing/windowing-overview) functionality through WinUI code
 
 # Background
 AppWindow provides good set of functionalities for using HWNDs than dealing with win32 apis directly. It is already accessible to winui desktop apps via winappsdk runtime. Currently, users must write a lot of boiler plate code to get to appwindow object and use it. 
 
-Xaml Window will expose AppWindow object directly to app developer through an api. Instead of writing a lot of boiler plate code everywhere, app developer can use this api, reducing code bloat, and making appwindow apis easily accessible from winui code.
+[Xaml Window](https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window) will expose AppWindow object directly to app developer through an api. Instead of writing a lot of boiler plate code everywhere, app developer can use this api, reducing code bloat, and making appwindow apis easily accessible from winui code.
 
 
 # API Pages
@@ -41,7 +41,7 @@ var xamlWindow = WindowHelper.GetWindowForElement(this /* some Xaml UIElement */
 //calling function foo directly
 xamlWindow.AppWindow.foo();  
 ```
-Notice how `xamlWindow.AppWindow.foo()` doesn't require additional steps of storing a ref to appwindow object to call the function `foo`.
+Notice how `xamlWindow.AppWindow.foo()` doesn't require additional steps to call the function `foo`.
 
 # API Details
 
@@ -57,11 +57,12 @@ namespace Microsoft.UI.Xaml
 ```
 
 # Appendix
-- Window.AppWindow api returns reference to the same appwindow object every time. 
+- Window.AppWindow api returns reference to the same appwindow object every time. It gets created during xaml window object's creation.
+
 
 - Since AppWindow is just an abstraction for HWND, its lifetime will be same as that of HWND. The api cannot return null as AppWindow will always be present if Window object is there. If called after window has been closed, it will fail similarly to other winui apis and return a failure HRESULT. 
 
 - There will be just one appwindow object per top level HWND, created during Window object creation. No new appwindow objects are created for child windows. 
 
-- Since this api is limited to top level HWND, there should be a way to get app window object for top level HWND from one of its nested children HWND which doesn’t require app developer writing a lot of code. 
+- Future scope : Since this api is limited to top level HWND, there should be a way to get app window object for top level HWND from one of its nested children HWND which doesn’t require app developer writing a lot of code. 
 

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -18,7 +18,7 @@ This newly introduced api will allow developers to use appwindow object directly
 ```c#
 public Microsoft.UI.Windowing.AppWindow Window.AppWindow { get; }
 ```
-
+_Spec note: Mapping an hwnd to an AppWindow causes the hwnd to be subclassed, meaning that the timing of when [AppWindow.GetFromWindowId](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Windowing.AppWindow.GetFromWindowId) is first called can potentially have a behavioral side effect. To ensure this is predictable, the AppWindow for Xaml's hwnd will be created during the Xaml Window's construction. Note that this could potentially be an observable behavior change from the behavior before the introduction of this API._
 These *before* and *after* C# code examples illustrate how this api simplifies integrating appwindow apis in winui codebase.
 
 

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -1,0 +1,67 @@
+Window.AppWindow api
+===
+New api to simplify accessing appwindow through WinUI code
+
+# Background
+AppWindow provides good set of functionalities for using HWNDs than dealing with win32 apis directly. It is already accessible to winui desktop apps via winappsdk runtime. Currently, users must write a lot of boiler plate code to get to appwindow object and use it. 
+
+Xaml Window will expose AppWindow object directly to app developer through an api. Instead of writing a lot of boiler plate code everywhere, app developer can use this api, reducing code bloat, and making appwindow apis easily accessible from winui code.
+
+
+# API Pages
+
+## Window.AppWindow property
+
+This newly introduced api will allow developers to use appwindow object directly within WinUI code.
+```c#
+public Microsoft.UI.Windowing.AppWindow Window.AppWindow { get; }
+```
+
+These *before* and *after* C# code examples illustrate how this api simplifies integrating appwindow apis in winui codebase.
+
+
+### Before
+```c#
+// This is needed to get any Window from inside a Xaml control 
+var xamlWindow = WindowHelper.GetWindowForElement(this /* some Xaml UIElement */);   
+
+// unnecessary boiler plate code 
+var windowId = Win32Interop.GetWindowIdFromWindow(WindowNative.GetWindowHandle(xamlWindow)); 
+var appWindow = AppWindow.GetFromWindowId(windowId); 
+
+//calling function foo  (not a real appwindow function)
+appWindow.foo();
+```
+
+### After
+```c#
+// This is needed to get any Window from inside a Xaml control 
+var xamlWindow = WindowHelper.GetWindowForElement(this /* some Xaml UIElement */);   
+
+//calling function foo directly
+xamlWindow.AppWindow.foo();  
+```
+Notice how `xamlWindow.AppWindow.foo()` doesn't require additional steps of storing a ref to appwindow object to call the function `foo`.
+
+# API Details
+
+```c# (but really MIDL3)
+namespace Microsoft.UI.Xaml
+{
+   unsealed runtimeclass Window
+  {
+      ...
+      Microsoft.UI.Windowing.AppWindow AppWindow{ get; };
+  }
+}
+```
+
+# Appendix
+- Window.AppWindow api returns reference to the same appwindow object every time. 
+
+- Since AppWindow is just an abstraction for HWND, its lifetime will be same as that of HWND. The api cannot return null as AppWindow will always be present if Window object is there. If called after window has been closed, it will fail similarly to other winui apis and return a failure HRESULT. 
+
+- There will be just one appwindow object per top level HWND, created during Window object creation. No new appwindow objects are created for child windows. 
+
+- Since this api is limited to top level HWND, there should be a way to get app window object for top level HWND from one of its nested children HWND which doesn’t require app developer writing a lot of code. 
+

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -22,7 +22,7 @@ These *before* and *after* C# code examples illustrate how this api simplifies i
 ### Before
 ```c#
 // This is needed to get any Window from inside a Xaml control 
-var xamlWindow = WindowHelper.GetWindowForElement(this /* some Xaml UIElement */);   
+var xamlWindow = WindowHelper.GetWindowForElement(this); // api to get window object from UIElement (not a real api)  
 
 // unnecessary boiler plate code 
 var windowId = Win32Interop.GetWindowIdFromWindow(WindowNative.GetWindowHandle(xamlWindow)); 
@@ -35,7 +35,8 @@ appWindow.foo();
 ### After
 ```c#
 // This is needed to get any Window from inside a Xaml control 
-var xamlWindow = WindowHelper.GetWindowForElement(this /* some Xaml UIElement */);   
+var xamlWindow = WindowHelper.GetWindowForElement(this); // api to get window object from UIElement (not a real api)  
+   
 
 //calling function foo directly
 xamlWindow.AppWindow.foo();  

--- a/specs/appwindow-spec.md
+++ b/specs/appwindow-spec.md
@@ -3,7 +3,9 @@ Window.AppWindow api
 New api to simplify accessing [appwindow](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/windowing/windowing-overview) functionality through WinUI code
 
 # Background
-AppWindow provides good set of functionalities for using HWNDs than dealing with win32 apis directly. It is already accessible to winui desktop apps via winappsdk runtime. Currently, users must write a lot of boiler plate code to get to appwindow object and use it. 
+Xaml has a [Window](https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Window) API that internally wraps an hwnd. Windows has an [AppWindow](https://docs.microsoft.com/uwp/api/Windows.UI.WindowManagement.AppWindow) class that similarly wraps an hwnd in UWP. WinAppSDK has a new [AppWindow](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Windowing.AppWindow) which wraps an hwnd and works on Desktop.
+
+You can get an AppWindow from a Xaml Window by calling a COM API to get Xaml and then a DLL export API to convert the hwnd to an AppWindow. This spec adds a simple `Window.AppWindow` property to make this much easier and more discoverable.
 
 [Xaml Window](https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window) will expose AppWindow object directly to app developer through an api. Instead of writing a lot of boiler plate code everywhere, app developer can use this api, reducing code bloat, and making appwindow apis easily accessible from winui code.
 


### PR DESCRIPTION
Spec PR to introduce a new Window.Appwindow api 
## Description
This spec PR introduces a new api for accessing appwindow object from mux code. More details are in the spec document itself.

## Motivation and Context
Mentioned in spec documented.
## Screenshots (if appropriate):
Code examples included in spec document.