### PR TITLE
Update PGO.compile.props to address a xfgcheck issue

### DIFF
--- a/PGO.compile.props
+++ b/PGO.compile.props
@@ -7,7 +7,7 @@
     <!-- Enable PGO optimization only for Release builds. -->
     <ItemDefinitionGroup Condition="'$(PGOBuildMode)' == 'Instrument'">
         <Link>
-            <AdditionalOptions>/GENPROFILE %(AdditionalOptions)</AdditionalOptions>
+            <AdditionalOptions>/GENPROFILE /debugtype:cv,fixup %(AdditionalOptions)</AdditionalOptions>
             <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
             <AdditionalDependencies Condition="'$(Platform)'=='ARM'">$(VC_ReferencesPath_VC_ARM)\pgort.lib;%(AdditionalDependencies)</AdditionalDependencies>
             <AdditionalDependencies Condition="'$(Platform)'=='ARM64'">$(VC_ReferencesPath_VC_ARM64)\pgort.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
A link time flag "/debugtype:cv,fixup" is added in an attempt to address a xfgcheck6 error reported by static analysis ). 

## Motivation and Context
This PR aims to address b#45848850.

## How Has This Been Tested?
No existing test can verify this change. The E2E test to is observe that static analysis no longer emits the xfgcheck6 error after this PR has merged.

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->