### PR TITLE
[WebView2] Apply text scale factor to CoreWebView2 content

### DIFF
--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -1456,6 +1456,22 @@ void WebView2::TryCompleteInitialization()
             [this](auto&&, auto&&) { UpdateDefaultVisualBackgroundColor(); });
     }
 
+    if (!m_textScaleChangedRevoker)
+    {
+        m_textScaleChangedRevoker = GetUISettings().TextScaleFactorChanged(winrt::auto_revoke,
+            [weakThis{ get_weak() }](auto&&, auto&&)
+            {
+                if (auto strongThis = weakThis.get())
+                {
+                    // OnTextScaleFactorChanged happens in non-UI thread, use dispatcher to call UpdateCoreWebViewScale in UI thread.
+                    strongThis->m_dispatcherHelper.RunAsync([strongThis]()
+                        {
+                            strongThis->UpdateCoreWebViewScale();
+                        });
+                }
+            });
+    }
+
     // WebView2 in WinUI 2 is a ContentControl that either renders its web content to a SpriteVisual, or in the case that
     // the WebView2 Runtime is not installed, renders a message to that effect as its Content. In the case where the
     // WebView2 starts with Visibility.Collapsed, hit testing code has trouble seeing the WebView2 if it does not have
@@ -1607,6 +1623,15 @@ void WebView2::Reload()
     }
 }
 
+void WebView2::UpdateCoreWebViewScale()
+{
+    if (m_coreWebViewController)
+    {
+        auto textScaleFactor = m_uiSettings.TextScaleFactor();
+        m_coreWebViewController.RasterizationScale(static_cast<double>(m_rasterizationScale * textScaleFactor));
+    }
+}
+
 void WebView2::NavigateToString(winrt::hstring htmlContent)
 {
     if (m_coreWebView)
@@ -1660,10 +1685,7 @@ void WebView2::XamlRootChangedHelper(bool forceUpdate)
     {
         m_rasterizationScale = scale;
         m_isHostVisible = hostVisibility; // If we did forceUpdate we'll want to update host visibility here too
-        if (m_coreWebViewController)
-        {
-            m_coreWebViewController.RasterizationScale(static_cast<double>(scale));
-        }
+        UpdateCoreWebViewScale();
         SetCoreWebViewAndVisualSize(static_cast<float>(ActualWidth()), static_cast<float>(ActualHeight()));
         CheckAndUpdateWebViewPosition();
         UpdateRenderedSubscriptionAndVisibility();
@@ -1927,4 +1949,13 @@ void WebView2::ResetProperties()
 {
     SetCanGoForward(false);
     SetCanGoBack(false);
+}
+
+winrt::UISettings WebView2::GetUISettings()
+{
+    if (m_uiSettings == nullptr)
+    {
+        m_uiSettings = winrt::UISettings();
+    }
+    return m_uiSettings;
 }

--- a/dev/WebView2/WebView2.h
+++ b/dev/WebView2/WebView2.h
@@ -15,6 +15,8 @@ namespace winrt
 
 #include "CoreWebView2InitializedEventArgs.g.h"
 
+#include "DispatcherHelper.h"
+
 #include "WebView2.g.h"
 #include "WebView2.properties.h"
 #pragma warning( push )
@@ -87,6 +89,8 @@ public:
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
     void OnLoaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
     void OnUnloaded(winrt::IInspectable const& sender, winrt::RoutedEventArgs const& args);
+
+    void UpdateCoreWebViewScale();
 
     winrt::IAsyncAction EnsureCoreWebView2Async();
     winrt::IAsyncOperation<winrt::hstring> ExecuteScriptAsync(winrt::hstring javascriptCode);
@@ -176,6 +180,8 @@ private:
     void CloseInternal(bool inShutdownPath);
 
     winrt::AccessibilitySettings GetAccessibilitySettings();
+    winrt::UISettings GetUISettings();
+
     bool SafeIsLoaded();
 
     void UpdateCoreWindowCursor();
@@ -245,6 +251,7 @@ private:
     winrt::FrameworkElement::ActualThemeChanged_revoker m_actualThemeChangedRevoker{};
     winrt::AccessibilitySettings m_accessibilitySettings;
     winrt::AccessibilitySettings::HighContrastChanged_revoker m_highContrastChangedRevoker{};
+    winrt::UISettings::TextScaleFactorChanged_revoker m_textScaleChangedRevoker{};
 
     // Pointer handling for CoreWindow
     void ResetPointerHelper(const winrt::PointerRoutedEventArgs& args);
@@ -279,6 +286,10 @@ private:
     winrt::Point m_webViewScaledSize{};
     // Last known position of the host window
     POINT m_hostWindowPosition{};
+
+    DispatcherHelper m_dispatcherHelper{ *this };
+
+    winrt::UISettings m_uiSettings;
 
     // Manually delay load functions to avoid WACK exceptions.
     decltype(&ClientToScreen) m_fnClientToScreen;


### PR DESCRIPTION
WebView2 was not accounting for system text scale (OS Settings | Accessibility | Text Size) while the rest of Xaml UI did, resulting in ignored accessibility preference and discrepancy of text size between WV2 and other Xaml content. An additional side effect was that, when text scale is set, WV2 context menus (right-click over web content) were sometimes rendered at wild offsets, showing up completely detached from click point (this usually happened when right-clicking near right/bottom edges of WV2).

Fix this by incorporating UISettings.TextScaleFactor when setting CoreWebView2 scale via ICoreWebView2Controller3::RasterizationScale. Also register for changes to the TextScaleFactor so we can update CoreWebView2 accordingly.