### PR TITLE
Guard island input site fallback during shutdown

### DIFF
--- a/src/dxaml/xcp/core/core/elements/depends.cpp
+++ b/src/dxaml/xcp/core/core/elements/depends.cpp
@@ -323,7 +323,7 @@ wrl::ComPtr<InputSiteHelper::IIslandInputSite> CDependencyObject::GetElementIsla
             return spPopup->GetIslandInputSite();
         }
 
-        if (coreServices->HasXamlIslandRoots())
+        if (coreServices && coreServices->HasXamlIslandRoots())
         {
             // If this element is in a XamlIslandRoot tree, return the IslandInputSite for that island.
             auto root = coreServices->GetRootForElement(this);
@@ -336,7 +336,15 @@ wrl::ComPtr<InputSiteHelper::IIslandInputSite> CDependencyObject::GetElementIsla
     }
 
     // By default, return the primary IslandInputSite that was registered with InputServices on startup.
-    return coreServices->GetInputServices()->GetPrimaryRegisteredIslandInputSite();
+    if (coreServices)
+    {
+        if (auto inputServices = coreServices->GetInputServices())
+        {
+            return inputServices->GetPrimaryRegisteredIslandInputSite();
+        }
+    }
+
+    return nullptr;
 }
 
 HWND CDependencyObject::GetElementPositioningWindow()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a crash during shutdown when the input island site has already been destroyed, avoid calling through a `nullptr.`

## PR Type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

A consistent crash on my machine in the "Tempo of UWP" app from @MikeHillberg happens during process shutdown (hitting alt-f4.) 

```
00 Microsoft_UI_Xaml!std::vector<CInputServices::IslandInputSiteRegistration,std::allocator<CInputServices::IslandInputSiteRegistration> >::empty
01 Microsoft_UI_Xaml!CInputServices::GetPrimaryRegisteredIslandInputSite
02 Microsoft_UI_Xaml!CDependencyObject::GetElementIslandInputSite
03 Microsoft_UI_Xaml!TextServicesHost::TxGetWindow
04 WinUIEdit!CTxtEdit::TxGetWindow
05 WinUIEdit!CTouchHandlerImpl::ShowGrippersHelper
```

In frame 2, the input services object returned was null, causing frames 1 & 0 to operate on a null `this` and crash.

* Add a null check when reading through the pointers
* Verified that all callsites have appropriate "returns null" behavior _except_ DirectManipulation
* This particular crash is from input services, not DManip

### Current Behavior

Currently, apps crash when shutting down in this way.

### New Behavior

No longer crashes.

### Motivation and Context

Crashing isn't fun. Less crashes is better.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
