### PR TITLE
Update GitHub ResourceManagement policy yml

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -8,7 +8,7 @@ where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-    - description: 
+    - description: Close needs-author-feedback issue with no-recent-activity after 7 days
       frequencies:
       - hourly:
           hour: 6
@@ -23,7 +23,8 @@ configuration:
           days: 7
       actions:
       - closeIssue
-    - description: 
+
+    - description: Add no-recent-activity to issue with needs-author-feedback after 7 days
       frequencies:
       - hourly:
           hour: 6
@@ -41,38 +42,63 @@ configuration:
           label: no-recent-activity
       - addReply:
           reply: This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**.
+
+
     eventResponderTasks:
-    - if:
+
+    - description: Declined PR
+      if: 
       - payloadType: Pull_Request
       - labelAdded:
           label: declined
       then:
       - addReply:
-          reply: We appreciate the feedback, however this doesn’t currently align to the project’s goals and roadmap and so will be automatically closed. Thank you for your contributions to WinUI!
+          reply: We appreciate the feedback, however this doesn't currently align to the project's goals and roadmap and so will be automatically closed. Thank you for your contributions to WinUI!
       - closeIssue
-      description: 
-    - if:
+
+
+    - description: Enable auto merge
+      if:
       - payloadType: Pull_Request
       - hasLabel:
           label: auto merge
       then:
       - enableAutoMerge:
           mergeMethod: Squash
-      description: 
-    - if:
+
+
+    - description: Disable auto merge
+      if: 
       - payloadType: Pull_Request
       - labelRemoved:
           label: auto merge
       then:
       - disableAutoMerge
-      description: 
-    - if:
+      
+
+    - description: working on it
+      if:
       - payloadType: Pull_Request
       then:
       - inPrLabel:
           label: working on it
-      description: 
-    - if:
+      
+
+    - description: Add needs-triage to new or reopened Issue
+      if:
+      - payloadType: Issues
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Reopened
+      then:
+      - addLabel:
+          label: needs-triage
+
+
+    - description: Add needs-triage to issues when team- label removed
+      if:
       - payloadType: Issues
       - or:
         - labelRemoved:
@@ -92,30 +118,35 @@ configuration:
       then:
       - addLabel:
           label: needs-triage
-      description: 
-    - if:
+      
+
+    - description: Remove needs-triage from Closed items
+      if:
       - payloadType: Issues
       - isAction:
           action: Closed
       then:
       - removeLabel:
           label: needs-triage
-      description: 
-    - if:
+
+
+      description: Add needs-triage to closed item if commented on by external user
+    - if: 
       - payloadType: Issue_Comment
       - not: isOpen
-      - hasLabel:
-          label: needs-triage
-      - or:
-        - activitySenderHasPermission:
-            permission: Write
-        - activitySenderHasPermission:
-            permission: Admin
+      - not:
+        - or:
+          - activitySenderHasPermission:
+              permission: Write
+          - activitySenderHasPermission:
+              permission: Admin
       then:
-      - removeLabel:
+      - addLabel:
           label: needs-triage
-      description: 
-    - if:
+
+
+    - description: Remove needs-author-feedback after comment from author and add needs-assignee-attention (if issue is assigned)
+      if:
       - payloadType: Issue_Comment
       - isAction:
           action: Created
@@ -129,8 +160,10 @@ configuration:
           label: needs-assignee-attention
       - removeLabel:
           label: needs-author-feedback
-      description: 
-    - if:
+      
+
+    - description: Remove needs-author-feedback after comment from author and add needs-triage (if issue is unassigned)
+      if:
       - payloadType: Issue_Comment
       - isAction:
           action: Created
@@ -144,8 +177,10 @@ configuration:
           label: needs-triage
       - removeLabel:
           label: needs-author-feedback
-      description: 
-    - if:
+      
+
+    - description: Add needs-triage to new PR
+      if:
       - payloadType: Pull_Request
       - or:
         - isAction:
@@ -155,8 +190,10 @@ configuration:
       then:
       - addLabel:
           label: needs-triage
-      description: 
-    - if:
+      
+
+    - description: Remove needs-author-feedback after comment from author and add needs-triage
+      if:
       - payloadType: Issue_Comment
       - isAction:
           action: Created
@@ -170,8 +207,10 @@ configuration:
           label: needs-triage
       - removeLabel:
           label: needs-author-feedback
-      description: 
-    - if:
+      
+
+    - description: Remove no-recent-activity from issue
+      if:
       - payloadType: Issues
       - not:
           isAction:
@@ -181,14 +220,18 @@ configuration:
       then:
       - removeLabel:
           label: no-recent-activity
-      description: 
-    - if:
+      
+
+    - description: Remove no-recent-activity from issue after comment
+      if:
       - payloadType: Issue_Comment
       - hasLabel:
           label: no-recent-activity
       then:
       - removeLabel:
           label: no-recent-activity
-      description: 
+          
+      
+
 onFailure: 
 onSuccess: 

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -95,29 +95,6 @@ configuration:
       then:
       - addLabel:
           label: needs-triage
-
-
-    - description: Add needs-triage to issues when team- label removed
-      if:
-      - payloadType: Issues
-      - or:
-        - labelRemoved:
-            label: team-CompInput
-        - labelRemoved:
-            label: team-Controls
-        - labelRemoved:
-            label: team-Framework
-        - labelRemoved:
-            label: team-Ink
-        - labelRemoved:
-            label: team-Markup
-        - labelRemoved:
-            label: team-Reach
-        - labelRemoved:
-            label: team-Rendering
-      then:
-      - addLabel:
-          label: needs-triage
       
 
     - description: Remove needs-triage from Closed items

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -135,7 +135,7 @@ configuration:
       - payloadType: Issue_Comment
       - not: isOpen
       - not:
-        - or:
+          or:
           - activitySenderHasPermission:
               permission: Write
           - activitySenderHasPermission:


### PR DESCRIPTION
Added descriptions to the different rules to make it clearer what each one does.

Added a new rule to add needs-triage to new or re-opened Issues.
Added a new rule to add needs-triage tag to Issues that get commented on after they are Closed.

Removed the rule that added needs-triage when the team-Foo label is changed on an Issue.

There is no great way for me to test these changes other than merging this PR and making sure that the bot works correctly after.