### PR TITLE
docs: fix InfoBadge spec typo

### DIFF
--- a/specs/InfoBadge/InfoBadge-spec.md
+++ b/specs/InfoBadge/InfoBadge-spec.md
@@ -190,7 +190,7 @@ The markup below would create an InfoBadge that takes on the color and icon of t
 ```
 
 ## Increment a numeric InfoBadge in a NavigationView
-Here’s a NavigationView that uses an InfoBadge to display the number of new emails in the inbox, and increments the number shown in the InfoBadge when a new message is recieved. 
+Here’s a NavigationView that uses an InfoBadge to display the number of new emails in the inbox, and increments the number shown in the InfoBadge when a new message is received.
 
 **XAML Markup:**
 ```xml


### PR DESCRIPTION
## Summary
- Fix a spelling typo in the InfoBadge spec example text.

## Test plan
- Ran `git diff --check`.
- Verified `recieved` no longer appears in `specs/InfoBadge/InfoBadge-spec.md`.