### PR TITLE
UpdateSpinButtonPlacement after TextBox Loaded

### DIFF
--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -175,7 +175,10 @@ void NumberBox::OnApplyTemplate()
         return textBox;
     }());
 
-    m_textBox.get().Loaded({ this, & NumberBox::OnTextBoxLoaded });
+    if (const auto textBox = m_textBox.get())
+    {
+        textBox.Loaded({ this, &NumberBox::OnTextBoxLoaded });
+    }
 
     m_popup.set(GetTemplateChildT<winrt::Popup>(c_numberBoxPopupName, controlProtected));
 

--- a/dev/NumberBox/NumberBox.cpp
+++ b/dev/NumberBox/NumberBox.cpp
@@ -36,8 +36,6 @@ NumberBox::NumberBox()
 {
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_NumberBox);
 
-    Loaded({ this, &NumberBox::OnLoaded });
-
     NumberFormatter(GetRegionalSettingsAwareDecimalFormatter());
 
     PointerWheelChanged({ this, &NumberBox::OnNumberBoxScroll });
@@ -177,6 +175,8 @@ void NumberBox::OnApplyTemplate()
         return textBox;
     }());
 
+    m_textBox.get().Loaded({ this, & NumberBox::OnTextBoxLoaded });
+
     m_popup.set(GetTemplateChildT<winrt::Popup>(c_numberBoxPopupName, controlProtected));
 
     if (SharedHelpers::IsThemeShadowAvailable())
@@ -231,9 +231,9 @@ void NumberBox::OnApplyTemplate()
     }
 }
 
-void NumberBox::OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
+void NumberBox::OnTextBoxLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
 {
-    // This is done OnLoaded so TextBox VisualStates can be updated properly.
+    // Updating again once TextBox is loaded so its visual states are set properly.
     UpdateSpinButtonPlacement();
 }
 
@@ -654,6 +654,7 @@ void NumberBox::UpdateSpinButtonPlacement()
     }
 
     winrt::VisualStateManager::GoToState(*this, state, false);
+
     if (const auto textbox = m_textBox.get())
     {
         winrt::VisualStateManager::GoToState(textbox, state, false);

--- a/dev/NumberBox/NumberBox.h
+++ b/dev/NumberBox/NumberBox.h
@@ -41,7 +41,7 @@ public:
 
     // IFrameworkElement
     void OnApplyTemplate();
-    void OnLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&);
+    void OnTextBoxLoaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&);
 
     void OnHeaderPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnHeaderTemplatePropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -39,7 +39,7 @@
                                         <Setter Target="DownSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="UpSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="InputEater.Visibility" Value="Visible" />
-                                        <Setter Target="InputBox.MinWidth" Value="{ThemeResource NumberBoxMinWidth}" />
+                                        <!--<Setter Target="InputBox.MinWidth" Value="{ThemeResource NumberBoxMinWidth}" />-->
                                     </VisualState.Setters>
                                 </VisualState>
 

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -39,7 +39,7 @@
                                         <Setter Target="DownSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="UpSpinButton.Visibility" Value="Visible" />
                                         <Setter Target="InputEater.Visibility" Value="Visible" />
-                                        <!--<Setter Target="InputBox.MinWidth" Value="{ThemeResource NumberBoxMinWidth}" />-->
+                                        <Setter Target="InputBox.MinWidth" Value="{ThemeResource NumberBoxMinWidth}" />
                                     </VisualState.Setters>
                                 </VisualState>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

TextBox is not yet loaded when `OnApplyTemplate` is called. Thus `UpdateSpinButtonPlacement()` does not properly update `NumberBoxTextBoxStyle`, specifically this line:

```
<VisualState x:Name="SpinButtonsVisible">
    <VisualState.Setters>
        <Setter Target="SpinButtonsColumn.Width" Value="72" />
    </VisualState.Setters>
</VisualState>
```

When loading normally, it goes as OnApplyTemplate -> Loaded. However, when toggling Visibility.Collapsed, it calls Loaded first, then OnApplyTemplate when Visibility is set to Visible. `UpdateSpinButtonPlacement` is thus updated to be called again after Textbox is loaded.
