### PR TITLE
Fix XAML Hot Reload for succinct Row/ColumnDefinitions syntax (#5944)

### DIFF
--- a/src/dxaml/xcp/dxaml/lib/DiagnosticsInterop.cpp
+++ b/src/dxaml/xcp/dxaml/lib/DiagnosticsInterop.cpp
@@ -55,6 +55,8 @@
 #include "DebugSettings_Partial.h"
 #include "XamlIslandRoot_Partial.h"
 #include "Unsealer.h"
+#include "ActivationAPI.h"
+#include "JoltCollections.h"
 
 #pragma warning(disable:4267) //'var' : conversion from 'size_t' to 'type', possible loss of data
 
@@ -390,6 +392,32 @@ DiagnosticsInterop::CreateInstance(
 
     IFC_RETURN(MetadataAPI::GetClassInfoByFullName(xephemeral_string_ptr(typeName, wcslen(typeName)), &pType));
 
+    // Hot Reload sends the succinct comma-separated collection syntax (e.g. "Auto,*")
+    // as a CreateInstance(typeName=<collection>, value="...") request. The normal type
+    // conversion path below cannot turn a string into a collection, so without this
+    // branch the CreateInstance call fails silently and the XAML edit never reaches
+    // the live tree. Inflate the collection here using the same per-item FromString
+    // path that the XAML parser uses, before falling through to scalar converters.
+    // Scope is intentionally limited to Row/ColumnDefinitionCollection because their
+    // item grammar (GridLength) is comma-free; broadening this requires reusing the
+    // full Parser::CollectionInitializationStringParser to handle quoting/escapes.
+    // Fixes microsoft/microsoft-ui-xaml#5944.
+    if (value &&
+        (pType->GetIndex() == KnownTypeIndex::RowDefinitionCollection ||
+         pType->GetIndex() == KnownTypeIndex::ColumnDefinitionCollection))
+    {
+        // Errors from this path are real failures (we already matched the scenario),
+        // so propagate them instead of silently falling through to the scalar
+        // converters where they would manifest as a no-op Hot Reload edit.
+        IFC_RETURN(TryCreateCollectionFromInitializationString(pType, value, ppInstance));
+        if (*ppInstance != nullptr)
+        {
+            return S_OK;
+        }
+        // S_OK with null ppInstance means "type matched but helper opted out"
+        // (e.g. metadata wasn't shaped as expected). Fall through to legacy behavior.
+    }
+
     const bool hasCustomTypeConverter = !pType->IsBuiltinType() && pType->HasTypeConverter() || pType->GetIndex() == KnownTypeIndex::IMediaPlaybackSource;
     // GetClassInfoByFullName guarantees on success that pType is not null, so we can go ahead and skip any checks.
     if (!pType->IsEnum() && pType->GetBaseType()->GetIndex() == KnownTypeIndex::UnknownType && !hasCustomTypeConverter && !pType->IsValueType())
@@ -457,6 +485,131 @@ DiagnosticsInterop::CreateInstance(
         // ActivationAPI to create the object
         return ActivationAPI::ActivateInstance(pType, ppInstance);
     }
+}
+
+// Inflate a Grid Row/ColumnDefinitionCollection from the comma-separated succinct
+// syntax accepted by the XAML parser at markup-time (e.g. "Auto,*,2*,100"). Mirrors
+// ObjectWriter::Logic_InitializeCollectionFromString.
+//
+// Contract:
+//  - S_OK with *ppInstance set:    success; caller takes ownership.
+//  - S_OK with *ppInstance null:   metadata isn't shaped as expected (no content DP,
+//                                  no core constructor for the item); caller may try
+//                                  legacy paths.
+//  - failing HRESULT:              real parse / activation failure; should be reported.
+_Check_return_ HRESULT
+DiagnosticsInterop::TryCreateCollectionFromInitializationString(
+    _In_ const CClassInfo* pCollectionType,
+    _In_z_ LPCWSTR value,
+    _Outptr_result_maybenull_ IInspectable** ppInstance)
+{
+    *ppInstance = nullptr;
+
+    // We need a content property whose target type tells us which item to instantiate
+    // per parsed token, and the item type must have a core constructor that understands
+    // a string CREATEPARAMETERS (i.e. provides a FromString). RowDefinition and
+    // ColumnDefinition both satisfy this via CDefinitionBase::FromString.
+    const CDependencyProperty* pContentDP = pCollectionType->GetContentProperty();
+    if (pContentDP == nullptr)
+    {
+        return S_OK; // opt-out: no content property metadata
+    }
+
+    const CClassInfo* pItemType = pContentDP->GetPropertyType();
+    if (pItemType == nullptr || !pItemType->IsBuiltinType())
+    {
+        return S_OK; // opt-out: cannot describe the item type
+    }
+
+    const CREATEPFN pfnCreateItem = pItemType->GetCoreConstructor();
+    if (pfnCreateItem == nullptr)
+    {
+        return S_OK; // opt-out: item has no core constructor
+    }
+
+    // Activate the empty collection through the standard path so that resource graph
+    // bookkeeping, peers, etc. all match a normally constructed instance.
+    wrl::ComPtr<IInspectable> spCollection;
+    IFC_RETURN(ActivationAPI::ActivateInstance(pCollectionType, nullptr, &spCollection));
+
+    // All PresentationFrameworkCollection subtypes (including RowDefinitionCollection
+    // and ColumnDefinitionCollection) implement IUntypedVector, which lets us append
+    // items without depending on the concrete templated IVector<T*> projection.
+    wrl::ComPtr<IUntypedVector> spVector;
+    IFC_RETURN(spCollection.As(&spVector));
+
+    DXamlCore* pCore = DXamlCore::GetCurrent();
+    IFCPTR_RETURN(pCore);
+
+    // Split on top-level commas. The succinct collection grammar used by the parser
+    // (see Parser::CollectionInitializationStringParser) supports quoting and escape
+    // sequences, but Grid's GridLength tokens never need either, so a simple split is
+    // sufficient. Callers gate this helper to Row/ColumnDefinitionCollection only.
+    auto trim = [](std::wstring& s)
+    {
+        const wchar_t* ws = L" \t\r\n";
+        const auto first = s.find_first_not_of(ws);
+        if (first == std::wstring::npos) { s.clear(); return; }
+        const auto last = s.find_last_not_of(ws);
+        s = s.substr(first, last - first + 1);
+    };
+
+    std::wstring input(value);
+    std::wstring trimmedInput = input;
+    trim(trimmedInput);
+
+    // RowDefinitions="" / "   " => empty collection. Matches XAML parser behavior
+    // where an attribute set to whitespace yields a default-initialized collection.
+    if (trimmedInput.empty())
+    {
+        *ppInstance = spCollection.Detach();
+        return S_OK;
+    }
+
+    std::vector<std::wstring> tokens;
+    std::size_t start = 0;
+    for (std::size_t i = 0; i <= input.size(); ++i)
+    {
+        if (i == input.size() || input[i] == L',')
+        {
+            tokens.emplace_back(input.substr(start, i - start));
+            trim(tokens.back());
+            start = i + 1;
+        }
+    }
+
+    for (const auto& token : tokens)
+    {
+        if (token.empty())
+        {
+            // Trailing/leading/consecutive commas are a parse error rather than a
+            // signal to drop items - surface a clear failure so the developer sees
+            // the broken syntax instead of a half-populated grid.
+            return E_INVALIDARG;
+        }
+
+        xstring_ptr tokenXstr;
+        IFC_RETURN(xstring_ptr::CloneBuffer(token.c_str(), static_cast<XUINT32>(token.size()), &tokenXstr));
+
+        // Use the string-flavoured CREATEPARAMETERS constructor so the per-item
+        // FromString path is invoked by the core type's CREATEPFN.
+        CREATEPARAMETERS cp(pCore->GetHandle(), tokenXstr);
+
+        xref_ptr<CDependencyObject> pCoreItem;
+        IFC_RETURN(pfnCreateItem(pCoreItem.ReleaseAndGetAddressOf(), &cp));
+
+        // Get the framework peer so we can hand it to the projected IVector.
+        ctl::ComPtr<DependencyObject> spItemPeer;
+        IFC_RETURN(pCore->GetPeer(pCoreItem.get(), &spItemPeer));
+
+        wrl::ComPtr<IInspectable> spItemAsI;
+        IFC_RETURN(spItemPeer.As(&spItemAsI));
+
+        IFC_RETURN(spVector->UntypedAppend(spItemAsI.Get()));
+    }
+
+    *ppInstance = spCollection.Detach();
+    return S_OK;
 }
 
 HRESULT DiagnosticsInterop::GetName(

--- a/src/dxaml/xcp/dxaml/lib/DiagnosticsInterop.h
+++ b/src/dxaml/xcp/dxaml/lib/DiagnosticsInterop.h
@@ -30,6 +30,7 @@ class CResourceDictionary;
 class CMarkupExtensionBase;
 class CResourceDictionaryCollection;
 class CCustomProperty;
+class CClassInfo;
 
 enum VisualElementState;
 
@@ -448,6 +449,21 @@ namespace Diagnostics
             _In_ const xstring_ptr& inputString,
             _In_ PCWSTR fallbackString,
             _Out_ HSTRING* outputString);
+
+        // Attempts to materialize a Grid Row/ColumnDefinitionCollection from the
+        // succinct comma-separated string syntax that the XAML parser accepts at
+        // markup-time (e.g. "Auto,*,2*"). On success returns S_OK with *ppInstance
+        // set. Returns S_OK with *ppInstance == nullptr when the type's metadata
+        // does not describe a parseable per-item shape (caller may try legacy paths).
+        // Returns a failing HRESULT when parsing/activation actually fails so that
+        // Hot Reload surfaces the broken edit instead of silently no-op'ing.
+        // This is used by Hot Reload (XamlDiagnostics::CreateInstance) so that
+        // edits to <Grid RowDefinitions="..."/> survive the diagnostics round-trip.
+        // See microsoft/microsoft-ui-xaml#5944.
+        static _Check_return_ HRESULT TryCreateCollectionFromInitializationString(
+            _In_ const CClassInfo* pCollectionType,
+            _In_z_ LPCWSTR value,
+            _Outptr_result_maybenull_ IInspectable** ppInstance);
 
         static CCoreServices* GetCore();
         template<class T, class U = T> static HRESULT VectorGetAt(


### PR DESCRIPTION
Fixes #5944.

## Problem

When a developer writes `<Grid RowDefinitions="Auto,*"/>` (or the equivalent for `ColumnDefinitions`) and then edits XAML while debugging, **XAML Hot Reload silently fails** — the change never reaches the running app. Users have to fall back to the verbose `<Grid.RowDefinitions>…</Grid.RowDefinitions>` form to get Hot Reload working.

## Root cause

VS XAML Live Property Explorer pushes the edit by calling:

```
IXamlDiagnostics::CreateInstance(typeName="RowDefinitionCollection", value="Auto,*")
↓
DiagnosticsInterop::CreateInstance (src/dxaml/xcp/dxaml/lib/DiagnosticsInterop.cpp)
```

The existing implementation tries to convert the string with `PropertyValue::CreateFromString` and `DynamicValueConverter`. Neither can produce a `RowDefinitionCollection`, so `CreateInstance` returns failure. VS treats that as "value couldn't be built" and never calls `SetProperty`. Hot Reload silently no-ops.

## Fix

Add a narrow branch in `DiagnosticsInterop::CreateInstance` that mirrors what the markup-time parser does (`ObjectWriter::Logic_InitializeCollectionFromString`):

- Gated to `RowDefinitionCollection` / `ColumnDefinitionCollection` only, because their item grammar (`GridLength`) is comma-free and a simple top-level split is sufficient. Broadening this to all collections would require pulling in `Parser::CollectionInitializationStringParser` to honor quoting/escapes — left for a follow-up.
- Activates an empty collection via `ActivationAPI::ActivateInstance`.
- Splits the input on top-level commas, trims whitespace.
- For each token, invokes the item type's core `CREATEPFN` with a string `CREATEPARAMETERS`. The `DECLARE_CREATE_WITH_TYPECONVERTER` macro dispatches to `_this->FromString(pCreate)`, which for `CDefinitionBase` calls `GridLengthFromString` — so we reuse the parser's exact semantics for `Auto`, `*`, `2.5*`, `100`, etc. instead of duplicating that logic.
- Gets the framework peer via `DXamlCore::GetPeer` and appends to the collection through `IUntypedVector::UntypedAppend` (which all `PresentationFrameworkCollection<T>` subtypes implement, including `RowDefinitionCollection`).
- Empty/whitespace input (`RowDefinitions=""`) yields an empty collection, matching parser behavior.
- Real failures after the type gate (activation, FromString parse error, append) are **propagated**, so malformed edits surface a clear failure instead of silently leaving the app in an inert state.

After `CreateInstance` returns the populated collection, the existing `XamlDiagnostics::SetProperty → DiagnosticsInterop::SetPropertyValue → SetValue` path takes over and replaces `Grid.RowDefinitions` / `Grid.ColumnDefinitions` like any other DP edit. `CGrid::InitializeDefinitionStructure` re-reads `m_pRowDefinitions` on the next layout pass.

## Out of scope

- Other succinct collection scenarios (e.g. `ItemContainer` style collections with commas in values). Those need the full `CollectionInitializationStringParser` and are not part of the reported bug.

## Testing

I verified the patch against the issue repro by inspection only — I do not have the WinUI build environment locally. **Reviewers please run:**

1. The full Hot Reload diagnostics test pass.
2. A new test that does the end-to-end flow:
   - `CreateInstance("Microsoft.UI.Xaml.Controls.RowDefinitionCollection", "Auto,*,2*,100")` → assert 4 items with expected `GridLength` values.
   - `SetProperty(grid, Grid_RowDefinitions, newCollection)` → force layout → assert `Grid.RowDefinitions.Size == 4`.
   - Edge cases: `""`, `"Auto"`, `"Auto, *"` (whitespace), `"Auto,,*"` (should fail), `"bogus"` (should fail with FromString error).

I'm happy to add a test file once a maintainer points me at the right harness — I didn't want to guess at the test infrastructure layout.

## Notes for reviewers

- Headers added: `ActivationAPI.h`, `JoltCollections.h` (for `IUntypedVector`).
- Forward decl added: `class CClassInfo;` in `DiagnosticsInterop.h`.
- No public API surface change.
- See the rubber-duck critique applied: scope narrowed to two known types, errors no longer fall through after the type gate, empty input handled.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
