### PR TITLE
Disable WebView2Tests.EdgeProcessFailedTest and ColorPickerTests.ValidateFractionalWidthDoesNotCrash

### DIFF
--- a/dev/ColorPicker/APITests/ColorPickerTests.cs
+++ b/dev/ColorPicker/APITests/ColorPickerTests.cs
@@ -234,6 +234,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        [TestProperty("Ignore", "True")] // Bug 42204580
         public void ValidateFractionalWidthDoesNotCrash()
         {
             ColorSpectrum colorSpectrum = null;

--- a/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -2679,6 +2679,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
         [TestMethod]
         [TestProperty("TestSuite", "D")]
+        [TestProperty("Ignore", "True")] // Bug 42203617
         public void EdgeProcessFailedTest()
         {
             using (var setup = new WebView2TestSetupHelper(new[] { "WebView2 Tests", "navigateToCoreObjectsWebView2" }))


### PR DESCRIPTION
This test is failing in main and is blocking PRs. Filed Bug 42203617 to track this.