### PR TITLE
API review: XAML resource reference tracing

### DIFF
--- a/specs/api_spec_template.md
+++ b/specs/api_spec_template.md
@@ -1,2 +1,2 @@
 Please use this template for new/modified APIs:
-https://github.com/microsoft/ProjectReunion/blob/main/specs/spec_template.md
+https://github.com/microsoft/WindowsAppSDK/blob/main/specs/spec_template.md

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -48,8 +48,7 @@ when you want to see the raw message.
 
 ## DebugSettings.IsXamlResourceReferenceTracingEnabled Property
 
-Gets or sets a value that indicates whether to engage the XAML resource reference tracing feature 
-of Microsoft Visual Studio when the app runs.
+Gets or sets a value that indicates whether to raise the `XamlResourceReferenceFailed` event when a Xaml resource lookup fails.
 
 ```c# 
 public bool IsXamlResourceReferenceTracingEnabled { get; set; }

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -163,7 +163,7 @@ Finished search for resource with key 'OutputTextBlockStyl'.
 
 ## XamlResourceReferenceFailedEventArgs.Message Property
 
-A human-readable (in English) explanation of the XAML resource reference failure.
+A human-readable explanation (in English) of the XAML resource reference failure.
 
 ```c#
 public string Message { get; }

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -4,7 +4,7 @@ Tracing XAML resource reference lookup failures
 # Background
 
 Failure to resolve a XAML resource reference (`{StaticResource}` or `{ThemeResource}`) is one of 
-the most common causes of app crashes. Such failures manifest as a stowed exception with the 
+the most common causes of app crashes. Such failures manifest in the _native code_ debug output with the 
 message "Cannot find a Resource with the Name/Key *foo*", and generally fall into one of two 
 buckets:
 

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -5,7 +5,7 @@ Tracing XAML resource reference lookup failures
 
 A XAML resource is an item in a 
 [ResourceDictionary](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Xaml.ResourceDictionary)
-that can be referenced in markup with a `{StaticResource}` or `{ThemeResourcd}` reference.
+that can be referenced in markup with a `{StaticResource}` or `{ThemeResource}` reference.
 For example:
 
 ```xml

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -73,7 +73,7 @@ XamlResourceReferenceFailed
 
 `IsXamlResourceReferenceTracingEnabled` must be `true` in order for this event to be raised.
 
-Error information is also logged to the native debug output,
+Error information is also logged to the native debug output when the event is raised,
 so attaching a `XamlResourceReferenceFailed` handler yourself is an advanced scenario for 
 getting the raw message programmatically.
 
@@ -181,7 +181,6 @@ namespace Microsoft.UI.Xaml
 
   runtimeclass XamlResourceReferenceFailedEventArgs
   {
-    XamlResourceReferenceFailedEventArgs();
     String Message{ get; };
   };
 }

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -163,7 +163,7 @@ Finished search for resource with key 'OutputTextBlockStyl'.
 
 ## XamlResourceReferenceFailedEventArgs.Message Property
 
-A human-readable explanation of the XAML resource reference failure.
+A human-readable (in English) explanation of the XAML resource reference failure.
 
 ```c#
 public string Message { get; }

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -104,8 +104,8 @@ public sealed class XamlResourceReferenceFailedEventArgs
 
 ### Remarks
 
-`XamlResourceReferenceFailedEventArgs` is used for debugging XAML resource references. Wire the event 
-handler using `DebugSettings`, and use this data class as the result in your handler. You'll mainly be 
+`XamlResourceReferenceFailedEventArgs` is used for debugging XAML resource references. Register the event 
+handler using `DebugSettings`. It will receive a reference to this class. You'll mainly be 
 interested in the `Message` value, which you could log or send to **Debug** output.
 
 The message in the event data contains the following information about the failed XAML resource 
@@ -160,7 +160,7 @@ Finished search for resource with key 'OutputTextBlockStyl'.
 
 ## XamlResourceReferenceFailedEventArgs.Message Property
 
