### PR TITLE
Switch NuGet version from dropdown to required text input in bug repo…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -42,15 +42,13 @@ body:
     attributes:
       label: Screenshots
       description: If applicable, add screenshots here to help explain your problem
-  - type: dropdown
+  - type: input
+    validations:
+      required: true
     attributes:
       label: NuGet package version
-      description: If you are seeing your issue on older versions please try the latest release
-      options:
-        - "WinUI 3 - Windows App SDK 1.8.5: 1.8.260209005"
-        - "WinUI 3 - Windows App SDK 2.0 Preview 1: 2.0.0-preview1"
-        - "WinUI 3 - Windows App SDK 2.0 Experimental 5: 2.0.0-experimental5"
-        - "WinUI 2 - Microsoft.UI.Xaml 2.8.7"
+      description: "Enter the NuGet package version you're using (e.g., 1.8.260317003 or Microsoft.UI.Xaml 2.8.7). You can find this in your project's packages.config or .csproj file."
+      placeholder: "e.g., 1.8.260317003"
   - type: dropdown
     attributes:
       label: Windows version


### PR DESCRIPTION
Replaces the hardcoded NuGet version dropdown with a free-text input field that users fill in themselves. The dropdown required manual updates every release and didn't cover older serviced versions users might still be on. The field is now required so bug reports always include a version