### PR TITLE
Fix logic to skip build stage in PR pipeline for markdown only changes

### DIFF
--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -50,37 +50,35 @@ stages:
       buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
       publishDir : $(Build.ArtifactStagingDirectory)
     steps:
-    - script: set
-      displayName: 'Display current environment variables'
-    # - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-    # - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+    - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+    - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-# - stage: Test
-#   dependsOn: Build
-#   jobs:
-#   - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-#     parameters:
-#       rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+- stage: Test
+  dependsOn: Build
+  jobs:
+  - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+    parameters:
+      rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
-# # Create Nuget Package
-# - stage: Pack
-#   dependsOn: Build
-#   jobs:
-#   - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-#     parameters:
-#       jobName: CreateNugetPackage
-#       primaryBuildArch: x64
-#       prereleaseVersionTag: pr
+# Create Nuget Package
+- stage: Pack
+  dependsOn: Build
+  jobs:
+  - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+    parameters:
+      jobName: CreateNugetPackage
+      primaryBuildArch: x64
+      prereleaseVersionTag: pr
 
-#   - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-#     parameters:
-#       dependsOn: CreateNugetPackage
-#       useFrameworkPkg: false
-#       runTests: 'false'
-#       matrix:
-#         Debug_x64:
-#           buildPlatform: 'x64'
-#           buildConfiguration: 'Debug'
-#         Release_x64:
-#           buildPlatform: 'x64'
-#           buildConfiguration: 'Release'
+  - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+    parameters:
+      dependsOn: CreateNugetPackage
+      useFrameworkPkg: false
+      runTests: 'false'
+      matrix:
+        Debug_x64:
+          buildPlatform: 'x64'
+          buildConfiguration: 'Debug'
+        Release_x64:
+          buildPlatform: 'x64'
+          buildConfiguration: 'Release'

--- a/build/MUX-PR.yml
+++ b/build/MUX-PR.yml
@@ -20,8 +20,7 @@ stages:
 
 - stage: Build
   dependsOn: Setup
-  condition: |
-      ne(stageDependencies.Setup.Setup.outputs['checkPayload.shouldSkipPRBuild'],'True')
+  condition: ne(dependencies.Setup.outputs['Setup.checkPayload.shouldSkipPRBuild'],'True')
   jobs:
   - job: Build
     condition: eq(variables['useBuildOutputFromBuildId'],'')
@@ -51,35 +50,37 @@ stages:
       buildOutputDir : $(Build.SourcesDirectory)\BuildOutput
       publishDir : $(Build.ArtifactStagingDirectory)
     steps:
-    - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
-    - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
+    - script: set
+      displayName: 'Display current environment variables'
+    # - template: AzurePipelinesTemplates\MUX-BuildDevProject-Steps.yml
+    # - template: AzurePipelinesTemplates\MUX-PublishProjectOutput-Steps.yml
 
-- stage: Test
-  dependsOn: Build
-  jobs:
-  - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
-    parameters:
-      rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
+# - stage: Test
+#   dependsOn: Build
+#   jobs:
+#   - template: AzurePipelinesTemplates\MUX-RunHelixTests-Job.yml
+#     parameters:
+#       rerunPassesRequiredToAvoidFailure: $(rerunPassesRequiredToAvoidFailure)
 
-# Create Nuget Package
-- stage: Pack
-  dependsOn: Build
-  jobs:
-  - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
-    parameters:
-      jobName: CreateNugetPackage
-      primaryBuildArch: x64
-      prereleaseVersionTag: pr
+# # Create Nuget Package
+# - stage: Pack
+#   dependsOn: Build
+#   jobs:
+#   - template: AzurePipelinesTemplates\MUX-CreateNugetPackage-Job.yml
+#     parameters:
+#       jobName: CreateNugetPackage
+#       primaryBuildArch: x64
+#       prereleaseVersionTag: pr
 
-  - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
-    parameters:
-      dependsOn: CreateNugetPackage
-      useFrameworkPkg: false
-      runTests: 'false'
-      matrix:
-        Debug_x64:
-          buildPlatform: 'x64'
-          buildConfiguration: 'Debug'
-        Release_x64:
-          buildPlatform: 'x64'
-          buildConfiguration: 'Release'
+#   - template: AzurePipelinesTemplates\MUX-NugetReleaseTest-Job.yml
+#     parameters:
+#       dependsOn: CreateNugetPackage
+#       useFrameworkPkg: false
+#       runTests: 'false'
+#       matrix:
+#         Debug_x64:
+#           buildPlatform: 'x64'
+#           buildConfiguration: 'Debug'
+#         Release_x64:
+#           buildPlatform: 'x64'
+#           buildConfiguration: 'Release'

