### PR TITLE
Use new windows.10.amd64.client.reunion Helix queues

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-RunHelixTests-Job.yml
@@ -21,8 +21,8 @@ parameters:
     Release_x64:
       buildPlatform: 'x64'
       buildConfiguration: 'release'
-      openHelixTargetQueues: 'Windows.10.Amd64.Client21H1.Open.xaml'
-      closedHelixTargetQueues: 'Windows.10.Amd64.Client21H1.xaml'
+      openHelixTargetQueues: 'windows.10.amd64.client.open.reunion'
+      closedHelixTargetQueues: 'windows.10.amd64.client.reunion'
 
 jobs:
 - job: ${{ parameters.name }}


### PR DESCRIPTION
We are switching over to use a new set of Helix queues.