### PR TITLE
Make CoreWebView2 handlers robust around WebView2 destruction

### DIFF
--- a/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
+++ b/dev/RadioButtons/InteractionTests/RadioButtonsTests.cs
@@ -736,6 +736,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
         }
         [TestMethod]
         [TestProperty("TestSuite", "B")]
+        [TestProperty("Ignore", "True")] // Bug 47130840: [WinUI2] RadioButtons.AccessKeys test is failing
         public void AccessKeys()
         { 
             if (!PlatformConfiguration.IsOsVersionGreaterThanOrEqual(OSVersion.Redstone3))

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -521,137 +521,157 @@ HWND WebView2::GetActiveInputWindowHwnd() noexcept
 void WebView2::RegisterCoreEventHandlers()
 {
     m_coreNavigationStartingRevoker = m_coreWebView.NavigationStarting(winrt::auto_revoke, {
-        [this](auto const&, winrt::CoreWebView2NavigationStartingEventArgs const& args)
+        [weakThis{ get_weak() }](auto const&, winrt::CoreWebView2NavigationStartingEventArgs const& args)
         {
-            // Update Uri without navigation
-            UpdateSourceInternal();
-            FireNavigationStarting(args);
+            if (auto strongThis = weakThis.get())
+            {
+                // Update Uri without navigation
+                strongThis->UpdateSourceInternal();
+                strongThis->FireNavigationStarting(args);
+            }
         } });
 
     m_coreSourceChangedRevoker = m_coreWebView.SourceChanged(winrt::auto_revoke, {
-        [this](auto const&, winrt::CoreWebView2SourceChangedEventArgs const& args)
+        [weakThis{ get_weak() }](auto const&, winrt::CoreWebView2SourceChangedEventArgs const& args)
         {
-            // Update Uri without navigation
-            UpdateSourceInternal();
+            if (auto strongThis = weakThis.get())
+            {
+                strongThis->UpdateSourceInternal();
+            }
         } });
 
     m_coreNavigationCompletedRevoker = m_coreWebView.NavigationCompleted(winrt::auto_revoke, {
-        [this](auto const&, winrt::CoreWebView2NavigationCompletedEventArgs const& args)
+        [weakThis{ get_weak() }](auto const&, winrt::CoreWebView2NavigationCompletedEventArgs const& args)
         {
-            FireNavigationCompleted(args);
+            if (auto strongThis = weakThis.get())
+            {
+                strongThis->FireNavigationCompleted(args);
+            }
         } });
 
     m_coreWebMessageReceivedRevoker = m_coreWebView.WebMessageReceived(winrt::auto_revoke, {
-        [this](auto const&, winrt::CoreWebView2WebMessageReceivedEventArgs const& args)
+        [weakThis{ get_weak() }](auto const&, winrt::CoreWebView2WebMessageReceivedEventArgs const& args)
         {
-            // Fire the MUXC side NavigationCompleted event when the CoreWebView2 event is received.
-            FireWebMessageReceived(args);
+            if (auto strongThis = weakThis.get())
+            {
+                strongThis->FireWebMessageReceived(args);
+            }
         } });
 
     m_coreMoveFocusRequestedRevoker = m_coreWebViewController.MoveFocusRequested(winrt::auto_revoke, {
-        [this](auto const&, const winrt::CoreWebView2MoveFocusRequestedEventArgs& args)
+        [weakThis{ get_weak() }](auto const&, const winrt::CoreWebView2MoveFocusRequestedEventArgs& args)
         {
-            winrt::CoreWebView2MoveFocusReason moveFocusRequestedReason{ args.Reason() };
-
-            if (moveFocusRequestedReason == winrt::CoreWebView2MoveFocusReason::Next ||
-                moveFocusRequestedReason == winrt::CoreWebView2MoveFocusReason::Previous)
+            if (auto strongThis = weakThis.get())
             {
-                winrt::FocusNavigationDirection xamlDirection{ moveFocusRequestedReason == winrt::CoreWebView2MoveFocusReason::Next ?
-                                                                   winrt::FocusNavigationDirection::Next : winrt::FocusNavigationDirection::Previous };
-                winrt::FindNextElementOptions findNextElementOptions;
+                winrt::CoreWebView2MoveFocusReason moveFocusRequestedReason{ args.Reason() };
 
-                auto contentRoot = [this]()
+                if (moveFocusRequestedReason == winrt::CoreWebView2MoveFocusReason::Next ||
+                    moveFocusRequestedReason == winrt::CoreWebView2MoveFocusReason::Previous)
                 {
-                    if (auto thisXamlRoot = try_as<winrt::IUIElement10>())
+                    winrt::FocusNavigationDirection xamlDirection{ moveFocusRequestedReason == winrt::CoreWebView2MoveFocusReason::Next ?
+                                                                    winrt::FocusNavigationDirection::Next : winrt::FocusNavigationDirection::Previous };
+                    winrt::FindNextElementOptions findNextElementOptions;
+
+                    auto contentRoot = [strongThis]()
                     {
-                        if (auto xamlRoot = thisXamlRoot.XamlRoot())
+                        if (auto thisXamlRoot = strongThis->try_as<winrt::IUIElement10>())
                         {
-                            return xamlRoot.Content();
+                            if (auto xamlRoot = thisXamlRoot.XamlRoot())
+                            {
+                                return xamlRoot.Content();
+                            }
                         }
-                    }
-                    return winrt::Window::Current().Content();
-                }();
-
-                if (contentRoot)
-                {
-                    findNextElementOptions.SearchRoot(contentRoot);
-                    winrt::DependencyObject nextElement = [=]() {
-                        if (SharedHelpers::Is19H1OrHigher())
-                        {
-                            return winrt::FocusManager::FindNextElement(xamlDirection, findNextElementOptions);
-                        }
-                        else
-                        {
-                            return winrt::FocusManager::FindNextElement(xamlDirection);
-                        }
+                        return winrt::Window::Current().Content();
                     }();
-                    if (nextElement && nextElement.try_as<winrt::WebView2>() == *this)
-                    {
-                        // If the next element is this webview, then we are the only focusable element. Move focus back into the webview,
-                        // or else we'll get stuck trying to tab out of the top or bottom of the page instead of looping around.
-                        MoveFocusIntoCoreWebView(moveFocusRequestedReason);
-                        args.Handled(TRUE);
-                    }
-                    else if (nextElement)
-                    {
-                        // If core webview is also losing focus via something other than TAB (web LostFocus event fired)
-                        // and the TAB handling is arriving later (eg due to longer MOJO delay), skip manually moving Xaml Focus to next element.
-                        if (m_webHasFocus)
-                        {
-                            const auto _ = [=]() {
-                                if (SharedHelpers::Is19H1OrHigher())
-                                {
-                                    return winrt::FocusManager::TryMoveFocusAsync(xamlDirection, findNextElementOptions);
-                                }
-                                else
-                                {
-                                    return winrt::FocusManager::TryMoveFocusAsync(xamlDirection);
-                                }
-                            }();
-                            m_webHasFocus = false;
-                        }
 
-                        args.Handled(TRUE);
+                    if (contentRoot)
+                    {
+                        findNextElementOptions.SearchRoot(contentRoot);
+                        winrt::DependencyObject nextElement = [=]() {
+                            if (SharedHelpers::Is19H1OrHigher())
+                            {
+                                return winrt::FocusManager::FindNextElement(xamlDirection, findNextElementOptions);
+                            }
+                            else
+                            {
+                                return winrt::FocusManager::FindNextElement(xamlDirection);
+                            }
+                        }();
+                        if (nextElement && nextElement.try_as<winrt::WebView2>() == strongThis)
+                        {
+                            // If the next element is this webview, then we are the only focusable element. Move focus back into the webview,
+                            // or else we'll get stuck trying to tab out of the top or bottom of the page instead of looping around.
+                            MoveFocusIntoCoreWebView(moveFocusRequestedReason);
+                            args.Handled(TRUE);
+                        }
+                        else if (nextElement)
+                        {
+                            // If core webview is also losing focus via something other than TAB (web LostFocus event fired)
+                            // and the TAB handling is arriving later (eg due to longer MOJO delay), skip manually moving Xaml Focus to next element.
+                            if (strongThis->m_webHasFocus)
+                            {
+                                const auto _ = [=]() {
+                                    if (SharedHelpers::Is19H1OrHigher())
+                                    {
+                                        return winrt::FocusManager::TryMoveFocusAsync(xamlDirection, findNextElementOptions);
+                                    }
+                                    else
+                                    {
+                                        return winrt::FocusManager::TryMoveFocusAsync(xamlDirection);
+                                    }
+                                }();
+                                strongThis->m_webHasFocus = false;
+                            }
+
+                            args.Handled(TRUE);
+                        }
                     }
                 }
-
-                // If nextElement is null, focus is maintained in Anaheim by not marking Handled.
-            }
+            }   // If nextElement is null, focus is maintained in Anaheim by not marking Handled.
         } });
 
     m_coreProcessFailedRevoker = m_coreWebView.ProcessFailed(winrt::auto_revoke, {
-        [this](auto const&, winrt::CoreWebView2ProcessFailedEventArgs const& args)
+        [weakThis{ get_weak() }](auto const&, const winrt::CoreWebView2ProcessFailedEventArgs& args)
         {
-            winrt::CoreWebView2ProcessFailedKind coreProcessFailedKind{ args.ProcessFailedKind() };
-            if (coreProcessFailedKind == winrt::CoreWebView2ProcessFailedKind::BrowserProcessExited)
+            if (auto strongThis = weakThis.get())
             {
-                m_isCoreFailure_BrowserExited_State = true;
+                winrt::CoreWebView2ProcessFailedKind coreProcessFailedKind{ args.ProcessFailedKind() };
+                if (coreProcessFailedKind == winrt::CoreWebView2ProcessFailedKind::BrowserProcessExited)
+                {
+                    strongThis->m_isCoreFailure_BrowserExited_State = true;
 
-                // CoreWebView2 takes care of clearing the event handlers when closing the host,
-                // but we still need to reset the event tokens
-                UnregisterCoreEventHandlers();
+                    // CoreWebView2 takes care of clearing the event handlers when closing the host,
+                    // but we still need to reset the event tokens
+                    strongThis->UnregisterCoreEventHandlers();
 
-                // Null these out so we can't try to use them anymore
-                m_coreWebViewCompositionController = nullptr;
-                m_coreWebViewController = nullptr;
-                m_coreWebView = nullptr;
-                ResetProperties();
+                    // Null these out so we can't try to use them anymore
+                    strongThis->m_coreWebViewCompositionController = nullptr;
+                    strongThis->m_coreWebViewController = nullptr;
+                    strongThis->m_coreWebView = nullptr;
+                    strongThis->ResetProperties();
+                }
+
+                strongThis->FireCoreProcessFailedEvent(args);
             }
-
-            FireCoreProcessFailedEvent(args);
         } });
 
     m_coreLostFocusRevoker = m_coreWebViewController.LostFocus(winrt::auto_revoke, {
-        [this](auto const&, auto const&)
+        [weakThis{ get_weak() }](auto const& controller, auto const& obj)
         {
-            // Unset our tracking of Edge focus when it is lost via something other than TAB navigation.
-            m_webHasFocus = false;
+            if (auto strongThis = weakThis.get())
+            {
+                // Unset our tracking of Edge focus when it is lost via something other than TAB navigation.
+                strongThis->m_webHasFocus = false;
+            }
         } });
 
     m_cursorChangedRevoker = m_coreWebViewCompositionController.CursorChanged(winrt::auto_revoke, {
-        [this](auto const& controller, auto const& obj)
+        [weakThis{ get_weak() }](auto const& controller, auto const& obj)
         {
-            UpdateCoreWindowCursor();
+            if (auto strongThis = weakThis.get())
+            {
+                strongThis->UpdateCoreWindowCursor();
+            }
         } });
 }
 

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -597,7 +597,7 @@ void WebView2::RegisterCoreEventHandlers()
                                 return winrt::FocusManager::FindNextElement(xamlDirection);
                             }
                         }();
