### PR TITLE
NavigationViewItem add child item fix

### DIFF
--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -330,6 +330,7 @@ void NavigationViewItem::OnInfoBadgePropertyChanged(const winrt::DependencyPrope
 void NavigationViewItem::OnMenuItemsVectorChanged(const winrt::Collections::IObservableVector<winrt::IInspectable>& sender, const winrt::Collections::IVectorChangedEventArgs& args)
 {
     LoadElementsForDisplayingChildren();
+    UpdateRepeaterItemsSource();
 }
 
 void NavigationViewItem::OnMenuItemsPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -1812,6 +1812,29 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         }
 
         [TestMethod]
+        public void VerifyAddingChildItemsToNavigationViewItem()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView Markup Test" }))
+            {
+                Log.Comment("Verify MI19 does not have the child we are going to look for.");
+                var childItem = FindElement.ByName("Child of MI19");
+                Verify.IsNull(childItem, "MI19 should not have this child item.");
+
+                Log.Comment("Programmatically add a child item to MI19.");
+                FindElement.ByName<Button>("Add Child Item to MenuItem19").Invoke();
+
+                Log.Comment("Expand MI19.");
+                var menuItem19 = FindElement.ByName("Menu Item 19");
+                InputHelper.LeftClick(menuItem19);
+                Wait.ForIdle();
+
+                Log.Comment("Verify MI19 has the child item we just added.");
+                var newChildItem = FindElement.ByName("Child of MI19");
+                Verify.IsNotNull(newChildItem, "MI19 should have a new child item.");
+            }
+        }
+
+        [TestMethod]
         public void VerifyNavigationViewItemInPaneFooterHasTemplateSettingBindings()
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "PaneFooterTestPage" }))

--- a/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -1816,7 +1816,13 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
         {
             using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView Markup Test" }))
             {
-                Log.Comment("Verify MI19 does not have the child we are going to look for.");
+                Log.Comment("Verify MI19 does not have the child item we are going to look for.");
+
+                Log.Comment("Click on MI19.");
+                var menuItem19 = FindElement.ByName("Menu Item 19");
+                InputHelper.LeftClick(menuItem19);
+                Wait.ForIdle();
+
                 var childItem = FindElement.ByName("Child of MI19");
                 Verify.IsNull(childItem, "MI19 should not have this child item.");
 
@@ -1824,7 +1830,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTests
                 FindElement.ByName<Button>("Add Child Item to MenuItem19").Invoke();
 
                 Log.Comment("Expand MI19.");
-                var menuItem19 = FindElement.ByName("Menu Item 19");
                 InputHelper.LeftClick(menuItem19);
                 Wait.ForIdle();
 

--- a/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewMarkup.xaml
+++ b/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewMarkup.xaml
@@ -86,6 +86,7 @@
                 <Button Content="Get Selected Item Label" x:Name="GetSelectedItemLabelButton" AutomationProperties.Name="GetSelectedItemLabelButton" Click="PrintSelectedItem"/>
                 <Button Content="Collapse Selected Item" Click="CollapseSelectedItem"/>
                 <Button Content="Remove Second MenuItem" Click="RemoveSecondMenuItem"/>
+                <Button Content="Add Child Item to MenuItem19" Click="AddChildItemToMI19"/>
                 <TextBlock x:Name="IsChildSelectedLabel" AutomationProperties.Name="IsChildSelectedLabel" Text="uninitialized"/>
                 <Button AutomationProperties.Name="PrintTopLevelIsChildSelectedItemsButton" Content="Print TopLevel IsChildSelected Items" Click="PrintTopLevelIsChildSelectedItems"/>
                 <Button Content="Select Second Item" Click="SelectSecondItem"/>

--- a/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewMarkup.xaml.cs
+++ b/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewMarkup.xaml.cs
@@ -56,6 +56,16 @@ namespace MUXControlsTestApp
             navview.MenuItems.RemoveAt(2);
         }
 
+        private void AddChildItemToMI19(object sender, RoutedEventArgs e)
+        {
+            MI19.MenuItems.Add(CreateMenuItem("Child of MI19"));
+        }
+
+        private NavigationViewItem CreateMenuItem(string title)
+        { 
+            return new NavigationViewItem{ Content = title };
+        }
+
         private void PrintTopLevelIsChildSelectedItems(object sender, RoutedEventArgs e)
         {
             string itemstring = "";


### PR DESCRIPTION
## Description
Fixed scenario where adding a child item to a NVI was not resulting it in being displayed. 

## Motivation and Context
Fixes #7533 

## How Has This Been Tested?
Added an interaction test for the scenario.