### PR TITLE
Add const keyword to resolve warnings (treated as errors) C26462 and C26496

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBoxHelper.cpp
+++ b/dev/AutoSuggestBox/AutoSuggestBoxHelper.cpp
@@ -54,7 +54,7 @@ void AutoSuggestBoxHelper::OnKeepInteriorCornersSquarePropertyChanged(
 {
     if (auto autoSuggestBox = sender.try_as<winrt::AutoSuggestBox>())
     {
-        bool shouldMonitorAutoSuggestEvents = unbox_value<bool>(args.NewValue());
+        const bool shouldMonitorAutoSuggestEvents = unbox_value<bool>(args.NewValue());
         if (shouldMonitorAutoSuggestEvents)
         {
             auto revokersInspectable = winrt::make<AutoSuggestEventRevokers>();

--- a/dev/Breadcrumb/BreadcrumbBarItem.cpp
+++ b/dev/Breadcrumb/BreadcrumbBarItem.cpp
@@ -732,7 +732,7 @@ bool BreadcrumbBarItem::IgnorePointerId(const winrt::PointerRoutedEventArgs& arg
 {
     MUX_ASSERT(m_isEllipsisDropDownItem);
 
-    uint32_t pointerId = args.Pointer().PointerId();
+    const uint32_t pointerId = args.Pointer().PointerId();
 
     if (m_trackedPointerId == 0)
     {

--- a/dev/Breadcrumb/BreadcrumbLayout.cpp
+++ b/dev/Breadcrumb/BreadcrumbLayout.cpp
@@ -106,7 +106,7 @@ int BreadcrumbLayout::GetFirstBreadcrumbBarItemToArrange(winrt::NonVirtualizingL
 
     for (int i = itemCount - 2; i >= 0; --i)
     {
-        float newAccumLength = accumLength + GetElementAt(context, i).DesiredSize().Width;
+        const float newAccumLength = accumLength + GetElementAt(context, i).DesiredSize().Width;
         if (newAccumLength > m_availableSize.Width)
         {
             return i + 1;

--- a/dev/ColorPicker/ColorPicker.cpp
+++ b/dev/ColorPicker/ColorPicker.cpp
@@ -323,8 +323,8 @@ void ColorPicker::OnColorChanged(winrt::DependencyPropertyChangedEventArgs const
         UpdateColorControls(ColorUpdateReason::ColorPropertyChanged);
     }
 
-    winrt::Color oldColor = unbox_value<winrt::Color>(args.OldValue());
-    winrt::Color newColor = unbox_value<winrt::Color>(args.NewValue());
+    const winrt::Color oldColor = unbox_value<winrt::Color>(args.OldValue());
+    const winrt::Color newColor = unbox_value<winrt::Color>(args.NewValue());
 
     if (oldColor.A != newColor.A ||
         oldColor.R != newColor.R ||

--- a/dev/ColorPicker/ColorPickerSlider.cpp
+++ b/dev/ColorPicker/ColorPickerSlider.cpp
@@ -59,7 +59,7 @@ void ColorPickerSlider::OnKeyDown(winrt::KeyRoutedEventArgs const& args)
         return;
     }
 
-    bool isControlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+    const bool isControlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 
     double minBound = 0;
     double maxBound = 0;

--- a/dev/ColorPicker/ColorSpectrum.cpp
+++ b/dev/ColorPicker/ColorSpectrum.cpp
@@ -106,7 +106,7 @@ void ColorSpectrum::OnKeyDown(winrt::KeyRoutedEventArgs const& args)
         return;
     }
 
-    bool isControlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+    const bool isControlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 
     winrt::ColorPickerHsvChannel incrementChannel = winrt::ColorPickerHsvChannel::Hue;
 

--- a/dev/ColorPicker/ColorSpectrumAutomationPeer.cpp
+++ b/dev/ColorPicker/ColorSpectrumAutomationPeer.cpp
@@ -89,7 +89,7 @@ winrt::hstring ColorSpectrumAutomationPeer::Value()
 void ColorSpectrumAutomationPeer::SetValue(winrt::hstring const& value)
 {
     winrt::ColorSpectrum colorSpectrumOwner = Owner().as<winrt::ColorSpectrum>();
-    winrt::Color color = unbox_value<winrt::Color>(winrt::XamlBindingHelper::ConvertValue({ winrt::hstring_name_of<winrt::Color>(), winrt::TypeKind::Metadata }, box_value(value)));
+    const winrt::Color color = unbox_value<winrt::Color>(winrt::XamlBindingHelper::ConvertValue({ winrt::hstring_name_of<winrt::Color>(), winrt::TypeKind::Metadata }, box_value(value)));
 
     colorSpectrumOwner.Color(color);
 

--- a/dev/ComboBox/ComboBoxHelper.cpp
+++ b/dev/ComboBox/ComboBoxHelper.cpp
@@ -53,7 +53,7 @@ void ComboBoxHelper::OnKeepInteriorCornersSquarePropertyChanged(
 {
     if (auto comboBox = sender.try_as<winrt::ComboBox>())
     {
-        bool shouldMonitorDropDownState = unbox_value<bool>(args.NewValue());
+        const bool shouldMonitorDropDownState = unbox_value<bool>(args.NewValue());
         if (shouldMonitorDropDownState)
         {
             auto revokersInspectable = winrt::make<ComboBoxDropDownEventRevokers>();

--- a/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -556,7 +556,7 @@ void CommandBarFlyoutCommandBar::UpdateVisualState(
 
         // If there isn't enough space to display the overflow below the command bar,
         // and if there is enough space above, then we'll display it above instead.
-        if (auto window = winrt::Window::Current() && !hadActualPlacement && m_secondaryItemsRoot)
+        if (const auto window = winrt::Window::Current() && !hadActualPlacement && m_secondaryItemsRoot)
         {
             double availableHeight = -1;
             const auto controlBounds = TransformToVisual(nullptr).TransformBounds({ 0, 0, static_cast<float>(ActualWidth()), static_cast<float>(ActualHeight()) });
@@ -595,7 +595,7 @@ void CommandBarFlyoutCommandBar::UpdateVisualState(
         winrt::VisualStateManager::GoToState(*this, shouldExpandUp ? L"ExpandedUp" : L"ExpandedDown", useTransitions && !isForSizeChange);
 
         // Union of AvailableCommandsStates and ExpansionStates
-        bool hasPrimaryCommands = (PrimaryCommands().Size() != 0);
+        const bool hasPrimaryCommands = (PrimaryCommands().Size() != 0);
         if (hasPrimaryCommands)
         {
             if (shouldExpandUp)

--- a/dev/CommandBarFlyout/TextCommandBarFlyout.cpp
+++ b/dev/CommandBarFlyout/TextCommandBarFlyout.cpp
@@ -208,7 +208,7 @@ void TextCommandBarFlyout::UpdateButtons()
     
     winrt::MenuFlyout proofingMenuFlyout = proofingFlyout.try_as<winrt::MenuFlyout>();
     
-    bool shouldIncludeProofingMenu =
+    const bool shouldIncludeProofingMenu =
         static_cast<bool>(proofingFlyout) &&
         (!proofingMenuFlyout || proofingMenuFlyout.Items().Size() > 0);
         
@@ -323,7 +323,7 @@ void TextCommandBarFlyout::UpdateButtons()
     addRichEditButtonToCommandsIfPresent(TextControlButtons::Underline, PrimaryCommands(),
         [](winrt::ITextSelection textSelection)
     {
-        auto underline = textSelection.CharacterFormat().Underline();
+        const auto underline = textSelection.CharacterFormat().Underline();
         return (underline != winrt::UnderlineType::None) && (underline != winrt::UnderlineType::Undefined);
     });
 
@@ -554,7 +554,7 @@ TextControlButtons TextCommandBarFlyout::GetPasswordBoxButtonsToAdd(winrt::Passw
 bool TextCommandBarFlyout::IsButtonInPrimaryCommands(TextControlButtons button)
 {
     uint32_t buttonIndex = 0;
-    bool wasFound = PrimaryCommands().IndexOf(GetButton(button), buttonIndex);
+    const bool wasFound = PrimaryCommands().IndexOf(GetButton(button), buttonIndex);
     return wasFound;
 }
 

--- a/dev/InfoBar/InfoBarPanel.cpp
+++ b/dev/InfoBar/InfoBarPanel.cpp
@@ -132,7 +132,7 @@ winrt::Size InfoBarPanel::ArrangeOverride(winrt::Size const& finalSize)
                 auto const desiredSize = child.DesiredSize();
                 if (desiredSize.Width != 0 && desiredSize.Height != 0)
                 {
-                    auto horizontalMargin = winrt::InfoBarPanel::GetHorizontalOrientationMargin(child);
+                    const auto horizontalMargin = winrt::InfoBarPanel::GetHorizontalOrientationMargin(child);
 
                     horizontalOffset += hasPreviousElement ? (float)horizontalMargin.Left : 0;
                     if (i < childCount - 1)

--- a/dev/Lights/MaterialHelper.cpp
+++ b/dev/Lights/MaterialHelper.cpp
@@ -970,7 +970,7 @@ winrt::CompositionSurfaceBrush MaterialHelper::GetNoiseBrushImpl()
 
         try
         {
-            winrt::ResolutionScale resScale{ winrt::DisplayInformation::GetForCurrentView().ResolutionScale() };
+            const winrt::ResolutionScale resScale{ winrt::DisplayInformation::GetForCurrentView().ResolutionScale() };
             if (resScale != winrt::ResolutionScale::Invalid)
             {
                 resScaleInt = static_cast<int>(resScale);

--- a/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
+++ b/dev/Materials/Backdrop/SystemBackdropWindowHandler.cpp
@@ -209,7 +209,7 @@ namespace SystemBackdropComponentInternal
         else if (retryOnNextTick && !m_nextTickRevoker)
         {
             // We don't have a root yet so let's start with the system theme as the best we can do until the content appears.
-            auto systemTheme = winrt::Application::Current().RequestedTheme();
+            const auto systemTheme = winrt::Application::Current().RequestedTheme();
             m_actualTheme = (systemTheme == winrt::ApplicationTheme::Dark) ? winrt::ElementTheme::Dark : winrt::ElementTheme::Light;
             m_controller->UpdateTheme(m_actualTheme);
 

--- a/dev/Materials/Reveal/RevealBrush.cpp
+++ b/dev/Materials/Reveal/RevealBrush.cpp
@@ -506,7 +506,7 @@ winrt::Windows::Graphics::Effects::IGraphicsEffect RevealBrush::CreateRevealHove
     //              </CompositeStepEffect>
     //          </ColorMatrixEffect>
     //      </ArithmeticCompositeEffect>
-    winrt::Color initBaseColor{ 0, 0, 0, 0 };
+    const winrt::Color initBaseColor{ 0, 0, 0, 0 };
 
     // (9) Noise image BorderEffect (infinitely tiles noise image)
     auto noiseBorderEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::BorderEffect>();
@@ -881,8 +881,8 @@ bool RevealBrush::ValidatePublicRootAncestor()
     // Either Window.Content is a Canvas, in which case it's the immediate child of the root visual and we should set lights
     // on it directly, or it isn't, in which case we should have walked up to the RootScrollViewer and set lights there.
     auto ancestor = GetAncestor(windowRoot);
-    bool windowContentIsCanvas = static_cast<bool>(windowRoot.try_as<winrt::Canvas>());
-    bool walkedUpToScrollViewer = winrt::VisualTreeHelper::GetParent(windowRoot) &&
+    const bool windowContentIsCanvas = static_cast<bool>(windowRoot.try_as<winrt::Canvas>());
+    const bool walkedUpToScrollViewer = winrt::VisualTreeHelper::GetParent(windowRoot) &&
         static_cast<bool>(ancestor.try_as<winrt::FxScrollViewer>());
 
     // On MUX + RS3/RS4, it's possible XCB::OnConnected is called before visual tree is constructed and the ancestor walk returns a false elemenet.
@@ -1054,7 +1054,7 @@ void RevealBrush::OnIsContainerPropertyChanged(
 {
     if (auto elementSender = sender.try_as<winrt::IUIElement5>())
     {
-        bool isAdding = unbox_value<bool>(args.NewValue());
+        const bool isAdding = unbox_value<bool>(args.NewValue());
 
         auto lights = elementSender.Lights();
         int i = 0;

--- a/dev/NavigationView/NavigationView.cpp
+++ b/dev/NavigationView/NavigationView.cpp
@@ -993,7 +993,7 @@ void NavigationView::RaiseItemInvokedForNavigationViewItem(const winrt::Navigati
     if (auto itemsSourceView = parentIR.ItemsSourceView())
     {
         auto inspectingDataSource = static_cast<InspectingDataSource*>(winrt::get_self<ItemsSourceView>(itemsSourceView));
-        auto itemIndex = parentIR.GetElementIndex(nvi);
+        const auto itemIndex = parentIR.GetElementIndex(nvi);
 
         // Check that index is NOT -1, meaning it is actually realized
         if (itemIndex != -1)
@@ -1005,7 +1005,7 @@ void NavigationView::RaiseItemInvokedForNavigationViewItem(const winrt::Navigati
 
     // Determine the recommeded transition direction.
     // Any transitions other than `Default` only apply in top nav scenarios.
-    auto recommendedDirection = [this, prevItem, nvi, parentIR]()
+    const auto recommendedDirection = [this, prevItem, nvi, parentIR]()
     {
         if (IsTopNavigationView() && nvi.SelectsOnInvoked())
         {
@@ -1209,7 +1209,7 @@ void NavigationView::OnRepeaterElementPrepared(const winrt::ItemsRepeater& ir, c
         nvibImpl->IsTopLevelItem(IsTopLevelItem(nvib));
 
         // Visual state info propagation
-        auto position = [this, ir]()
+        const auto position = [this, ir]()
         {
             if (IsTopNavigationView())
             {
@@ -2350,7 +2350,7 @@ void NavigationView::ChangeSelection(const winrt::IInspectable& prevItem, const 
         // otherwise if prevItem is on left side of nextActualItem, transition is from left
         //           if prevItem is on right side of nextActualItem, transition is from right
         // click on Settings item is considered Default
-        auto recommendedDirection = [this, prevItem, nextItem]()
+        const auto recommendedDirection = [this, prevItem, nextItem]()
         {
             if (IsTopNavigationView())
             {
@@ -2943,7 +2943,7 @@ void NavigationView::OnKeyDown(winrt::KeyRoutedEventArgs const& e)
         m_TabKeyPrecedesFocusChange = true;
         break;
     case winrt::VirtualKey::Left:
-        auto altState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Menu);
+        const auto altState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Menu);
         const bool isAltPressed = (altState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 
         if (isAltPressed && IsPaneOpen() && IsLightDismissible())
@@ -4936,7 +4936,7 @@ void NavigationView::UpdatePaneShadow()
 
         // Shadow will get clipped if casting on the splitView.Content directly
         // Creating a canvas with negative margins as receiver to allow shadow to be drawn outside the content grid 
-        winrt::Thickness shadowReceiverMargin = { 0, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
+        const winrt::Thickness shadowReceiverMargin = { 0, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ, -c_paneElevationTranslationZ };
 
         // Ensuring shadow is aligned to the left
         shadowReceiver.HorizontalAlignment(winrt::HorizontalAlignment::Left);

--- a/dev/NavigationView/NavigationViewItem.cpp
+++ b/dev/NavigationView/NavigationViewItem.cpp
@@ -848,7 +848,7 @@ void NavigationViewItem::PropagateDepthToChildren(int depth)
 {
     if (auto const repeater = m_repeater.get())
     {
-        auto itemsCount = repeater.ItemsSourceView().Count();
+        const auto itemsCount = repeater.ItemsSourceView().Count();
         for (int index = 0; index < itemsCount; index++)
         {
             if (auto const element = repeater.TryGetElement(index))
@@ -934,7 +934,7 @@ void NavigationViewItem::ResetTrackedPointerId()
 // Returns True when the provided pointer Id does not match the currently tracked Id.
 bool NavigationViewItem::IgnorePointerId(const winrt::PointerRoutedEventArgs& args)
 {
-    uint32_t pointerId = args.Pointer().PointerId();
+    const uint32_t pointerId = args.Pointer().PointerId();
 
     if (m_trackedPointerId == 0)
     {

--- a/dev/NavigationView/NavigationViewItemsFactory.cpp
+++ b/dev/NavigationView/NavigationViewItemsFactory.cpp
@@ -129,7 +129,7 @@ void NavigationViewItemsFactory::RecycleElementCore(winrt::ElementFactoryRecycle
         }
 
         // Do not recycle SettingsItem
-        bool isSettingsItem = m_settingsItem && m_settingsItem == args.Element();
+        const bool isSettingsItem = m_settingsItem && m_settingsItem == args.Element();
         
         UnlinkElementFromParent(args);
         if (m_itemTemplateWrapper && !isSettingsItem)

--- a/dev/ParallaxView/ScrollInputHelper.cpp
+++ b/dev/ParallaxView/ScrollInputHelper.cpp
@@ -366,7 +366,7 @@ void ScrollInputHelper::UpdateContentSize()
         return;
     }
 
-    int childrenCount = winrt::VisualTreeHelper::GetChildrenCount(itemsPresenter);
+    const int childrenCount = winrt::VisualTreeHelper::GetChildrenCount(itemsPresenter);
 
     if (childrenCount > 0)
     {
@@ -474,7 +474,7 @@ void ScrollInputHelper::UpdateViewportSize()
 
             if (itemsPresenter)
             {
-                int childrenCount = winrt::VisualTreeHelper::GetChildrenCount(itemsPresenter);
+                const int childrenCount = winrt::VisualTreeHelper::GetChildrenCount(itemsPresenter);
 
                 if (childrenCount > 0)
                 {
@@ -580,8 +580,8 @@ void ScrollInputHelper::UpdateIsTargetElementInSource()
 
     if (targetElement)
     {
-        bool sourceIsScrollViewer = m_scrollViewer != nullptr;
-        bool sourceIsScrollPresenter = m_scrollPresenter != nullptr;
+        const bool sourceIsScrollViewer = m_scrollViewer != nullptr;
+        const bool sourceIsScrollPresenter = m_scrollPresenter != nullptr;
 
         if (sourceIsScrollViewer || sourceIsScrollPresenter)
         {
@@ -820,7 +820,7 @@ bool ScrollInputHelper::IsScrollContentPresenterIScrollInfoProvider() const
 
             if (itemsPresenter)
             {
-                int childrenCount = winrt::VisualTreeHelper::GetChildrenCount(itemsPresenter);
+                const int childrenCount = winrt::VisualTreeHelper::GetChildrenCount(itemsPresenter);
 
                 if (childrenCount > 0)
                 {

--- a/dev/PersonPicture/InitialsGenerator.cpp
+++ b/dev/PersonPicture/InitialsGenerator.cpp
@@ -37,7 +37,7 @@ winrt::hstring InitialsGenerator::InitialsFromContactObject(const winrt::Contact
     // available, that is the data which should be used.
     if (!contact.FirstName().empty() && !contact.LastName().empty())
     {
-        CharacterType type = GetCharacterType(contact.FirstName());
+        const CharacterType type = GetCharacterType(contact.FirstName());
 
         // We'll attempt to make initials only if we recognize a name in the Standard character set.
         if (type == CharacterType::Standard)

--- a/dev/RatingControl/RatingControl.cpp
+++ b/dev/RatingControl/RatingControl.cpp
@@ -70,7 +70,7 @@ void RatingControl::UpdateCaptionMargins()
     // When text scale changes we need to update top margin to make the text follow start center.
     if (auto captionTextBlock = m_captionTextBlock.safe_get())
     {
-        double textScaleFactor = GetUISettings().TextScaleFactor();
+        const double textScaleFactor = GetUISettings().TextScaleFactor();
         winrt::Thickness margin = captionTextBlock.Margin();
         margin.Top = c_defaultCaptionTopMargin - (ActualRatingFontSize() * c_verticalScaleAnimationCenterPoint);
 
@@ -767,7 +767,7 @@ void RatingControl::OnPointerMovedOverBackgroundStackPanel(const winrt::IInspect
         if (ShouldEnableAnimation())
         {
             m_sharedPointerPropertySet.InsertScalar(L"starsScaleFocalPoint", xPosition);
-            auto deviceType = args.Pointer().PointerDeviceType();
+            const auto deviceType = args.Pointer().PointerDeviceType();
 
             switch (deviceType)
             {
@@ -914,7 +914,7 @@ void RatingControl::OnKeyDown(winrt::KeyRoutedEventArgs const& eventArgs)
             flowDirectionReverser *= -1.0;
         }
 
-        auto originalKey = eventArgs.as<winrt::KeyRoutedEventArgs>().OriginalKey();
+        const auto originalKey = eventArgs.as<winrt::KeyRoutedEventArgs>().OriginalKey();
 
         // Up down are right/left in keyboard only
         if (originalKey == winrt::VirtualKey::Up)
@@ -989,7 +989,7 @@ void RatingControl::OnPreviewKeyDown(winrt::KeyRoutedEventArgs const& eventArgs)
 
     if (!IsReadOnly() && IsFocusEngaged() && IsFocusEngagementEnabled())
     {
-        auto originalKey = eventArgs.as<winrt::KeyRoutedEventArgs>().OriginalKey();
+        const auto originalKey = eventArgs.as<winrt::KeyRoutedEventArgs>().OriginalKey();
         if (originalKey == winrt::VirtualKey::GamepadA)
         {
             m_shouldDiscardValue = false;
@@ -1024,7 +1024,7 @@ void RatingControl::OnPreviewKeyDown(winrt::KeyRoutedEventArgs const& eventArgs)
 
 void RatingControl::OnPreviewKeyUp(winrt::KeyRoutedEventArgs const& eventArgs)
 {
-    auto originalKey = eventArgs.as<winrt::KeyRoutedEventArgs>().OriginalKey();
+    const auto originalKey = eventArgs.as<winrt::KeyRoutedEventArgs>().OriginalKey();
 
     if (IsFocusEngagementEnabled() && originalKey == winrt::VirtualKey::GamepadA && m_disengagedWithA)
     {

--- a/dev/RatingControl/RatingControlAutomationPeer.cpp
+++ b/dev/RatingControl/RatingControlAutomationPeer.cpp
@@ -27,14 +27,14 @@ bool RatingControlAutomationPeer::IsReadOnly()
 
 hstring RatingControlAutomationPeer::IValueProvider_Value()
 {
-    double ratingValue = GetRatingControl().Value();
+    const double ratingValue = GetRatingControl().Value();
     winrt::hstring valueString;
 
     winrt::hstring ratingString;
 
     if (ratingValue == -1)
     {
-        double placeholderValue = GetRatingControl().PlaceholderValue();
+        const double placeholderValue = GetRatingControl().PlaceholderValue();
         if (placeholderValue == -1)
         {
             valueString = ResourceAccessor::GetLocalizedStringResource(SR_RatingUnset);
@@ -86,7 +86,7 @@ double RatingControlAutomationPeer::Minimum()
 double RatingControlAutomationPeer::Value()
 {
     // Change this to provide a placeholder value too.
-    double value = GetRatingControl().Value();
+    const double value = GetRatingControl().Value();
     if (value == -1)
     {
         return 0;
@@ -123,12 +123,12 @@ winrt::AutomationControlType RatingControlAutomationPeer::GetAutomationControlTy
 void RatingControlAutomationPeer::RaisePropertyChangedEvent(double newValue)
 {
     // UIA doesn't tolerate a null doubles, so we convert them to zeroes.
-    double oldValue = GetRatingControl().Value();
+    const double oldValue = GetRatingControl().Value();
     auto oldValueProp = winrt::PropertyValue::CreateDouble(oldValue);
 
     if (newValue == -1)
     {
-        auto newValueProp = winrt::PropertyValue::CreateDouble(0.0);
+        const auto newValueProp = winrt::PropertyValue::CreateDouble(0.0);
         __super::RaisePropertyChangedEvent(winrt::ValuePatternIdentifiers::ValueProperty(), oldValueProp, newValueProp);
         __super::RaisePropertyChangedEvent(winrt::RangeValuePatternIdentifiers::ValueProperty(), oldValueProp, newValueProp);
     }

--- a/dev/Repeater/ElementManager.cpp
+++ b/dev/Repeater/ElementManager.cpp
@@ -314,7 +314,7 @@ void ElementManager::DataSourceChanged(const winrt::IInspectable& /*source*/, wi
             break;
 
         case winrt::NotifyCollectionChangedAction::Move:
-            int size = args.OldItems() != NULL ? args.OldItems().Size() : 1;
+            const int size = args.OldItems() != NULL ? args.OldItems().Size() : 1;
             OnItemsRemoved(args.OldStartingIndex(), size);
             OnItemsAdded(args.NewStartingIndex(), size);
             break;

--- a/dev/Repeater/ItemsRepeater.cpp
+++ b/dev/Repeater/ItemsRepeater.cpp
@@ -721,7 +721,7 @@ void ItemsRepeater::OnLayoutChanged(const winrt::Layout& oldValue, const winrt::
         m_arrangeInvalidated = newValue.ArrangeInvalidated(winrt::auto_revoke, { this, &ItemsRepeater::InvalidateArrangeForLayout });
     }
 
-    bool isVirtualizingLayout = newValue != nullptr && newValue.try_as<winrt::VirtualizingLayout>() != nullptr;
+    const bool isVirtualizingLayout = newValue != nullptr && newValue.try_as<winrt::VirtualizingLayout>() != nullptr;
     m_viewportManager->OnLayoutChanged(isVirtualizingLayout);
     InvalidateMeasure();
 }

--- a/dev/Repeater/Phaser.cpp
+++ b/dev/Repeater/Phaser.cpp
@@ -145,10 +145,10 @@ void Phaser::DoPhasedWorkCallback()
             {
                 // If the next element is oustide the visible window and there are elements in the visible window
                 // go back to the visible window.
-                bool nextItemIsVisible = SharedHelpers::DoRectsIntersect(visibleWindow, m_pendingElements[currentIndex].VirtInfo()->ArrangeBounds());
+                const bool nextItemIsVisible = SharedHelpers::DoRectsIntersect(visibleWindow, m_pendingElements[currentIndex].VirtInfo()->ArrangeBounds());
                 if (!nextItemIsVisible)
                 {
-                    bool haveVisibleItems = SharedHelpers::DoRectsIntersect(visibleWindow, m_pendingElements[pendingCount - 1].VirtInfo()->ArrangeBounds());
+                    const bool haveVisibleItems = SharedHelpers::DoRectsIntersect(visibleWindow, m_pendingElements[pendingCount - 1].VirtInfo()->ArrangeBounds());
                     if (haveVisibleItems)
                     {
                         currentIndex = pendingCount - 1;

--- a/dev/Repeater/RecyclePool.cpp
+++ b/dev/Repeater/RecyclePool.cpp
@@ -104,7 +104,7 @@ winrt::UIElement RecyclePool::TryGetElementCore(
                 if (panel)
                 {
                     unsigned int childIndex = 0;
-                    bool found = panel.Children().IndexOf(elementInfo.Element(), childIndex);
+                    const bool found = panel.Children().IndexOf(elementInfo.Element(), childIndex);
                     if (!found)
                     {
                         throw winrt::hresult_error(E_FAIL, L"ItemsRepeater's child not found in its Children collection.");

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -190,7 +190,7 @@ winrt::IVectorView<winrt::IInspectable> SelectionModel::SelectedItems()
                     const unsigned int currentCount = node->SelectedCount();
                     if (index >= currentIndex && index < currentIndex + currentCount)
                     {
-                        cnst int targetIndex = node->SelectedIndices().at(index - currentIndex);
+                        const int targetIndex = node->SelectedIndices().at(index - currentIndex);
                         item = node->ItemsSourceView().GetAt(targetIndex);
                         break;
                     }

--- a/dev/Repeater/SelectionModel.cpp
+++ b/dev/Repeater/SelectionModel.cpp
@@ -190,7 +190,7 @@ winrt::IVectorView<winrt::IInspectable> SelectionModel::SelectedItems()
                     const unsigned int currentCount = node->SelectedCount();
                     if (index >= currentIndex && index < currentIndex + currentCount)
                     {
-                        int targetIndex = node->SelectedIndices().at(index - currentIndex);
+                        cnst int targetIndex = node->SelectedIndices().at(index - currentIndex);
                         item = node->ItemsSourceView().GetAt(targetIndex);
                         break;
                     }
@@ -245,7 +245,7 @@ winrt::IVectorView<winrt::IndexPath> SelectionModel::SelectedIndices()
                     const unsigned int currentCount = node->SelectedCount();
                     if (index >= currentIndex && index < currentIndex + currentCount)
                     {
-                        int targetIndex = node->SelectedIndices().at(index - currentIndex);
+                        const int targetIndex = node->SelectedIndices().at(index - currentIndex);
                         path = winrt::get_self<IndexPath>(info.Path)->CloneWithChildIndex(targetIndex);
                         break;
                     }

--- a/dev/ScrollPresenter/ScrollPresenter.cpp
+++ b/dev/ScrollPresenter/ScrollPresenter.cpp
@@ -4339,7 +4339,7 @@ void ScrollPresenter::OnPointerWheelChangedHandler(
         return;
     }
 
-    winrt::CoreVirtualKeyStates ctrlState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Control);
+    const winrt::CoreVirtualKeyStates ctrlState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Control);
     winrt::PointerPoint pointerPoint = args.GetCurrentPoint(*this);
     winrt::PointerPointProperties pointerPointProperties = pointerPoint.Properties();
     const bool isHorizontalMouseWheel = pointerPointProperties.IsHorizontalMouseWheel();

--- a/dev/ScrollPresenter/ScrollPresenterAnchoring.cpp
+++ b/dev/ScrollPresenter/ScrollPresenterAnchoring.cpp
@@ -189,7 +189,7 @@ void ScrollPresenter::ComputeElementAnchorPoint(
 
     if (m_anchorElement.get())
     {
-        winrt::Rect anchorElementBounds = isForPreArrange ? m_anchorElementBounds : GetDescendantBounds(Content(), m_anchorElement.get());
+        const winrt::Rect anchorElementBounds = isForPreArrange ? m_anchorElementBounds : GetDescendantBounds(Content(), m_anchorElement.get());
 
         ComputeAnchorPoint(anchorElementBounds, elementAnchorPointHorizontalOffset, elementAnchorPointVerticalOffset);
 

--- a/dev/ScrollView/ScrollBarController.cpp
+++ b/dev/ScrollView/ScrollBarController.cpp
@@ -550,7 +550,7 @@ bool ScrollBarController::RaiseScrollToRequested(
 
     m_scrollToRequested(*this, *scrollToRequestedEventArgs);
 
-    int32_t offsetChangeCorrelationId = scrollToRequestedEventArgs.as<winrt::ScrollControllerScrollToRequestedEventArgs>().CorrelationId();
+    const int32_t offsetChangeCorrelationId = scrollToRequestedEventArgs.as<winrt::ScrollControllerScrollToRequestedEventArgs>().CorrelationId();
 
     // Only increment m_operationsCount when the returned OffsetsChangeCorrelationId represents a new request that was not coalesced with a pending request. 
     if (offsetChangeCorrelationId != -1 && offsetChangeCorrelationId != m_lastOffsetChangeCorrelationIdForScrollTo)
@@ -583,7 +583,7 @@ bool ScrollBarController::RaiseScrollByRequested(
 
     m_scrollByRequested(*this, *scrollByRequestedEventArgs);
 
-    int32_t offsetChangeCorrelationId = scrollByRequestedEventArgs.as<winrt::ScrollControllerScrollByRequestedEventArgs>().CorrelationId();
+    const int32_t offsetChangeCorrelationId = scrollByRequestedEventArgs.as<winrt::ScrollControllerScrollByRequestedEventArgs>().CorrelationId();
 
     // Only increment m_operationsCount when the returned OffsetsChangeCorrelationId represents a new request that was not coalesced with a pending request. 
     if (offsetChangeCorrelationId != -1 && offsetChangeCorrelationId != m_lastOffsetChangeCorrelationIdForScrollBy)
@@ -623,7 +623,7 @@ bool ScrollBarController::RaiseAddScrollVelocityRequested(
 
     m_addScrollVelocityRequested(*this, *addScrollVelocityRequestedEventArgs);
 
-    int32_t offsetChangeCorrelationId = addScrollVelocityRequestedEventArgs.as<winrt::ScrollControllerAddScrollVelocityRequestedEventArgs>().CorrelationId();
+const int32_t offsetChangeCorrelationId = addScrollVelocityRequestedEventArgs.as<winrt::ScrollControllerAddScrollVelocityRequestedEventArgs>().CorrelationId();
 
     // Only increment m_operationsCount when the returned OffsetsChangeCorrelationId represents a new request that was not coalesced with a pending request. 
     if (offsetChangeCorrelationId != -1 && offsetChangeCorrelationId != m_lastOffsetChangeCorrelationIdForAddScrollVelocity)

--- a/dev/ScrollView/ScrollView.cpp
+++ b/dev/ScrollView/ScrollView.cpp
@@ -810,8 +810,8 @@ void ScrollView::OnPropertyChanged(const winrt::DependencyPropertyChangedEventAr
     SCROLLVIEW_TRACE_VERBOSE(nullptr, L"%s(property: %s)\n", METH_NAME, DependencyPropertyToString(dependencyProperty).c_str());
 #endif
 
-    bool horizontalChange = dependencyProperty == s_HorizontalScrollBarVisibilityProperty;
-    bool verticalChange = dependencyProperty == s_VerticalScrollBarVisibilityProperty;
+    const bool horizontalChange = dependencyProperty == s_HorizontalScrollBarVisibilityProperty;
+    const bool verticalChange = dependencyProperty == s_VerticalScrollBarVisibilityProperty;
 
     if (horizontalChange || verticalChange)
     {

--- a/dev/SplitButton/SplitButton.cpp
+++ b/dev/SplitButton/SplitButton.cpp
@@ -355,7 +355,7 @@ void SplitButton::OnSplitButtonKeyUp(const winrt::IInspectable& sender, const wi
     }
     else if (key == winrt::VirtualKey::Down)
     {
-        winrt::CoreVirtualKeyStates menuState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Menu);
+        const winrt::CoreVirtualKeyStates menuState = winrt::CoreWindow::GetForCurrentThread().GetKeyState(winrt::VirtualKey::Menu);
         const bool menuKeyDown = (menuState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 
         if (IsEnabled() && menuKeyDown)

--- a/dev/SwipeControl/SwipeControl.cpp
+++ b/dev/SwipeControl/SwipeControl.cpp
@@ -1646,10 +1646,10 @@ void SwipeControl::UpdateThresholdReached(float value)
 
 void SwipeControl::ThrowIfHasVerticalAndHorizontalContent(bool setIsHorizontal)
 {
-    bool hasLeftContent = LeftItems() && LeftItems().Size() > 0;
-    bool hasRightContent = RightItems() && RightItems().Size() > 0;
-    bool hasTopContent = TopItems() && TopItems().Size() > 0;
-    bool hasBottomContent = BottomItems() && BottomItems().Size() > 0;
+    const bool hasLeftContent = LeftItems() && LeftItems().Size() > 0;
+    const bool hasRightContent = RightItems() && RightItems().Size() > 0;
+    const bool hasTopContent = TopItems() && TopItems().Size() > 0;
+    const bool hasBottomContent = BottomItems() && BottomItems().Size() > 0;
     if (setIsHorizontal)
     {
         m_isHorizontal = hasLeftContent || hasRightContent || !(hasTopContent || hasBottomContent);

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -152,7 +152,7 @@ void TabView::OnApplyTemplate()
                 winrt::ThemeShadow shadow;
                 shadow.Receivers().Append(GetShadowReceiver());
 
-                double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));
+                const double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));
 
                 const auto currentTranslation = shadowCaster.Translation();
                 const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
@@ -228,8 +228,8 @@ void TabView::OnListViewGettingFocus(const winrt::IInspectable& sender, const wi
         {
             if (auto&& listView = m_listView.get())
             {
-                bool oldItemIsFromThisTabView = listView.IndexFromContainer(oldItem) != -1;
-                bool newItemIsFromThisTabView = listView.IndexFromContainer(newItem) != -1;
+                const bool oldItemIsFromThisTabView = listView.IndexFromContainer(oldItem) != -1;
+                const bool newItemIsFromThisTabView = listView.IndexFromContainer(newItem) != -1;
                 if (oldItemIsFromThisTabView && newItemIsFromThisTabView)
                 {
                     const auto inputDevice = args.InputDevice();
@@ -365,7 +365,7 @@ void TabView::UpdateListViewItemContainerTransitions()
                 // Because the default ItemContainerTransitions collection is defined in the TabViewListView style, all ListView instances share the same
                 // collection by default. Thus to avoid one TabView affecting all other ones, a new ItemContainerTransitions collection is created
                 // when the original one contains an AddDeleteThemeTransition or ContentThemeTransition instance.
-                bool transitionCollectionHasAddDeleteOrContentThemeTransition = [listView]()
+                const bool transitionCollectionHasAddDeleteOrContentThemeTransition = [listView]()
                 {
                     if (auto itemContainerTransitions = listView.ItemContainerTransitions())
                     {
@@ -816,7 +816,7 @@ winrt::TabViewItem TabView::FindTabViewItemFromDragItem(const winrt::IInspectabl
     if (!tab)
     {
         // This is a fallback scenario for tabs without a data context
-        auto numItems = static_cast<int>(TabItems().Size());
+        const auto numItems = static_cast<int>(TabItems().Size());
         for (int i = 0; i < numItems; i++)
         {
             auto tabItem = ContainerFromIndex(i).try_as<winrt::TabViewItem>();
@@ -967,7 +967,7 @@ void TabView::RequestCloseTab(winrt::TabViewItem const& container, bool updateTa
             {
                 if (!args.Cancel() && !args.Handled())
                 {
-                    int focusedIndex = IndexFromContainer(container);
+                    const int focusedIndex = IndexFromContainer(container);
                     winrt::DependencyObject newFocusedElement{ nullptr };
 
                     for (int i = focusedIndex + 1; i < GetItemCount(); i++)
@@ -1136,7 +1136,7 @@ void TabView::UpdateTabWidths(bool shouldUpdateWidths, bool fillAllAvailableSpac
 
                     // Size tab column to needed size
                     tabColumn.MaxWidth(availableWidth + headerWidth + footerWidth);
-                    auto requiredWidth = tabWidth * TabItems().Size() + headerWidth + footerWidth;
+                    const auto requiredWidth = tabWidth * TabItems().Size() + headerWidth + footerWidth;
                     if (requiredWidth > availableWidth - (padding.Left + padding.Right))
                     {
                         tabColumn.Width(winrt::GridLengthHelper::FromPixels(availableWidth));

--- a/dev/TabView/TabView.cpp
+++ b/dev/TabView/TabView.cpp
@@ -724,7 +724,7 @@ void TabView::OnItemsChanged(winrt::IInspectable const& item)
     {
         m_tabItemsChangedEventSource(*this, args);
 
-        int numItems = static_cast<int>(TabItems().Size());
+        const int numItems = static_cast<int>(TabItems().Size());
         const auto listViewInnerSelectedIndex = m_listView.get().SelectedIndex();
         auto selectedIndex = SelectedIndex();
         

--- a/dev/TabView/TabViewItem.cpp
+++ b/dev/TabView/TabViewItem.cpp
@@ -105,7 +105,7 @@ void TabViewItem::OnApplyTemplate()
                 }
                 m_shadow = shadow;
 
-                double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));
+                const double shadowDepth = unbox_value<double>(SharedHelpers::FindInApplicationResources(c_tabViewShadowDepthName, box_value(c_tabShadowDepth)));
 
                 const auto currentTranslation = Translation();
                 const auto translation = winrt::float3{ currentTranslation.x, currentTranslation.y, (float)shadowDepth };
@@ -422,7 +422,7 @@ void TabViewItem::OnPointerPressed(winrt::PointerRoutedEventArgs const& args)
         auto pointerPoint = args.GetCurrentPoint(*this);
         if (pointerPoint.Properties().IsLeftButtonPressed())
         {
-            auto isCtrlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+            const auto isCtrlDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Control) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
             if (isCtrlDown)
             {
                 // Return here so the base class will not pick it up, but let it remain unhandled so someone else could handle it.
@@ -545,8 +545,8 @@ void TabViewItem::OnKeyDown(winrt::KeyRoutedEventArgs const& args)
         // ListView also handles Alt+Arrow  (no Shift) by just doing regular XY focus,
         // same as how it handles Arrow without any modifier keys, so in that case
         // we do want to handle things so we get the improved keyboarding experience.
-        auto isAltDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Menu) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
-        auto isShiftDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Shift) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+        const auto isAltDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Menu) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+        const auto isShiftDown = (winrt::Window::Current().CoreWindow().GetKeyState(winrt::VirtualKey::Shift) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 
         if (!isAltDown || !isShiftDown)
         {

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -88,7 +88,7 @@ void TabViewItemAutomationPeer::RemoveFromSelection()
 
 void TabViewItemAutomationPeer::Select()
 {
-    if (auto owner = Owner().try_as<TabViewItem>().get())
+    if (const auto owner = Owner().try_as<TabViewItem>().get())
     {
         owner->IsSelected(true);
     }

--- a/dev/TabView/TabViewItemAutomationPeer.cpp
+++ b/dev/TabView/TabViewItemAutomationPeer.cpp
@@ -88,7 +88,7 @@ void TabViewItemAutomationPeer::RemoveFromSelection()
 
 void TabViewItemAutomationPeer::Select()
 {
-    if (const auto owner = Owner().try_as<TabViewItem>().get())
+    if (const auto* owner = Owner().try_as<TabViewItem>().get())
     {
         owner->IsSelected(true);
     }

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -1181,7 +1181,7 @@ bool TeachingTip::HandleF6Clicked(bool fromPopup)
 
     if (hasFocusInSubtree && fromPopup)
     {
-        bool setFocus = SetFocus(m_previouslyFocusedElement.get(), winrt::FocusState::Programmatic);
+        const bool setFocus = SetFocus(m_previouslyFocusedElement.get(), winrt::FocusState::Programmatic);
         m_previouslyFocusedElement = nullptr;
         return setFocus;
     }
@@ -1612,7 +1612,7 @@ void TeachingTip::CreateExpandAnimation()
 {
     auto const compositor = winrt::Window::Current().Compositor();
 
-    auto&& expandEasingFunction = [this, compositor]()
+    const auto&& expandEasingFunction = [this, compositor]()
     {
         if (!m_expandEasingFunction)
         {
@@ -1659,7 +1659,7 @@ void TeachingTip::CreateContractAnimation()
 {
     auto const compositor = winrt::Window::Current().Compositor();
 
-    auto&& contractEasingFunction = [this, compositor]()
+    const auto&& contractEasingFunction = [this, compositor]()
     {
         if (!m_contractEasingFunction)
         {

--- a/dev/TreeView/TreeViewItem.cpp
+++ b/dev/TreeView/TreeViewItem.cpp
@@ -314,7 +314,7 @@ void TreeViewItem::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
     {
         if (property == s_IsExpandedProperty)
         {
-            bool value = unbox_value<bool>(args.NewValue());
+            const bool value = unbox_value<bool>(args.NewValue());
             if (node.IsExpanded() != value)
             {
                 UpdateNodeIsExpandedAsync(node, value);
@@ -327,7 +327,7 @@ void TreeViewItem::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
         }
         else if (property == s_HasUnrealizedChildrenProperty)
         {
-            bool value = unbox_value<bool>(args.NewValue());
+            const bool value = unbox_value<bool>(args.NewValue());
             node.HasUnrealizedChildren(value);
         }
     }
@@ -601,7 +601,7 @@ void TreeViewItem::HandleReorder(winrt::VirtualKey key)
 
     winrt::TreeViewNode parentNode = targetNode.Parent();
     const auto listControl = AncestorTreeView()->ListControl();
-    unsigned int position = listControl->IndexFromContainer(*this);
+    const unsigned int position = listControl->IndexFromContainer(*this);
     if (key == winrt::VirtualKey::Up || key == winrt::VirtualKey::Left && position != 0)
     {
         unsigned int childIndex;

--- a/dev/TreeView/TreeViewItemAutomationPeer.cpp
+++ b/dev/TreeView/TreeViewItemAutomationPeer.cpp
@@ -138,7 +138,7 @@ int32_t TreeViewItemAutomationPeer::GetSizeOfSetCore()
     {
         if (const auto targetParentNode = targetNode.Parent())
         {
-            UINT32 size = targetParentNode.Children().Size();
+            const UINT32 size = targetParentNode.Children().Size();
             setSize = static_cast<int>(size);
         }
     }

--- a/dev/TreeView/TreeViewList.cpp
+++ b/dev/TreeView/TreeViewList.cpp
@@ -50,7 +50,7 @@ void TreeViewList::OnDragItemsStarting(const winrt::IInspectable& /*sender*/, co
         bool isMultipleDragging = false;
         if (IsMutiSelectWithSelectedItems())
         {
-            int selectedCount = ListViewModel()->GetSelectedNodes().Size();
+            const int selectedCount = ListViewModel()->GetSelectedNodes().Size();
             if (selectedCount > 1)
             {
                 auto settings = tvItem.as<winrt::TreeViewItem>().TreeViewItemTemplateSettings();
@@ -461,7 +461,7 @@ void TreeViewList::UpdateDropTargetDropEffect(bool forceUpdate, bool isLeaving, 
                 int insertIndex = -1;
                 int afterInsertIndex = -1;
                 int beforeInsertIndex = -1;
-                auto dragItemIndex = IndexFromContainer(dragItem);
+                const auto dragItemIndex = IndexFromContainer(dragItem);
 
                 if (keyboardReorderedContainer)
                 {
@@ -557,7 +557,7 @@ std::vector<winrt::TreeViewNode> TreeViewList::GetRootsOfSelectedSubtrees() cons
 int TreeViewList::FlatIndex(const winrt::TreeViewNode& node) const
 {
     unsigned int flatIndex = 0;
-    bool found = ListViewModel()->IndexOfNode(node, flatIndex);
+    const bool found = ListViewModel()->IndexOfNode(node, flatIndex);
     flatIndex = found ? flatIndex : -1;
     return flatIndex;
 }

--- a/dev/TreeView/TreeViewNode.cpp
+++ b/dev/TreeView/TreeViewNode.cpp
@@ -96,7 +96,7 @@ void TreeViewNode::UpdateDepth(int depth)
 
 void TreeViewNode::UpdateHasChildren()
 {
-    bool hasChildren = ((Children().Size() != 0) || m_HasUnrealizedChildren);
+    const bool hasChildren = ((Children().Size() != 0) || m_HasUnrealizedChildren);
     SetValue(s_HasChildrenProperty, box_value(hasChildren));
 }
 

--- a/dev/TreeView/ViewModel.cpp
+++ b/dev/TreeView/ViewModel.cpp
@@ -603,7 +603,7 @@ int ViewModel::AddNodeDescendantsToView(const winrt::TreeViewNode& value, unsign
 {
     if (value.IsExpanded())
     {
-        unsigned int size = value.Children().Size();
+        const unsigned int size = value.Children().Size();
         for (unsigned int i = 0; i < size; i++)
         {
             auto childNode = value.Children().GetAt(i).as<winrt::TreeViewNode>();
@@ -623,7 +623,7 @@ void ViewModel::RemoveNodeAndDescendantsFromView(const winrt::TreeViewNode& valu
     UINT32 valueIndex;
     if (value.IsExpanded())
     {
-        unsigned int size = value.Children().Size();
+        const unsigned int size = value.Children().Size();
         for (unsigned int i = 0; i < size; i++)
         {
             auto childNode = value.Children().GetAt(i).as<winrt::TreeViewNode>();
@@ -689,7 +689,7 @@ winrt::TreeViewNode ViewModel::GetRemovedChildTreeViewNodeByIndex(winrt::TreeVie
 int ViewModel::CountDescendants(const winrt::TreeViewNode& value)
 {
     int descendantCount = 0;
-    unsigned int size = value.Children().Size();
+    const unsigned int size = value.Children().Size();
     for (unsigned int i = 0; i < size; i++)
     {
         auto childNode = value.Children().GetAt(i).as<winrt::TreeViewNode>();
@@ -917,8 +917,8 @@ bool ViewModel::IndexOfNode(winrt::TreeViewNode const& targetNode, uint32_t& ind
 
 void ViewModel::TreeViewNodeVectorChanged(winrt::TreeViewNode const& sender, winrt::IInspectable const& args)
 {
-    winrt::CollectionChange collectionChange = args.as<winrt::IVectorChangedEventArgs>().CollectionChange();
-    unsigned int index = args.as<winrt::IVectorChangedEventArgs>().Index();
+    const winrt::CollectionChange collectionChange = args.as<winrt::IVectorChangedEventArgs>().CollectionChange();
+    const unsigned int index = args.as<winrt::IVectorChangedEventArgs>().Index();
 
     switch (collectionChange)
     {
@@ -1035,8 +1035,8 @@ void ViewModel::TreeViewNodeVectorChanged(winrt::TreeViewNode const& sender, win
 
 void ViewModel::SelectedNodeChildrenChanged(winrt::TreeViewNode const& sender, winrt::IInspectable const& args)
 {
-    winrt::CollectionChange collectionChange = args.as<winrt::IVectorChangedEventArgs>().CollectionChange();
-    unsigned int index = args.as<winrt::IVectorChangedEventArgs>().Index();
+    const winrt::CollectionChange collectionChange = args.as<winrt::IVectorChangedEventArgs>().CollectionChange();
+    const unsigned int index = args.as<winrt::IVectorChangedEventArgs>().Index();
     auto changingChildrenNode = sender.as<winrt::TreeViewNode>();
 
     switch (collectionChange)

--- a/dev/inc/DispatcherHelper.h
+++ b/dev/inc/DispatcherHelper.h
@@ -32,7 +32,7 @@ public:
     {
         if (dispatcherQueue)
         {
-            auto result = dispatcherQueue.TryEnqueue(winrt::Windows::System::DispatcherQueueHandler(func));
+            const auto result = dispatcherQueue.TryEnqueue(winrt::Windows::System::DispatcherQueueHandler(func));
             if (!result)
             {
                 if (fallbackToThisThread)

--- a/dev/inc/SharedHelpers.h
+++ b/dev/inc/SharedHelpers.h
@@ -162,7 +162,7 @@ public:
 
     static winrt::FrameworkElement FindInVisualTree(winrt::FrameworkElement const& parent, std::function<bool(winrt::FrameworkElement element)> const& isMatch)
     {
-        int numChildren = winrt::VisualTreeHelper::GetChildrenCount(parent);
+        const int numChildren = winrt::VisualTreeHelper::GetChildrenCount(parent);
 
         winrt::FrameworkElement foundElement = parent;
         if (isMatch(foundElement))

--- a/docs/winui3_migration.md
+++ b/docs/winui3_migration.md
@@ -8,7 +8,7 @@
 The purpose of the [try-convert WinUI3 feature](https://github.com/dotnet/try-convert/tree/feature/winui) is to create a porting solution to allow developers to convert WinUI2 projects to the new WinUI3 format.
 
 - WinUI is a native user experience (UX) framework for both Windows Desktop and UWP applications. WinUI ships as part of the Windows OS. 
-[More on WinUI](https://microsoft.github.io/microsoft-ui-xaml), [Docs](https://docs.microsoft.com/en-us/windows/apps/winui)
+[More on WinUI](http://aka.ms/winui), [Docs](https://docs.microsoft.com/en-us/windows/apps/winui)
 - WinUI3 is the next version of WinUI. It runs on the native Windows 10 UI platform and supports both Windows Desktop and UWP apps. WinUI3 ships as a NuGet package.
 [More on WinUI3](https://docs.microsoft.com/en-us/windows/apps/winui/winui3)
 


### PR DESCRIPTION
In recent weeks, WinUI2 builds (local and lab) are failing due to the static analysis warnings (treated as errors) C26462 and C26496. These warnings enforce the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#con4-use-const-to-define-objects-with-values-that-do-not-change-after-construction) rule "Con.4: Use const to define objects with values that do not change after construction."

C26462 and C26496 have been part of build/PrefastWarnings.ruleset since July 2020 and their handling in the build does not appear to have changed, so it's not clear why new occurrences are being picked up now. My best guess is that recent fixes/improvements to VS toolset have enabled new classes of this condition to be identified, and as the update rolls out, we are seeing increasing build failures of this sort.

Address the 100 newly identified "should use const" warnings (-> errors) by adding const keyword to variable/pointer variable declarations.