### PR TITLE
Disable unreliable test RatingControlTests.MaxRatingTest

### DIFF
--- a/dev/RatingControl/InteractionTests/RatingControlTests.cs
+++ b/dev/RatingControl/InteractionTests/RatingControlTests.cs
@@ -126,6 +126,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("Ignore", "True")] // RatingControlTests.MaxRatingTest is unreliable #7668
         public void MaxRatingTest()
         {
             using (var setup = new TestSetupHelper("RatingControl Tests")) // This clicks the button corresponding to the test page, and navs there


### PR DESCRIPTION
This failure keeps showing up in failed Pipeline runs. Disabling this test for now. Issue is tracked by: RatingControlTests.MaxRatingTest is unreliable #7668