### PR TITLE
Fix Grid child arrangement to correct layout rounding errors that cause overlap

### DIFF
--- a/dxaml/xcp/core/core/elements/Grid.cpp
+++ b/dxaml/xcp/core/core/elements/Grid.cpp
@@ -1321,6 +1321,11 @@ _Check_return_ HRESULT CGrid::ArrangeOverride(_In_ XSIZEF finalSize, _Out_ XSIZE
             arrangeRect.Width = GetFinalSizeForRange(m_pColumns, columnIndex, GetColumnSpan(currentChild), columnSpacing);
             arrangeRect.Height = GetFinalSizeForRange(m_pRows, rowIndex, GetRowSpan(currentChild), rowSpacing);
 
+            if (currentChild->GetUseLayoutRounding())
+            {
+                AdjustRectForChildLayoutRounding(currentChild, arrangeRect, /* adjustX */ columnIndex > 0, /* adjustY */ rowIndex > 0);
+            }
+
             IFC_RETURN(currentChild->Arrange(arrangeRect));
         }
     }
@@ -1328,6 +1333,50 @@ _Check_return_ HRESULT CGrid::ArrangeOverride(_In_ XSIZEF finalSize, _Out_ XSIZE
     newFinalSize = finalSize;
 
     return S_OK;
+}
+
+
+//------------------------------------------------------------------------
+//
+//  Method:   CGrid::AdjustRectForChildLayoutRounding
+//
+//  Synopsis:
+//      Adjusts rect to correct for child element's layout rounding
+//
+//------------------------------------------------------------------------
+void CGrid::AdjustRectForChildLayoutRounding(
+    _In_ CUIElement* pChild,
+    _Inout_ XRECTF& rect,
+    bool adjustX,
+    bool adjustY
+    )
+{
+    // If the child's layout rounding would position it too far to the left or
+    // top, we adjust rect to force it to be positioned correctly.
+
+    XFLOAT inverseScale = 1.0f / pChild->GetScaleFactorForLayoutRounding();
+
+    if (adjustX)
+    {
+        XFLOAT roundedX = pChild->LayoutRound(rect.X);
+        if (roundedX < rect.X)
+        {
+            XFLOAT newX = roundedX + inverseScale;
+            rect.Width = std::max(0.0f, rect.Width - (newX - rect.X));
+            rect.X = newX;
+        }
+    }
+
+    if (adjustY)
+    {
+        XFLOAT roundedY = pChild->LayoutRound(rect.Y);
+        if (roundedY < rect.Y)
+        {
+            XFLOAT newY = roundedY + inverseScale;
+            rect.Height = std::max(0.0f, rect.Height - (newY - rect.Y));
+            rect.Y = newY;
+        }
+    }
 }
 
 

--- a/dxaml/xcp/core/inc/Grid.h
+++ b/dxaml/xcp/core/inc/Grid.h
@@ -154,6 +154,13 @@ private:
 
     void EnsureTempDefinitionsStorage(unsigned int minCount);
 
+    void AdjustRectForChildLayoutRounding(
+        _In_ CUIElement* pChild,
+        _Inout_ XRECTF& rect,
+        bool adjustX,
+        bool adjustY
+        );
+
     void DistributeStarSpace(
         _In_reads_(cStarDefinitions) CDefinitionBase** ppStarDefinitions,
         XUINT32 cStarDefinitions,


### PR DESCRIPTION
## Fixes

Fixes #11166

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Adds logic to Grid's implementation of child arrangement to correct layout rounding errors.

In some cases Grids' child elements get positioned so that they overlap by 1 pixel. The new logic detects when this is would happen, and fixes the child element's position.

### Current Behavior

Currently, Grid just passes the accumulated x,y to child elements without adjustment. If you set Padding to a midpoint between layout rounding units, then that will get carried over to child elements, because Padding doesn't get layout-rounded. Child elements will round up or down inconsistently, because of floating point over/under-approximation.

### New Behavior

Grid will detect when a child element would position itself earlier than expected, and pass an adjusted x,y so that the final position will be correct.

## Customer Impact

This will remove the very noticeable line in cases where the bug gets triggered. For example, the bug creates an apparent divider (actually overlap) with the specific Width of SplitButtons in my app.

## Regression Potential

This only effects very specific layouts where the code would otherwise produce overlap. It doesn't do anything in most cases.

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally