### PR TITLE
Update Placeholder Text Foreground to Secondary on Focused

### DIFF
--- a/build/PrefastWarnings.ruleset
+++ b/build/PrefastWarnings.ruleset
@@ -52,6 +52,7 @@
     <Rule Id="C26463" Action="Warning" />
     <Rule Id="C26464" Action="Warning" />
     <Rule Id="C26465" Action="Warning" />
+    <Rule Id="C26478" Action="Warning" />
     <Rule Id="C26496" Action="Warning" />
     <Rule Id="C26497" Action="Warning" />
     <Rule Id="C26498" Action="Warning" />

--- a/build/PrefastWarnings.ruleset
+++ b/build/PrefastWarnings.ruleset
@@ -52,7 +52,7 @@
     <Rule Id="C26463" Action="Warning" />
     <Rule Id="C26464" Action="Warning" />
     <Rule Id="C26465" Action="Warning" />
-    <Rule Id="C26478" Action="Warning" />
+    <Rule Id="C26478" Action="None" />
     <Rule Id="C26496" Action="Warning" />
     <Rule Id="C26497" Action="Warning" />
     <Rule Id="C26498" Action="Warning" />

--- a/dev/AnimatedIcon/AnimatedIcon.cpp
+++ b/dev/AnimatedIcon/AnimatedIcon.cpp
@@ -10,6 +10,8 @@
 #include "Utils.h"
 #include <mutex>
 
+#pragma warning( disable : 26478)
+
 static constexpr wstring_view s_progressPropertyName{ L"Progress"sv };
 static constexpr wstring_view s_foregroundPropertyName{ L"Foreground"sv };
 static constexpr wstring_view s_transitionInfix{ L"To"sv };

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -43,7 +43,7 @@
             <StaticResource x:Key="TextControlForegroundDisabled" ResourceKey="TemporaryTextFillColorDisabled" />
             <StaticResource x:Key="TextControlPlaceholderForeground" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TextControlPlaceholderForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TextControlPlaceholderForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="TextControlSelectionHighlightColor" ResourceKey="AccentFillColorSelectedTextBackgroundBrush" />
 
@@ -163,7 +163,7 @@
             <StaticResource x:Key="TextControlForegroundDisabled" ResourceKey="TemporaryTextFillColorDisabled" />
             <StaticResource x:Key="TextControlPlaceholderForeground" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TextControlPlaceholderForegroundPointerOver" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="TextFillColorTertiaryBrush" />
+            <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="TextFillColorSecondaryBrush" />
             <StaticResource x:Key="TextControlPlaceholderForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
             <StaticResource x:Key="TextControlSelectionHighlightColor" ResourceKey="AccentFillColorSelectedTextBackgroundBrush" />
 

--- a/dev/NumberBox/NumberBoxParser.cpp
+++ b/dev/NumberBox/NumberBoxParser.cpp
@@ -6,6 +6,8 @@
 #include "NumberBoxParser.h"
 #include "Utils.h"
 
+#pragma warning( disable : 26478)
+
 static constexpr wstring_view c_numberBoxOperators{ L"+-*/^"sv };
 
 // Returns list of MathTokens from expression input string. If there are any parsing errors, it returns an empty vector.

--- a/dev/ProgressBar/ProgressBar.cpp
+++ b/dev/ProgressBar/ProgressBar.cpp
@@ -8,6 +8,8 @@
 #include "RuntimeProfiler.h"
 #include "ResourceAccessor.h"
 
+#pragma warning( disable : 26478)
+
 ProgressBar::ProgressBar()
 {
     __RP_Marker_ClassById(RuntimeProfiler::ProfId_ProgressBar);

--- a/dev/ProgressRing/ProgressRing.cpp
+++ b/dev/ProgressRing/ProgressRing.cpp
@@ -9,6 +9,8 @@
 #include "ResourceAccessor.h"
 #include "math.h"
 
+#pragma warning( disable : 26478)
+
 static constexpr wstring_view s_LayoutRootName{ L"LayoutRoot"sv };
 static constexpr wstring_view s_LottiePlayerName{ L"LottiePlayer"sv };
 static constexpr wstring_view s_DefaultForegroundThemeResourceName{ L"SystemControlHighlightAccentBrush"sv };

--- a/dev/TeachingTip/TeachingTip.cpp
+++ b/dev/TeachingTip/TeachingTip.cpp
@@ -13,6 +13,8 @@
 #include "../ResourceHelper/Utils.h"
 #include <enum_array.h>
 
+#pragma warning( disable : 26478)
+
 static constexpr auto c_TitleTextBlockVisibleStateName = L"ShowTitleTextBlock"sv;
 static constexpr auto c_TitleTextBlockCollapsedStateName = L"CollapseTitleTextBlock"sv;
 static constexpr auto c_SubtitleTextBlockVisibleStateName = L"ShowSubtitleTextBlock"sv;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update `TextControlPlaceholderForegroundFocused` from `TextFillColorTertiaryBrush` to `TextFillColorSecondaryBrush` to stay compliant with Accessibility standards.

Updating this resource automatically updates AutoSuggestBox, ComboBox, PasswordBox, RichEditBox, and NumberBox that depend on this resource.

Before:
![image](https://github.com/microsoft/microsoft-ui-xaml/assets/7976322/c32e6fa3-aa24-486f-8d6c-3c14bce3709c)

After:
![image](https://github.com/microsoft/microsoft-ui-xaml/assets/7976322/08b63eba-9a08-4465-8c76-91ef2e504885)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #xxx" or "Fixes #xxx" so that GitHub will close the issue once the PR is complete. -->
Internal Bug:
[Bug 45806832](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/45806832): [Auth & Identity]: The color contrast ratio for the text "Pin" while editing is 3.262:1 which is less than expected (4.5:1)

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Manual verification with Accessibility Insights for Windows.
