### PR TITLE
Fix AccessViolation on grouped ListView with Drag+Drop

### DIFF
--- a/src/dxaml/xcp/core/input/InputServices.cpp
+++ b/src/dxaml/xcp/core/input/InputServices.cpp
@@ -6629,15 +6629,42 @@ CInputServices::InitializeDirectManipulationViewportValues(
         IFC(pViewport->GetClipContent(iClipContent, &pContent));
         if (pContent)
         {
-            IFC(pDirectManipulationService->GetSecondaryClipContentTransform(
-                pViewport,
-                pContent,
-                pContent->GetContentType(),
-                translationX,
-                translationY,
-                uncompressedZoomFactor,
-                zoomFactorX,
-                zoomFactorY));
+            if (pDirectManipulationService)
+            {
+                IFC(pDirectManipulationService->GetSecondaryClipContentTransform(
+                    pViewport,
+                    pContent,
+                    pContent->GetContentType(),
+                    translationX,
+                    translationY,
+                    uncompressedZoomFactor,
+                    zoomFactorX,
+                    zoomFactorY));
+            }
+            else
+            {
+                // Use provided values for instance for edge scrolling scenarios.
+                switch (pContent->GetContentType())
+                {
+                case XcpDMContentTypeTopLeftHeader:
+                    translationX = 0.0f;
+                    translationY = 0.0f;
+                    break;
+                case XcpDMContentTypeTopHeader:
+                    translationX = initialTranslationX;
+                    translationY = 0.0f;
+                    break;
+                case XcpDMContentTypeLeftHeader:
+                    translationX = 0.0f;
+                    translationY = initialTranslationY;
+                    break;
+                case XcpDMContentTypeCustom:
+                case XcpDMContentTypeDescendant:
+                    translationX = 0.0f;
+                    translationY = 0.0f;
+                    break;
+                }
+            }
 
             pContent->SetInitialTransformationValues(
                 translationX, translationY, uncompressedZoomFactor, zoomFactorX, zoomFactorY);


### PR DESCRIPTION
This PR should fix the AccessViolation that happens when using DragDrop on grouped ListView or GridView, see Issue #9119.

## Description
As can be seen from the strack trace of the crashes, the error comes from CInputServices::InitializeDirectManipulationViewportValues. This method has a parameter pDirectManipulationService which is marked as optional. It is called with a NULL parameter in case of beginning of mouse edge scrolling here:

https://github.com/microsoft/microsoft-ui-xaml/blob/aeed4c19e2fc7c2c093216a51b651f2f0890c930/src/dxaml/xcp/core/input/InputServices.cpp#L9306

```
                            // Set the CDMViewport's initial and current transformation values, as well as for its potential secondary contents,
                            // for mouse-driven auto scrolling. Values were already initialized for touch scenarios and must not be re-initialized
                            // when an auto scroll was interrupted.
                            IFC(InitializeDirectManipulationViewportValues(
                                pViewport,
                                NULL /*pDirectManipulationService*/,
                                contentTranslationX,
                                contentTranslationY,
                                contentZoomFactor));
```

There are multiple places where pDirectManipulationService is accessed inside InitializeDirectManipulationViewportValues, each time with a check against null. But in case of clip content, there is no check. Looks like grouping will result in clip content being used, and this in turn will lead to the AccessViolation when the framework tries to begin an edge scroll animation (where NULL is passed for pDirectManipulationService). There is no other place in this method where unchecked parameters are accessed, so I am very confident that this is the exact place where the AccessViolation occurs.

Like in all other places where pDirectManipulationService is checked against null, the provided translations from the method parameters are used as a replacement, when the pDirectManipulationService is not available. See similar calls here:

https://github.com/microsoft/microsoft-ui-xaml/blob/aeed4c19e2fc7c2c093216a51b651f2f0890c930/src/dxaml/xcp/core/input/InputServices.cpp#L6523

Or here:

https://github.com/microsoft/microsoft-ui-xaml/blob/aeed4c19e2fc7c2c093216a51b651f2f0890c930/src/dxaml/xcp/core/input/InputServices.cpp#L6571

## Motivation and Context
Both Drag+Drop and Grouping are critical core features. Both can be used easily together in all XAML platforms except for WinUI 3. This PR aims to make it possible to use these important features together in WinUI 3 as well.

## How Has This Been Tested?
Since Microsoft has not yet made public all build dependencies, I could not fully test this myself. But the access violation definitely comes from this method, and this is the only place in the method where an unchecked access to an optional parameter happens. A simpe repro is available in the linked issue.
