### PR TITLE
Fix horizontal scrolling on trackpad

### DIFF
--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -335,7 +335,18 @@ void WebView2::HandlePointerWheelChanged(const winrt::Windows::Foundation::IInsp
 {
     // Chromium handles WM_MOUSEXXX for mouse, WM_POINTERXXX for touch
     winrt::PointerDeviceType deviceType{ args.Pointer().PointerDeviceType() };
-    UINT message = deviceType == winrt::PointerDeviceType::Mouse ? WM_MOUSEWHEEL : WM_POINTERWHEEL;
+    winrt::PointerPoint pointerPoint{ args.GetCurrentPoint(*this) };
+    winrt::PointerPointProperties properties{ pointerPoint.Properties() };
+    UINT message;
+
+    if (deviceType == winrt::PointerDeviceType::Mouse)
+    {
+        message = properties.IsHorizontalMouseWheel() ? WM_MOUSEHWHEEL : WM_MOUSEWHEEL;
+    }
+    else
+    {
+        message = WM_POINTERWHEEL;
+    }
     OnXamlPointerMessage(message, args);
 }
 


### PR DESCRIPTION
## Summary
<!--- Provide a general summary of your changes in the Title above -->
Adds a boolean check to see if a horizontal scrolling is available

## Description
Amended the `HandlePointerWheelChanged` method to check if the mouse pointer is capable of being scrolled horizontally, if so, use a horizontal mouse wheel movement instead of a vertical one

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enables horizontal scrolling

Fixes #7772

## How Has This Been Tested?
see above

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
### Before 
https://user-images.githubusercontent.com/22731314/232791044-4ee42e70-961c-4beb-ba89-c253a930be73.mp4



### After
https://user-images.githubusercontent.com/22731314/232791066-f1379f20-e37c-4333-9b8b-da840f027213.mp4

EDIT: ~~After reading the contribution guidelines I thought creating an interaction test would be sufficient, similar to this [test](https://github.com/microsoft/microsoft-ui-xaml/blob/4041a77fa1468062ef45bfe7a136aeca6e9044f2/dev/WebView2/InteractionTests/WebView2Tests.cs#L591). However it seems that the test automation library doesn't have an equivalent method to enable horizontal scrolling. Is there a different way I could go about testing this fix? Appreciate any help as this is new to me.~~





