### PR TITLE
Fix PR template to stop linking to old PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 <!--- If it fixes an open issue, please link to the issue here. -->
-<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
+<!--- Use the syntax "Closes #xxx" or "Fixes #xxx" so that GitHub will close the issue once the PR is complete. -->
 
 ## How Has This Been Tested?
 <!--- Please describe how you tested your changes. -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the user did not delete the comments, the new PR was always linked to 1234 and 5678.

## Motivation and Context
Change the template to not reference actual existing PRs, even in comments.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->