### PR TITLE
Fix Voice Access 'Show Bubbles' annotation of WebView2 Content

### DIFF
--- a/dev/WebView2/WebView2AutomationPeer.cpp
+++ b/dev/WebView2/WebView2AutomationPeer.cpp
@@ -42,17 +42,25 @@ winrt::Rect WebView2AutomationPeer::GetBoundingRectangleCore()
     return boundingRect;
 }
 
-#if WINUI3
 HRESULT WebView2AutomationPeer::GetRawElementProviderSimple(_Outptr_opt_ IRawElementProviderSimple** value)
 {
+    *value = nullptr;
+
     InitProvider();
-    m_provider.copy_to(value);
+
+    auto wrapperSimple = m_providerWrapper.try_as<IRawElementProviderSimple>();
+    if (wrapperSimple)
+    {
+        wrapperSimple.copy_to(value);
+    }
+
     return S_OK;
 }
 
 HRESULT WebView2AutomationPeer::IsCorrectPeerForHwnd(HWND hwnd, _Out_ bool* value)
 {
     *value = false;
+
     if (!InitProvider())
     {
         return S_OK;
@@ -63,9 +71,9 @@ HRESULT WebView2AutomationPeer::IsCorrectPeerForHwnd(HWND hwnd, _Out_ bool* valu
     {
         *value = true;
     }
+
     return S_OK;
 }
-#endif
 
 struct ProviderWrapper : winrt::implements<ProviderWrapper, winrt::IInspectable, ::IRawElementProviderSimple, ::IRawElementProviderSimple2, ::IRawElementProviderFragment, ::IRawElementProviderFragmentRoot>
 {

--- a/dev/WebView2/WebView2AutomationPeer.cpp
+++ b/dev/WebView2/WebView2AutomationPeer.cpp
@@ -44,6 +44,8 @@ winrt::Rect WebView2AutomationPeer::GetBoundingRectangleCore()
 
 HRESULT WebView2AutomationPeer::GetRawElementProviderSimple(_Outptr_opt_ IRawElementProviderSimple** value)
 {
+    if (value == nullptr) return S_OK;
+    
     *value = nullptr;
 
     InitProvider();

--- a/dev/WebView2/WebView2AutomationPeer.cpp
+++ b/dev/WebView2/WebView2AutomationPeer.cpp
@@ -220,7 +220,10 @@ public:
     HRESULT STDMETHODCALLTYPE GetFocus(
         /* [retval][out] */ __RPC__deref_out_opt IRawElementProviderFragment** pRetVal) noexcept override
     {
-        return E_NOTIMPL;
+            // We don't answer the question about a current focus. We return NULL here since if we return
+            // an error UIA will bail out the entire focus operation rather than continueing its search.
+            *pRetVal = nullptr;
+            return S_OK;
     }
 
 private:

--- a/dev/WebView2/WebView2AutomationPeer.h
+++ b/dev/WebView2/WebView2AutomationPeer.h
@@ -7,12 +7,20 @@
 #include "WebView2.h"
 #include "UIAutomationCore.h"
 
+MIDL_INTERFACE("865F5B88-6506-4E64-A4C5-4B7723650731")
+IAutomationPeerHwndInterop : public IUnknown
+{
+public:
+    virtual /* [propput] */ HRESULT STDMETHODCALLTYPE GetRawElementProviderSimple(
+        /* [retval][out] */ _Outptr_opt_ IRawElementProviderSimple * *value) = 0;
+
+    virtual /* [propget] */ HRESULT STDMETHODCALLTYPE IsCorrectPeerForHwnd(
+                            HWND hwnd,
+        /* [retval][out] */ _Out_ bool* value) = 0;
+};
+
 class WebView2AutomationPeer :
-    public ReferenceTracker<WebView2AutomationPeer, winrt::implementation::WebView2AutomationPeerT
-#if WINUI3
-    , IAutomationPeerHwndInterop
-#endif
-    >
+    public ReferenceTracker<WebView2AutomationPeer, winrt::implementation::WebView2AutomationPeerT, IAutomationPeerHwndInterop>
 {
 public:
     WebView2AutomationPeer(winrt::WebView2 const& owner);
@@ -27,10 +35,8 @@ public:
     winrt::IInspectable GetElementFromPointCore(winrt::Point pointInWindowCoordinates);
 
     // IAutomationPeerHwndInterop
-#if WINUI3
     HRESULT STDMETHODCALLTYPE GetRawElementProviderSimple(_Outptr_opt_ IRawElementProviderSimple** value);
     HRESULT STDMETHODCALLTYPE IsCorrectPeerForHwnd(HWND hwnd, _Out_ bool* value);
-#endif
 
 private:
     com_ptr<WebView2> GetImpl();


### PR DESCRIPTION
Summary: this PR completes recent improvements made to OS Xaml accessibility with WebView2, specifically unblocking Voice Access "Show Numbers" functionality, which is currently unusable when WinUI2.8 WebView2 is present, with no known workaround.

Recent collaboration with internal app teams identified several incorrectly implemented UIA interfaces in WinUI2 WebView2 control. A major impacted scenario is VA "Show Numbers" feature, which maps controls to numbered bubbles that can be activated via voice. Currently, any WinUI2 app with an initialized CoreWebView2 produces hundreds of spurious voice bubbles and makes navigation of the app via VA Show Numbers impossible (see 'Before' screenshot below).

The OS/Windows.UI.Xaml.dll part of the fixes has already been checked in as part of SearchHost+WV2 work. To light up the scenario on public WinUI2.8, we need the changes to Microsoft.UI.Xaml.dll that are the payload of this PR.

In more detail, the full fix consists of: 
1. WebView2-aware implementations of [_IRawElementProviderHwndOverride_] CUIAWindow::GetOverrideProviderForHwnd and [_IRawElementProviderFragment_] CUIAWrapper::GetEmbeddedFragmentRoots
    + Without these, VA walk of WV2 - which involves redirection to the underlying EmbeddedBrowserWebViewUIAProvider - is not executed properly, causing UIA to continuously re-walk the web content tree (until max recursion depth is hit) and produce hundreds of spurious VA bubbles.
    + These changes span (a) Windows.UI.Xaml.dll/OS and (b) Microsoft.UI.Xaml.dll/WinUI2. 
        1. WUX change was recently checked into OS 
            + Augments generic CUIAWrapper/CUIAWindow objects of Xaml's UIA interface with special handling for WebView2 via the new Interface IAutomationPeerHwndInterop linking to CWV2Controller/EmbeddedBrowserWebViewUIAProvider.
        2. MUX change has so far only been deployed internally, and are being ported to the WinUI 2.8 WebView2 control with this PR.
            + Implements IAutomationPeerHwndInterop which links WebView2AutomationPeer to CoreWebView2Controller/EmbeddedBrowserWebViewUIAProvider via existing WebViw2 helpers.

2. Fix [_IRawElementProviderFragmentRoot_] ProviderWrapper:GetFocus (implementing IRawElementProviderFragmentRoot)
    + Without this fix, if Show Numbers is invoked while WebView2 has focus, it bails immediately due to GetFocus returning E_NOTIMPL, causing no bubbles to get generated for web content.
        + Changes GetFocus() to return S_OK which allows UIA to complete the walk of web content.
            + This change is limited to Microsoft.UI.Xaml.dll.

Screen shots of MUXControlsTestApp w/ WebView2 navigated to Bing homepage:
**Before**
<img width="667" alt="WV2_ShowNumbers_MainFixAbsent" src="https://github.com/microsoft/microsoft-ui-xaml/assets/45051803/49fc24d3-5dfe-4d26-a9fb-2cb03bfe02f2">

**After**
![WV2_ShowNumbers_AllFixes](https://github.com/microsoft/microsoft-ui-xaml/assets/45051803/5cd72c29-ca6b-4bd8-9f12-0dc2363f1274)
