### PR TITLE
Ensure OutputPath adds directory separator

### DIFF
--- a/src/src/XamlCompiler/Targets/Microsoft.UI.Xaml.Markup.Compiler.interop.targets
+++ b/src/src/XamlCompiler/Targets/Microsoft.UI.Xaml.Markup.Compiler.interop.targets
@@ -888,8 +888,8 @@ Licensed under the MIT License. See LICENSE in the project root for license info
             <GeneratedXamlSrc0 Condition="'%(AllProjectXamlPages.Link)'!=''" Include="@(AllProjectXamlPages->'$(XamlGeneratedOutputPath)%(Link)')" />
             <GeneratedXamlSrc0 Condition="'%(AllProjectXamlPages.Link)'==''" Include="@(AllProjectXamlPages->'$(XamlGeneratedOutputPath)$([MSBuild]::MakeRelative('$(ProjectDir)','%(Identity)'))')" />
 
-            <GeneratedXamlDest0 Condition="'%(AllProjectXamlPages.Link)'!=''" Include="@(AllProjectXamlPages->'$(OutputPath)%(Link)')" />
-            <GeneratedXamlDest0 Condition="'%(AllProjectXamlPages.Link)'==''" Include="@(AllProjectXamlPages->'$(OutputPath)$([MSBuild]::MakeRelative('$(ProjectDir)','%(Identity)'))')" />
+            <GeneratedXamlDest0 Condition="'%(AllProjectXamlPages.Link)'!=''" Include="@(AllProjectXamlPages->'$(OutputPath)\%(Link)')" />
+            <GeneratedXamlDest0 Condition="'%(AllProjectXamlPages.Link)'==''" Include="@(AllProjectXamlPages->'$(OutputPath)\$([MSBuild]::MakeRelative('$(ProjectDir)','%(Identity)'))')" />
         </ItemGroup>
 
         <!-- Swap in the XBF suffix if appropriate. -->


### PR DESCRIPTION

## Fixes #11072

## PR Type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description
Ensures trailing `\` is added to the output path.

### Current Behavior
Invalid outputs generated when setting OutputPath property from commandline build

### New Behavior
Ensure trailing backslash is added (this is done everywhere else except these two places)

### Motivation and Context
I spent all day finding my missing '\` when upgrading from 1.6 and the apps generated from my CI build was not working due to missing XBF files.
This helps reduce some of the papercuts.

## How Has This Been Tested?
Manually edited the unpackaged nuget files and verified it generates a valid build.

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes

## Screenshots (if appropriate):
<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->