### PR TITLE
Improve text scale support on TextBox and NavigationView buttons

### DIFF
--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources.xaml
@@ -122,6 +122,7 @@
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     Text="&#xE894;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/AutoSuggestBox/AutoSuggestBox_themeresources_v1.xaml
+++ b/dev/AutoSuggestBox/AutoSuggestBox_themeresources_v1.xaml
@@ -115,6 +115,7 @@
                                                     Text="&#xE894;"
                                                     FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/CommonStyles/PasswordBox_themeresources.xaml
+++ b/dev/CommonStyles/PasswordBox_themeresources.xaml
@@ -127,6 +127,7 @@
                                                     FontSize="{ThemeResource PasswordBoxIconFontSize}"
                                                     Text="&#xF78D;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/CommonStyles/PasswordBox_themeresources_v1.xaml
+++ b/dev/CommonStyles/PasswordBox_themeresources_v1.xaml
@@ -126,6 +126,7 @@
                                                     FontSize="{ThemeResource PasswordBoxIconFontSize}"
                                                     Text="&#xF78D;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/CommonStyles/TextBox_themeresources.xaml
+++ b/dev/CommonStyles/TextBox_themeresources.xaml
@@ -292,6 +292,7 @@
                                                     FontSize="{ThemeResource TextBoxIconFontSize}"
                                                     Text="&#xE894;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/CommonStyles/TextBox_themeresources_v1.xaml
+++ b/dev/CommonStyles/TextBox_themeresources_v1.xaml
@@ -174,6 +174,7 @@
                                                     FontSize="{ThemeResource TextBoxIconFontSize}"
                                                     Text="&#xE894;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/NavigationView/NavigationView_rs1_themeresources.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources.xaml
@@ -416,6 +416,7 @@
         <Setter Property="HorizontalAlignment" Value="Center" />
         <Setter Property="FocusVisualMargin" Value="-4,0" />
         <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <Setter Property="IsTextScaleFactorEnabled" Value="False" />
     </Style>
 
     <Style x:Key="NavigationViewOverflowButtonStyleWhenPaneOnTop" TargetType="Button">

--- a/dev/NavigationView/NavigationView_rs1_themeresources_v1.xaml
+++ b/dev/NavigationView/NavigationView_rs1_themeresources_v1.xaml
@@ -408,6 +408,7 @@
         <Setter Property="BorderThickness" Value="{ThemeResource NavigationViewToggleBorderThickness}" />
         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />
         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
+        <Setter Property="IsTextScaleFactorEnabled" Value="False" />
     </Style>
 
     <Style x:Key="NavigationViewOverflowButtonStyleWhenPaneOnTop" TargetType="Button">

--- a/dev/NumberBox/NumberBox.xaml
+++ b/dev/NumberBox/NumberBox.xaml
@@ -381,6 +381,7 @@
                                                     FontSize="{ThemeResource TextBoxIconFontSize}"
                                                     Text="&#xE894;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>

--- a/dev/NumberBox/NumberBox_v1.xaml
+++ b/dev/NumberBox/NumberBox_v1.xaml
@@ -286,6 +286,7 @@
                                                     FontSize="12"
                                                     Text="&#xE894;"
                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    IsTextScaleFactorEnabled="False"
                                                     AutomationProperties.AccessibilityView="Raw" />
                                             </Grid>
                                         </ControlTemplate>


### PR DESCRIPTION
Some TexBlocks with glyphs don't properly ignore the system text scale accessibility setting and, for the NavigationView search button, can scale beyond the control limits. The design [guidance](https://learn.microsoft.com/en-us/windows/apps/design/input/text-scaling#dont-scale-font-based-icons-or-symbols).

## Description
- Disable `IsTextScaleFactorEnabled` on the `NavigationViewPaneSearchButtonStyle`, ported back from WinUI 3.
https://github.com/microsoft/microsoft-ui-xaml/blob/2a60e27c591846556fa9ec4d8f305afdf0f96dc1/controls/dev/NavigationView/NavigationView_themeresources.xaml#L343

- Disable `IsTextScaleFactorEnabled` on the RevealButtonstyle for the PasswordBox control.

- Disable `IsTextScaleFactorEnabled` on the DeleteButtonStyle for the TextBox/NumberBox/PasswordBox/AutoSuggestBox controls

## Motivation and Context
Provide better accessibility text size support.

## How Has This Been Tested?
Created a test app WinUI 2 with and without the changes.

## Screenshots (if appropriate):
|Before (IsTextScaleFactorEnabled="True")|After (IsTextScaleFactorEnabled="False")|
|-|-|
|![ClearButtonBefore](https://github.com/microsoft/microsoft-ui-xaml/assets/698155/82413a88-2844-4c6a-b087-67f4391a00be)|![ClearButton](https://github.com/microsoft/microsoft-ui-xaml/assets/698155/f2b73460-fe8c-4ea0-bd21-5779e9d65c2e)|
|![RevealBefore](https://github.com/microsoft/microsoft-ui-xaml/assets/698155/cfba9714-eed6-410b-8aab-7cdf9bc04339)|![Reveal](https://github.com/microsoft/microsoft-ui-xaml/assets/698155/bbddcd52-063e-44a1-a491-85614dc5b0e2)|



