### PR TITLE
TabView TabGeometry Animation Loop & Under Tab Line Fix

### DIFF
--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -1174,7 +1174,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths, bool fillAllAvailableSpac
                 }
                 else
                 {
-                    // Case: TabWidthMode "Compact" or "FitToContent"
+                    // Case: TabWidthMode "Compact" or "SizeToContent"
                     tabColumn.MaxWidth(availableWidth);
                     tabColumn.Width(winrt::GridLengthHelper::FromValueAndType(1.0, winrt::GridUnitType::Auto));
                     if (auto&& listview = m_listView.get())

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -735,7 +735,6 @@
 
                         <Border x:Name="BottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.ColumnSpan="3" VerticalAlignment="Bottom"/>
 
-
                         <Path x:Name="LeftRadiusRenderArc"
                             x:Load="False"
                             Fill="{ThemeResource TabViewBorderBrush}"

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -734,7 +734,8 @@
                         </VisualStateManager.VisualStateGroups>
 
                         <Border x:Name="BottomBorderLine" BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1" Height="1" Grid.ColumnSpan="3" VerticalAlignment="Bottom"/>
-                        
+
+
                         <Path x:Name="LeftRadiusRenderArc"
                             x:Load="False"
                             Fill="{ThemeResource TabViewBorderBrush}"
@@ -755,15 +756,17 @@
                             Height="4"
                             Width="4"
                             Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z"/>
-
-                        <Path x:Name="SelectedBackgroundPath"
-                            x:Load="False"
-                            Grid.ColumnSpan="3"
-                            Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
-                            VerticalAlignment="Bottom"
-                            Margin="-4,0,-4,0"
-                            Visibility="Collapsed"
-                            Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}" />
+                        
+                        <Canvas>
+                            <Path x:Name="SelectedBackgroundPath"
+                                x:Load="False"
+                                Grid.ColumnSpan="3"
+                                Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
+                                VerticalAlignment="Bottom"
+                                Margin="-4,0,-4,0"
+                                Visibility="Collapsed"
+                                Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}" />
+                        </Canvas>
 
                         <Border x:Name="TabSeparator"
                             HorizontalAlignment="Right"

--- a/dev/TabView/TabView.xaml
+++ b/dev/TabView/TabView.xaml
@@ -755,7 +755,8 @@
                             Height="4"
                             Width="4"
                             Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z"/>
-                        
+
+                        <!-- This Path wrapped in a Canvas to prevent an infinite loop in calculating its width. -->
                         <Canvas>
                             <Path x:Name="SelectedBackgroundPath"
                                 x:Load="False"

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -127,9 +127,6 @@ void TabViewItem::OnApplyTemplate()
 void TabViewItem::UpdateTabGeometry()
 {
     auto const templateSettings = winrt::get_self<TabViewItemTemplateSettings>(TabViewTemplateSettings());
-    auto const scaleFactor = SharedHelpers::Is19H1OrHigher() ?
-        static_cast<float>(XamlRoot().RasterizationScale()) :
-        static_cast<float>(winrt::DisplayInformation::GetForCurrentView().RawPixelsPerViewPixel());
 
     auto const height = ActualHeight();
     auto const popupRadius = unbox_value<winrt::CornerRadius>(ResourceAccessor::ResourceLookup(*this, box_value(c_overlayCornerRadiusKey)));
@@ -141,11 +138,11 @@ void TabViewItem::UpdateTabGeometry()
 
     WCHAR strOut[1024];
     StringCchPrintf(strOut, ARRAYSIZE(strOut), data,
-        height - 1.0,
+        height,
         leftCorner, leftCorner, leftCorner, leftCorner, leftCorner,
-        ActualWidth() - (leftCorner + rightCorner + 1.0f / scaleFactor),
+        ActualWidth() - (leftCorner + rightCorner),
         rightCorner, rightCorner, rightCorner, rightCorner,
-        height - (5.0 + rightCorner));
+        height - (4.0f + rightCorner));
 
     const auto geometry = winrt::XamlReader::Load(strOut).try_as<winrt::Geometry>();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When changing TabWidthMode from Equal to SizeToContent, the `1 / ScaleFactor` adjustment was causing the TabGeometry to be slightly smaller than its parent LayoutRoot, causing a continuous loop of `OnSizeChanged()` / `UpdateTabGeometry()` calls.

**Solution:**
`SelectedBackgroundPath` is now wrapped in a `Canvas` as it does not take up space in the xaml layout. This prevents the infinite loop where the children and parent are dependent on one another for sizing, and prevents regression from these bug fixes: #6954 and #7174

I've also updated the Path geometry and removed the 1p adjustment to remove the line between the tabs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #xxx" or "Fixes #xxx" so that GitHub will close the issue once the PR is complete. -->
Fixes internal bug 44190129 and 40692364


## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manual verification.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->


![image](https://user-images.githubusercontent.com/7976322/234128533-447a3333-fb7b-4e85-800c-ebfd2cfb5626.png)