### PR TITLE
Preventing repeater to reuse default layout

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -537,6 +537,8 @@ void BreadcrumbBarItem::InstantiateFlyout()
             winrt::AutomationProperties::SetName(ellipsisItemsRepeater, s_ellipsisItemsRepeaterAutomationName);
             ellipsisItemsRepeater.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
 
+            ellipsisItemsRepeater.Layout(winrt::StackLayout());
+
             m_ellipsisElementFactory = winrt::make_self<BreadcrumbElementFactory>();
             ellipsisItemsRepeater.ItemTemplate(*m_ellipsisElementFactory);
 


### PR DESCRIPTION
Repeater was reusing default layout, which in some scenarios might be created in a different thread, causing a crash.

So, setting up a layout for repeater before setting item source to prevent using default one.