### PR TITLE
Update similar-issues-bot.yml tolerance to 0.81

### DIFF
--- a/.github/workflows/similar-issues-bot.yml
+++ b/.github/workflows/similar-issues-bot.yml
@@ -17,7 +17,7 @@ jobs:
           issueTitle: ${{ github.event.issue.title }}
           issueBody: ${{ github.event.issue.body }}
           repo: ${{ github.repository }}
-          similaritytolerance: "0.70"
+          similaritytolerance: "0.81"
           commentBody: | 
             Hi I'm an AI powered bot that finds similar issues based off the issue title.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This updates the tolerance for the similar issues bot to 0.81. 

## Motivation and Context
Main motivation is to decrease the noise from the bot. With this higher tolerance value it is much more likely to only show issues that are actually a duplicate.

### How was 0.81 chosen?

We did a statistical analysis of the likelihood of an issue being a dupe or not a dupe as identified by the bot, and found that 0.81 is a good balance to be more strict and show less false positives (non-dupes) while still being low enough to not exclude lots of good duplicate issues (false negatives). 