### PR TITLE
Adjust apiset fallback for user32 dependencies in WebView2

### DIFF
--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -29,10 +29,10 @@ static constexpr wstring_view s_error_cwv2_not_present_closed{ L"Failed because 
 
 WebView2::WebView2()
 {
-    auto user32module = GetModuleHandleW(L"user32.dll");
+    auto user32module = GetModuleHandleW(L"ext-ms-win-rtcore-webview-l1-1-0.dll");
     if (!user32module)
     {
-        user32module = GetModuleHandleW(L"ext-ms-win-rtcore-webview-l1-1-0.dll");
+        user32module = GetModuleHandleW(L"user32.dll");
     }
 
     if (user32module)


### PR DESCRIPTION
Reverse the order of the user32 apiset fallback. If the app had already loaded a user32 forwarder, it was trying to use the wrong module.