-                        if (nextElement && nextElement.try_as<winrt::WebView2>() == strongThis->try_as<winrt::WebView2>())
+                        if (nextElement && nextElement.try_as<winrt::WebView2>() == *(strongThis.get()))
                         {
                             // If the next element is this webview, then we are the only focusable element. Move focus back into the webview,
                             // or else we'll get stuck trying to tab out of the top or bottom of the page instead of looping around.

--- a/dev/WebView2/WebView2.cpp
+++ b/dev/WebView2/WebView2.cpp
@@ -597,11 +597,11 @@ void WebView2::RegisterCoreEventHandlers()
                                 return winrt::FocusManager::FindNextElement(xamlDirection);
                             }
                         }();
-                        if (nextElement && nextElement.try_as<winrt::WebView2>() == strongThis)
+                        if (nextElement && nextElement.try_as<winrt::WebView2>() == strongThis->try_as<winrt::WebView2>())
                         {
                             // If the next element is this webview, then we are the only focusable element. Move focus back into the webview,
                             // or else we'll get stuck trying to tab out of the top or bottom of the page instead of looping around.
-                            MoveFocusIntoCoreWebView(moveFocusRequestedReason);
+                            strongThis->MoveFocusIntoCoreWebView(moveFocusRequestedReason);
                             args.Handled(TRUE);
                         }
                         else if (nextElement)

