### PR TITLE
Fix nullptr dereferencing in RadioMenuFlyoutItem destructor

### DIFF
--- a/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
+++ b/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
@@ -27,7 +27,7 @@ RadioMenuFlyoutItem::RadioMenuFlyoutItem()
 RadioMenuFlyoutItem::~RadioMenuFlyoutItem()
 {
     // If this is the checked item, remove it from the lookup.
-    if (m_isChecked)
+    if (m_isChecked && s_selectionMap)
     {
         SharedHelpers::EraseIfExists(*s_selectionMap, m_groupName);
     }


### PR DESCRIPTION
## Description
This prevents dereferencing a null s_selectionMap if final_release fails to destroy the RadioMenuFlyoutItem on the UI thread. 

The fix was to add a null-check to prevent accessing the s_selectionMap if it is not set. This means an entry for that groupName will not be cleared, which is a minimal "leak" as the number of entries is bound by the amount of groups. 

## Motivation and Context
This can happen if the destructor is called on a thread different than the UI thread, e.g. C# garbage collection, and that the UI thread is no longer available. This will result in a crash when dereferencing a null s_selectionMap as it is static local_thread.

## How Has This Been Tested?
Seeing as it is tricky to reproduce the issue, I have simply verified that the null checks work by manually forcing it to null programatically.