### PR TITLE
Add src\.dotnet and src\.tools to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,7 @@ HelixPayload/
 /test/MUXControlsTestApp/MSTest/MUXControlsTestApp_Test
 /test/MUXControlsTestApp/TAEF/MUXControlsTestApp_Test
 UnreliableTestReport.csv
+
+# tools
+src/.dotnet/
+src/.tools/


### PR DESCRIPTION
Running `init.cmd` installs tools in `src\.dotnet\` and `src\.tools`, which then show as untracked files. Add these folders to `.gitignore`.