### PR TITLE
Remove unnecessary bold emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For info on the WinUI release schedule and high level plans please see the [Wind
 ## WinUI 3 is a part of the Windows App SDK family
 The [Windows App SDK](https://github.com/microsoft/ProjectReunion) is a set of libraries, frameworks, components, and tools that you can use in your apps to access powerful Windows platform functionality from all kinds of apps on many versions of Windows. The Windows App SDK combines the powers of Win32 native applications alongside modern API usage techniques, so your apps light up everywhere your users are. 
  
-Other Windows App SDK components are: [WebView2](https://docs.microsoft.com/microsoft-edge/webview2/),  [MSIX (MSIX-Core)](https://docs.microsoft.com/windows/msix/overview), [C++/WinRT](https://github.com/microsoft/cppwinrt), [Rust/WinRT](https://github.com/microsoft/winrt-rs), and [C#/WinRT](https://github.com/microsoft/cswinrt). If you'd like to learn more and contribute to Windows App SDK, or have **UWP/app model related questions**, visit our [Github repo](https://github.com/microsoft/WindowsAppSDK). 
+Other Windows App SDK components are: [WebView2](https://docs.microsoft.com/microsoft-edge/webview2/),  [MSIX (MSIX-Core)](https://docs.microsoft.com/windows/msix/overview), [C++/WinRT](https://github.com/microsoft/cppwinrt), [Rust/WinRT](https://github.com/microsoft/winrt-rs), and [C#/WinRT](https://github.com/microsoft/cswinrt). If you'd like to learn more and contribute to Windows App SDK, or have UWP/app model related questions, visit our [Github repo](https://github.com/microsoft/WindowsAppSDK). 
 
 For a detailed look at the features we're planning on releasing in WinAppSDK check out the [Windows App SDK feature roadmap](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md).
 


### PR DESCRIPTION
## Description
Removed unnecessary bold emphasis.

## Motivation and Context
The only bold emphasis within a sentence on "**UWP/app model related questions**" shouldn't be necessary.

## How Has This Been Tested?
Checked the markdown preview.

## Screenshots (if appropriate):