### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Runs a single command using the runners shell
       - name: Check links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
       - name: Check links

--- a/.github/workflows/similar-issues-bot.yml
+++ b/.github/workflows/similar-issues-bot.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       message: ${{ steps.getbody.outputs.message }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: getbody
         uses: craigloewen-msft/GitGudSimilarIssues@main
         with:


### PR DESCRIPTION
Pull Request Description:

Changes Made:
Updated the workflow file to address the deprecation warning for Node.js 16 actions.
Replaced actions/checkout@v2 with actions/checkout@v4 to use Node.js 20 as recommended in the GitHub Actions transition guide (https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

Reason for the Update:
The workflow was triggering a deprecation warning indicating the use of deprecated Node.js 16 actions. To maintain compatibility and adhere to the GitHub Actions transition, I have updated the actions/checkout action to version v4, ensuring compatibility with Node.js 20.

Testing:
I have locally tested the updated workflow to ensure it works as expected with the new Node.js version.

![image](https://github.com/microsoft/microsoft-ui-xaml/assets/157403288/3edd0a84-5927-43bd-9309-cc82822b586e)
