### PR TITLE
Cleanup of stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,8 @@ jobs:
         days-before-stale: 180
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        any-of-labels: 'code-vs-markup-mismatch, spec issue'
+        any-of-labels: 'code-vs-markup-mismatch, discussion, documentation, question, spec issue, test issue, wpf-vs-winui-mismatch'
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow
+        operations-per-run: 500

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: windows-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'no-issue-activity'
+        stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+        days-before-stale: 180
+        days-before-close: 5
+        any-of-labels: 'discussion'
+        debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
         days-before-stale: 180
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        any-of-labels: 'code-vs-markup-mismatch, discussion, documentation, question, spec issue, test issue, wpf-vs-winui-mismatch'
+        any-of-labels: 'bug, code-vs-markup-mismatch, discussion, documentation, question, spec issue, test issue, wpf-vs-winui-mismatch'
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
         # any-of-labels: documentation
-        only-labels: documentation
+        only-labels: code-vs-markup-mismatch
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
         days-before-stale: 180
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        any-of-labels: code-vs-markup-mismatch,'spec issue'
+        any-of-labels: 'code-vs-markup-mismatch, spec issue'
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,4 +32,4 @@ jobs:
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow
-        operations-per-run: 500
+        operations-per-run: 1000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,4 +32,4 @@ jobs:
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow
-        operations-per-run: 3000
+        operations-per-run: 4000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,9 +22,13 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        ascending: true # older issues first
         stale-issue-label: 'no-issue-activity'
         stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
         days-before-stale: 180
+        days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        any-of-labels: 'discussion'
+        any-of-labels: documentation
+        exempt-issue-labels: 'feature proposal'
+        exempt-all-milestones: true
         debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@
 name: Mark stale issues
 
 on:
-  pull_request:
+  #pull_request:
   
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@
 name: Mark stale issues
 
 on:
-  #pull_request:
+  pull_request:
   
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -28,8 +28,7 @@ jobs:
         days-before-stale: 180
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        # any-of-labels: documentation
-        only-labels: code-vs-markup-mismatch
+        any-of-labels: code-vs-markup-mismatch,'spec issue'
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,7 @@
 # You can adjust the behavior by modifying this file.
 # For more information, see:
 # https://github.com/actions/stale
-name: Mark stale issues and pull requests
+name: Mark stale issues
 
 on:
   pull_request:
@@ -28,7 +28,8 @@ jobs:
         days-before-stale: 180
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        any-of-labels: documentation
+        # any-of-labels: documentation
+        only-labels: documentation
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
-        debug-only: true
+        debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
         days-before-stale: 180
         days-before-pr-stale: -1 # issues only
         days-before-close: 5
-        any-of-labels: 'bug, code-vs-markup-mismatch, discussion, documentation, question, spec issue, test issue, wpf-vs-winui-mismatch'
+        # any-of-labels: 'bug, code-vs-markup-mismatch, discussion, documentation, question, spec issue, test issue, wpf-vs-winui-mismatch'
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
       issues: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         ascending: true # older issues first

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,4 +32,4 @@ jobs:
         exempt-issue-labels: 'feature proposal'
         exempt-all-milestones: true
         debug-only: ${{ github.event_name == 'pull_request' }} # Dry-run changes to the workflow
-        operations-per-run: 1000
+        operations-per-run: 3000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,8 @@
 name: Mark stale issues and pull requests
 
 on:
+  pull_request:
+  
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a manual-only workflow that is being used for the actual cleanup.

## Motivation and Context
As we mentioned in the [last community call](https://www.youtube.com/watch?v=4CzUfD1YL8A&t=1s&ab_channel=WindowsDeveloper), we are moving away from the model that tracked issues separately in github and AzureDevOps and towards a single list of issue that includes both. This will involve bringing all active github issues internally. To do this, we can’t (and shouldn’t) drown ourselves in the significant backlog that we have allowed to grow in github (mea culpa!).

What this means is that we will be bulk closing any issue that has not seen any activity in the last 180 days. We will be creating an exception for Feature Requests, and handling those separately.

If you have issues that you still care deeply about that have been lying dormant, all you need to do is post a single comment. That will set the Last Activity Date as today, and the issue will remain as-is. After any item is closed, it (of course) may be reopened.

Our logic here is that 180 days takes us back to the release of WinAppSDK 1.2. Please attempt to repro any older bugs on a recent build and update the results.
