### PR TITLE
Cherry-Pick: WinUI Vpack: Include re-merged winmd

### DIFF
--- a/build/CreateCBSVPack.ps1
+++ b/build/CreateCBSVPack.ps1
@@ -52,6 +52,23 @@ function Get-WebView2PackageVersion {
     return $webView2Version
 }
 
+function RemergeWinMd([string] $winmdSourceFolder, [string] $winmdTargetFolder, [string] $winmdReferencesDir)
+{
+    Write-Host "re-merge Microsoft.UI.Xaml.winmd"
+
+    New-Item -Path "$winmdTargetFolder" -ItemType Directory | Out-Null
+
+    # We need to re-merge Microsoft.UI.Xaml.winmd against the OS internal metadata instead of against the metadata from the public sdk:
+    $mdMergeArgs = "-v -metadata_dir ""$winmdReferencesDir"" -o ""$winmdTargetFolder"" -i ""$winmdSourceFolder"" -partial -n:3 -createPublicMetadata -transformExperimental:transform"
+    Write-Host "mdmerge $mdMergeArgs"
+    Invoke-Expression "mdmerge $mdMergeArgs" | Out-Null
+    if($LASTEXITCODE)
+    {
+        Write-Error "mdmerge exited with error ($LASTEXITCODE)"
+        exit
+    }
+}
+
 if (-not (Test-Path "$releaseFolder"))
 {
     Write-Error "Not found folder $releaseFolder"
@@ -71,7 +88,7 @@ if(!(Get-Command mdmerge -ErrorAction Ignore))
 }
 $winuiVpackFolder = "$releaseFolder\WinUIVpack"
 $cbsFolder = "$releaseFolder\CBS"
-$winmdFolder = "$cbsFolder\winmd"
+$cbswinmdFolder = "$cbsFolder\winmd"
 $packagesDir = Join-Path $repoRoot "packages"
 $winmdReferencesDir = Join-Path $repoRoot "winmdreferences"
 
@@ -95,7 +112,6 @@ if (Test-Path $winmdReferencesDir)
 
 New-Item -Path "$winuiVpackFolder" -ItemType Directory | Out-Null
 New-Item -Path "$cbsFolder" -ItemType Directory | Out-Null
-New-Item -Path "$winmdFolder" -ItemType Directory | Out-Null
 New-Item -Path "$winmdReferencesDir" -ItemType Directory | Out-Null
 
 Write-Host "Copy OS publics to $winmdReferencesDir"
@@ -123,7 +139,9 @@ foreach ($flavour in $buildFlavours)
 foreach ($flavour in $buildFlavours) 
 {
     $sourceFolder = "$releaseFolder\$flavour\FrameworkPackage"
+    $winmdSourceFolder = "$releaseFolder\$flavour\Microsoft.UI.Xaml\sdk"
     $targetFolder = "$winuiVpackFolder\$flavour"
+    $winmdTargetFolder = "$winuiVpackFolder\winmd"
 
     New-Item -Path "$targetFolder" -ItemType Directory | Out-Null
 
@@ -142,6 +160,11 @@ foreach ($flavour in $buildFlavours)
 
     Write-Verbose "Copy item from '$sourcePathFull' to '$destPathFull' "
     Copy-Item $sourcePathFull $destPathFull
+
+    if ($flavour -ieq "X64")
+    {
+        RemergeWinMd $winmdSourceFolder $winmdTargetFolder $winmdReferencesDir
+    }
 }
 
 # Create CBS Vpacks:
@@ -161,17 +184,7 @@ foreach ($flavour in $buildFlavours)
 
     if ($flavour -ieq "X64")
     {
-        Write-Host "re-merge Microsoft.UI.Xaml.winmd"
-
-        # We need to re-merge Microsoft.UI.Xaml.winmd against the OS internal metadata instead of against the metadata from the public sdk:
-        $mdMergeArgs = "-v -metadata_dir ""$winmdReferencesDir"" -o ""$winmdFolder"" -i ""$targetFolder"" -partial -n:3 -createPublicMetadata -transformExperimental:transform"
-        Write-Host "mdmerge $mdMergeArgs"
-        Invoke-Expression "mdmerge $mdMergeArgs" | Out-Null
-        if($LASTEXITCODE)
-        {
-            Write-Error "mdmerge exited with error ($LASTEXITCODE)"
-            exit
-        }
+        RemergeWinMd $targetFolder $cbswinmdFolder $winmdReferencesDir
     }
 }
 


### PR DESCRIPTION
Cherry-pick #7179 to release/2.7 branch.

This is required so that when we create a new 2.7 framework package the vpack contains a usable .winmd.

Full details in original PR: #7179