--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -1,74 +1,76 @@
-﻿# Determine if the current PR payload requires a build.
-# We skip the build if the only files changed are .md files.
+﻿# # Determine if the current PR payload requires a build.
+# # We skip the build if the only files changed are .md files.
 
-function AllChangedFilesAreSkippable
-{
-    Param($files)
+# function AllChangedFilesAreSkippable
+# {
+#     Param($files)
 
-    $skipExts = @(".md", ".png", ".PNG", ".jpg", ".ics")
-    $skipFiles = @(".github/ISSUE_TEMPLATE/bug_report.yaml")
-    $allFilesAreSkippable = $true
+#     $skipExts = @(".md", ".png", ".PNG", ".jpg", ".ics")
+#     $skipFiles = @(".github/ISSUE_TEMPLATE/bug_report.yaml")
+#     $allFilesAreSkippable = $true
 
-    foreach($file in $files)
-    {
-        Write-Host "Checking '$file'"
-        try
-        {
-            $ext = [System.IO.Path]::GetExtension($file)
-            $fileIsSkippable = $ext -in $skipExts
+#     foreach($file in $files)
+#     {
+#         Write-Host "Checking '$file'"
+#         try
+#         {
+#             $ext = [System.IO.Path]::GetExtension($file)
+#             $fileIsSkippable = $ext -in $skipExts
 
-            if(!$fileIsSkippable)
-            {
-                $fileIsSkippable = $file -in $skipFiles
-            }
-        }
-        catch
-        {
-            $fileIsSkippable = $false
-        }
+#             if(!$fileIsSkippable)
+#             {
+#                 $fileIsSkippable = $file -in $skipFiles
+#             }
+#         }
+#         catch
+#         {
+#             $fileIsSkippable = $false
+#         }
 
-        Write-Host "File '$file' is skippable: '$fileIsSkippable'"
+#         Write-Host "File '$file' is skippable: '$fileIsSkippable'"
 
-        if(!$fileIsSkippable)
-        {
-            $allFilesAreSkippable = $false
-        }
-    }
+#         if(!$fileIsSkippable)
+#         {
+#             $allFilesAreSkippable = $false
+#         }
+#     }
 
-    return $allFilesAreSkippable
-}
+#     return $allFilesAreSkippable
+# }
 
-$shouldSkipBuild = $false
+# $shouldSkipBuild = $false
 
-if($env:BUILD_REASON -eq "PullRequest")
-{
-    # Azure DevOps sets this variable with refs/heads/ at the beginning.
-    # This trims it so the $gitCommandLine is formatted properly
-    if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH.StartsWith("refs/heads/"))
-    {
-        $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH.Substring("11")
+# if($env:BUILD_REASON -eq "PullRequest")
+# {
+#     # Azure DevOps sets this variable with refs/heads/ at the beginning.
+#     # This trims it so the $gitCommandLine is formatted properly
+#     if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH.StartsWith("refs/heads/"))
+#     {
+#         $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH.Substring("11")
         
-    }
-    else 
-    {
-        $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-    }
+#     }
+#     else 
+#     {
+#         $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+#     }
 
-    $targetBranch = "origin/$systemPullRequestTargetBranch"
+#     $targetBranch = "origin/$systemPullRequestTargetBranch"
 
-    $gitCommandLine = "git diff $targetBranch --name-only"
-    Write-Host "$gitCommandLine"
+#     $gitCommandLine = "git diff $targetBranch --name-only"
+#     Write-Host "$gitCommandLine"
 
-    $diffOutput = Invoke-Expression $gitCommandLine
-    Write-Host $diffOutput
+#     $diffOutput = Invoke-Expression $gitCommandLine
+#     Write-Host $diffOutput
 
-    $files = $diffOutput.Split([Environment]::NewLine)
+#     $files = $diffOutput.Split([Environment]::NewLine)
 
-    Write-Host "Files changed: $files"
+#     Write-Host "Files changed: $files"
     
 
-    $shouldSkipBuild = AllChangedFilesAreSkippable($files)
-}
+#     $shouldSkipBuild = AllChangedFilesAreSkippable($files)
+# }
+
+$shouldSkipBuild = $true
 
 Write-Host "shouldSkipBuild = $shouldSkipBuild"
 

--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -1,76 +1,74 @@
-﻿# # Determine if the current PR payload requires a build.
-# # We skip the build if the only files changed are .md files.
+﻿# Determine if the current PR payload requires a build.
+# We skip the build if the only files changed are .md files.
 
