### PR TITLE
Remove infinitely looping BufferingProgressBar animation from MTC template

### DIFF
--- a/dev/CommonStyles/MediaTransportControls_themeresources.xaml
+++ b/dev/CommonStyles/MediaTransportControls_themeresources.xaml
@@ -150,11 +150,13 @@
                                 <VisualState x:Name="Buffering">
                                     <VisualState.Setters>
                                         <Setter Target="BufferingProgressBar.Visibility" Value="Visible" />
+                                        <Setter Target="BufferingProgressBar.ShowPaused" Value="False" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="Loading">
                                     <VisualState.Setters>
                                         <Setter Target="BufferingProgressBar.Visibility" Value="Visible" />
+                                        <Setter Target="BufferingProgressBar.ShowPaused" Value="False" />
                                     </VisualState.Setters>
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetName="ProgressSlider" Storyboard.TargetProperty="Opacity" To="0" Duration="0" />
@@ -304,7 +306,7 @@
                                                 Height="{ThemeResource MediaTransportControlsSliderHeight}"
                                                 VerticalAlignment="Center"
                                                 IsThumbToolTipEnabled="False" />
-                                        <ProgressBar x:Name="BufferingProgressBar" Height="4" IsIndeterminate="True" IsHitTestVisible="False" VerticalAlignment="Top" Margin="0,2,0,0" Visibility="Collapsed" />
+                                        <ProgressBar x:Name="BufferingProgressBar" Height="4" IsIndeterminate="True" ShowPaused="True" IsHitTestVisible="False" VerticalAlignment="Top" Margin="0,2,0,0" Visibility="Collapsed" />
                                         <Grid x:Name="TimeTextGrid" Margin="7,0,7,2" Grid.Row="1" Height="16">
                                             <TextBlock x:Name="TimeElapsedElement" Style="{StaticResource CaptionTextBlockStyle}" Margin="0" Text="00:00" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
                                             <TextBlock x:Name="TimeRemainingElement" Style="{StaticResource CaptionTextBlockStyle}" Text="00:00" HorizontalAlignment="Right" VerticalAlignment="Bottom" />


### PR DESCRIPTION
The default MediaTransportControls template has an infinitely looping "BufferingProgressBar" that will keep the UI thread active even when it's not visible. This change updates the template to pause this progress bar by default and only animate it when it's actually visible.