### PR TITLE
[do not review] Run full WinUI PR validation from GitHub bootstrap

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -1,0 +1,98 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# GitHub-facing bootstrap for Azure Pipelines PR validation.
+#
+# This file is intentionally separate from the internal Azure Repos PR pipeline
+# so the existing ADO PR validation path can remain unchanged while we validate
+# the GitHub-backed ADO pipeline path.
+
+trigger: none
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - main
+    - winui3/main
+  drafts: true
+
+name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.NonOfficial.yml@templates
+  parameters:
+    featureFlags:
+      EnableCDPxPAT: false
+      WindowsHostVersion:
+        Version: 2022
+        Network: KS3
+    platform:
+      name: 'windows_undocked'
+    git:
+      submodules: false
+    globalsdl:
+      tsa:
+        enabled: false
+      codeql:
+        tsandjs:
+          enabled: false
+        python:
+          enabled: false
+        psscriptanalyzer:
+          enable: false
+      prefast:
+        enabled: false
+      apiscan:
+        enabled: false
+      binskim:
+        enabled: false
+
+    stages:
+    - stage: Bootstrap
+      displayName: Validate GitHub PR trigger bootstrap
+      jobs:
+      - job: ValidateGitHubPrContext
+        displayName: Validate GitHub PR context
+        pool:
+          type: windows
+        variables:
+          ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+        steps:
+        - checkout: self
+          submodules: false
+          fetchDepth: 1
+          fetchTags: false
+
+        - task: PowerShell@2
+          displayName: Validate GitHub PR trigger context
+          inputs:
+            targetType: inline
+            script: |
+              $ErrorActionPreference = 'Stop'
+
+              Write-Host "Build.Reason=$env:BUILD_REASON"
+              Write-Host "Build.Repository.Provider=$env:BUILD_REPOSITORY_PROVIDER"
+              Write-Host "Build.Repository.Name=$env:BUILD_REPOSITORY_NAME"
+              Write-Host "Build.SourceBranch=$env:BUILD_SOURCEBRANCH"
+              Write-Host "System.PullRequest.TargetBranch=$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
+
+              if ($env:BUILD_REPOSITORY_PROVIDER -notin @('GitHub', 'GitHubEnterprise')) {
+                throw "Expected a GitHub-backed Azure Pipelines run, but Build.Repository.Provider was '$env:BUILD_REPOSITORY_PROVIDER'."
+              }
+
+              if ($env:BUILD_REASON -eq 'PullRequest') {
+                $allowedTargetBranches = @('main', 'winui3/main', 'refs/heads/main', 'refs/heads/winui3/main')
+                if ($allowedTargetBranches -notcontains $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+                  throw "Unexpected GitHub PR target branch '$env:SYSTEM_PULLREQUEST_TARGETBRANCH'."
+                }
+              }
+
+              Write-Host "GitHub PR bootstrap validation completed."

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -1,11 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# GitHub-facing bootstrap for Azure Pipelines PR validation.
+# GitHub-facing wrapper for Azure Pipelines PR validation.
 #
 # This file is intentionally separate from the internal Azure Repos PR pipeline
-# so the existing ADO PR validation path can remain unchanged while we validate
-# the GitHub-backed ADO pipeline path.
+# so the existing ADO PR validation path can remain unchanged.
 
 trigger: none
 
@@ -22,7 +21,7 @@ name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
 
 parameters:
 - name: runFullValidation
-  displayName: "Run shared WinUI PR validation stages"
+  displayName: "Run full WinUI PR validation stages"
   type: boolean
   default: true
 - name: MUXFinalRelease
@@ -101,8 +100,8 @@ extends:
         break: true
 
     stages:
-    - stage: Bootstrap
-      displayName: Validate GitHub PR trigger bootstrap
+    - stage: ValidateGitHubPrContext
+      displayName: Validate GitHub PR context
       jobs:
       - job: ValidateGitHubPrContext
         displayName: Validate GitHub PR context
