### PR TITLE
Set default to raise ItemInvoked after selection change

### DIFF
--- a/src/controls/dev/NavigationView/NavigationView.h
+++ b/src/controls/dev/NavigationView/NavigationView.h
@@ -495,7 +495,7 @@ private:
     // A flag to track that the selectionchange is caused by selection a item in topnav overflow menu
     bool m_selectionChangeFromOverflowMenu{ false };
     // Flag indicating whether selection change should raise item invoked. This is needed to be able to raise ItemInvoked before SelectionChanged while SelectedItem should point to the clicked item
-    bool m_shouldRaiseItemInvokedAfterSelection{ false };
+    bool m_shouldRaiseItemInvokedAfterSelection{ true };
 
     TopNavigationViewLayoutState m_topNavigationMode{ TopNavigationViewLayoutState::Uninitialized };
 


### PR DESCRIPTION
Changed the default value of `m_shouldRaiseItemInvokedAfterSelection` in `NavigationView.h` from `false` to `true`. This ensures that the "item invoked" event is raised by default after a selection change, aligning with the intended behavior of the `NavigationView` component. This change may affect how selection changes are handled and how the component interacts with other parts of the application.

<!--- Provide a general summary of your changes in the Title above -->

## Fixes #####
<!-- Add the relevant issue number after the word 'Fixes' mentioned above. -->
<!-- PRs without assigned issues will be closed unless minor changes to documentation/typos. -->

Fix an issue that `NavigationView.ItemInvoke` event is not invoked for the first item navigation.

## PR Type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
<!--- Describe your changes in detail -->

### Current Behavior
<!-- How does this work currently atop the latest stable release? -->

The first item navigation will not invoke `ItemInvoke` event

### New Behavior
<!-- How will it work now with this fix? -->

The first item navigation will invoke `ItemInvoke` event

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the syntax "Closes #xxx" or "Fixes #xxx" so that GitHub will close the issue once the PR is complete. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes and check off the boxes below. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->