### PR TITLE
Fix BreadcrumbBar KeyDown Handling

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -450,7 +450,7 @@ bool BreadcrumbBar::MoveFocus(int indexIncrement)
         {
             auto focusedIndex = itemsRepeater.GetElementIndex(focusedElement);
 
-            if (focusedIndex >= 0)
+            if (focusedIndex >= 0 && indexIncrement != 0)
             {
                 focusedIndex += indexIncrement;
                 auto const itemCount = itemsRepeater.ItemsSourceView().Count();
@@ -520,37 +520,6 @@ bool BreadcrumbBar::MoveFocusNext()
     return MoveFocus(movementNext);
 }
 
-// If we haven't handled the key yet and the original source was the first(for up and left)
-// or last(for down and right) element in the repeater we need to handle the key so
-// BreadcrumbBarItem doesn't, which would result in the behavior.
-bool BreadcrumbBar::HandleEdgeCaseFocus(bool first, const winrt::IInspectable& source)
-{
-    if (auto const& itemsRepeater = m_itemsRepeater.get())
-    {
-        if (auto const& sourceAsUIElement = source.try_as<winrt::UIElement>())
-        {
-            auto const index = [first, itemsRepeater]()
-            {
-                if (first)
-                {
-                    return 0;
-                }
-                if (auto const& itemsSourceView = itemsRepeater.ItemsSourceView())
-                {
-                    return itemsSourceView.Count() - 1;
-                }
-                return -1;
-            }();
-
-            if (itemsRepeater.GetElementIndex(sourceAsUIElement) == index)
-            {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 winrt::FindNextElementOptions BreadcrumbBar::GetFindNextElementOptions()
 {
     auto const& findNextElementOptions = winrt::FindNextElementOptions{};
@@ -581,7 +550,6 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
-        args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
     }
     // Moving to previous element
     else if ((flowDirectionIsLTR && keyIsLeft) || (!flowDirectionIsLTR && keyIsRight))
@@ -600,7 +568,6 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
-        args.Handled(HandleEdgeCaseFocus(true, args.OriginalSource()));
     }
     else if (args.Key() == winrt::VirtualKey::Down)
     {
@@ -620,7 +587,6 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
-        args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
     }
     else if (args.Key() == winrt::VirtualKey::Up)
     {
@@ -640,7 +606,6 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
-        args.Handled(HandleEdgeCaseFocus(true, args.OriginalSource()));
     }
 }
 

--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -569,44 +569,6 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
             }
         }
     }
-    else if (args.Key() == winrt::VirtualKey::Down)
-    {
-        if (args.OriginalKey() != winrt::VirtualKey::GamepadDPadDown)
-        {
-            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Right, GetFindNextElementOptions()))
-            {
-                args.Handled(true);
-                return;
-            }
-        }
-        else
-        {
-            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Right))
-            {
-                args.Handled(true);
-                return;
-            }
-        }
-    }
-    else if (args.Key() == winrt::VirtualKey::Up)
-    {
-        if (args.OriginalKey() != winrt::VirtualKey::GamepadDPadUp)
-        {
-            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Left, GetFindNextElementOptions()))
-            {
-                args.Handled(true);
-                return;
-            }
-        }
-        else
-        {
-            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Left))
-            {
-                args.Handled(true);
-                return;
-            }
-        }
-    }
 }
 
 void BreadcrumbBar::OnAccessKeyInvoked(const winrt::UIElement&, const winrt::AccessKeyInvokedEventArgs& args)

--- a/dev/Breadcrumb/BreadcrumbBar.h
+++ b/dev/Breadcrumb/BreadcrumbBar.h
@@ -48,7 +48,6 @@ private:
     bool MoveFocus(int initialIndexIncrement);
     bool MoveFocusPrevious();
     bool MoveFocusNext();
-    bool HandleEdgeCaseFocus(bool first, const winrt::IInspectable& source);
     void OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
 
     void UpdateItemsRepeaterItemsSource();


### PR DESCRIPTION
Improvements on BreadcrumbBar KeyDown event handling:

- BreadcrumbBar was moving focus on key Up/Down, so disabling that.
- Also was marking all keydowns as handled even when not taking any action on it, this PR stops marking them as such.
- `HandleEdgeCaseFocus` was copied from RadioButtons, and has no real use on BreadcrumbBar, simplifing the code by removing that, which was affecting the handling of events too.