### PR TITLE
[WinUI OSS] Enable GitHub PR validation through ADO

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -150,3 +150,4 @@ extends:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
+          buildProductOnly: true

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -145,7 +145,7 @@ extends:
     - ${{ if eq(parameters.runFullValidation, true) }}:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
         parameters:
-          pipelineKind: PR
+          pipelineKind: GitHubPR
           buildScenarioApps: false
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -53,7 +53,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/user/hmishra/gh-ado-public-validation-guards
+      ref: refs/heads/main
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -149,3 +149,4 @@ extends:
           buildScenarioApps: false
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+          pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -53,7 +53,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/feature/ado-public-validation-guards
+      ref: refs/heads/user/hmishra/gh-ado-public-validation-guards
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -53,7 +53,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/feature/ado-public-validation-guards
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
@@ -179,4 +179,6 @@ extends:
           pipelineKind: PR
           dependsOn: Build
           runArm64Tests: ${{ parameters.runArm64Tests }}
+
+
 

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -180,5 +180,3 @@ extends:
           dependsOn: Build
           runArm64Tests: ${{ parameters.runArm64Tests }}
 
-
-

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -1,0 +1,182 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# GitHub-facing wrapper for Azure Pipelines PR validation.
+#
+# This file is intentionally separate from the internal Azure Repos PR pipeline
+# so the existing ADO PR validation path can remain unchanged.
+
+trigger: none
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - feature/ado-test
+    - feature/test-ado-pr
+    - main
+    - winui3/main
+  drafts: true
+
+name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
+
+parameters:
+- name: runFullValidation
+  displayName: "Run full WinUI PR validation stages"
+  type: boolean
+  default: true
+- name: MUXFinalRelease
+  type: boolean
+  default: false
+- name: runArm64Tests
+  displayName: "Enable running tests on arm64"
+  type: boolean
+  default: true
+- name: runStaticAnalysis
+  displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
+  type: boolean
+  default: false
+
+variables:
+- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
+- template: build\AzurePipelinesTemplates\WinUI-BuildVariables.yml@WinUIInternal
+- group: WinUI-Variable-Library
+- name: WindowsContainerImage
+  value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: WinUIInternal
+      type: git
+      name: WinUI/microsoft-ui-xaml-lift
+      ref: refs/heads/main
+    - repository: WindowsAppSDKConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
+    - repository: WindowsAppSDKVersionConfig
+      type: git
+      name: ProjectReunion/WindowsAppSDKConfig
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.NonOfficial.yml@templates
+  parameters:
+    featureFlags:
+      EnableCDPxPAT: false
+      WindowsHostVersion:
+        Version: 2022
+        Network: KS3
+    platform:
+      name: 'windows_undocked'
+    git:
+      submodules: false
+    globalsdl:
+      tsa:
+        enabled: false
+      enableXFGCheck: false
+      codeql:
+        tsandjs:
+          enabled: true
+        python:
+          enabled: false
+        psscriptanalyzer:
+          enable: true
+      prefast:
+        ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
+          enabled: true
+        ${{ else }}:
+          enabled: false
+        break: true
+      apiscan:
+        enabled: false
+        break: false
+      binskim:
+        enabled: true
+        analyzeTargetGlob: $(BinskimExclusion)
+        break: true
+
+    stages:
+    - stage: ValidateGitHubPrContext
+      displayName: Validate GitHub PR context
+      jobs:
+      - job: ValidateGitHubPrContext
+        displayName: Validate GitHub PR context
+        pool:
+          type: windows
+        variables:
+          ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+        steps:
+        - checkout: self
+          submodules: false
+          fetchDepth: 1
+          fetchTags: false
+
+        - task: PowerShell@2
+          displayName: Validate GitHub PR context
+          inputs:
+            targetType: inline
+            script: |
+              $ErrorActionPreference = 'Stop'
+
+              Write-Host "Build.Reason=$env:BUILD_REASON"
+              Write-Host "Build.Repository.Provider=$env:BUILD_REPOSITORY_PROVIDER"
+              Write-Host "Build.Repository.Name=$env:BUILD_REPOSITORY_NAME"
+              Write-Host "Build.SourceBranch=$env:BUILD_SOURCEBRANCH"
+              Write-Host "System.PullRequest.TargetBranch=$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
+
+              if ($env:BUILD_REPOSITORY_PROVIDER -notin @('GitHub', 'GitHubEnterprise')) {
+                throw "Expected a GitHub-backed Azure Pipelines run, but Build.Repository.Provider was '$env:BUILD_REPOSITORY_PROVIDER'."
+              }
+
+              if ($env:BUILD_REASON -eq 'PullRequest') {
+                $allowedTargetBranches = @('feature/ado-test', 'feature/test-ado-pr', 'main', 'winui3/main', 'refs/heads/feature/ado-test', 'refs/heads/feature/test-ado-pr', 'refs/heads/main', 'refs/heads/winui3/main')
+                if ($allowedTargetBranches -notcontains $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+                  throw "Unexpected GitHub PR target branch '$env:SYSTEM_PULLREQUEST_TARGETBRANCH'."
+                }
+              }
+
+              Write-Host "GitHub PR context validation completed."
+
+    - ${{ if eq(parameters.runFullValidation, true) }}:
+      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          buildScenarioApps: true
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+
+      - template: build\AzurePipelinesTemplates\WinUI-TestMockWinAppSDKPackageUpdate-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          buildScenarioApps: false
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+
+      - ${{ if eq(parameters.MUXFinalRelease, 'false') }}:
+        - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+          parameters:
+            stageName: Build_MUXFinalRelease
+            pipelineKind: PR-2
+            buildScenarioApps: false
+            MUXFinalRelease: true
+            runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
+        parameters:
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          dependsOn: Build
+          runArm64Tests: ${{ parameters.runArm64Tests }}
+

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -12,10 +12,9 @@ pr:
   autoCancel: true
   branches:
     include:
-    - feature/ado-test
-    - feature/test-ado-pr
     - main
     - winui3/main
+    - feature/*
   drafts: true
 
 name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
@@ -134,8 +133,10 @@ extends:
               }
 
               if ($env:BUILD_REASON -eq 'PullRequest') {
-                $allowedTargetBranches = @('feature/ado-test', 'feature/test-ado-pr', 'main', 'winui3/main', 'refs/heads/feature/ado-test', 'refs/heads/feature/test-ado-pr', 'refs/heads/main', 'refs/heads/winui3/main')
-                if ($allowedTargetBranches -notcontains $env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+                $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+                $allowedExactTargetBranches = @('main', 'winui3/main', 'refs/heads/main', 'refs/heads/winui3/main')
+                $isAllowedFeatureBranch = $targetBranch -like 'feature/*' -or $targetBranch -like 'refs/heads/feature/*'
+                if (($allowedExactTargetBranches -notcontains $targetBranch) -and -not $isAllowedFeatureBranch) {
                   throw "Unexpected GitHub PR target branch '$env:SYSTEM_PULLREQUEST_TARGETBRANCH'."
                 }
               }

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -146,37 +146,6 @@ extends:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
         parameters:
           pipelineKind: PR
-          buildScenarioApps: true
-          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
-          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
-
-      - template: build\AzurePipelinesTemplates\WinUI-TestMockWinAppSDKPackageUpdate-Stage.yml@WinUIInternal
-        parameters:
-          pipelineKind: PR
           buildScenarioApps: false
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
-
-      - ${{ if eq(parameters.MUXFinalRelease, 'false') }}:
-        - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
-          parameters:
-            stageName: Build_MUXFinalRelease
-            pipelineKind: PR-2
-            buildScenarioApps: false
-            MUXFinalRelease: true
-            runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
-
-      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
-        parameters:
-          pipelineKind: PR
-
-      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
-        parameters:
-          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
-
-      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
-        parameters:
-          pipelineKind: PR
-          dependsOn: Build
-          runArm64Tests: ${{ parameters.runArm64Tests }}
-


### PR DESCRIPTION
Adds the GitHub-facing ADO wrapper for WinUI PR validation. This enables GitHub PRs to trigger the Phase 1 ADO validation path through the internal WinUI templates.

The current rollout validates the product-only GitHubPR build matrix with PGO disabled and GitHub-incompatible internal-only steps skipped. The wrapper now consumes the merged ADO templates from main.

ADO template PR: https://microsoft.visualstudio.com/WinUI/_git/microsoft-ui-xaml-lift/pullrequest/15911115