### PR TITLE
Remove a mention of WindowsAppSDK v1.2 as the latest version

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@ It focuses on enabling three main use cases:
 3. **Enabling other frameworks**
     * Providing the native implementation for other frameworks like [React Native](https://github.com/Microsoft/react-native-windows) and .NET [MAUI](https://docs.microsoft.com/dotnet/maui/what-is-maui) when running on Windows.
 
-WinUI 3 is available as a part of the [Windows App SDK](https://docs.microsoft.com/windows/apps/windows-app-sdk) for building stable and supported desktop/Win32 apps for production scenarios. The latest release is the Windows App SDK 1.2, which you can download and read more about at the documentation linked below:
+WinUI 3 is available as a part of the [Windows App SDK](https://docs.microsoft.com/windows/apps/windows-app-sdk) for building stable and supported desktop/Win32 apps for production scenarios. You can download and read more about the latest releases of the Windows App SDK at the following documentation.
 
 [Stable release channel for the Windows App SDK](https://docs.microsoft.com/windows/apps/windows-app-sdk/stable-channel)
 


### PR DESCRIPTION
## Description
Edited roadmap.md in a way that a specific WindowsAppSDK version is not mentioned.

## Motivation and Context
The mention about the latest WindowsAppSDK version will be wrong unless this documentation is updated every time a new version is released.

## How Has This Been Tested?
Checked the markdown preview.

## Screenshots (if appropriate):