### PR TITLE
API spec for XAML custom conditional feature in WinUI3

### DIFF
--- a/specs/CustomCondition/CustomCondition-Spec.md
+++ b/specs/CustomCondition/CustomCondition-Spec.md
@@ -43,7 +43,7 @@ _(Each of the following L2 sections correspond to a page that will be on docs.mi
 ## IXamlCondition interface
 
 IXamlCondition interface defines a custom conditional that can be used in XAML conditionals. This interface consists of a single method,
-Evaluate, which takes a vector of string arguments and returns a boolean value indicating the result of the conditional evaluation. This allows
+Evaluate, which takes a string argument and returns a boolean value indicating the result of the conditional evaluation. This allows
 developers to implement their own logic for determining conditions in XAML based on application-specific requirements. A developer-defined
 class implementing this interface can then be referenced in XAML to control the inclusion or exclusion of markup
 based on the evaluation result.
@@ -59,10 +59,9 @@ namespace CustomConditionNamespace
         {
 
         }
-        public bool Evaluate(IReadOnlyList<string> arguments)
+        public bool Evaluate(string argument)
         {
-            var arg = arguments.FirstOrDefault();
-            if (arg == "ConditionOne" || arg == "ConditionThree" || arg == "ConditionDerived" )
+            if (argument == "ConditionOne" || argument == "ConditionThree" || argument == "ConditionDerived" )
                 return true;
             else
                 return false;
@@ -201,7 +200,7 @@ More examples:
 
 | Name | Description |
 |-|-|
-| Evaluate | Evaluate method accepts a vector of string arguments and returns a boolean value indicating the result of the conditional evaluation. |
+| Evaluate | Evaluate method accepts a string argument and returns a boolean value indicating the result of the conditional evaluation. |
 
 # API Details
 
@@ -212,7 +211,7 @@ namespace Microsoft.UI.Xaml.Markup
     [webhosthidden]
     interface IXamlCondition 
     {
-        Boolean Evaluate(Windows.Foundation.Collections.IVectorView<String> arguments);
+        Boolean Evaluate(String argument);
     };
 }
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is an API spec for introducing custom predicate in WinUI3.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## Description
This spec introduces a capability that provides applications using WinUI3 with the ability to define custom predicates in XAML. This extends the concept from
the pre-existing XAML conditionals (https://learn.microsoft.com/windows/uwp/debug-test-perf/conditional-xaml).
XAML conditionals allow you to conditionally include or exclude markup based on runtime conditions.

### Motivation and Context
Custom predicates address scenarios where you need conditional XAML based on:
- Application-specific feature flags
- Custom device capabilities
- Business logic conditions
- Configuration settings
- Any other runtime condition specific to your application

By implementing the `IXamlPredicate` interface, you can create predicates that work seamlessly with XAML's conditional namespace syntax,
evaluated at runtime

## How Has This Been Tested?
<!--- Please describe how you tested your changes and check off the boxes below. -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