-Gets the explanation of the XAML resource reference failure.
+A human-readable explanation of the XAML resource reference failure.
 
 ```c#
 public string Message { get; }

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -124,6 +124,9 @@ Below is an example message from the WinUI Gallery sample app after an incorrect
 that the desired resource is defined in `App.xaml`, then the failure to locate it in there is a
 strong indicator of an erroneous reference.
 
+Note: The below example output is for illustrative purposes only. The precise format of the message is 
+implementation-defined and may change in the future. Applications should not attempt to parse the message.
+
 ```
 Beginning search for resource with key 'OutputTextBlockStyl'.
   Searching dictionary 'ms-appx:///Controls/ControlExample.xaml' for resource with key 'OutputTextBlockStyl'.

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -1,0 +1,165 @@
+Tracing XAML resource reference lookup failures
+===
+
+# Background
+
+Failure to resolve a XAML resource reference (`{StaticResource}` or `{ThemeResource}`) is one of 
+the most common causes of app crashes. Such failures manifest as a stowed exception with the 
+message "Cannot find a Resource with the Name/Key *foo*", and generally fall into one of two 
+buckets:
+
+1. The referenced resource legitimately does not exist, e.g. the referenced key is misspelled or 
+the intended matching resource has not been added to the app.
+2. The referenced resource *does* exist in the app, but it is not reachable from the reference 
+at run-time.
+
+Unfortunately, the stowed exception message is the *only* information provided about the error, 
+which makes it difficult or, more often, outright impossible to debug. This spec describes a new 
+API on the `DebugSettings` class that developers can use to access more detailed information about 
+the resource reference lookup failure.
+
+# API Pages
+
+_(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
+
+## DebugSettings.XamlResourceReferenceFailed Event
+
+Occurs when a [XAML resource reference](https://learn.microsoft.com/en-us/windows/apps/design/style/xaml-resource-dictionary) cannot be resolved.
+
+_Spec note: is there a version of the 'ResourceDictionary and XAML resource references' article that 
+links to the Windows App SDK documentation for relevant APIs?_
+
+```c#
+public event TypedEventHandler<DebugSettings,XamlResourceReferenceFailedEventArgs> 
+XamlResourceReferenceFailed
+
+```
+
+### Remarks
+
+`IsXamlResourceReferenceTracingEnabled` must be `true` and there must be a debugger attached to 
+the app process in order for `XamlResourceReferenceFailed` to fire and for tracing to appear in 
+debugger output. You don't need to handle the event in order to see tracing appear in a debugger. 
+The debugger output contains message information that goes to the **Output** window of the 
+debugger. Attaching a `XamlResourceReferenceFailed` handler yourself is an advanced scenario for 
+when you want to see the raw message.
+
+
+
+## DebugSettings.IsXamlResourceReferenceTracingEnabled Property
+
+Gets or sets a value that indicates whether to engage the XAML resource reference tracing feature 
+of Microsoft Visual Studio when the app runs.
+
+```c# 
+public bool IsXamlResourceReferenceTracingEnabled { get; set; }
+```
+
+### Remarks
+
+This property is `true` by default, but for XAML resource reference tracing to work, you must also 
+enable **Native debugging** in Microsoft Visual Studio on the **Debug** page of the project designer.
+
+When XAML resource reference tracing is enabled and you run your app with the debugger attached, any 
+XAML resource reference errors appear in the **Output** window in Microsoft Visual Studio.
+
+
+## XamlResourceReferenceFailedEventArgs Class
+
+Provides event data for the `DebugSettings.XamlResourceReferenceFailed` event.
+
+```c#
+public sealed class XamlResourceReferenceFailedEventArgs
+```
+
+### Remarks
+
+`XamlResourceReferenceFailedEventArgs` is used for debugging XAML resource references, using a 
+technique that you shouldn't include in production code. Wire the event handler using 
+`DebugSettings`, and use this data class as the result in your handler. You'll mainly be interested
+in the `Message` value, which you could log or send to **Debug** output.
+
+The message in the event data contains the following information about the failed XAML resource 
+reference:
+
+* The URI of the XAML page containing each `ResourceDictionary` that was searched
+* The order in which the `ResourceDictionary`s were searched
+
+You can use this information to investigate why the XAML resource reference could not be resolved; 
+perhaps the `ResourceDictionary` it is contained in was not in the list of searched 
+`ResourceDictionary`s, or perhaps that `ResourceDictionary` was searched which could indicate that 
+an incorrect resource key was specified.
+
+Below is an example message from the WinUI Gallery sample app after an incorrect resource reference
+(`OutputTextBlockStyl` rather than `OutputTextBlockStyle`) was deliberately inserted. If you know
+that the desired resource is defined in `App.xaml`, then the failure to locate it in there is a
+strong indicator of an erroneous reference.
+
+```
+Beginning search for resource with key 'OutputTextBlockStyl'.
+  Searching dictionary 'ms-appx:///Controls/ControlExample.xaml' for resource with key 'OutputTextBlockStyl'.
+  Finished searching dictionary 'ms-appx:///Controls/ControlExample.xaml'.
+  Searching dictionary 'Framework-defined colors' for resource with key 'OutputTextBlockStyl'.
+  Finished searching dictionary 'Framework-defined colors'.
+  Searching dictionary 'Framework ThemeResources.xbf' for resource with key 'OutputTextBlockStyl'.
+    Searching theme dictionary (active theme: 'Light') for resource with key 'OutputTextBlockStyl'.
+      Searching dictionary '<anonymous dictionary>' for resource with key 'OutputTextBlockStyl'.
+      Finished searching dictionary '<anonymous dictionary>'.
+    Finished searching theme dictionary (active theme: 'Light').
+  Finished searching dictionary 'Framework ThemeResources.xbf'.
+  Searching dictionary 'ms-appx:///App.xaml' for resource with key 'OutputTextBlockStyl'.
+    Searching merged dictionary with index '1' for resource with key 'OutputTextBlockStyl'.
+      Searching dictionary 'ms-appx:///Microsoft.UI.Xaml/Themes/themeresources.xaml' for resource with key 'OutputTextBlockStyl'.
+        Searching theme dictionary (active theme: 'Light') for resource with key 'OutputTextBlockStyl'.
+          Searching dictionary 'ms-appx:///Microsoft.UI.Xaml/Themes/themeresources.xaml' for resource with key 'OutputTextBlockStyl'.
+          Finished searching dictionary 'ms-appx:///Microsoft.UI.Xaml/Themes/themeresources.xaml'.
+        Finished searching theme dictionary (active theme: 'Light').
+      Finished searching dictionary 'ms-appx:///Microsoft.UI.Xaml/Themes/themeresources.xaml'.
+    Finished searching merged dictionary with index '1'.
+    Searching merged dictionary with index '0' for resource with key 'OutputTextBlockStyl'.
+      Searching dictionary 'ms-appx:///ItemTemplates.xaml' for resource with key 'OutputTextBlockStyl'.
+      Finished searching dictionary 'ms-appx:///ItemTemplates.xaml'.
+    Finished searching merged dictionary with index '0'.
+    Searching theme dictionary (active theme: 'Light') for resource with key 'OutputTextBlockStyl'.
+      Searching dictionary 'ms-appx:///App.xaml' for resource with key 'OutputTextBlockStyl'.
+      Finished searching dictionary 'ms-appx:///App.xaml'.
+    Finished searching theme dictionary (active theme: 'Light').
+  Finished searching dictionary 'ms-appx:///App.xaml'.
+Finished search for resource with key 'OutputTextBlockStyl'.
+```
+
+
+## XamlResourceReferenceFailedEventArgs.Message Property
+
+Gets the explanation of the XAML resource reference failure.
+
+```c#
+public string Message { get; }
+```
+
+
+# API Details
+```c#
+namespace Microsoft.UI.Xaml
+{
+  runtimeclass DebugSettings
+  {
+    // existing ...
+
+    Boolean IsXamlResourceReferenceTracingEnabled;
+    event Windows.Foundation.TypedEventHandler<Microsoft.UI.Xaml.DebugSettings,Microsoft.UI.Xaml.XamlResourceReferenceFailedEventArgs> XamlResourceReferenceFailed;
+  };
+
+  runtimeclass XamlResourceReferenceFailedEventArgs
+  {
+    XamlResourceReferenceFailedEventArgs();
+    String Message{ get; };
+  };
+}
+
+```
+
+
+# Appendix
+
+This API is modeled on the existing `DebugSettings.BindingFailed` event. Like XAML resource references, classic Bindings cannot be modeled solely through static evaluation, e.g. at compile-time, and so a run-time event when a failure occurs is the best approach for providing developers with a means of determining the root cause.

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -38,7 +38,7 @@ XamlResourceReferenceFailed
 ### Remarks
 
 `IsXamlResourceReferenceTracingEnabled` must be `true` and there must be a debugger attached to 
-the app process in order for `XamlResourceReferenceFailed` to fire and for tracing to appear in 
+the app process in order for `XamlResourceReferenceFailed` to be raised and for tracing to appear in 
 debugger output. You don't need to handle the event in order to see tracing appear in a debugger. 
 The debugger output contains message information that goes to the **Output** window of the 
 debugger. Attaching a `XamlResourceReferenceFailed` handler yourself is an advanced scenario for 

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -18,6 +18,7 @@ which makes it difficult or, more often, outright impossible to debug. This spec
 API on the `DebugSettings` class that developers can use to access more detailed information about 
 the resource reference lookup failure.
 
+
 # API Pages
 
 _(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
@@ -25,6 +26,11 @@ _(Each of the following L2 sections correspond to a page that will be on docs.mi
 ## DebugSettings.XamlResourceReferenceFailed Event
 
 Occurs when a [XAML resource reference](https://learn.microsoft.com/en-us/windows/apps/design/style/xaml-resource-dictionary) cannot be resolved.
+
+This API is modeled on the `DebugSettings.BindingFailed` event. Like XAML resource references, 
+classic Bindings cannot be modeled solely through static evaluation, e.g. at compile-time, and so a run-time 
+event when a failure occurs is the best approach for providing developers with a means of determining the 
+root cause.
 
 _Spec note: is there a version of the 'ResourceDictionary and XAML resource references' article that 
 links to the Windows App SDK documentation for relevant APIs?_
@@ -37,10 +43,10 @@ XamlResourceReferenceFailed
 
 ### Remarks
 
-`IsXamlResourceReferenceTracingEnabled` must be `true` and there must be a debugger attached to 
-the app process in order for `XamlResourceReferenceFailed` to be raised and for tracing to appear in 
-debugger output. You don't need to handle the event in order to see tracing appear in a debugger. 
-The debugger output contains message information that goes to the **Output** window of the 
+`IsXamlResourceReferenceTracingEnabled` must be `true` in order for `XamlResourceReferenceFailed` 
+to be raised, and there must be a native debugger attached to  the app process for tracing to appear
+in debugger output. You don't need to handle the event in order to see tracing appear in a debugger. 
+The debugger output contains message information that goes to the **Output** window of the native
 debugger. Attaching a `XamlResourceReferenceFailed` handler yourself is an advanced scenario for 
 when you want to see the raw message.
 
@@ -56,11 +62,9 @@ public bool IsXamlResourceReferenceTracingEnabled { get; set; }
 
 ### Remarks
 
-This property is `true` by default, but for XAML resource reference tracing to work, you must also 
-enable **Native debugging** in Microsoft Visual Studio on the **Debug** page of the project designer.
-
-When XAML resource reference tracing is enabled and you run your app with the debugger attached, any 
-XAML resource reference errors appear in the **Output** window in Microsoft Visual Studio.
+This property is `true` by default. When XAML resource reference tracing is enabled and you 
+run your app with the native debugger attached, any  XAML resource reference errors appear 
+in the **Output** window in Microsoft Visual Studio.
 
 
 ## XamlResourceReferenceFailedEventArgs Class
@@ -73,10 +77,9 @@ public sealed class XamlResourceReferenceFailedEventArgs
 
 ### Remarks
 
-`XamlResourceReferenceFailedEventArgs` is used for debugging XAML resource references, using a 
-technique that you shouldn't include in production code. Wire the event handler using 
-`DebugSettings`, and use this data class as the result in your handler. You'll mainly be interested
-in the `Message` value, which you could log or send to **Debug** output.
+`XamlResourceReferenceFailedEventArgs` is used for debugging XAML resource references. Wire the event 
+handler using `DebugSettings`, and use this data class as the result in your handler. You'll mainly be 
+interested in the `Message` value, which you could log or send to **Debug** output.
 
 The message in the event data contains the following information about the failed XAML resource 
 reference:
@@ -157,8 +160,3 @@ namespace Microsoft.UI.Xaml
 }
 
 ```
-
-
-# Appendix
-
-This API is modeled on the existing `DebugSettings.BindingFailed` event. Like XAML resource references, classic Bindings cannot be modeled solely through static evaluation, e.g. at compile-time, and so a run-time event when a failure occurs is the best approach for providing developers with a means of determining the root cause.

--- a/specs/xaml-resource-references-tracing-spec.md
+++ b/specs/xaml-resource-references-tracing-spec.md
@@ -3,7 +3,24 @@ Tracing XAML resource reference lookup failures
 
 # Background
 
-Failure to resolve a XAML resource reference (`{StaticResource}` or `{ThemeResource}`) is one of 
+A XAML resource is an item in a 
+[ResourceDictionary](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Xaml.ResourceDictionary)
+that can be referenced in markup with a `{StaticResource}` or `{ThemeResourcd}` reference.
+For example:
+
+```xml
+<StackPanel >
+    <StackPanel.Resources>
+        <SolidColorBrush x:Key="myBrush" Color="Red"/>
+    </StackPanel.Resources>
+
+    <Rectangle Fill="{StaticResource myBrush}"/>
+```
+
+`ResourceDictionary`s can be defined in multiple places, so the resource reference is resolved
+as a search.
+
+Failure to resolve a XAML resource reference is one of 
 the most common causes of app crashes. Such failures manifest in the _native code_ debug output with the 
 message "Cannot find a Resource with the Name/Key *foo*", and generally fall into one of two 
 buckets:
@@ -14,23 +31,34 @@ the intended matching resource has not been added to the app.
 at run-time.
 
 Unfortunately, the stowed exception message is the *only* information provided about the error, 
-which makes it difficult or, more often, outright impossible to debug. This spec describes a new 
+which makes it difficult or, more often, outright impossible to debug.
+
+This spec describes a new 
 API on the `DebugSettings` class that developers can use to access more detailed information about 
 the resource reference lookup failure.
+The new APIs here are patterned after the existing
+[DebugSettings.BindingFailed](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Xaml.DebugSettings.BindingFailed)
+and
+[DebugSettings.IsBindingTracingEnabled](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Xaml.DebugSettings.IsBindingTracingEnabled)
+APIs.
 
 
 # API Pages
 
-_(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
+_(Updates to the 
+[DebugSettings](https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/Microsoft.UI.Xaml.DebugSettings)
+class)_
 
 ## DebugSettings.XamlResourceReferenceFailed Event
 
-Occurs when a [XAML resource reference](https://learn.microsoft.com/en-us/windows/apps/design/style/xaml-resource-dictionary) cannot be resolved.
+Occurs when a
+[XAML resource reference](https://learn.microsoft.com/en-us/windows/apps/design/style/xaml-resource-dictionary)
+cannot be resolved.
 
-This API is modeled on the `DebugSettings.BindingFailed` event. Like XAML resource references, 
-classic Bindings cannot be modeled solely through static evaluation, e.g. at compile-time, and so a run-time 
+_Spec note: This API is similar to the `DebugSettings.BindingFailed` event. Like XAML resource references, 
+Bindings cannot be modeled solely through static evaluation, e.g. at compile-time, and so a run-time 
 event when a failure occurs is the best approach for providing developers with a means of determining the 
-root cause.
+root cause._
 
 _Spec note: is there a version of the 'ResourceDictionary and XAML resource references' article that 
 links to the Windows App SDK documentation for relevant APIs?_
@@ -43,18 +71,17 @@ XamlResourceReferenceFailed
 
 ### Remarks
 
-`IsXamlResourceReferenceTracingEnabled` must be `true` in order for `XamlResourceReferenceFailed` 
-to be raised, and there must be a native debugger attached to  the app process for tracing to appear
-in debugger output. You don't need to handle the event in order to see tracing appear in a debugger. 
-The debugger output contains message information that goes to the **Output** window of the native
-debugger. Attaching a `XamlResourceReferenceFailed` handler yourself is an advanced scenario for 
-when you want to see the raw message.
+`IsXamlResourceReferenceTracingEnabled` must be `true` in order for this event to be raised.
 
-
+Error information is also logged to the native debug output,
+so attaching a `XamlResourceReferenceFailed` handler yourself is an advanced scenario for 
+getting the raw message programmatically.
 
 ## DebugSettings.IsXamlResourceReferenceTracingEnabled Property
 
-Gets or sets a value that indicates whether to raise the `XamlResourceReferenceFailed` event when a Xaml resource lookup fails.
+Gets or sets a value indicating that when a XAML resource reference error occurs,
+the `XamlResourceReferenceFailed` event should be raised,
+and error information should be logged in the native debug output.
 
 ```c# 
 public bool IsXamlResourceReferenceTracingEnabled { get; set; }


### PR DESCRIPTION
This change contains a document detailing the proposed API for a new feature in WinUI 3 that allows developers to more easily diagnose failures to resolve XAML Static/ThemeResource references. The feature in question is already available in WinAppSDK 1.3 Experimental, so the purpose of this review is to collect feedback on the API before we finalize it.