### PR TITLE
Set default window icon from host executable during window creation

### DIFF
--- a/src/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/src/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -166,8 +166,8 @@ void DesktopWindowImpl::OnCreate() noexcept
             // by project template), EnumResourceNamesW always finds the first icon group
             // regardless of its ID.
             // LR_SHARED lets the system manage the icon lifetime — no DestroyIcon needed.
-            struct IconSearchContext { HMODULE module; LPCWSTR resourceId; };
-            IconSearchContext ctx { hExeModule, nullptr };
+            struct IconSearchContext { LPCWSTR resourceId; };
+            IconSearchContext ctx { nullptr };
 
             ::EnumResourceNamesW(hExeModule, RT_GROUP_ICON,
                 [](HMODULE, LPCWSTR, LPWSTR lpName, LONG_PTR lParam) -> BOOL
@@ -180,14 +180,15 @@ void DesktopWindowImpl::OnCreate() noexcept
 
             if (ctx.resourceId)
             {
+                UINT dpi = ::GetDpiForWindow(m_hwnd.get());
                 HICON hIconLarge = static_cast<HICON>(::LoadImageW(
                     hExeModule, ctx.resourceId, IMAGE_ICON,
-                    ::GetSystemMetrics(SM_CXICON), ::GetSystemMetrics(SM_CYICON),
+                    ::GetSystemMetricsForDpi(SM_CXICON, dpi), ::GetSystemMetricsForDpi(SM_CYICON, dpi),
                     LR_DEFAULTCOLOR | LR_SHARED));
 
                 HICON hIconSmall = static_cast<HICON>(::LoadImageW(
                     hExeModule, ctx.resourceId, IMAGE_ICON,
-                    ::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON),
+                    ::GetSystemMetricsForDpi(SM_CXSMICON, dpi), ::GetSystemMetricsForDpi(SM_CYSMICON, dpi),
                     LR_DEFAULTCOLOR | LR_SHARED));
 
                 if (hIconLarge)

--- a/src/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/src/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -136,6 +136,71 @@ void DesktopWindowImpl::OnCreate() noexcept
     // instead of whenever user code calls appwindow api, providing subclassing consistency
     ctl::ComPtr<ixp::IAppWindow> appWindow;
     IFCFAILFAST(get_AppWindowImpl(&appWindow));
+
+    // Set a default window icon from the application's executable.
+    //
+    // The WinUI window class is registered with hIcon=NULL because g_hInstance refers
+    // to the WinUI framework DLL, which does not contain the app's icon. As a result,
+    // windows start with no icon in the taskbar, Alt+Tab, and title bar.
+    //
+    // For packaged apps (including sparse-packaged apps), the shell may briefly show the
+    // correct icon from the package manifest during launch, but once the WinUI window is
+    // created with a NULL-icon class, the icon reverts to the system default.
+    // See: https://github.com/microsoft/microsoft-ui-xaml/issues/10856
+    //      https://github.com/microsoft/WinUI-Gallery/issues/1512
+    //
+    // We load the icon from the host executable (not the framework DLL) using
+    // GetModuleHandleW(nullptr). This works for both packaged and unpackaged apps:
+    // - Packaged apps: packaging tools embed the app icon into the exe as a resource
+    // - Unpackaged apps: the exe typically contains its own icon resource
+    //
+    // If the exe has no icon resource, LoadImageW returns NULL and we silently skip —
+    // preserving the existing behavior (no icon). Apps can always override this default
+    // by calling AppWindow.SetIcon() after window creation.
+    {
+        HMODULE hExeModule = ::GetModuleHandleW(nullptr);
+        if (hExeModule)
+        {
+            // Enumerate the first icon group resource in the executable — this is the icon
+            // the shell uses for the .exe file. Unlike a hardcoded resource ID (which varies
+            // by project template), EnumResourceNamesW always finds the first icon group
+            // regardless of its ID.
+            // LR_SHARED lets the system manage the icon lifetime — no DestroyIcon needed.
+            struct IconSearchContext { HMODULE module; LPCWSTR resourceId; };
+            IconSearchContext ctx { hExeModule, nullptr };
+
+            ::EnumResourceNamesW(hExeModule, RT_GROUP_ICON,
+                [](HMODULE, LPCWSTR, LPWSTR lpName, LONG_PTR lParam) -> BOOL
+                {
+                    auto* pCtx = reinterpret_cast<IconSearchContext*>(lParam);
+                    pCtx->resourceId = lpName;
+                    return FALSE; // stop after first
+                },
+                reinterpret_cast<LONG_PTR>(&ctx));
+
+            if (ctx.resourceId)
+            {
+                HICON hIconLarge = static_cast<HICON>(::LoadImageW(
+                    hExeModule, ctx.resourceId, IMAGE_ICON,
+                    ::GetSystemMetrics(SM_CXICON), ::GetSystemMetrics(SM_CYICON),
+                    LR_DEFAULTCOLOR | LR_SHARED));
+
+                HICON hIconSmall = static_cast<HICON>(::LoadImageW(
+                    hExeModule, ctx.resourceId, IMAGE_ICON,
+                    ::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON),
+                    LR_DEFAULTCOLOR | LR_SHARED));
+
+                if (hIconLarge)
+                {
+                    ::SendMessageW(m_hwnd.get(), WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(hIconLarge));
+                }
+                if (hIconSmall)
+                {
+                    ::SendMessageW(m_hwnd.get(), WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(hIconSmall));
+                }
+            }
+        }
+    }
 }
 
 DesktopWindowImpl::~DesktopWindowImpl()