@@ -117,7 +116,7 @@ extends:
           fetchTags: false
 
         - task: PowerShell@2
-          displayName: Validate GitHub PR trigger context
+          displayName: Validate GitHub PR context
           inputs:
             targetType: inline
             script: |
@@ -140,7 +139,7 @@ extends:
                 }
               }
 
-              Write-Host "GitHub PR bootstrap validation completed."
+              Write-Host "GitHub PR context validation completed."
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -13,6 +13,7 @@ pr:
   autoCancel: true
   branches:
     include:
+    - feature/test-ado-pr
     - main
     - winui3/main
   drafts: true
@@ -92,7 +93,7 @@ extends:
               }
 
               if ($env:BUILD_REASON -eq 'PullRequest') {
-                $allowedTargetBranches = @('main', 'winui3/main', 'refs/heads/main', 'refs/heads/winui3/main')
+                $allowedTargetBranches = @('feature/test-ado-pr', 'main', 'winui3/main', 'refs/heads/feature/test-ado-pr', 'refs/heads/main', 'refs/heads/winui3/main')
                 if ($allowedTargetBranches -notcontains $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
                   throw "Unexpected GitHub PR target branch '$env:SYSTEM_PULLREQUEST_TARGETBRANCH'."
                 }

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -19,6 +19,9 @@ pr:
 
 name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
 
+variables:
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+
 resources:
   repositories:
     - repository: templates

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -20,14 +20,47 @@ pr:
 
 name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
 
+parameters:
+- name: runFullValidation
+  displayName: "Run shared WinUI PR validation stages"
+  type: boolean
+  default: true
+- name: MUXFinalRelease
+  type: boolean
+  default: false
+- name: runArm64Tests
+  displayName: "Enable running tests on arm64"
+  type: boolean
+  default: true
+- name: runStaticAnalysis
+  displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
+  type: boolean
+  default: false
+
 variables:
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
+- template: build\AzurePipelinesTemplates\WinUI-BuildVariables.yml@WinUIInternal
+- group: WinUI-Variable-Library
+- name: WindowsContainerImage
+  value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
 
 resources:
   repositories:
     - repository: templates
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: WinUIInternal
+      type: git
+      name: WinUI/microsoft-ui-xaml-lift
+      ref: refs/heads/main
+    - repository: WindowsAppSDKConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
+    - repository: WindowsAppSDKVersionConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
       ref: refs/heads/main
 
 extends:
@@ -45,19 +78,27 @@ extends:
     globalsdl:
       tsa:
         enabled: false
+      enableXFGCheck: false
       codeql:
         tsandjs:
-          enabled: false
+          enabled: true
         python:
           enabled: false
         psscriptanalyzer:
-          enable: false
+          enable: true
       prefast:
-        enabled: false
+        ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
+          enabled: true
+        ${{ else }}:
+          enabled: false
+        break: true
       apiscan:
         enabled: false
+        break: false
       binskim:
-        enabled: false
+        enabled: true
+        analyzeTargetGlob: $(BinskimExclusion)
+        break: true
 
     stages:
     - stage: Bootstrap
@@ -100,3 +141,41 @@ extends:
               }
 
               Write-Host "GitHub PR bootstrap validation completed."
+
+    - ${{ if eq(parameters.runFullValidation, true) }}:
+      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          buildScenarioApps: true
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+
+      - template: build\AzurePipelinesTemplates\WinUI-TestMockWinAppSDKPackageUpdate-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          buildScenarioApps: false
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+
+      - ${{ if eq(parameters.MUXFinalRelease, 'false') }}:
+        - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+          parameters:
+            stageName: Build_MUXFinalRelease
+            pipelineKind: PR-2
+            buildScenarioApps: false
+            MUXFinalRelease: true
+            runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
+        parameters:
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          dependsOn: Build
+          runArm64Tests: ${{ parameters.runArm64Tests }}


### PR DESCRIPTION
Extends the GitHub-backed ADO bootstrap YAML so it can call existing internal WinUI PR validation stages against GitHub PR source.