### PR TITLE
Update similar-issues-bot.yml tolerance

### DIFF
--- a/.github/workflows/similar-issues-bot.yml
+++ b/.github/workflows/similar-issues-bot.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           issuetitle: ${{ github.event.issue.title }}
           repo: ${{ github.repository }}
-          similaritytolerance: "0.75"
+          similaritytolerance: "0.70"
           commentBody: | 
             Hi I'm an AI powered bot that finds similar issues based off the issue title.
 

--- a/.github/workflows/similar-issues-bot.yml
+++ b/.github/workflows/similar-issues-bot.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    if: needs.getsimilarissues.outputs.message != ''
     steps:
       - name: Add comment
         run: gh issue comment "$NUMBER" --repo "$REPO" --body "$BODY"


### PR DESCRIPTION
## Description
The tolerance value for a similar issue was changed from 0.75 to 0.70.

## Motivation and Context
This is because I changed the backend service for this to use pinecone instead of Azure AI search (see here https://github.com/craigloewen-msft/GitGudIssues/commit/f72fa59e23c0b7501b613daea95371cb13831d42 ) and the metric changed as a result of that. They are slightly lower than they were before, so this should offset that.

## How Has This Been Tested?
Validated with the same calls to the Azure AI search and then to the new database to determine that minusing 0.05 would be sufficient.
