### PR TITLE
Fix crash on disabled TitleBarPaneToggleButton style

### DIFF
--- a/src/controls/dev/TitleBar/TitleBar_themeresources.xaml
+++ b/src/controls/dev/TitleBar/TitleBar_themeresources.xaml
@@ -26,7 +26,7 @@
         <StaticResource x:Key="TitleBarPaneToggleButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
         <StaticResource x:Key="TitleBarPaneToggleButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
         <StaticResource x:Key="TitleBarPaneToggleButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
-        <StaticResource x:Key="TitleBarPaneToggleForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+        <StaticResource x:Key="TitleBarPaneToggleButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
         <Color x:Key="TitleBarCaptionButtonForegroundColor">#FFFFFF</Color>
         <Color x:Key="TitleBarCaptionButtonHoverForegroundColor">#FFFFFF</Color>
         <Color x:Key="TitleBarCaptionButtonPressedForegroundColor">#CFCFCF</Color>
@@ -55,7 +55,7 @@
         <StaticResource x:Key="TitleBarPaneToggleButtonForeground" ResourceKey="TextFillColorPrimaryBrush" />
         <StaticResource x:Key="TitleBarPaneToggleButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
         <StaticResource x:Key="TitleBarPaneToggleButtonForegroundPressed" ResourceKey="TextFillColorSecondaryBrush" />
-        <StaticResource x:Key="TitleBarPaneToggleForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+        <StaticResource x:Key="TitleBarPaneToggleButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
         <Color x:Key="TitleBarCaptionButtonForegroundColor">#191919</Color>
         <Color x:Key="TitleBarCaptionButtonHoverForegroundColor">#191919</Color>
         <Color x:Key="TitleBarCaptionButtonPressedForegroundColor">#606060</Color>
@@ -84,7 +84,7 @@
         <StaticResource x:Key="TitleBarPaneToggleButtonForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
         <StaticResource x:Key="TitleBarPaneToggleButtonForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
         <StaticResource x:Key="TitleBarPaneToggleButtonForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-        <StaticResource x:Key="TitleBarPaneToggleForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+        <StaticResource x:Key="TitleBarPaneToggleButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
         <StaticResource x:Key="TitleBarCaptionButtonForegroundColor" ResourceKey="TextFillColorPrimary" />
         <StaticResource x:Key="TitleBarCaptionButtonHoverForegroundColor" ResourceKey="TextFillColorPrimary" />
         <StaticResource x:Key="TitleBarCaptionButtonPressedForegroundColor" ResourceKey="TextFillColorSecondary" />
@@ -224,7 +224,7 @@
                                 </VisualState>
                                 <VisualState x:Name="Disabled">
                                     <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Content" Storyboard.TargetProperty="Background">
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TitleBarPaneToggleButtonBackgroundDisabled}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Content" Storyboard.TargetProperty="Foreground">


### PR DESCRIPTION
## Fixes #####
- Fixes #10739

## PR Type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
Fixes a crash when disabling the `TitleBarPaneToggleButtonStyle`.  
The crash was caused by a storyboard targeting an invalid property (`Background` on `AnimatedIcon`) and by the absence of a `TitleBarPaneToggleButtonForegroundDisabled` resource.

### Current Behavior
- Disabling a button with the style causes the app to crash.  
- Crash occurs because `AnimatedIcon` does not support `Background`, and the style references a missing resource.

### New Behavior
- Storyboard now targets `RootGrid.Background` instead of `AnimatedIcon.Background`.  
- A new resource `TitleBarPaneToggleButtonForegroundDisabled` has been added.
- Button disables gracefully without crashing, with proper visual feedback.

### Motivation and Context
This change prevents application crashes when the button is disabled. 

## How Has This Been Tested?
- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->
<img width="52" height="60" alt="image" src="https://github.com/user-attachments/assets/d016ab73-7a70-4e2d-8ae1-f9793911c281" />
<img width="56" height="52" alt="image" src="https://github.com/user-attachments/assets/b086776c-9181-41f5-a7ef-fc51813c0b5b" />