--- a/docs/contribution_workflow.md
+++ b/docs/contribution_workflow.md
@@ -89,11 +89,6 @@ Pull requests from a fork will not automatically trigger all of these checks. A 
 team can trigger the Azure Pipeline checks by commenting `/azp run` on the PR. The Azure Pipelines
 bot will then trigger the build.
 
-In order to have PRs automatically merge once all checks have passed (including optional 
-checks), maintainers can apply the [auto merge](https://github.com/Microsoft/microsoft-ui-xaml/labels/auto%20merge) 
-label. It will take effect after an 8 hour delay, 
-[more info here (internal link)](https://microsoft.sharepoint.com/teams/FabricBot/SitePages/AutoMerge,-Bot-Templates-and.aspx).
-
 ### Other Pipelines
 
 Unlike the above checks these are not required for all PRs, but you may see them on some PRs so we 


### PR DESCRIPTION
In WebView2, we have a race condition when subscribed events on CoreWebView2/CoreWebView2Controller end up getting raised around the time WebView2 is destructed. The events are raised on the UI thread, but are asynchronous and involve MOJO/IPC, so it's possible in the meantime for WebView2 to be destructed leading to a dangling reference in the handlers. This has surfaced recently with a spike of Watson hits in microsoftmahjong crashing via Microsoft.UI.Xaml.dll!ITrackerHandleManager::DeleteTrackerHandle with HR 0xc0000409 (nominally STATUS_STACK_BUFFER_OVERRUN, but in actuality FAIL_FAST_FATAL_APP_EXIT as logged by Watson, more on that below).  The fix is to protect access to WebView2 instance inside CWV2 event handler with a weak ref.

In a representative dump, we see Xaml getting notified of an incoming web message when the owning WebView2 object has already been destructed. We are able to dance around the released WebView2 object's memory during much of WebView2::FireWebMessageReceived, but finally crash at the end of the app's WV2.WebMessageReceived invocation, as we try to invoke WebView2->DeleteTrackerHandle to clean up the temporary tracker_ref<TypedEventHandler<…>> 'handler' variable as shown below: 

```
template <typename... A> void operator()(A const & ... args) const
{
    auto handlers = m_handlers;

   if (auto * map = handlers.get())
   {
        for (const auto & pair : *map)
        {
            auto handler = Impl()->unwrap(pair.second);
            handler(args...);  
        } <--- uh-oh, handler going out of scope, watch out for ref_tracker dtor...
    }
}
```

At the end of the for() loop scope, handler (tracker_ref<TypedEventHandler<…>>) goes out of scope, and tracker_ref's cleanup invokes ITrackerOwner::DeleteTrackerHandler on the owning WebView2 object. It is this access to (released) WV2 via ITrackerOwner that triggers app termination:

```
~tracker_ref()
    {
        if (m_owner)
        {
            if (!ShouldFallbackToComPointers())
            {
                if (m_handle)
                {
                    MUX_ASSERT(m_owner);
                    m_owner->DeleteTrackerHandle(m_handle);  <--- crash right about here!
                }
            }
…
}
```

The invocation of ITrackerOwner::DeleteTrackerHandle on the released WV2 leads to immediate termination via CRT abort(), per frame 0 of stack:
`[0x0]            : ucrtbase!abort + 0x4e [Switch To]`

Thanks to insight from [Raymond Chen's blog post](https://devblogs.microsoft.com/oldnewthing/20190108-00/?p=100655), 0xc0000409/STATUS_STACK_BUFFER_OVERRUN doesn't necessarily mean there was a stack buffer overrun, in fact most often it doesn't... in this case it maps to FAIL_FAST_FATAL_APP_EXIT, which is indeed associated with abort() -triggered termination.

In addition to addressing this for the identified WebMessageRecieved handler, apply the fix to all of WebView2's CoreWebView2 subscriptions.