### PR TITLE
Fix navigation button size

### DIFF
--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -1818,7 +1818,7 @@ void NavigationView::UpdatePaneButtonsWidths()
     }();
  
     templateSettings->PaneToggleButtonWidth(newButtonWidths);
-    templateSettings->SmallerPaneToggleButtonWidth(std::max(0.0, newButtonWidths - 8));
+    templateSettings->SmallerPaneToggleButtonWidth(std::max(0.0, newButtonWidths));
 }
 
 void NavigationView::OnBackButtonClicked(const winrt::IInspectable& sender, const winrt::RoutedEventArgs& args)

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -241,7 +241,7 @@
     <Thickness x:Key="NavigationViewAutoSuggestBoxMargin">16,0</Thickness>
     <Thickness x:Key="TopNavigationViewAutoSuggestBoxMargin">4,0</Thickness>
     <x:Double x:Key="PaneToggleButtonHeight">36</x:Double>
-    <x:Double x:Key="PaneToggleButtonWidth">40</x:Double>
+    <x:Double x:Key="PaneToggleButtonWidth">48</x:Double>
     <x:Double x:Key="NavigationViewCompactPaneLength">48</x:Double>
     <x:Double x:Key="NavigationViewIconBoxWidth">40</x:Double>
     <x:Double x:Key="NavigationViewTopPaneHeight">48</x:Double>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to fix the "Open/Close Navigation" button size.

## Motivation and Context
The current button size causes the button to look cut off and misaligned.

## How Has This Been Tested?
Changing the Width of the button in an app experiencing this issue using XAML Live Property Explorer + Live Visual Tree.

## Screenshots (if appropriate):
**Current width:**
<img width="145" alt="image" src="https://user-images.githubusercontent.com/29563098/189366567-359b8048-0c87-46fe-a988-26abb5ba576a.png">

**Fixed width:**
<img width="157" alt="image" src="https://user-images.githubusercontent.com/29563098/189366918-9b9bd76e-9a0b-44bf-b5c7-b04dfeedfdad.png">