### PR DESCRIPTION
## Summary

WinUI desktop windows show no icon (or the system default) in the taskbar, Alt+Tab, and title bar. This PR fixes the issue by loading the application's icon from the host executable during window creation.

### The Problem

As reported in [WinUI-Gallery#1512](https://github.com/microsoft/WinUI-Gallery/issues/1512), WinUI apps display the default Windows icon instead of the app's own icon in Alt+Tab / taskbar:
<img width="3361" height="1481" alt="image" src="https://github.com/user-attachments/assets/dd592021-4129-40f8-b7ec-38e1e7fc4231" />

*(Screenshot from WinUI-Gallery#1512 -- the WinUI Gallery app shows a default icon in Alt+Tab instead of its actual icon)*

Currently the workaround is for every app to manually call `AppWindow.SetIcon("path/to/icon.ico")` after window creation. But this is:
1. **Error-prone** -- relative paths resolve against CWD, which differs between VS debugging and installed/packaged apps
2. **Unnecessary** -- the app's icon is already embedded in the executable as a Win32 resource; WinUI just doesn't use it
3. **Not discoverable** -- developers expect the icon from Package.appxmanifest or the exe resource to "just work"

## Root Cause

`DesktopWindowImpl::RegisterDesktopWindowClass()` registers `WinUIDesktopWin32WindowClass` with `hIcon = NULL`:

```cpp
WNDCLASSEXW wndClassEx = {};  // zero-initialized -- hIcon and hIconSm are NULL
wndClassEx.cbSize = sizeof(WNDCLASSEX);
wndClassEx.style = CS_HREDRAW | CS_VREDRAW;
wndClassEx.hCursor = LoadCursor(nullptr, IDC_ARROW);
wndClassEx.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
wndClassEx.lpszClassName = s_windowClassName;
// hIcon is NEVER set -- remains NULL
```

This is because `g_hInstance` refers to the **WinUI framework DLL**, not the application's executable. The DLL has no icon resources.

After window creation in `OnCreate()`, even though the `AppWindow` object is obtained, **no icon is ever loaded or set**. Every WinUI window starts with a blank/default icon.

## Fix

In `OnCreate()`, after `AppWindow` initialization, we now load the app's own icon:

1. **Get the host executable's module** via `GetModuleHandleW(nullptr)`
2. **Dynamically find the first icon group resource** using `EnumResourceNamesW` with `RT_GROUP_ICON`
3. **Load both large and small icon sizes** via `LoadImageW` with `LR_SHARED`
4. **Set the icon** via `WM_SETICON`

### Why this is better than the `AppWindow.SetIcon()` workaround

| | `AppWindow.SetIcon()` workaround | This fix |
|---|---|---|
| **Who does the work** | Every app developer | WinUI framework (automatic) |
| **Path resolution** | Relative paths break in packaged apps | Uses module handle -- no paths involved |
| **Icon source** | Requires a separate .ico file | Uses the icon already embedded in the exe |
| **Discoverability** | Developer must know to call it | Just works -- icon appears automatically |
| **Override** | N/A | Apps can still call `AppWindow.SetIcon()` to override |

### Why `EnumResourceNamesW` instead of a hardcoded resource ID

Different project templates use different icon resource IDs (1, 101, 107, 128, etc.). `EnumResourceNamesW(hExeModule, RT_GROUP_ICON, ...)` dynamically finds the **first** icon group -- the same icon the Windows shell displays for the .exe -- regardless of its numeric ID.

## Compatibility

| Scenario | Before | After |
|----------|--------|-------|
| App with icon resource in exe | No icon shown | Correct icon shown |
| App without icon resource | System default | System default (unchanged -- silently skips) |
| App calls `AppWindow.SetIcon()` later | Works | Works (later `WM_SETICON` overrides) |
| Fully packaged app | No icon | Icon from exe resource |
| Sparse-packaged app | No icon | Icon from exe resource |
| Unpackaged app | No icon | Icon from exe resource |
| Framework-dependent deployment | No icon | Icon from host exe |
| Self-contained deployment | No icon | Icon from host exe |

## Performance

Runs once per window during `OnCreate()` -- all calls are trivial:
- `GetModuleHandleW(nullptr)` -- no module load, just returns cached handle
- `EnumResourceNamesW` -- scans PE resource directory, stops at first hit
- `LoadImageW` with `LR_SHARED` -- system-cached
- `SendMessageW` to own window on same thread -- synchronous, no marshaling

## Memory and Thread Safety

- `LR_SHARED` icons are system-managed -- no `DestroyIcon()` needed, no leak
- `OnCreate()` runs synchronously during `CreateWindowExW()` on the creating thread -- no threading concerns

Fixes #10856
Relates to https://github.com/microsoft/WinUI-Gallery/issues/1512