### PR TITLE
Bind the corner radius to the tabview presenter

### DIFF
--- a/src/controls/dev/TabView/TabView.xaml
+++ b/src/controls/dev/TabView/TabView.xaml
@@ -42,7 +42,7 @@
               </Border>
               <ContentPresenter Grid.Column="3" x:Name="RightContentPresenter" HorizontalAlignment="Stretch" Content="{TemplateBinding TabStripFooter}" ContentTemplate="{TemplateBinding TabStripFooterTemplate}" />
             </Grid>
-            <ContentPresenter x:Name="TabContentPresenter" Grid.Row="1" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" />
+            <ContentPresenter x:Name="TabContentPresenter" Grid.Row="1" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>


### PR DESCRIPTION
## Description
Fixes #9846


## How Has This Been Tested?
Applying the template in the app as an override

## Screenshots (if appropriate):
Bottom corners rounded using
```xml
 <TabView BorderBrush="{ThemeResource TabViewBorderBrush}" BorderThickness="1,0,1,1" CornerRadius="0,0,10,10" >
```
![image](https://github.com/user-attachments/assets/8bcf1f3d-7cca-4530-a3b8-14031c7d4850)

