### PR TITLE
Fix link in titleBar-dev-spec.md

### DIFF
--- a/specs/TitleBar/titleBar-dev-spec.md
+++ b/specs/TitleBar/titleBar-dev-spec.md
@@ -152,7 +152,7 @@ _The Default LayoutUpdated event fires for every little (non-relevant) events._
 
 # Functional spec link
 
-[Functional Spec](titleBar-functional-spec.md)
+[Functional Spec](titlebar-functional-spec.md)
 
 # Architectural overview
 


### PR DESCRIPTION
Link is broken due to casing