### PR TITLE
TabView.ItemChanged Event Fix

### DIFF
--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -327,13 +327,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void DragBetweenTabViewsTest()
         {
-            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone5))
-            {
-                // TODO 19727004: Re-enable this on versions below RS5 after fixing the bug where mouse click-and-drag doesn't work.
-                Log.Warning("This test relies on touch input, the injection of which is only supported in RS5 and up. Test is disabled.");
-                return;
-            }
-
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
                 UIObject firstTab = FindElement.ByName("FirstTab");
@@ -361,13 +354,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void ReorderItemsTest()
         {
-            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone5))
-            {
-                // TODO 19727004: Re-enable this on versions below RS5 after fixing the bug where mouse click-and-drag doesn't work.
-                Log.Warning("This test relies on touch input, the injection of which is only supported in RS5 and up. Test is disabled.");
-                return;
-            }
-
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
                 Button tabItemsSourcePageButton = FindElement.ByName<Button>("TabViewTabItemsSourcePageButton");
@@ -408,13 +394,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestMethod]
         public void ItemChangedEventOnDragTest()
         {
-            if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone5))
-            {
-                // TODO 19727004: Re-enable this on versions below RS5 after fixing the bug where mouse click-and-drag doesn't work.
-                Log.Warning("This test relies on touch input, the injection of which is only supported in RS5 and up. Test is disabled.");
-                return;
-            }
-
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
                 Button addButton = FindElement.ByName<Button>("Add New Tab");

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -412,7 +412,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(dropTab);
 
                 Log.Comment("Dragging tab to the last overflow tab...");
-                InputHelper.DragToTarget(sourceTab, dropTab, 50);
+                InputHelper.DragToTarget(sourceTab, dropTab, 40);
                 Wait.ForIdle();
                 ElementCache.Refresh();
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -429,7 +429,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Verify.IsNotNull(sourceTab);
 
-                UIObject dropTab = FindElement.ByName("LastTab");
+                UIObject dropTab = FindElement.ByName("New Tab 1");
                 Verify.IsNotNull(dropTab);
 
                 Log.Comment("Dragging tab to the last overflow tab...");

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -429,11 +429,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
                 Verify.IsNotNull(sourceTab);
 
-                UIObject dropTab = FindElement.ByName("New Tab 1");
+                UIObject dropTab = FindElement.ByName("LastTab");
                 Verify.IsNotNull(dropTab);
 
                 Log.Comment("Dragging tab to the last overflow tab...");
-                InputHelper.DragToTarget(sourceTab, dropTab);
+                InputHelper.DragToTarget(sourceTab, dropTab, 25);
                 Wait.ForIdle();
                 ElementCache.Refresh();
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -412,7 +412,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(dropTab);
 
                 Log.Comment("Dragging tab to the last overflow tab...");
-                InputHelper.DragToTarget(sourceTab, dropTab, 25);
+                InputHelper.DragToTarget(sourceTab, dropTab, 50);
                 Wait.ForIdle();
                 ElementCache.Refresh();
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -392,7 +392,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(dropTab);
 
                 Log.Comment("Reordering tabs with drag-drop operation...");
-                InputHelper.DragToTarget(sourceTab, dropTab, -5);
+                InputHelper.DragToTarget(sourceTab, dropTab);
                 Wait.ForIdle();
                 ElementCache.Refresh();
                 Log.Comment("...reordering done. Expecting a TabView.TabItemsChanged event was raised with CollectionChange=ItemInserted and Index=1.");
