### PR TITLE
Adding containment on BreadcrumbBar fixes

### DIFF
--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -443,7 +443,7 @@ void BreadcrumbBar::FocusElementAt(int index)
 
 bool BreadcrumbBar::MoveFocus(int indexIncrement)
 {
-    if(WI_IS_FEATURE_ENABLED(Feature_Crumbs) && indexIncrement == 0)
+    if(Feature_Crumbs::IsEnabled() && indexIncrement == 0)
     {
         return false;
     }
@@ -586,7 +586,7 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
-        if(!WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+        if(!Feature_Crumbs::IsEnabled())
         {
             args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
         }
@@ -608,12 +608,12 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
-        if(!WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+        if(!Feature_Crumbs::IsEnabled())
         {
             args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
         }
     }
-    else if(WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+    else if(Feature_Crumbs::IsEnabled())
     {
         return;
     }

--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -610,7 +610,7 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
         }
         if(!Feature_Crumbs::IsEnabled())
         {
-            args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
+            args.Handled(HandleEdgeCaseFocus(true, args.OriginalSource()));
         }
     }
     else if(Feature_Crumbs::IsEnabled())

--- a/dev/Breadcrumb/BreadcrumbBar.cpp
+++ b/dev/Breadcrumb/BreadcrumbBar.cpp
@@ -10,6 +10,7 @@
 #include "BreadcrumbBarItem.h"
 #include "BreadcrumbLayout.h"
 #include "BreadcrumbBarItemClickedEventArgs.h"
+#include "velocity.h"
 
 BreadcrumbBar::BreadcrumbBar()
 {
@@ -442,6 +443,10 @@ void BreadcrumbBar::FocusElementAt(int index)
 
 bool BreadcrumbBar::MoveFocus(int indexIncrement)
 {
+    if(WI_IS_FEATURE_ENABLED(Feature_Crumbs) && indexIncrement == 0)
+    {
+        return false;
+    }
     if (auto const& itemsRepeater = m_itemsRepeater.get())
     {
         const auto& focusedElem = winrt::FocusManager::GetFocusedElement();
@@ -450,7 +455,7 @@ bool BreadcrumbBar::MoveFocus(int indexIncrement)
         {
             auto focusedIndex = itemsRepeater.GetElementIndex(focusedElement);
 
-            if (focusedIndex >= 0 && indexIncrement != 0)
+            if (focusedIndex >= 0)
             {
                 focusedIndex += indexIncrement;
                 auto const itemCount = itemsRepeater.ItemsSourceView().Count();
@@ -520,6 +525,37 @@ bool BreadcrumbBar::MoveFocusNext()
     return MoveFocus(movementNext);
 }
 
+// If we haven't handled the key yet and the original source was the first(for up and left)
+// or last(for down and right) element in the repeater we need to handle the key so
+// BreadcrumbBarItem doesn't, which would result in the behavior.
+bool BreadcrumbBar::HandleEdgeCaseFocus(bool first, const winrt::IInspectable& source)
+{
+    if (auto const& itemsRepeater = m_itemsRepeater.get())
+    {
+        if (auto const& sourceAsUIElement = source.try_as<winrt::UIElement>())
+        {
+            auto const index = [first, itemsRepeater]()
+            {
+                if (first)
+                {
+                    return 0;
+                }
+                if (auto const& itemsSourceView = itemsRepeater.ItemsSourceView())
+                {
+                    return itemsSourceView.Count() - 1;
+                }
+                return -1;
+            }();
+
+            if (itemsRepeater.GetElementIndex(sourceAsUIElement) == index)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 winrt::FindNextElementOptions BreadcrumbBar::GetFindNextElementOptions()
 {
     auto const& findNextElementOptions = winrt::FindNextElementOptions{};
@@ -550,6 +586,10 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
+        if(!WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+        {
+            args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
+        }
     }
     // Moving to previous element
     else if ((flowDirectionIsLTR && keyIsLeft) || (!flowDirectionIsLTR && keyIsRight))
@@ -568,6 +608,54 @@ void BreadcrumbBar::OnChildPreviewKeyDown(const winrt::IInspectable&, const winr
                 return;
             }
         }
+        if(!WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+        {
+            args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
+        }
+    }
+    else if(WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+    {
+        return;
+    }
+    else if (args.Key() == winrt::VirtualKey::Down)
+    {
+        if (args.OriginalKey() != winrt::VirtualKey::GamepadDPadDown)
+        {
+            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Right, GetFindNextElementOptions()))
+            {
+                args.Handled(true);
+                return;
+            }
+        }
+        else
+        {
+            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Right))
+            {
+                args.Handled(true);
+                return;
+            }
+        }
+        args.Handled(HandleEdgeCaseFocus(false, args.OriginalSource()));
+    }
+    else if (args.Key() == winrt::VirtualKey::Up)
+    {
+        if (args.OriginalKey() != winrt::VirtualKey::GamepadDPadUp)
+        {
+            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Left, GetFindNextElementOptions()))
+            {
+                args.Handled(true);
+                return;
+            }
+        }
+        else
+        {
+            if (winrt::FocusManager::TryMoveFocus(winrt::FocusNavigationDirection::Left))
+            {
+                args.Handled(true);
+                return;
+            }
+        }
+        args.Handled(HandleEdgeCaseFocus(true, args.OriginalSource()));
     }
 }
 

--- a/dev/Breadcrumb/BreadcrumbBar.h
+++ b/dev/Breadcrumb/BreadcrumbBar.h
@@ -48,6 +48,7 @@ private:
     bool MoveFocus(int initialIndexIncrement);
     bool MoveFocusPrevious();
     bool MoveFocusNext();
+    bool HandleEdgeCaseFocus(bool first, const winrt::IInspectable& source);
     void OnChildPreviewKeyDown(const winrt::IInspectable& sender, const winrt::KeyRoutedEventArgs& args);
 
     void UpdateItemsRepeaterItemsSource();

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -538,7 +538,7 @@ void BreadcrumbBarItem::InstantiateFlyout()
             winrt::AutomationProperties::SetName(ellipsisItemsRepeater, s_ellipsisItemsRepeaterAutomationName);
             ellipsisItemsRepeater.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
 
-            if(WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+            if(Feature_Crumbs::IsEnabled())
             {
                 ellipsisItemsRepeater.Layout(winrt::StackLayout());
             }

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -8,6 +8,7 @@
 #include "ItemTemplateWrapper.h"
 #include "BreadcrumbBar.h"
 #include "BreadcrumbBarItemAutomationPeer.h"
+#include "velocity.h"
 
 namespace winrt::Microsoft::UI::Xaml::Controls
 {
@@ -537,7 +538,10 @@ void BreadcrumbBarItem::InstantiateFlyout()
             winrt::AutomationProperties::SetName(ellipsisItemsRepeater, s_ellipsisItemsRepeaterAutomationName);
             ellipsisItemsRepeater.HorizontalAlignment(winrt::HorizontalAlignment::Stretch);
 
-            ellipsisItemsRepeater.Layout(winrt::StackLayout());
+            if(WI_IS_FEATURE_ENABLED(Feature_Crumbs))
+            {
+                ellipsisItemsRepeater.Layout(winrt::StackLayout());
+            }
 
             m_ellipsisElementFactory = winrt::make_self<BreadcrumbElementFactory>();
             ellipsisItemsRepeater.ItemTemplate(*m_ellipsisElementFactory);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1353,7 +1353,7 @@ bool TabView::MoveFocus(bool moveForward)
 
     // At this point, we know that the focused control is indeed in the focus list, so we'll move focus to the next or previous control in the list.
 
-    int sourceIndex = static_cast<int>(position - focusOrderList.begin());
+    const int sourceIndex = static_cast<int>(position - focusOrderList.begin());
     const int listSize = static_cast<int>(focusOrderList.size());
     const int increment = moveForward ? 1 : -1;
     int nextIndex = sourceIndex + increment;

--- a/dev/inc/velocity.h
+++ b/dev/inc/velocity.h
@@ -1,4 +1,4 @@
-#ifndef __features_FeatureStaging_SampleFeature
+﻿#ifndef __features_FeatureStaging_SampleFeature
 #define __features_FeatureStaging_SampleFeature
 #endif
 
@@ -35,7 +35,6 @@ WI_DEFINE_FEATURE(
 WI_DEFINE_FEATURE(
     Feature_Crumbs, 40950262, DisabledByDefault,
     WilStagingChangeTime(OnReboot),
-    WilStagingRequiresFeature(Feature_Crumbs),
     WilStagingGroup("", R"()"));
 
 #pragma warning(pop)

--- a/dev/inc/velocity.h
+++ b/dev/inc/velocity.h
@@ -32,4 +32,10 @@ WI_DEFINE_FEATURE(
     WilStagingRequiresFeature(Feature_NWMTest1),
     WilStagingGroup("", R"()"));
 
+WI_DEFINE_FEATURE(
+    Feature_Crumbs, 40950262, DisabledByDefault,
+    WilStagingChangeTime(OnReboot),
+    WilStagingRequiresFeature(Feature_Crumbs),
+    WilStagingGroup("", R"()"));
+
 #pragma warning(pop)


### PR DESCRIPTION
Adding containment on two cherry picked PRs:
[Preventing repeater to reuse default layout #8246](https://github.com/microsoft/microsoft-ui-xaml/pull/8246)
[Fix BreadcrumbBar KeyDown Handling #8272](https://github.com/microsoft/microsoft-ui-xaml/pull/8272)

Manually verified keys are working.
