### PR TITLE
Update Signing to use ESRP task V5

### DIFF
--- a/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-BuildDevProject-Steps.yml
@@ -64,10 +64,15 @@ steps:
       artifactName: nativecodeanalysis
 
   - ${{ if eq( parameters.signOutput, true) }}:
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
       displayName: 'CodeSign'
       inputs:
-        ConnectedServiceName: WinUISigning
+        ConnectedServiceName: $(WinUI2SigningConnectedServiceName)
+        AppRegistrationClientId: $(WinUI2SigningAppRegistrationClientId)
+        AppRegistrationTenantId: $(WinUI2SigningAppRegistrationTenantId)
+        AuthAKVName: $(ProjectReunionCerts)
+        AuthCertName: $(WinUI2SigningAuthCertName)
+        AuthSignCertName: $(WinUI2SigningAuthSignCertName)
         FolderPath: '$(buildOutputDir)/$(buildConfiguration)/$(buildPlatform)/Microsoft.UI.Xaml'
         # Recursively finds files matching these patterns:
         Pattern: |

--- a/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
+++ b/build/AzurePipelinesTemplates/MUX-CreateNugetPackage-Job.yml
@@ -55,10 +55,15 @@ jobs:
     displayName: 'build-nupkg.ps1'
 
   - ${{ if eq( parameters.signOutput, true) }}:
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
       displayName: 'CodeSign (nupkg)'
       inputs:
-        ConnectedServiceName: WinUISigning
+        ConnectedServiceName: $(WinUI2SigningConnectedServiceName)
+        AppRegistrationClientId: $(WinUI2SigningAppRegistrationClientId)
+        AppRegistrationTenantId: $(WinUI2SigningAppRegistrationTenantId)
+        AuthAKVName: $(ProjectReunionCerts)
+        AuthCertName: $(WinUI2SigningAuthCertName)
+        AuthSignCertName: $(WinUI2SigningAuthSignCertName)
         FolderPath: '${{ parameters.nupkgdir }}'
         Pattern: |
           **/Microsoft.UI.Xaml*.nupkg

--- a/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
+++ b/build/AzurePipelinesTemplates/MUX-MakeFrameworkPackages-Steps.yml
@@ -28,10 +28,15 @@ steps:
     displayName: 'Make FrameworkPackages'
 
   - ${{ if eq( parameters.signOutput, true) }}:
-    - task: EsrpCodeSigning@1
+    - task: EsrpCodeSigning@5
       displayName: First Party StoreSign Framework Package
       inputs:
-        ConnectedServiceName: WinUISigning
+        ConnectedServiceName: $(WinUI2SigningConnectedServiceName)
+        AppRegistrationClientId: $(WinUI2SigningAppRegistrationClientId)
+        AppRegistrationTenantId: $(WinUI2SigningAppRegistrationTenantId)
+        AuthAKVName: $(ProjectReunionCerts)
+        AuthCertName: $(WinUI2SigningAuthCertName)
+        AuthSignCertName: $(WinUI2SigningAuthSignCertName)
         FolderPath: '${{ parameters.buildOutputDir }}\$(buildConfiguration)\$(buildPlatform)\FrameworkPackage'
         Pattern: |
           *.appx

--- a/build/WinUI-OB-Official.yml
+++ b/build/WinUI-OB-Official.yml
@@ -243,10 +243,15 @@ extends:
                 -BuildFlavor Release
             displayName: 'build-nupkg.ps1'
 
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'CodeSign (nupkg)'
             inputs:
-              ConnectedServiceName: WinUISigning
+              ConnectedServiceName: $(WinUI2SigningConnectedServiceName)
+              AppRegistrationClientId: $(WinUI2SigningAppRegistrationClientId)
+              AppRegistrationTenantId: $(WinUI2SigningAppRegistrationTenantId)
+              AuthAKVName: $(ProjectReunionCerts)
+              AuthCertName: $(WinUI2SigningAuthCertName)
+              AuthSignCertName: $(WinUI2SigningAuthSignCertName)
               FolderPath: $(nupkgdir)
               Pattern: |
                 **/Microsoft.UI.Xaml*.nupkg


### PR DESCRIPTION
Updating ESRP CodeSigning task to use V5

## Description
V5 updates the authentication to move away from using secrets 

## Motivation and Context
Secrets are less secure than using SN+I auth 

## How Has This Been Tested?
Running pipelines and checking output

## Screenshots (if appropriate):
