### PR TITLE
Instrument ReferenceTracker cleanup to try to catch double delete crashes

### DIFF
--- a/dev/inc/DispatcherHelper.h
+++ b/dev/inc/DispatcherHelper.h
@@ -77,6 +77,7 @@ public:
     }
 
     auto DispatcherQueue() { return dispatcherQueue; }
+    auto CoreDispatcher() { return coreDispatcher; }
 
 private:
     winrt::Windows::System::DispatcherQueue dispatcherQueue{ nullptr };

--- a/dev/inc/RuntimeClassHelpers.h
+++ b/dev/inc/RuntimeClassHelpers.h
@@ -148,7 +148,7 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
             // We're not on the UI thread
             auto instance = static_cast<ReferenceTracker<D, ImplT, I...>*>(self.release());
             instance->m_dispatcherHelper.RunAsync(
-                [instance, loggingState](bool)
+                [instance, loggingState]()
                 {
                     if (loggingState->runCount++ == 0)
                     {

--- a/dev/inc/RuntimeClassHelpers.h
+++ b/dev/inc/RuntimeClassHelpers.h
@@ -134,14 +134,13 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
     // return false.  If we're off the UI thread but can't get to it, then do the DeleteInstance() here (asynchronously).
     static void DeleteInstanceOnUIThread(std::unique_ptr<D>&& self) noexcept
     {
-        bool queued = false;
-        
         // See if we're on the UI thread
         if(!self->IsOnThread())
         {
             struct LoggingState
             {
                 void* dispatcherQueueWhenLambdaRan{ nullptr };
+                void* coreDispatcherWhenLambdaRan{ nullptr };
                 std::atomic<int> runCount;
             };
             auto loggingState = std::make_shared<LoggingState>();
@@ -153,6 +152,7 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
                     if (loggingState->runCount++ == 0)
                     {
                         loggingState->dispatcherQueueWhenLambdaRan = winrt::get_abi(instance->m_dispatcherHelper.DispatcherQueue());
+                        loggingState->coreDispatcherWhenLambdaRan = winrt::get_abi(instance->m_dispatcherHelper.CoreDispatcher());
                         delete instance;
                     }
                     else


### PR DESCRIPTION
We're seeing sporadic double delete crashes in the vicinity of ReferenceTracker's DeleteInstanceOnUIThread cleanup lambda. My best guess (supported by some appverifier pageheap instrumented crashes) is that the lambda is running twice -- both on the .NET GC thread, but also on the UI thread.

I don't see any way this could happen unless DispatcherQueue.TryEnqueue is returning false but then also running the lambda, but that also doesn't seem plausible from looking at the TryEnqueue code.

At this point we think we need to instrument this cleanup code to get closer to the source of the problem. Initially I tried to rewrite this code so that we never delete on the GC thread, but there are legitimate scenarios where a .NET caller could hold objects alive beyond the lifetime of the UI thread / DispatcherQueue, and it would be best if we don't leak in those scenarios.

Just to keep things simple, I've changed the lambda to keep track of the state when it was run so that if it in gets run a second time we'll have information about what happened the first time through. Also this will crash instead of corrupting the heap.

The simplest way to do this is to allocate another blob of shared state to track this -- I'm open to suggestions about how to do this without needing another heap allocation though.