### PR TITLE
Add instrumentation to help chase this double-delete crash

### DIFF
--- a/dev/inc/DispatcherHelper.h
+++ b/dev/inc/DispatcherHelper.h
@@ -76,6 +76,8 @@ public:
         }
     }
 
+    auto DispatcherQueue() { return dispatcherQueue; }
+
 private:
     winrt::Windows::System::DispatcherQueue dispatcherQueue{ nullptr };
     winrt::CoreDispatcher coreDispatcher{ nullptr };

--- a/dev/inc/DispatcherHelper.h
+++ b/dev/inc/DispatcherHelper.h
@@ -76,9 +76,6 @@ public:
         }
     }
 
-    auto DispatcherQueue() { return dispatcherQueue; }
-    auto CoreDispatcher() { return coreDispatcher; }
-
 private:
     winrt::Windows::System::DispatcherQueue dispatcherQueue{ nullptr };
     winrt::CoreDispatcher coreDispatcher{ nullptr };

--- a/dev/inc/RuntimeClassHelpers.h
+++ b/dev/inc/RuntimeClassHelpers.h
@@ -135,35 +135,24 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
     // return false.  If we're off the UI thread but can't get to it, then do the DeleteInstance() here (asynchronously).
     static void DeleteInstanceOnUIThread(std::unique_ptr<D>&& self) noexcept
     {
+        bool queued = false;
+        
         // See if we're on the UI thread
         if(!self->IsOnThread())
         {
-            struct LoggingState
-            {
-                void* dispatcherQueueWhenLambdaRan{ nullptr };
-                void* coreDispatcherWhenLambdaRan{ nullptr };
-                std::atomic<int> runCount;
-            };
-            auto loggingState = std::make_shared<LoggingState>();
             // We're not on the UI thread
-            auto instance = static_cast<ReferenceTracker<D, ImplT, I...>*>(self.release());
-            instance->m_dispatcherHelper.RunAsync(
-                [instance, loggingState]()
+            static_cast<ReferenceTracker<D, ImplT, I...>*>(self.get())->m_dispatcherHelper.RunAsync(
+                [instance = self.release()]()
                 {
-                    if (loggingState->runCount++ == 0)
-                    {
-                        loggingState->dispatcherQueueWhenLambdaRan = winrt::get_abi(instance->m_dispatcherHelper.DispatcherQueue());
-                        loggingState->coreDispatcherWhenLambdaRan = winrt::get_abi(instance->m_dispatcherHelper.CoreDispatcher());
-                        delete instance;
-                    }
-                    else
-                    {
-                        MUX_FAIL_FAST();
-                    }
+                    delete instance;
                 },
-                true /* fallbackToThisThread */);
+                true /*fallbackToThisThread*/);
+
+            queued = true;
         }
-        else
+        
+
+        if (!queued)
         {
             self.reset();
         }

--- a/dev/inc/RuntimeClassHelpers.h
+++ b/dev/inc/RuntimeClassHelpers.h
@@ -144,8 +144,6 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
         }
         me->m_destroying = true;
 
-        bool queued = false;
-        
         // See if we're on the UI thread
         if(!self->IsOnThread())
         {
@@ -156,12 +154,8 @@ struct ReferenceTracker : public ImplT<D, I ..., ::IReferenceTrackerExtension>, 
                     delete instance;
                 },
                 true /*fallbackToThisThread*/);
-
-            queued = true;
         }
-        
-
-        if (!queued)
+        else
         {
             self.reset();
         }


### PR DESCRIPTION
The last round of instrumentation disproved the previous theory, so I spent time trying to come up with a theory for what could cause this. It seems as though we're running through final_release twice so I want to try to catch the time when we're running through the second time before we have done the heap delete.

I've reverted the previous instrumentation and simplified to just adding an m_destroying field and a failfast assert in the destruction path.

My theory is that this is a use-after-free situation which looks like this:
1)	Starts with: Use-after-free-caller has a pointer to memory they shouldn’t…
2)	.NET caller gets a reference to a newly allocated 112-byte sized Iterator object 
3)	.NET user is done and drops its reference
4)	During the GC walk:
a.	Iterator object gets its final reference dropped (m_references = 0) and it is queued for deletion. At this point m_references is set to 1 as a sentinel.
b.	The user-after-free-caller zeros out the memory in our Iterator allocation – overwriting the m_references and dispatcherQueue fields.
c.	The XAML reference walk does an AddRef/Release on the Iterator. Normally this is fine: m_references goes 1->2->1 and nothing happens. But because we’re the victim of this heap corruption now m_references goes back to 0 and final_release gets called again, and because the dispatcherQueue field _also_ got zeroed, we fall back to calling delete right away!
5)	Later the deletion request happens on the UI thread and it tries to delete the Iterator but it already got deleted in 4c. 💥