-# function AllChangedFilesAreSkippable
-# {
-#     Param($files)
+function AllChangedFilesAreSkippable
+{
+    Param($files)
 
-#     $skipExts = @(".md", ".png", ".PNG", ".jpg", ".ics")
-#     $skipFiles = @(".github/ISSUE_TEMPLATE/bug_report.yaml")
-#     $allFilesAreSkippable = $true
+    $skipExts = @(".md", ".png", ".PNG", ".jpg", ".ics")
+    $skipFiles = @(".github/ISSUE_TEMPLATE/bug_report.yaml")
+    $allFilesAreSkippable = $true
 
-#     foreach($file in $files)
-#     {
-#         Write-Host "Checking '$file'"
-#         try
-#         {
-#             $ext = [System.IO.Path]::GetExtension($file)
-#             $fileIsSkippable = $ext -in $skipExts
+    foreach($file in $files)
+    {
+        Write-Host "Checking '$file'"
+        try
+        {
+            $ext = [System.IO.Path]::GetExtension($file)
+            $fileIsSkippable = $ext -in $skipExts
 
-#             if(!$fileIsSkippable)
-#             {
-#                 $fileIsSkippable = $file -in $skipFiles
-#             }
-#         }
-#         catch
-#         {
-#             $fileIsSkippable = $false
-#         }
+            if(!$fileIsSkippable)
+            {
+                $fileIsSkippable = $file -in $skipFiles
+            }
+        }
+        catch
+        {
+            $fileIsSkippable = $false
+        }
 
-#         Write-Host "File '$file' is skippable: '$fileIsSkippable'"
+        Write-Host "File '$file' is skippable: '$fileIsSkippable'"
 
-#         if(!$fileIsSkippable)
-#         {
-#             $allFilesAreSkippable = $false
-#         }
-#     }
+        if(!$fileIsSkippable)
+        {
+            $allFilesAreSkippable = $false
+        }
+    }
 
-#     return $allFilesAreSkippable
-# }
-
-# $shouldSkipBuild = $false
-
-# if($env:BUILD_REASON -eq "PullRequest")
-# {
-#     # Azure DevOps sets this variable with refs/heads/ at the beginning.
-#     # This trims it so the $gitCommandLine is formatted properly
-#     if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH.StartsWith("refs/heads/"))
-#     {
-#         $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH.Substring("11")
-        
-#     }
-#     else 
-#     {
-#         $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-#     }
-
-#     $targetBranch = "origin/$systemPullRequestTargetBranch"
-
-#     $gitCommandLine = "git diff $targetBranch --name-only"
-#     Write-Host "$gitCommandLine"
-
-#     $diffOutput = Invoke-Expression $gitCommandLine
-#     Write-Host $diffOutput
-
-#     $files = $diffOutput.Split([Environment]::NewLine)
-
-#     Write-Host "Files changed: $files"
-    
-
-#     $shouldSkipBuild = AllChangedFilesAreSkippable($files)
-# }
+    return $allFilesAreSkippable
+}
 
 $shouldSkipBuild = $false
+
+if($env:BUILD_REASON -eq "PullRequest")
+{
+    # Azure DevOps sets this variable with refs/heads/ at the beginning.
+    # This trims it so the $gitCommandLine is formatted properly
+    if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH.StartsWith("refs/heads/"))
+    {
+        $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH.Substring("11")
+        
+    }
+    else 
+    {
+        $systemPullRequestTargetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+    }
+
+    $targetBranch = "origin/$systemPullRequestTargetBranch"
+
+    $gitCommandLine = "git diff $targetBranch --name-only"
+    Write-Host "$gitCommandLine"
+
+    $diffOutput = Invoke-Expression $gitCommandLine
+    Write-Host $diffOutput
+
+    $files = $diffOutput.Split([Environment]::NewLine)
+
+    Write-Host "Files changed: $files"
+    
+
+    $shouldSkipBuild = AllChangedFilesAreSkippable($files)
+}
 
 Write-Host "shouldSkipBuild = $shouldSkipBuild"
 

--- a/build/ShouldSkipPRBuild.ps1
+++ b/build/ShouldSkipPRBuild.ps1
@@ -70,7 +70,7 @@
 #     $shouldSkipBuild = AllChangedFilesAreSkippable($files)
 # }
 
-$shouldSkipBuild = $true
+$shouldSkipBuild = $false
 
 Write-Host "shouldSkipBuild = $shouldSkipBuild"
 


### PR DESCRIPTION
The WinUI-PR validation pipeline has logic to skip the Build and Test jobs in the case of a PR containing changes only to markdown and image files. This logic got broken by #8439 in the updating of the Pipeline to use multiple Stages. 

This fixes the yml dependencies syntax.