### PR TITLE
Restore incorrectly deleted NuGet.config

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <clear />
+    <add key="globalPackagesFolder" value="$\..\packages" />
+    <add key="repositoryPath" value="$\..\packages" />
+  </config>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+  <packageSources>
+    <clear />
+    <!-- For more info, see https://docs.nuget.org/consume/nuget-config-file -->
+    <!-- DON'T ADD NEW FEEDS TO THIS LIST -->
+    <!-- Instead set the feed as an upstream of this feed, or push the required nupkg to this feed. -->
+    <!-- See this page for info on nuget upstream sources: https://docs.microsoft.com/en-us/azure/devops/artifacts/concepts/upstream-sources -->
+    <add key="WinUI.Dependencies" value="https://pkgs.dev.azure.com/shine-oss/microsoft-ui-xaml/_packaging/WinUI-Dependencies/nuget/v3/index.json" />
+    <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
+    <add key="packagestore" value="packagestore" />
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
The mirroring process incorrectly deleted the NuGet.config added in #10899. Mirroring has (hopefully) been fixed, so add back that file.