### PR TITLE
Fix Validate Doc Links workflow hanging and failing on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,3 +29,4 @@ jobs:
       - name: Check links
         run: npx --yes unbroken
         working-directory: docs
+        timeout-minutes: 10

--- a/docs/.unbroken_exclusions
+++ b/docs/.unbroken_exclusions
@@ -1,0 +1,7 @@
+# Azure DevOps URLs return HTTP 203 (non-authoritative) to unauthenticated clients;
+# unbroken only accepts 200, so it retries 5 times and reports failure.
+URL not found https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=21 while parsing contribution_workflow.md after 5 retries
+URL not found https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=20 while parsing contribution_workflow.md after 5 retries
+
+# Microsoft Store returns HTTP 403 to non-browser user agents
+URL not found https://www.microsoft.com/store/p/windbg/9pgjgd53tn86 while parsing debugging_crashes.md (HTTP 403)

--- a/docs/contribution_handling.md
+++ b/docs/contribution_handling.md
@@ -6,7 +6,7 @@ The WinUI repo is intended as a place for the WinUI team to gather community fee
 
 Feature requests and bugs are tracked as GitHub issues.
 
-For reporting security issues please see the [Security Policy](SECURITY.md).
+For reporting security issues please see the [Security Policy](../SECURITY.md).
 
 For all other bugs and general issues please [file a new issue](https://github.com/Microsoft/microsoft-ui-xaml/issues/new/choose) using the Bug Report template.
 

--- a/docs/contribution_workflow.md
+++ b/docs/contribution_workflow.md
@@ -99,7 +99,7 @@ define them here:
 
 #### [WinUI-Public-MUX-CI](https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=20)
 
-This pipeline extends [WinUI-Public-MUX-PR](https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=21) 
+This pipeline extends WinUI-Public-MUX-PR
 to validate more platforms, adding Debug and ARM. It is run after your changes are merged to 
 main.
 

--- a/docs/debugging_crashes.md
+++ b/docs/debugging_crashes.md
@@ -19,14 +19,14 @@ This type of crash might manifest as a crash in your app, usually with a functio
 
 ### Using WinDbg
 
-In [WinDbg](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools), use `.dump /ma <filename>` to save a full memory dump to the specified file when the crash happens.
+In [WinDbg](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools), use `.dump /ma <filename>` to save a full memory dump to the specified file when the crash happens.
 * If the crash happens sometime after app launch, then you can launch the app, attach to the app with WinDbg, and then do the repro steps to hit the crash.
 * If the crash happens on launch, then [WinDbg Preview](https://www.microsoft.com/store/p/windbg/9pgjgd53tn86) is recommended, since it contains a "Launch app package" option in
 "Start Debugging" which can launch and debug UWP and packaged apps from launch.
 
 ### Other options
 
-Another option is to set some regkeys to tell Windows to keep some crash dumps locally (see https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps).
+Another option is to set some regkeys to tell Windows to keep some crash dumps locally (see https://learn.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps).
 For example, running these commands in an administrative command prompt will set regkeys to tell Windows to save full (type=2) dumps into `C:\dumps`:
 
     reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" /v DumpFolder /d "C:\dumps"
@@ -53,12 +53,9 @@ But if it is a stowed exception crash, which has exception code: 0xc000027b, the
 
 Stowed exception crashes save away a possible error, which gets used later if no one handles the exception.
 XAML sometimes decides the error is fatal immediately, in which case the direct crash stack may be good, but more frequently the stack has unwound before it was determined to be fatal.
-This channel9 talk describes stowed exceptions in more detail: https://channel9.msdn.com/Shows/Inside/C000027B?term=stowed%20exception&lang-en=true.
-
 For stowed exception crashes, you can get more info on the crash by loading a crash dump in WinDbg and then using !pde.dse to dump the stowed exceptions.
-The !pde debugger extension is available [here](https://onedrive.live.com/?authkey=%21AJeSzeiu8SQ7T4w&id=DAE128BD454CF957%217152&cid=DAE128BD454CF957) in the PDE*.zip.
-(It is linked off the channel9 page above.)
-Put the appropiate x64 or x86 dll in that zip in the winext directory of a WinDbg install, and then "!pde.dse" should work on stowed exception crash dumps.
+The PDE debugger extension is included in modern versions of [WinDbg](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools).
+Load it with `.load pde` and then run `!pde.dse` to dump stowed exception information.
 
 Frequently there will be multiple stowed exceptions, with some at the end which got handled/ignored.
 Most commonly, the first stowed exception is the interesting one.

--- a/docs/feature_proposal_process.md
+++ b/docs/feature_proposal_process.md
@@ -37,7 +37,7 @@ We'll keep the issue open for community discussion until the team owner decides 
 Note that if an issue isn't a high priority or has many open questions then it might stay open for a long time.
 
 4. **Owner Review**  
-The WinUI team will review the proposal and either approve or close the issue based on whether it broadly aligns with the [WinUI roadmap](roadmap.md) and [contribution guidelines](../CONTRIBUTING.md).
+The WinUI team will review the proposal and either approve or close the issue based on whether it broadly aligns with the [WinUI roadmap](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md) and [contribution guidelines](../CONTRIBUTING.md).
 
 5. **API Review**  
 If the feature adds new APIs then we'll start an API review in the [WinUI API review repo](https://github.com/microsoft/microsoft-ui-xaml-specs). All new public APIs must be reviewed before merging.  
@@ -51,10 +51,10 @@ Our contribution guidelines can be found [here](../CONTRIBUTING.md).
 Once a feature is complete and tested according to the [contribution guidelines](../CONTRIBUTING.md) you can send us a PR to merge it to main.  
 
 8. **Documentation and sample updates**  
-We will update the [documentation on docs.microsoft.com](https://docs.microsoft.com/windows/uwp) and if applicable add a sample to the [Xaml Controls Gallery](https://github.com/Microsoft/Xaml-Controls-Gallery) app.  
+We will update the [documentation on docs.microsoft.com](https://learn.microsoft.com/windows/uwp) and if applicable add a sample to the [WinUI 3 Gallery](https://github.com/microsoft/WinUI-Gallery) app.  
 Feel free to also contribute to docs and samples!  
 Once the docs and samples are updated we'll close the issue.
 
 9. **Binaries**  
-We periodically produce signed prerelease binaries from the main branch which are published to [NuGet](https://www.nuget.org/profiles/winui): see the [Roadmap](roadmap.md) for info on build frequency.   
+We periodically produce signed prerelease binaries from the main branch which are published to [NuGet](https://www.nuget.org/profiles/winui): see the [Windows App SDK Roadmap](https://github.com/microsoft/WindowsAppSDK/blob/main/docs/roadmap.md) for info on build frequency.   
 After the feature has been sufficiently validated as part of a prerelease package we will include it in the next stable binary release on NuGet.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -67,7 +67,7 @@ We also need to monitor:
 
 1. New and re-opened issues get `needs-triage` label added
 1. `needs-triage` label is added whenever `team-...` labels change so that the new team sees the status change on the issue.
-1. If `feature proposal` is added or removed it gets added/removed from the [feature tracking project board](https://github.com/microsoft/microsoft-ui-xaml/projects/4) accordingly.
+1. If `feature proposal` is added or removed it gets added/removed from the feature tracking project board accordingly.
 1. If `declined` is added, bot adds a friendly message and closes.
 1. Tags issues/PR with release announcement.
 1. When moving into `Front Burner` column, gets added to the `API review` board.


### PR DESCRIPTION
## Fixes

<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

N/A — This fixes the `Validate doc links` GitHub Actions workflow that has been failing/timing out on all PRs.

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Description

<!-- Describe your changes in detail. -->

The `Validate doc links` GitHub Actions check has been failing on every PR, hanging for 6 hours until the GitHub Actions 360-minute timeout cancels it.

### Current Behavior
<!-- How does this work today? -->

The `unbroken` markdown link checker hangs indefinitely due to a combination of issues:

1. **Deadlock bug**: `dev.azure.com` URLs return HTTP 203 (non-authoritative) to unauthenticated clients. `unbroken` only accepts HTTP 200, so it retries 5 times and sets the URL cache to `-1` (sentinel for "pending"). A second markdown reference to the same `definitionId=21` URL in `contribution_workflow.md` enters a spin-lock (`while (result === -1)`) waiting for the first check to complete — but it already finished with a non-200 result, creating a **deadlock**.
2. **Hanging URLs**: An outdated OneDrive personal share link causes `axios.get` to hang indefinitely (no timeout configured in `unbroken`).
3. **Broken references**: `roadmap.md` and `SECURITY.md` local file references don't resolve, and `projects/4` returns 404.

### New Behavior
<!-- How will it work after this PR? -->

- `npx unbroken` completes in ~30 seconds with **0 errors, 2 warnings** (suppressed dev.azure.com URLs), exit code 0.
- Added a `timeout-minutes: 10` safety net to the workflow step.

**Specific changes:**
- Add `.unbroken_exclusions` file to suppress `dev.azure.com` (HTTP 203) and Microsoft Store (HTTP 403) URL errors
- Remove duplicate `dev.azure.com` link reference that triggered the spin-lock deadlock
- Remove outdated `channel9.msdn.com` and `onedrive.live.com` links; PDE debugger extension is now built into WinDbg
- Fix `SECURITY.md` relative path (`../SECURITY.md`)
- Update `roadmap.md` links to point to WindowsAppSDK roadmap
- Update `Xaml-Controls-Gallery` link to `WinUI-Gallery` (repo was renamed)
- Remove dead `projects/4` link (404)
- Migrate `docs.microsoft.com` URLs to `learn.microsoft.com`

## Customer Impact

<!-- How does this change affect end users? Is it user-facing or infra changes? -->

Infrastructure/CI change only. No impact on end users. Unblocks the `Validate doc links` check that has been failing on all PRs.

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

Changes are limited to markdown documentation files and the GitHub Actions workflow. No code, API, or build changes.

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

Verified locally by running `npx unbroken` in the `docs/` directory:
- **Before**: Hangs indefinitely (deadlock on duplicate dev.azure.com URL)
- **After**: Completes in ~30s with 0 errors, 2 warnings (suppressed), exit code 0

## Screenshots (if appropriate)

<!-- If you are making visual changes, include before/after screenshots. -->

N/A — no visual changes.