@@ -406,7 +406,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
-        public void DragTabOverflowTest()
+        public void ItemChangedEventOnDragTest()
         {
             if (PlatformConfiguration.IsOSVersionLessThan(OSVersion.Redstone5))
             {
@@ -417,51 +417,33 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 
             using (var setup = new TestSetupHelper("TabView Tests"))
             {
-                // Navigate to TabView TabItemSource Page
-                Button tabItemsSourcePageButton = FindElement.ByName<Button>("TabViewTabItemsSourcePageButton");
-                tabItemsSourcePageButton.InvokeAndWait();
-
                 Button addButton = FindElement.ByName<Button>("Add New Tab");
                 Verify.IsNotNull(addButton);
 
-                Log.Comment("Add 10 tabs so scroll buttons appear.");
-
-                for (var i = 0; i < 9; i++)
-                {
-                    addButton.DoubleClick();
-                }
+                Log.Comment("Add tab so scroll buttons appear.");
+                addButton.InvokeAndWait();
 
                 Verify.IsTrue(AreScrollButtonsVisible(), "Scroll buttons should appear");
 
-                UIObject sourceTab = null;
-                int attempts = 0;
-
-                do
-                {
-                    Wait.ForMilliseconds(100);
-                    ElementCache.Refresh();
-
-                    sourceTab = FindElement.ByName("tabViewItem0");
-                    attempts++;
-                }
-                while (sourceTab == null && attempts < 4);
+                UIObject sourceTab =  FindElement.ByName("FirstTab");
 
                 Verify.IsNotNull(sourceTab);
 
-                UIObject dropTab = FindElement.ByName("tabViewItem10");
+                UIObject dropTab = FindElement.ByName("LastTab");
                 Verify.IsNotNull(dropTab);
 
-                Log.Comment("Reordering tabs with drag-drop operation...");
-                InputHelper.DragToTarget(sourceTab, dropTab, -10);
+                Log.Comment("Dragging tab to the last overflow tab...");
+                InputHelper.DragToTarget(sourceTab, dropTab);
                 Wait.ForIdle();
                 ElementCache.Refresh();
-                Log.Comment("...reordering done. Expecting a TabView.TabItemsChanged event was raised with CollectionChange=ItemInserted and Index=1.");
 
-                TextBlock tblIVectorChangedEventArgsCollectionChange = FindElement.ByName<TextBlock>("tblIVectorChangedEventArgsCollectionChange");
-                Verify.AreEqual("ItemInserted", tblIVectorChangedEventArgsCollectionChange.DocumentText);
+                Log.Comment("...reordering done. Expecting a TabView.TabItemsChanged event to be raised with CollectionChange=ItemInserted and Index=5.");
 
-                TextBlock tblIVectorChangedEventArgsIndex = FindElement.ByName<TextBlock>("tblIVectorChangedEventArgsIndex");
-                Verify.AreEqual("1", tblIVectorChangedEventArgsIndex.DocumentText);
+                TextBlock tabsItemChangedEventArgsTextBlock = FindElement.ByName<TextBlock>("TabsItemChangedEventArgsTextBlock");
+                Verify.AreEqual("ItemInserted", tabsItemChangedEventArgsTextBlock.DocumentText);
+
+                TextBlock tabsItemChangedEventArgsIndexTextBlock = FindElement.ByName<TextBlock>("TabsItemChangedEventArgsIndexTextBlock");
+                Verify.AreEqual("5", tabsItemChangedEventArgsIndexTextBlock.DocumentText);
             }
         }
 

--- a/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/dev/TabView/InteractionTests/TabViewTests.cs
@@ -392,7 +392,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
                 Verify.IsNotNull(dropTab);
 
                 Log.Comment("Reordering tabs with drag-drop operation...");
-                InputHelper.DragToTarget(sourceTab, dropTab);
+                InputHelper.DragToTarget(sourceTab, dropTab, -5);
                 Wait.ForIdle();
                 ElementCache.Refresh();
                 Log.Comment("...reordering done. Expecting a TabView.TabItemsChanged event was raised with CollectionChange=ItemInserted and Index=1.");

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -720,11 +720,6 @@ void TabView::BringSelectedTabIntoView()
 
 void TabView::OnItemsChanged(winrt::IInspectable const& item)
 {
-    if (m_isDragging)
-    {
-        return;
-    }
-
     if (auto args = item.as<winrt::IVectorChangedEventArgs>())
     {
         m_tabItemsChangedEventSource(*this, args);
@@ -863,11 +858,13 @@ void TabView::OnListViewDragItemsCompleted(const winrt::IInspectable& sender, co
 {
     m_isDragging = false;
 
-    // Selection change was disabled during drag, update SelectedIndex now
+    // Selection may have changed during drag if dragged outside, so we update SelectedIndex again.
     if (auto&& listView = m_listView.get())
     {
         SelectedIndex(listView.SelectedIndex());
         SelectedItem(listView.SelectedItem());
+
+        BringSelectedTabIntoView();
     }
 
     auto item = args.Items().GetAt(0);

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -131,10 +131,8 @@
                 <controls:TabView
                     x:Name="Tabs"
                     TabWidthMode="Equal"
-                    CanDragTabs="True"
                     SelectionChanged="TabViewSelectionChanged"
                     TabCloseRequested="TabViewTabCloseRequested"
-                    TabDragStarting="OnTabDragStarting"
                     TabStripDragOver="OnTabStripDragOver"
                     TabStripDrop="OnTabStripDrop"
                     TabDroppedOutside="TabViewTabDroppedOutside"
@@ -238,7 +236,8 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <controls:TabView x:Name="DataBindingTabView" IsAddTabButtonVisible="false" Background="#66336699" SelectedIndex="2">
+                    <controls:TabView x:Name="DataBindingTabView" 
+                    CanDragTabs="True" IsAddTabButtonVisible="false" Background="#66336699" SelectedIndex="2">
                         <controls:TabView.Resources>
                             <ResourceDictionary>
                                 <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="SystemAccentColor"/>
@@ -273,6 +272,14 @@
                         <controls:TabView.TabItems>
 
                             <controls:TabViewItem x:Name="TabInSecondTabView" AutomationProperties.Name="TabInSecondTabView" Header="Hello">
+                                <controls:TabViewItem.IconSource>
+                                    <controls:SymbolIconSource Symbol="Placeholder"/>
+                                </controls:TabViewItem.IconSource>
+
+                                <TextBlock Padding="16" Text="Content"/>
+                            </controls:TabViewItem>
+
+                            <controls:TabViewItem x:Name="Tab2InSecondTabView" AutomationProperties.Name="Tab2InSecondTabView" Header="Hello">
                                 <controls:TabViewItem.IconSource>
                                     <controls:SymbolIconSource Symbol="Placeholder"/>
                                 </controls:TabViewItem.IconSource>

--- a/dev/TabView/TestUI/TabViewPage.xaml
+++ b/dev/TabView/TestUI/TabViewPage.xaml
@@ -119,6 +119,11 @@
                         <Button x:Name="GetScrollIncreaseButtonToolTipButton" AutomationProperties.Name="GetScrollIncreaseButtonToolTipButton" Content="TooltipScrollIncreaseButton" Click="GetScrollIncreaseButtonToolTipButton_Click"/>
                         <TextBlock x:Name="ScrollIncreaseButtonToolTipTextBlock" AutomationProperties.Name="ScrollIncreaseButtonToolTipTextBlock" Margin="4,0,0,0" Text=""/>
                     </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <TextBlock x:Name="TabsItemChangedEventArgsTextBlock" AutomationProperties.Name="TabsItemChangedEventArgsTextBlock" Margin="4,0,0,0" Text="" />
+                    <TextBlock x:Name="TabsItemChangedEventArgsIndexTextBlock" AutomationProperties.Name="TabsItemChangedEventArgsIndexTextBlock" Margin="4,0,0,0" Text="" />
+                    </StackPanel>
                 </StackPanel>
             </ScrollViewer>
             
@@ -131,8 +136,10 @@
                 <controls:TabView
                     x:Name="Tabs"
                     TabWidthMode="Equal"
+                    CanDragTabs="True"
                     SelectionChanged="TabViewSelectionChanged"
                     TabCloseRequested="TabViewTabCloseRequested"
+                    TabDragStarting="OnTabDragStarting"
                     TabStripDragOver="OnTabStripDragOver"
                     TabStripDrop="OnTabStripDrop"
                     TabDroppedOutside="TabViewTabDroppedOutside"
@@ -236,8 +243,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <controls:TabView x:Name="DataBindingTabView" 
-                    CanDragTabs="True" IsAddTabButtonVisible="false" Background="#66336699" SelectedIndex="2">
+                    <controls:TabView x:Name="DataBindingTabView" IsAddTabButtonVisible="false" Background="#66336699" SelectedIndex="2">
                         <controls:TabView.Resources>
                             <ResourceDictionary>
                                 <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="SystemAccentColor"/>
@@ -272,14 +278,6 @@
                         <controls:TabView.TabItems>
 
                             <controls:TabViewItem x:Name="TabInSecondTabView" AutomationProperties.Name="TabInSecondTabView" Header="Hello">
-                                <controls:TabViewItem.IconSource>
-                                    <controls:SymbolIconSource Symbol="Placeholder"/>
-                                </controls:TabViewItem.IconSource>
-
-                                <TextBlock Padding="16" Text="Content"/>
-                            </controls:TabViewItem>
-
-                            <controls:TabViewItem x:Name="Tab2InSecondTabView" AutomationProperties.Name="Tab2InSecondTabView" Header="Hello">
                                 <controls:TabViewItem.IconSource>
                                     <controls:SymbolIconSource Symbol="Placeholder"/>
                                 </controls:TabViewItem.IconSource>

--- a/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -47,6 +47,8 @@ namespace MUXControlsTestApp
             _iconSource = new SymbolIconSource();
             _iconSource.Symbol = Symbol.Placeholder;
 
+            Tabs.TabItemsChanged += Tabs_TabItemsChanged;
+
             ObservableCollection<TabDataItem> itemSource = new ObservableCollection<TabDataItem>();
             for (int i = 0; i < 5; i++)
             {
@@ -61,6 +63,12 @@ namespace MUXControlsTestApp
             backgroundColorCache = BackgroundGrid.Background;
             activeTabContentBackgroundBrushCache = FirstTabContent.Background;
             CacheFirstTabSelectedBackgroundPathFill();
+        }
+
+        private void Tabs_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
+        {
+            TabsItemChangedEventArgsTextBlock.Text = args.CollectionChange.ToString();
+            TabsItemChangedEventArgsIndexTextBlock.Text = args.Index.ToString();
         }
 
         private Brush backgroundColorCache;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/TabView/TabView.cpp#L725
From #6632 to fix internal bug 37608918 caused a regression where TabView.ItemChanged event is simply not raised. 

Upon investigation, normally, `OnItemsChanged` is raised twice when dragged past the overflow scroll buttons:
1. `CollectionChanged::ItemRemoved` - Dragged item being removed since it's "overflow"
2. `CollectionChanged::ItemInserted` - Dragged item being dropped back in

Since TabView thinks the tab is being removed, it finds the closest tab to give selection: https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/TabView/TabView.cpp#L764

**Fix:** 
Remove the `m_isDragging` check and simply call `BringSelectedTabIntoView()` `OnListViewDragItemsCompleted` for the original bug fix.

Removing the `m_isDragging` check also prevents a regression where a tab is being dragged to another window, causing no tab to be selected.

(This is a regression)
![image](https://user-images.githubusercontent.com/7976322/233506649-1643edb8-a0d6-4f33-8539-cbe826492e52.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #xxx" or "Fixes #xxx" so that GitHub will close the issue once the PR is complete. -->
Fixes internal bug 44190134

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Added new test `ItemChangedEventOnDragTest` to avoid regression where ItemChanged Event is not called.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->