### PR TITLE
API Spec: Window.Width and Window.Height properties

### DIFF
--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -1,0 +1,203 @@
+<!--
+    Before submitting, delete all "<!-- TEMPLATE marked" comments in this file,
+    and the following quote banner:
+-->
+> See comments in Markdown for how to use this spec template
+
+<!-- TEMPLATE
+    The purpose of this spec is to describe new APIs, in a way
+    that will transfer to docs.microsoft.com (DMC).
+
+    There are two audiences for the spec. The first are people that want to evaluate and
+    give feedback on the API, as part of the submission process.
+    When it's complete it will be incorporated into the public documentation at
+    http://docs.microsoft.com (DMC).
+    Hopefully we'll be able to copy it mostly verbatim. So the second audience is
+    everyone that reads there to learn how and why to use this API.
+    Some of this text also shows up in Visual Studio Intellisense.
+
+    For example, much of the examples and descriptions in the `RadialGradientBrush` API spec
+    (https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/RadialGradientBrush/RadialGradientBrush.md)
+    were carried over to the public API page on DMC
+    (https://docs.microsoft.com/windows/winui/api/microsoft.ui.xaml.media.radialgradientbrush?view=winui-2.5)
+
+    Once the API is on DMC, that becomes the official copy, and this spec becomes an archive.
+    For example if the description is updated, that only needs to happen on DMC and needn't
+    be duplicated here.
+
+    Examples:
+    * New class (RadialGradientBrush):
+      https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/RadialGradientBrush/RadialGradientBrush.md
+    * New member on an existing class (UIElement.ProtectedCursor):
+      https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/UIElement/ElementCursor.md
+
+    Style guide:
+    * Use second person; speak to the developer who will be learning/using this API.
+    (For example "you use this to..." rather than "the developer uses this to...")
+    * Use hard returns to keep the page width within ~100 columns.
+    (Otherwise it's more difficult to leave comments in a GitHub PR.)
+    * Talk about an API's behavior, not its implementation.
+    (Speak to the developer using this API, not to the team implementing it.)
+    * A picture is worth a thousand words.
+    * An example is worth a million words.
+    * Keep examples realistic but simple; don't add unrelated complications.
+    (An example that passes a stream needn't show the process of launching the File-Open dialog.)
+
+-->
+
+Title
+===
+
+# Background
+
+<!-- TEMPLATE
+    Use this section to provide background context for the new API(s) 
+    in this spec. Try to briefly provide enough information to be able to read
+    the rest of the document.
+
+    This section and the appendix are the only sections that likely
+    do not get copied to DMC; they're just an aid to reading this spec.
+
+    For example this is a place to provide a brief explanation of some dependent
+    area, just explanation enough to understand this new API, rather than telling
+    the reader "go read 100 pages of background information posted at ...".
+
+    For example this section is a place to explain why you're adding this new API rather than
+    using an existing related API.
+
+    For a simple example see the spec for the UIElement.ProtectedCursor property
+    (https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/UIElement/ElementCursor.md)
+    which has some of the thinking about how this Xaml API relates to existing
+    Composition and WPF APIs. This is interesting background both for the current reader
+    and the future reader trying to understand why we designed it this way,
+    but not the kind of information
+    that would land on DMC.
+-->
+
+# Conceptual pages (How To)
+
+_(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
+
+<!-- TEMPLATE
+    (Optional)
+
+    All APIs have a page on DMC, some APIs or groups of APIs have an additional high level,
+    conceptual page (called a "how-to" page). This section can be used for that content.
+
+    For example, there are several Xaml controls for different forms of text input,
+    each with an API page, and then there's also a conceptual page that
+    discusses them collectively
+    (https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/text-controls).
+
+    Another way to use this section is as a draft of a blog post that introduces the new feature.
+
+    Sometimes it's difficult to decide if text belongs on a how-to page or an API page.
+    It's not important to make a final decision on that in this spec; we can always
+    adjust it when copying to DMC.
+-->
+
+# API Pages
+
+_(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
+
+<!-- TEMPLATE
+
+  Each of the L2 sections in this "API Pages" section corresponds to a page on DMC.
+
+  It's not necessary to have a section for every class member though:
+  * If its purpose and usage is obvious from it's name/type, it's not necessary to
+    create a section for it.
+  * If its purpose and usage is fully explained by brief description, either
+      put it in a table in the "Other [class] members" section
+      put it with /// comments in the IDL section
+
+  Create an L2 section here for each API that needs more description or examples.
+  For a new class with members, the members should go in their own L2 section.
+
+  Example layout
+    ## MyClass
+    ## MyClass.Member1
+    ## MyClass.Member2
+    ## Other MyClass members
+    ## MyOtherClass
+    ## ...
+
+  Notes:
+  * The first line of each of these sections should become that first line on the DMC page,
+    which then becomes the description you see in Intellisense.
+  * Each page can have description, examples, and remarks.
+    Remarks are where the documentation calls out special considerations that the developer
+    should be aware of.
+  * It can be helpful at the top of an API page (or after the Intellisense text) to add the
+    API signature in C#
+  * Add a "_Spec note: ..._" to add a note that's useful in this spec but shouldn't go to DMC.
+  * Show _examples_, not _samples_; an example is a snippet, a sample is a full working app.
+
+-->
+
+## MyExample class
+
+Brief description of this class.
+
+Introduction to one or more example usages of a MyExample class:
+
+```c#
+void SampleMethod() 
+{
+  var show = new MyExample();
+  show.SomeMembers = AndWhyItMight(be, interesting)
+}
+```
+Remarks about the MyExample class. For example,
+APIs should only throw exceptions in exceptional conditions; basically,
+only when there's a bug in the caller, such as argument exception.  But if for some
+reason it's necessary for a caller to catch an exception from an API, call that
+out with an explanation either here or in the Examples
+
+## MyExample.PropertyOne property
+
+Brief description of the MyExample.PropertyOne property.
+
+Paragraph with more detail about the property.
+
+_Spec note: internal comment about this property that won't go into the public docs._
+
+Introduction to one or more usages of the MyExample.PropertyOne property.
+
+```c#
+...
+```
+
+## Other MyExample members
+
+| Name | Description |
+|-|-|
+| PropertyTwo | Brief description of the PropertyTwo property (defaults to ...) |
+| MethodOne | Brief description of the MethodOne method |
+
+# API Details
+
+```c# (but really MIDL3)
+namespace Microsoft.Name.Space
+{
+  runtimeclass MyExample
+  {
+      Int32 PropertyOne;
+      String PropertyTwo { get; }
+      void MethodOne();
+
+       /// Brief description of the MethodTwo method
+      void MethodTwo();
+  }
+}
+```
+
+# Appendix
+
+<!-- TEMPLATE
+  Anything else that you want to write down about implementation notes and for posterity,
+  but that isn't necessary to understand the purpose and usage of the API.
+
+  This or the Background section are a good place to describe alternative designs
+  and why they were rejected.
+-->

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -23,6 +23,9 @@ These mirror what people expect from
 and `System.Windows.Window.Height` in WPF, with a couple of important
 differences (see the WPF compare/contrast section below).
 
+A driving scenario behind this work is setting Width and Height directly in XAML markup -- something WPF developers
+already do and find natural.
+
 These APIs ship as **experimental** first (`[feature(Feature_ExperimentalApi)]`),
 so the behavior may change based on early adopter feedback before they get
 promoted to stable.
@@ -45,21 +48,44 @@ property that returns the **client area** of the window in DIPs. The
   setter is a no-op there; see below.)
 - The setters change the **client area** size in DIPs.
 
+You can set the Width and Height properties in XAML markup and in code-behind.
+
+It's often natural to set your Window's initial size in your XAML markup near the markup for your app:
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="MyApp.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MyApp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Width="800"
+    Height="600"
+    Title="MyApp">
+
+    <!-- window content -->
+</Window>
+```
+
+You can also set it from code-behind:
+
 ```csharp
-// Code-behind in a packaged WinUI desktop app
+// Code-behind in a WinUI desktop app
 public MainWindow()
 {
     this.InitializeComponent();
 
-    // 800 x 600 DIP client area, no matter the monitor DPI.
+    // Set client area to 800 x 600 (DIPs)
     this.Width  = 800;
     this.Height = 600;
 }
 ```
 
-You set `Width` and `Height` from code (C# or C++/WinRT), the same way you set
-`Title` or `ExtendsContentIntoTitleBar`. They are not declarable in XAML markup
-on `<Window>`.
+Note you can use x:bind (`{x:Bind ...}`} bindings to set the Width/Height properties, but you CAN'T use classic data binding
+(`{Binding ...}`) to set them.  This is because the Window type is not a FrameworkElement.
 
 ## Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32
 
@@ -248,7 +274,7 @@ window's non-client chrome (caption, borders, and so on) gets added on top of
 `value` to work out the window rect, using the current per-monitor
 DPI. Height is left unchanged.
 
-Throws `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
+Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 ### Behavior by window state
 
@@ -295,15 +321,13 @@ the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what count
 as client area, so the getter (and `Bounds`) can change even though the window
 rect did not; re-apply the setter if you need a specific size after toggling.
 
-**XAML markup.** Width and Height are settable from C# / C++/WinRT code-behind
-only. They are **not** surfaced in XAML markup on `<Window>`, so there is no
-markup attribute to set (and therefore no markup-vs-code mismatch to trip over).
-XAML markup support could be added later if there is demand and a sensible
-parsing order, that is, Width/Height applied after Activate.
+**XAML markup.** Width and Height are settable from C++/WinRT code-behind
+AND from XAML on the `<Window>` object.
 
 **Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
-take part in data binding and do not raise change notifications. This matches the
-rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar).
+take part in data binding and do not raise change notifications. (This matches the
+rest of `Window`'s API surface).  You can, however, use `x:Bind` to set them
+in XAML markup.
 
 **Threading.** You must set these properties on the thread that owns the Window
 (the dispatcher thread). Calls from other threads return the standard
@@ -311,12 +335,14 @@ rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar).
 
 ### Errors
 
+All errors will call RoOriginateError and set an error message to help the app developer diagnose the problem.
+
 | Input                         | Result                              |
 | ----------------------------- | ----------------------------------- |
-| `value < 0`                   | Throws `E_INVALIDARG`               |
-| `Double.NaN`                  | Throws `E_INVALIDARG`               |
-| `Double.PositiveInfinity`     | Throws `E_INVALIDARG`               |
-| `Double.NegativeInfinity`     | Throws `E_INVALIDARG`               |
+| `value < 0`                   | Returns `E_INVALIDARG`              |
+| `Double.NaN`                  | Returns `E_INVALIDARG`              |
+| `Double.PositiveInfinity`     | Returns `E_INVALIDARG`              |
+| `Double.NegativeInfinity`     | Returns `E_INVALIDARG`              |
 | Window in a non-default presenter | Silent no-op (the call succeeds; the live window is unchanged) when the window uses the `FullScreen` or `CompactOverlay` presenter. Subject to change in a future release. |
 | `0`                           | Allowed. The window resizes so the client area has zero width. The OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
@@ -341,7 +367,7 @@ window's non-client chrome (caption, borders, and so on) gets added on top of
 `value` to work out the window rect, using the current per-monitor DPI. Width is
 left unchanged.
 
-Throws `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
+Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 ### Behavior by window state
 
@@ -390,15 +416,13 @@ rect did not; re-apply the setter if you need a specific size after toggling.
 Height is the axis most affected, since the caption region is at the top of the
 window.
 
-**XAML markup.** Width and Height are settable from C# / C++/WinRT code-behind
-only. They are **not** surfaced in XAML markup on `<Window>`, so there is no
-markup attribute to set (and therefore no markup-vs-code mismatch to trip over).
-XAML markup support could be added later if there is demand and a sensible
-parsing order, that is, Width/Height applied after Activate.
+**XAML markup.** Width and Height are settable from C++/WinRT code-behind
+AND from XAML on the `<Window>` object.
 
 **Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
-take part in data binding and do not raise change notifications. This matches the
-rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar).
+take part in data binding and do not raise change notifications. (This matches the
+rest of `Window`'s API surface).  You can, however, use `x:Bind` to set them
+in XAML markup.
 
 **Threading.** You must set these properties on the thread that owns the Window
 (the dispatcher thread). Calls from other threads return the standard
@@ -406,12 +430,14 @@ rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar).
 
 ### Errors
 
+All errors will call RoOriginateError and set an error message to help the app developer diagnose the problem.
+
 | Input                         | Result                              |
 | ----------------------------- | ----------------------------------- |
-| `value < 0`                   | Throws `E_INVALIDARG`               |
-| `Double.NaN`                  | Throws `E_INVALIDARG`               |
-| `Double.PositiveInfinity`     | Throws `E_INVALIDARG`               |
-| `Double.NegativeInfinity`     | Throws `E_INVALIDARG`               |
+| `value < 0`                   | Returns `E_INVALIDARG`               |
+| `Double.NaN`                  | Returns `E_INVALIDARG`               |
+| `Double.PositiveInfinity`     | Returns `E_INVALIDARG`               |
+| `Double.NegativeInfinity`     | Returns `E_INVALIDARG`               |
 | Window in a non-default presenter | Silent no-op (the call succeeds; the live window is unchanged) when the window uses the `FullScreen` or `CompactOverlay` presenter. Subject to change in a future release. |
 | `0`                           | Allowed. The window resizes so the client area has zero height; the OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as tall as the OS allows. |
@@ -478,11 +504,8 @@ chrome and DPI scale the setter used. So the getter/setter round-trip in every
 state except the non-default presenters (`FullScreen` and `CompactOverlay`),
 where the setter is a no-op.
 
-**UWP host.** When a `Window` is hosted by a UWP `CoreWindow` (legacy path), the
-setter calls `SetWindowPos` directly with physical pixels (computed once via
-`AdjustWindowRectExForDpi`). We deliberately bypass `CoreWindowWrapper::SetPosition`
-here because that wrapper takes DIPs and re-scales internally. Going through it
-would double-scale and produce a window roughly `scale^2` larger than requested.
+**UWP host.** The implementation will provide basic UWP support to keep
+existing UWP tests running.
 
 ## Design rationale
 
@@ -518,12 +541,16 @@ the user-visible impact.
 
 ## FAQ
 
-These came up as questions during design and now have answers.
+These came up as questions during design.
 
-**Will `Width` and `Height` be dependency properties so I can set or bind them in
-XAML markup?** No. `Window` is not a `DependencyObject` (unlike WPF), so these are
-plain WinRT properties you set from code, not `DependencyProperty`-backed and not
-bindable.
+**Will `Width` and `Height` be dependency properties so I can bind to them in XAML markup?**
+No. `Window` is not a `DependencyObject` (unlike WPF), so these are
+plain WinRT properties that you can't set with classic Bindings.
+You *can* however use `x:Bind` to set the properties from markup.
+
+**Can we change `Window` to be a `FrameworkElement` to allow binding and other scenarios?**
+Not in the short term.  We may consider it later if it unblocks a lot of scenarios and we
+can find a compat-friendly way to do it.
 
 **Will `Window.Bounds` change to report the *desired* size (the most recent setter
 value) instead of the actual current size?** No. `Window.Bounds` has shipped as

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -37,11 +37,12 @@ property that returns the **client area** of the window in DIPs. The
 `Width` and `Height` properties round out that surface:
 
 - The getters return the **client area** width and height in DIPs. In the
-  Normal and Fullscreen states this matches `Bounds.Width` / `Bounds.Height`.
-  In the Maximized or Minimized states the getter returns the **restore** size,
-  the size the window will have when it goes back to Normal, so that
-  `Width`/`Height` round-trip with the setter in those states. (Fullscreen is
-  the one state where they do not round-trip; see below.)
+  Normal, Fullscreen, and CompactOverlay states this matches `Bounds.Width` /
+  `Bounds.Height`. In the Maximized or Minimized states the getter returns the
+  **restore** size, the size the window will have when it goes back to Normal, so
+  that `Width`/`Height` round-trip with the setter in those states. (Fullscreen
+  and CompactOverlay are the states where they do not round-trip, because the
+  setter is a no-op there; see below.)
 - The setters change the **client area** size in DIPs.
 
 ```csharp
@@ -58,79 +59,114 @@ public MainWindow()
 
 You set `Width` and `Height` from code (C# or C++/WinRT), the same way you set
 `Title` or `ExtendsContentIntoTitleBar`. They are not declarable in XAML markup
-on `<Window>`. See the Bindings and XAML markup remarks on the `Window.Width` page.
+on `<Window>`.
 
-## A note on units: DIPs vs physical pixels
+## Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32
 
-There are two windowing surfaces in the platform and they use different units, so
-it is worth being clear up front:
+Every WinUI desktop window is, underneath, a single Win32 `HWND`. Three different
+API layers can read and size that same window, and they do **not** all agree on
+units or on what they measure. Here is the whole picture in one place.
 
-- **`Microsoft.UI.Xaml.Window`** (this class) works in **DIPs**. `Bounds`,
-  and now `Width` and `Height`, are all DIPs. The plan going forward is that
-  every size-related property on `Xaml.Window` stays in DIPs, so you do not have
-  to remember which one is which.
-- **`Microsoft.UI.Windowing.AppWindow`** and its presenters work in **physical
-  pixels** (they take `SizeInt32`). That includes `AppWindow.Size`,
-  `AppWindow.Resize(...)`, and `AppWindow.ResizeClient(...)`.
+The three layers:
 
-So `Window.Width = 800` (DIPs) and `AppWindow.ResizeClient(new SizeInt32(800, 600))`
-(physical pixels) are NOT the same on a scaled display. To go from DIPs to
-physical pixels, multiply by `GetDpiForWindow(hwnd) / 96.0`.
+- **`Microsoft.UI.Xaml.Window`** (this class, the XAML window) works in **DIPs**.
+  `Bounds`, and now `Width` and `Height`, are all DIPs. 
+- **`Microsoft.UI.Windowing.AppWindow`** (you get it from `Window.AppWindow`) and
+  its presenters work in **physical pixels** (they take and return `SizeInt32`).
+- **Raw Win32** on the `HWND` (get the handle from
+  `WinRT.Interop.WindowNative.GetWindowHandle`, or `IWindowNative::get_WindowHandle`
+  in C++) also works in **physical pixels**. These are the same functions any
+  classic Win32 app uses, and can also be used to size the window.
 
-If you want to size the **outer** window (chrome included) instead of the client
-area, use `AppWindow.Resize(...)` (physical pixels). For a physical-pixel client
-size, use `AppWindow.ResizeClient(...)`.
+Because two of the three layers are in physical pixels and one is in DIPs,
+`Window.Width = 800` (DIPs) and `AppWindow.ResizeClient(new SizeInt32(800, 600))`
+(pixels) are **not** the same on a scaled display. Convert with the window's DPI:
 
-## WPF compare/contrast
-
-WPF developers work with the WPF `Window.Width` and `Window.Height` properties. The
-WinUI properties are meant to feel familiar but they are **not identical**.
-Here is a side-by-side:
-
-| Aspect                    | WPF `Window.Width/Height`                            | WinUI `Window.Width/Height` (this spec)         |
-| ------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| Unit                      | DIPs (1/96 inch)                                     | DIPs (1/96 inch), same                          |
-| What it measures          | **Outer** window (includes chrome)                   | **Client area** (matches `Window.Bounds`)       |
-| Default / initial value   | `Double.NaN` (auto-size to content)                  | The current actual client size (never NaN)      |
-| Setting `NaN`             | Allowed; means "size to content"                     | **Throws `E_INVALIDARG`**. No size-to-content.  |
-| Setting negative          | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
-| Setting `Infinity`        | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
-| `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
-| Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
-| Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
-| Behavior when Fullscreen  | WPF has no built-in fullscreen mode                  | **No-op** (stays fullscreen, restore not updated; subject to change) |
-| Dependency property       | Yes; bindable                                        | Plain WinRT property; not bindable              |
-
-The most important difference is **client rect vs window rect**. WPF picked window bounds
-because WPF windows draw their own chrome. WinUI Windows usually host system
-chrome (caption buttons drawn by DWM), so the client area is the more useful
-unit for laying out app content. It also means `Width`/`Height` round-trip with
-`Window.Bounds` right away:
-
-```csharp
-this.Width  = 800;
-this.Height = 600;
-Debug.Assert(this.Bounds.Width  == this.Width);
-Debug.Assert(this.Bounds.Height == this.Height);
+```
+physicalPixels = dips * GetDpiForWindow(hwnd) / 96.0
 ```
 
-That round-trip holds in Normal, Maximized, and Minimized states. In the
-Maximized and Minimized states the setter updates the *restore* bounds and the
-getter reads them back, so both directions agree on the same value even though
-the live window is a different size:
+Here is every sizing API across the three layers, side by side:
 
-```csharp
-// Window is maximized, live client area is e.g. 1920 x 1040.
-this.Width = 800;        // updates the restore width only; live window unchanged
-double w = this.Width;   // == 800 (restore width, NOT 1920)
-// The live window is still maximized at 1920 x 1040.
-// Un-maximize, then:
-double w2 = this.Width;  // == 800 (now the live width too)
-```
+| API                                         | Layer         | Unit         | Measures                  | Read / write    | Notes                              |
+| ------------------------------------------- | ------------- | ------------ | ------------------------- | --------------- | ---------------------------------- |
+| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restore size when Max/Min          |
+| `Window.Bounds`                             | `Xaml.Window` | DIPs         | **Client** area           | get only        | Always the live size               |
+| `AppWindow.ClientSize`                      | `AppWindow`   | Physical px  | **Client** area           | get only        | Always the live size               |
+| `AppWindow.Size`                            | `AppWindow`   | Physical px  | **Window** rect           | get only        | Always the live size               |
+| `AppWindow.ResizeClient(sz)`                | `AppWindow`   | Physical px  | **Client** area           | set (method)    | Acts on the live window            |
+| `AppWindow.Resize(sz)`                      | `AppWindow`   | Physical px  | **Window** rect           | set (method)    | Acts on the live window            |
+| `GetClientRect(hwnd, &r)`                   | Win32         | Physical px  | **Client** area           | get only        | Live size; origin is (0,0)         |
+| `GetWindowRect(hwnd, &r)`                   | Win32         | Physical px  | **Window** rect           | get only        | Live size; screen coordinates      |
+| `SetWindowPos` / `MoveWindow`               | Win32         | Physical px  | **Window** rect           | set             | Acts on the live window            |
+| `GetWindowPlacement` / `SetWindowPlacement` | Win32         | Physical px  | **Window** rect (normal/min/max rects) | get **and** set | Reads/writes the restore rect |
 
-The one exception is Fullscreen: the setter is a silent no-op and the getter
-returns the live fullscreen size, so they do not round-trip. See the per-state
-table below.
+A few things to notice:
+
+- **Unit.** `Xaml.Window` is DIPs. `AppWindow` and raw Win32 are physical pixels.
+- **Client vs window rect.** `Window.Width/Height`, `Window.Bounds`,
+  `AppWindow.ClientSize`, and `GetClientRect` measure the **client** area (where
+  your XAML content lives). `AppWindow.Size` / `AppWindow.Resize(...)`,
+  `GetWindowRect`, and `SetWindowPos` / `MoveWindow` measure the **window rect**
+  (caption and borders included).
+- **Live vs restore.** Almost every API reports the **live** window. The two that
+  deal in the **restore** size are `Window.Width/Height` (in the Max/Min states)
+  and Win32 `Get/SetWindowPlacement` (its `rcNormalPosition`). That is not a
+  coincidence: the `Width/Height` getter and setter are built on exactly that
+  placement rect.
+- **Read vs write.** `Window.Width/Height` is the only single member you both read
+  and write. `AppWindow` splits it (a get-only property plus a separate method),
+  and Win32 splits it across different functions too.
+
+Rule of thumb: to size the **client** area in **DIPs**, set `Window.Width/Height`.
+For **physical pixels**, use `AppWindow.ResizeClient(...)` (client) or
+`AppWindow.Resize(...)` (the window rect). Reach for raw Win32 (`SetWindowPos` and
+friends) only when you need something the WinUI surfaces do not expose; mixing it
+with the XAML window means you own the DIP/pixel conversion yourself.
+
+### How the AppWindow presenter affects sizing
+
+The same sizing APIs behave differently depending on which `AppWindowPresenter`
+the window is using. You pick a presenter with `AppWindow.SetPresenter(...)`.
+The dividing line is simple: **the default `Overlapped` presenter honors the
+setter; any non-default presenter (`FullScreen`, `CompactOverlay`) makes the
+setter a no-op.** The `Overlapped` presenter also has three show states
+(Restored, Maximized, Minimized) that each behave on their own. Here is what the
+`Window.Width/Height` setter and getter do in each:
+
+| Presenter (`AppWindowPresenterKind`) | What it is                                   | `Window.Width/Height` **setter**                       | `Window.Width/Height` **getter** returns |
+| ------------------------------------ | -------------------------------------------- | ------------------------------------------------------ | ---------------------------------------- |
+| `Overlapped` - Restored (Normal)     | Standard window: caption + borders, resizable | Resizes the **live** window now                       | Live client size                         |
+| `Overlapped` - Maximized             | Fills the monitor work area                  | Updates the **restore** size only; live window unchanged | Restore size (not the live maximized size) |
+| `Overlapped` - Minimized             | Sits in the taskbar                          | Updates the **restore** size only; window stays minimized | Restore size                          |
+| `FullScreen`                         | Borderless, covers the whole monitor         | **No-op** (does not resize)                            | Live fullscreen size                     |
+| `CompactOverlay`                     | Small always-on-top picture-in-picture window | **No-op** (does not resize)                           | Live client size                         |
+
+Notes:
+
+- **`Overlapped`** is the default presenter and the only one that honors the
+  setter. It is also the only one with multiple show states. `Restored` is the
+  "Normal" case where `Width == Bounds.Width`. Maximized and Minimized are where
+  the setter/getter switch to the *restore* size instead of the live size.
+- **`FullScreen` and `CompactOverlay`** are the non-default presenters. Today the
+  setter is a silent **no-op** for both, and the getter reports the live size, so
+  `Width`/`Height` does not round-trip while you are in one of these modes. This
+  is still under discussion; see the open question in the appendix.
+
+For the two non-default presenters, this no-op behavior is close to, but not exactly, what
+the lower-level `AppWindow.ResizeClient(...)` already does:
+
+| Presenter        | `Window.Width/Height` setter | `AppWindow.ResizeClient(...)`                                  |
+| ---------------- | ---------------------------- | -------------------------------------------------------------- |
+| `FullScreen`     | No-op                        | No-op (the presenter owns the full-monitor bounds)           |
+| `CompactOverlay` | No-op                        | May resize, but **clamped** to the presenter's allowed min/max range |
+
+So in `FullScreen` the two surfaces agree (both do nothing). In `CompactOverlay`
+they differ: `Window.Width/Height` does nothing at all, while `ResizeClient` can
+still change the size within the presenter's limits. We chose the stricter no-op
+for `Width`/`Height` to keep one simple rule ("non-default presenter = no-op").
+If you actually need to resize a compact-overlay window, drop down to
+`AppWindow.ResizeClient(...)` (physical pixels).
 
 ## Where Width/Height equals Bounds and where it does not
 
@@ -146,30 +182,51 @@ return the restore size instead:
 | Fullscreen   | Live fullscreen size     | Live fullscreen size                   | Yes   |
 | CompactOverlay | Live client size       | Live client size                       | Yes   |
 
-In short: `Width == Bounds.Width` when the window is in its "natural" state
-(Normal, Fullscreen, or CompactOverlay). In the Maximized and Minimized states,
-`Width` and `Height` tell you what the window *will be* when restored, while
-`Bounds` tells you what the window *is right now*.
+In short: the getter equals `Bounds` in Normal, Fullscreen, and CompactOverlay,
+but for different reasons. In **Normal** the setter actually drove the window to
+that size. In **Fullscreen** and **CompactOverlay** the setter is a no-op, so the
+getter just reflects whatever live size the presenter chose. In the **Maximized**
+and **Minimized** states the getter instead returns the *restore* size, so
+`Width`/`Height` tell you what the window *will be* when restored while `Bounds`
+tells you what it *is right now*.
 
-If you want to size by outer bounds instead, you can still call
-`AppWindow.Resize(...)` (physical pixels, not DIPs; see the units note above).
+If you want to size by the window rect instead, you can still call
+`AppWindow.Resize(...)` (physical pixels, not DIPs; see the three-layers section above).
 
-## Porting from WPF: watch the unit change
+## WPF Comparison
 
-A WPF app that does `this.Width = 800` makes a window whose outer **window** rectangle
+WPF developers work with the WPF `Window.Width` and `Window.Height` properties. The
+WinUI properties are meant to feel familiar but they are **not identical**.
+
+A WPF app that does `this.Width = 800` makes a window whose **window rect**
 is 800 DIPs wide, so the usable client area inside is something like ~784 DIPs
 after chrome. The same line in WinUI gives a **client area** of exactly 800
-DIPs, so the outer window is ~816 DIPs. Both behaviors are self-consistent; the
+DIPs, so the window rect is ~816 DIPs. Both behaviors are self-consistent; the
 cross-framework number just does not carry over 1:1.
 
-This was a deliberate choice for WinUI. `Window.Bounds` was already the client
-area, so the new setters round-trip with it right away (`Width == Bounds.Width`).
-Making the setters mean "outer window" would have produced two different units on one
-Window object, which is even more confusing.
+Here is a side-by-side breakdown of more WPF vs WinUI behavior:
+
+| Aspect                    | WPF `Window.Width/Height`                            | WinUI `Window.Width/Height` (this spec)         |
+| ------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| Unit                      | DIPs (1/96 inch)                                     | DIPs (1/96 inch), same                          |
+| What it measures          | **Window rect** (includes chrome)                    | **Client area** (matches `Window.Bounds`)       |
+| Default / initial value   | `Double.NaN` (auto-size to content)                  | The current actual client size (never NaN)      |
+| Setting `NaN`             | Allowed; means "size to content"                     | **Throws `E_INVALIDARG`**. No size-to-content.  |
+| Setting negative          | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
+| Setting `Infinity`        | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
+| `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
+| Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
+| Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
+| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes        | **No-op** in `FullScreen` and `CompactOverlay` (live window unchanged; subject to change) |
+| Dependency property       | Yes; bindable                                        | Plain WinRT property; not bindable              |
 
 # API Pages
 
 _(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
+
+> **Editor note:** The `Window.Width` and `Window.Height` sections are
+> intentionally near-identical so each can stand alone as its own docs page. If
+> you change behavior in one, make the matching change in the other.
 
 ## Window.Width property
 
@@ -180,25 +237,25 @@ pixels (DIPs, 1/96 inch).
 public double Width { get; set; }
 ```
 
-**Getter**: returns the current client-area width in DIPs. In the Normal and
-Fullscreen states this equals `Window.Bounds.Width`. In the Maximized or
-Minimized state the getter returns the **restore** width, the width the window
-will have when it goes back to Normal, so the getter round-trips with the
-setter in those states.
+**Getter**: returns the current client-area width in DIPs. In the Normal,
+Fullscreen, and CompactOverlay states this equals `Window.Bounds.Width`. In the
+Maximized or Minimized state the getter returns the **restore** width, the width
+the window will have when it goes back to Normal, so the getter round-trips with
+the setter in those states.
 
 **Setter**: changes the window so its client area is `value` DIPs wide. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
-`value` to work out the outer window rectangle, using the current per-monitor
+`value` to work out the window rect, using the current per-monitor
 DPI. Height is left unchanged.
 
 Throws `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 ### Behavior by window state
 
-These four behaviors are driven by the window's show state, not directly by the
-`AppWindow` presenter. The only presenter the setter special-cases is
-`FullScreen` (see below). An `Overlapped` presenter maps to Normal / Maximized /
-Minimized based on its state, and `CompactOverlay` maps to Normal.
+These behaviors split by presenter. The default `Overlapped` presenter honors
+the setter and maps to Normal / Maximized / Minimized based on its show state.
+The non-default presenters, `FullScreen` and `CompactOverlay`, both make the
+setter a **no-op**.
 
 - **Normal**: the window resizes right away to the requested client width.
   Position is preserved.
@@ -209,18 +266,11 @@ Minimized based on its state, and `CompactOverlay` maps to Normal.
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
 - **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the call is a
-  silent **no-op** for now. The live window stays fullscreen and the restore
-  bounds are not updated. We deliberately do not commit to "stash and apply on
-  exit" or "throw" yet. A silent no-op keeps us free to pick a stronger contract
-  later without breaking apps. Apps that need a specific post-fullscreen size
-  should stash it themselves and re-apply after leaving fullscreen.
+  silent **no-op**. The live window stays fullscreen and the getter returns the
+  live fullscreen size, so it does not round-trip in this mode.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): treated the same as Normal. The
-  setter resizes the live compact-overlay window to the requested client size
-  and the getter reads it back from `Bounds`. Note the CompactOverlay presenter
-  may clamp the window to its own allowed size range, so the value you read back
-  can differ from what you set. This path is not special-cased and is currently
-  untested, so the behavior may change.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, the setter is a
+  silent **no-op** and the getter returns the live size.
 
 ### Remarks
 
@@ -240,58 +290,20 @@ with a different scale factor after you call the setter, the OS re-scales the
 window per its normal rules. The client-area size in DIPs is preserved across
 the move.
 
-**Interaction with ExtendsContentIntoTitleBar.**
-`Window.ExtendsContentIntoTitleBar` changes what the OS treats as "client area".
-When it is **off** (the default), DWM draws the caption bar as non-client chrome,
-so the client area starts below it. When it is **on**, the client area stretches
-up to include the caption region, so app content can render behind the caption
-buttons.
-
-Because `Width` and `Height` measure the client area, the same pixel values mean
-slightly different things in each mode:
-
-```
-  ExtendsContentIntoTitleBar = false          ExtendsContentIntoTitleBar = true
-  +---[caption / min|max|close]---+           +---[   min|max|close  ]---+
-  |                               |           |   (caption region)       |
-  +-------------------------------+           |   now part of client     |
-  |                               |           |                          |
-  |   client area                 |           |   client area            |
-  |   (Height measures this)      |           |   (Height measures       |
-  |                               |           |    ALL of this)          |
-  |                               |           |                          |
-  +-------------------------------+           +--------------------------+
-```
-
-In both modes, `Width` and `Height` equal `Bounds.Width` and `Bounds.Height` in
-the Normal state. The difference is only in how much non-client chrome sits
-outside that client rect:
-
-| Aspect                    | ECITB off (default)                  | ECITB on                                 |
-| ------------------------- | ------------------------------------ | ---------------------------------------- |
-| Top chrome                | Resize border + caption bar          | Resize border only (a few px)            |
-| Side + bottom chrome      | Resize borders                       | Resize borders (same)                    |
-| `Height = 600` means      | 600 DIPs of content below caption    | 600 DIPs including caption region        |
-| Outer window height       | 600 + caption + borders              | 600 + borders (smaller outer window)     |
-| Usable content height     | 600 DIPs (all content)               | ~570 DIPs (600 minus ~30 caption region) |
-
-The setter handles this for you. If you set `Height = 600` and then flip
-`ExtendsContentIntoTitleBar`, the OS recalculates the client area, so
-`Bounds.Height` (and the getter) will change because the boundary between client
-and non-client moved, even though the outer window size did not. If pixel-perfect
-sizing matters after toggling, call the setter again.
+**Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
+the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what counts
+as client area, so the getter (and `Bounds`) can change even though the window
+rect did not; re-apply the setter if you need a specific size after toggling.
 
 **XAML markup.** Width and Height are settable from C# / C++/WinRT code-behind
-only. They are **not** surfaced in XAML markup on `<Window>` for this
-experimental release, so there is no markup attribute to set (and therefore no
-markup-vs-code mismatch to trip over). XAML markup support could be added later
-if there is demand and a sensible parsing order, that is, Width/Height applied
-after Activate.
+only. They are **not** surfaced in XAML markup on `<Window>`, so there is no
+markup attribute to set (and therefore no markup-vs-code mismatch to trip over).
+XAML markup support could be added later if there is demand and a sensible
+parsing order, that is, Width/Height applied after Activate.
 
 **Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
 take part in data binding and do not raise change notifications. This matches the
-rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar) and keeps
-the experimental surface small.
+rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar).
 
 **Threading.** You must set these properties on the thread that owns the Window
 (the dispatcher thread). Calls from other threads return the standard
@@ -305,8 +317,8 @@ the experimental surface small.
 | `Double.NaN`                  | Throws `E_INVALIDARG`               |
 | `Double.PositiveInfinity`     | Throws `E_INVALIDARG`               |
 | `Double.NegativeInfinity`     | Throws `E_INVALIDARG`               |
-| Window is fullscreen          | Silent no-op (the call succeeds; the live window stays fullscreen and the restore size is unchanged). Subject to change in a future release. |
-| `0`                           | Allowed. The window resizes so the client area has zero width (or height). The OS may clamp to a minimum tracking size; nothing crashes. |
+| Window in a non-default presenter | Silent no-op (the call succeeds; the live window is unchanged) when the window uses the `FullScreen` or `CompactOverlay` presenter. Subject to change in a future release. |
+| `0`                           | Allowed. The window resizes so the client area has zero width. The OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
 
 ## Window.Height property
@@ -318,9 +330,91 @@ pixels (DIPs, 1/96 inch).
 public double Height { get; set; }
 ```
 
-Same semantics as [Window.Width](#windowwidth-property), just for the
-client-area height instead of width. The getter, setter, per-state behavior,
-DPI handling, ECITB interaction, errors, and threading rules are all identical.
+**Getter**: returns the current client-area height in DIPs. In the Normal,
+Fullscreen, and CompactOverlay states this equals `Window.Bounds.Height`. In the
+Maximized or Minimized state the getter returns the **restore** height, the height
+the window will have when it goes back to Normal, so the getter round-trips with
+the setter in those states.
+
+**Setter**: changes the window so its client area is `value` DIPs tall. The
+window's non-client chrome (caption, borders, and so on) gets added on top of
+`value` to work out the window rect, using the current per-monitor DPI. Width is
+left unchanged.
+
+Throws `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
+
+### Behavior by window state
+
+These behaviors split by presenter. The default `Overlapped` presenter honors
+the setter and maps to Normal / Maximized / Minimized based on its show state.
+The non-default presenters, `FullScreen` and `CompactOverlay`, both make the
+setter a **no-op**.
+
+- **Normal**: the window resizes right away to the requested client height.
+  Position is preserved.
+- **Maximized**: the live (maximized) window does not resize. The *restore*
+  bounds (the size the window snaps to when un-maximized) get updated. The other
+  axis (Width) of the restore bounds is preserved.
+- **Minimized**: same as Maximized. The *restore* bounds get updated and the
+  window stays minimized (it snaps to the new size when restored). The other
+  axis of the restore bounds is preserved.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the call is a
+  silent **no-op**. The live window stays fullscreen and the getter returns the
+  live fullscreen size, so it does not round-trip in this mode.
+- **CompactOverlay** (picture-in-picture, via
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, the setter is a
+  silent **no-op** and the getter returns the live size.
+
+### Remarks
+
+**Units and DPI.** The setter converts the requested DIP value to physical
+pixels using the window's current per-monitor DPI:
+
+```
+physicalPixels = round(dips * GetDpiForWindow(hwnd) / 96.0)
+```
+
+Because of integer-pixel rounding, the value you read back from the getter may
+differ from the value you passed to the setter by up to a couple of DIPs. The
+scenario tests allow a 2-DIP tolerance when comparing.
+
+**DPI changes during the window's lifetime.** If the window moves to a monitor
+with a different scale factor after you call the setter, the OS re-scales the
+window per its normal rules. The client-area size in DIPs is preserved across
+the move.
+
+**Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
+the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what counts
+as client area, so the getter (and `Bounds`) can change even though the window
+rect did not; re-apply the setter if you need a specific size after toggling.
+Height is the axis most affected, since the caption region is at the top of the
+window.
+
+**XAML markup.** Width and Height are settable from C# / C++/WinRT code-behind
+only. They are **not** surfaced in XAML markup on `<Window>`, so there is no
+markup attribute to set (and therefore no markup-vs-code mismatch to trip over).
+XAML markup support could be added later if there is demand and a sensible
+parsing order, that is, Width/Height applied after Activate.
+
+**Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
+take part in data binding and do not raise change notifications. This matches the
+rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar).
+
+**Threading.** You must set these properties on the thread that owns the Window
+(the dispatcher thread). Calls from other threads return the standard
+`RPC_E_WRONG_THREAD` error from the XAML framework.
+
+### Errors
+
+| Input                         | Result                              |
+| ----------------------------- | ----------------------------------- |
+| `value < 0`                   | Throws `E_INVALIDARG`               |
+| `Double.NaN`                  | Throws `E_INVALIDARG`               |
+| `Double.PositiveInfinity`     | Throws `E_INVALIDARG`               |
+| `Double.NegativeInfinity`     | Throws `E_INVALIDARG`               |
+| Window in a non-default presenter | Silent no-op (the call succeeds; the live window is unchanged) when the window uses the `FullScreen` or `CompactOverlay` presenter. Subject to change in a future release. |
+| `0`                           | Allowed. The window resizes so the client area has zero height; the OS may apply a minimum size. |
+| Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as tall as the OS allows. |
 
 # API Details
 
@@ -359,15 +453,17 @@ _(This section will not be part of public docs)_
 ## Implementation notes
 
 These are implementation details, not part of the public contract. They are
-here for posterity, not for DMC.
+here for posterity, not for the public docs.
 
-**Applying the size.** The setter computes the matching *outer* window rectangle
+**Applying the size.** The setter computes the matching *window rect*
 by adding the window's non-client chrome to the requested client size, then
 applies it with `SetWindowPos` (Normal state) or by updating `rcNormalPosition`
-via `SetWindowPlacement` (Maximized or Minimized). Fullscreen is a silent no-op.
+via `SetWindowPlacement` (Maximized or Minimized). A non-default presenter
+(`FullScreen` or `CompactOverlay`) is a silent no-op; the setter checks the
+presenter kind up front and bails before touching the window.
 
 **Where the chrome comes from.** For desktop (HWND) windows in Normal state, the
-chrome is taken from the window's *observed* outer-window-minus-client delta rather than
+chrome is taken from the window's *observed* window-rect-minus-client delta rather than
 from a purely style-based calculation (`AdjustWindowRectExForDpi`). This is what
 makes `ExtendsContentIntoTitleBar` work correctly. When the window is Maximized
 or Minimized, the live rects do not represent normal chrome, so the style-based
@@ -375,11 +471,12 @@ calculation is used instead, with a correction that zeros out the top chrome whe
 ECITB is active.
 
 **Reading the size back.** The getter returns client-area size in DIPs. In the
-Normal and Fullscreen states it reads from `Window.Bounds`. In the Maximized or
-Minimized state it computes the restore client size from the `rcNormalPosition`
-stored in `WINDOWPLACEMENT`, subtracting the same non-client chrome and DPI scale
-the setter used. So the getter/setter round-trip in every state except
-Fullscreen.
+Normal, Fullscreen, and CompactOverlay states it reads from `Window.Bounds`. In
+the Maximized or Minimized state it computes the restore client size from the
+`rcNormalPosition` stored in `WINDOWPLACEMENT`, subtracting the same non-client
+chrome and DPI scale the setter used. So the getter/setter round-trip in every
+state except the non-default presenters (`FullScreen` and `CompactOverlay`),
+where the setter is a no-op.
 
 **UWP host.** When a `Window` is hosted by a UWP `CoreWindow` (legacy path), the
 setter calls `SetWindowPos` directly with physical pixels (computed once via
@@ -389,35 +486,57 @@ would double-scale and produce a window roughly `scale^2` larger than requested.
 
 ## Design rationale
 
-The big decision was **client area vs outer window** as the unit. WinUI picked
+The big decision was **client area vs window rect** as the unit. WinUI picked
 client area so `Width`/`Height` round-trip with `Window.Bounds`, which already
-ships as the client area. The alternative (outer window bounds, like WPF) would have put
+ships as the client area. The alternative (the window rect, like WPF) would have put
 two different units on one Window object. See the "Porting from WPF" section for
 the user-visible impact.
 
 ## Open questions
 
-1. Should `Width` and `Height` become `DependencyProperty`-backed before
-   promoting out of experimental? That would enable XAML markup setters and data
-   binding, at the cost of a larger ABI commitment.
-   **No**, because Window is not a DependencyObject (unlike WPF).
-2. Should `Window.Bounds` change to track only the *desired* size (the most
-   recent setter value) rather than the actual current size? No.
-   `Window.Bounds` has shipped as the actual size and changing it would be a
-   breaking change.
-3. Do we add matching `MinWidth` / `MaxWidth` properties? Out of scope for now,
-   coming back to this soon.
-4. How should we expose "size to content" (the WPF `NaN` behavior)? Out of scope.
-5. Implementation: should we call to the AppWindow for window-related operations
+1. Implementation: should we call to the AppWindow for window-related operations
    whenever possible?
-6. Presenters: the setter only special-cases the `FullScreen` presenter.
-   `CompactOverlay`, and `Overlapped` windows configured as non-resizable
-   (`IsResizable = false`), currently flow through the normal live-resize path
-   and are untested. Should any of these be a no-op, throw, or clamp explicitly
-   instead of relying on the OS/presenter to clamp?
+2. Presenters and round-tripping: in a non-default presenter (`FullScreen` or
+   `CompactOverlay`) the setter currently no-ops, so `Width`/`Height` does not
+   round-trip in those modes. **Open for review, which behavior do we want?**
+   - *Option 1 (current): no-op.* Simplest to implement; the rule is "non-default
+     presenter = no-op." Cost: `Width`/`Height` does not round-trip while in one
+     of these modes.
+   - *Option 2: record and apply on return.* The setter records the desired
+     *normal* size and applies it when the window returns to `Overlapped`, the
+     way Maximized/Minimized already work. `Width`/`Height` round-trips in every
+     state and the non-default-presenter special cases go away, leaving one rule:
+     "`Width`/`Height` is the Normal-state client size; `Bounds` is the live size."
+     Cost: the size applies later, which can surprise.
+   - *Option 3: throw.* Setting in a non-default presenter throws instead of
+     silently doing nothing. Loud and honest, but apps must guard every set with
+     a presenter check.
+
+   Separately, `Overlapped` windows configured as non-resizable
+   (`IsResizable = false`) still flow through the normal live-resize path and are
+   untested; should that be a no-op, throw, or clamp explicitly?
+
+## FAQ
+
+These came up as questions during design and now have answers.
+
+**Will `Width` and `Height` be dependency properties so I can set or bind them in
+XAML markup?** No. `Window` is not a `DependencyObject` (unlike WPF), so these are
+plain WinRT properties you set from code, not `DependencyProperty`-backed and not
+bindable.
+
+**Will `Window.Bounds` change to report the *desired* size (the most recent setter
+value) instead of the actual current size?** No. `Window.Bounds` has shipped as
+the actual size, and changing it would be a breaking change.
+
+**Are you adding matching `MinWidth` / `MaxWidth` properties?** Not in this spec.
+It is out of scope for now, but we expect to come back to it soon.
+
+**Is there a "size to content" behavior, like setting WPF's `Width` to `NaN`?** No,
+that is out of scope. Setting `NaN` throws `E_INVALIDARG`.
 
 ## Acknowledgements
 
 This API is based on community contribution
 [microsoft/microsoft-ui-xaml#11052](https://github.com/microsoft/microsoft-ui-xaml/pull/11052)
-by external contributors. Thanks!
+from [dotMorten](https://github.com/dotMorten). Thanks!

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -46,8 +46,8 @@ App developers keep asking for a more natural managed way to do this, the same
 way they have it in WPF. This spec adds two new properties to
 `Microsoft.UI.Xaml.Window`:
 
-- `Window.Width` (Double, in DIPs)
-- `Window.Height` (Double, in DIPs)
+- `Window.Width` (Double, in logical pixels)
+- `Window.Height` (Double, in logical pixels)
 
 These mirror what people expect from
 [`System.Windows.Window.Width`](https://learn.microsoft.com/dotnet/api/system.windows.window.width)
@@ -65,7 +65,7 @@ promoted to stable.
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
-`Width` and `Height` get or set the restored size of the window's client area in DIPs.
+`Width` and `Height` get or set the restored size of the window's client area in logical pixels.
 
 The **restored size** is conceptually the size the window is (or will be) when in the restored state -- when its
 AppWindow is using the default presenter, and it's not minimized or maximized. For the default WinUI `Window`,
@@ -85,7 +85,7 @@ In these cases, the getters work the same way: they return the restored size, no
 **A user resize wins over an app-set size.** If your app sets `Width`/`Height` and the user later drags the
 window to a new size, the user's size is the one that sticks. For example:
 
-1. App sets `Window.Width = 500` (the window becomes 500 DIPs wide).
+1. App sets `Window.Width = 500` (the window becomes 500 logical pixels wide).
 2. User drags the edge to resize it to 600.
 3. App enters the `FullScreen` presenter.
 4. App exits `FullScreen` (back to `Overlapped`).
@@ -108,8 +108,8 @@ units or on what they measure. Here is the whole picture in one place.
 
 The three layers:
 
-- **`Microsoft.UI.Xaml.Window`** (this class, the XAML window) works in **DIPs**.
-  `Bounds`, and now `Width` and `Height`, are all DIPs. 
+- **`Microsoft.UI.Xaml.Window`** (this class, the XAML window) works in **logical pixels**.
+  `Bounds`, and now `Width` and `Height`, are all logical pixels. 
 - **`Microsoft.UI.Windowing.AppWindow`** (you get it from `Window.AppWindow`) and
   its presenters work in **physical pixels** (they take and return `SizeInt32`).
 - **Raw Win32** on the `HWND` (get the handle from
@@ -117,16 +117,16 @@ The three layers:
   in C++) also works in **physical pixels**. These are the same functions any
   classic Win32 app uses, and can also be used to size the window.
 
-Because two of the three layers are in physical pixels and one is in DIPs,
-`Window.Width = 800` (DIPs) and `AppWindow.ResizeClient(new SizeInt32(800, 600))`
+Because two of the three layers are in physical pixels and one is in logical pixels,
+`Window.Width = 800` (logical pixels) and `AppWindow.ResizeClient(new SizeInt32(800, 600))`
 (pixels) are **not** the same on a scaled display.
 
 Here are the key sizing APIs across the three layers, side by side:
 
 | API                                         | Layer         | Unit         | Measures                  | Read / write    | Notes                              |
 | ------------------------------------------- | ------------- | ------------ | ------------------------- | --------------- | ---------------------------------- |
-| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restored size                       |
-| `Window.Bounds`                             | `Xaml.Window` | DIPs         | **Client** area           | get only        | Live size                          |
+| `Window.Width` / `Height`                   | `Xaml.Window` | Logical px   | **Client** area           | get **and** set | Restored size                       |
+| `Window.Bounds`                             | `Xaml.Window` | Logical px   | **Client** area           | get only        | Live size                          |
 | `AppWindow.ClientSize`                      | `AppWindow`   | Physical px  | **Client** area           | get only        | Live size                          |
 | `AppWindow.Size`                            | `AppWindow`   | Physical px  | **Window** rect           | get only        | Live size                          |
 | `AppWindow.ResizeClient(sz)`                | `AppWindow`   | Physical px  | **Client** area           | set (method)    | Acts on the live window            |
@@ -138,7 +138,7 @@ Here are the key sizing APIs across the three layers, side by side:
 
 A few things to notice:
 
-- **Unit.** `Xaml.Window` is DIPs. `AppWindow` and raw Win32 are physical pixels.
+- **Unit.** `Xaml.Window` is logical pixels. `AppWindow` and raw Win32 are physical pixels.
 - **Client vs window rect.** `Window.Width/Height`, `Window.Bounds`,
   `AppWindow.ClientSize`, and `GetClientRect` measure the **client** area (where
   your XAML content lives). `AppWindow.Size` / `AppWindow.Resize(...)`,
@@ -154,16 +154,16 @@ A few things to notice:
   and write. `AppWindow` splits it (a get-only property plus a separate method),
   and Win32 splits it across different functions too.
 
-Rule of thumb: to size the **client** area in **DIPs**, set `Window.Width/Height`.
+Rule of thumb: to size the **client** area in **logical pixels**, set `Window.Width/Height`.
 For **physical pixels**, use `AppWindow.ResizeClient(...)` (client) or
 `AppWindow.Resize(...)` (the window rect). Reach for raw Win32 (`SetWindowPos` and
 related) only when you need something the WinUI surfaces do not expose; mixing it
-with the XAML window means you must handle the DIP/pixel conversion yourself.
+with the XAML window means you must handle the logical/physical pixel conversion yourself.
 
 ## 2.2. How Window sizing works with Window.ExtendsContentIntoTitleBar
 
 Setting `Window.ExtendsContentIntoTitleBar` to `true` tells the window you want to draw its title bar
-yourself.  This shifts the client area ~30 DIPs upward (depending on system settings).
+yourself.  This shifts the client area ~30 logical pixels upward (depending on system settings).
 
 If you set `Window.Height` and then toggle `ExtendsContentIntoTitleBar`, the runtime keeps the
 `Height` value you set.  The physical window shrinks slightly to account for the missing title bar
@@ -194,16 +194,16 @@ WPF developers work with the WPF `Window.Width` and `Window.Height` properties. 
 WinUI properties are meant to feel familiar but they are **not identical**.
 
 A WPF app that does `this.Width = 800` makes a window whose **window rect**
-is 800 DIPs wide, so the usable client area inside is something like ~784 DIPs
+is 800 logical pixels wide, so the usable client area inside is something like ~784 logical pixels
 after chrome. The same line in WinUI gives a **client area** of exactly 800
-DIPs, so the window rect is ~816 DIPs. Both behaviors are self-consistent; the
+logical pixels, so the window rect is ~816 logical pixels. Both behaviors are self-consistent; the
 cross-framework number just does not carry over 1:1.
 
 Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 
 | Aspect                    | WPF `Window.Width/Height`                            | WinUI `Window.Width/Height` (this spec)         |
 | ------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| Unit                      | DIPs (1/96 inch)                                     | DIPs (1/96 inch), same                          |
+| Unit                      | Logical pixels                                       | Logical pixels, same                            |
 | What it measures          | **Window rect** (includes chrome)                    | **Client area** (matches `Window.Bounds`)       |
 | Default / initial value   | `Double.NaN` (auto-size to content)                  | The current actual client size (never NaN)      |
 | Setting `NaN`             | Allowed; means "size to content"                     | **Returns `E_INVALIDARG`**. No size-to-content.  |
@@ -328,14 +328,13 @@ _(Each of the following L2 sections correspond to a page that will be on docs.mi
 
 ## 4.1. Window.Width property
 
-Gets or sets the width of the Window's **client area** in device-independent
-pixels (DIPs, 1/96 inch).
+Gets or sets the width of the Window's **client area** in logical pixels.
 
 ```csharp
 public double Width { get; set; }
 ```
 
-**Getter**: returns the client-area width in DIPs.
+**Getter**: returns the client-area width in logical pixels.
 
 - In the **Restored** state this equals `Window.Bounds.Width`.
 - In the **Maximized** or **Minimized** state it returns the *restored* width -- the
@@ -346,7 +345,7 @@ public double Width { get; set; }
   (whether set by your code or by the user resizing), or a value you set on
   `Width` while in the non-default presenter.
 
-**Setter**: changes the window so its client area is `value` DIPs wide. The
+**Setter**: changes the window so its client area is `value` logical pixels wide. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
 `value` to work out the window rect, using the current per-monitor
 DPI. Height is left unchanged.
@@ -379,20 +378,20 @@ affecting the live window in the meantime.
 
 ### 4.1.2. Remarks
 
-**Units and DPI.** The setter converts the requested DIP value to physical
+**Units and DPI.** The setter converts the requested logical-pixel value to physical
 pixels using the window's current per-monitor DPI:
 
 ```
-physicalPixels = round(dips * GetDpiForWindow(hwnd) / 96.0)
+physicalPixels = round(logicalPixels * GetDpiForWindow(hwnd) / 96.0)
 ```
 
 Because of integer-pixel rounding, the value you read back from the getter may
-differ from the value you passed to the setter by up to a couple of DIPs. The
-scenario tests allow a 2-DIP tolerance when comparing.
+differ from the value you passed to the setter by up to a couple of logical pixels. The
+scenario tests allow a 2-logical-pixel tolerance when comparing.
 
 **DPI changes during the window's lifetime.** If the window moves to a monitor
 with a different scale factor after you call the setter, the OS re-scales the
-window per its normal rules. The client-area size in DIPs is preserved across
+window per its normal rules. The client-area size in logical pixels is preserved across
 the move.
 
 **Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
@@ -430,14 +429,13 @@ In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
 
 ## 4.2. Window.Height property
 
-Gets or sets the height of the Window's **client area** in device-independent
-pixels (DIPs, 1/96 inch).
+Gets or sets the height of the Window's **client area** in logical pixels.
 
 ```csharp
 public double Height { get; set; }
 ```
 
-**Getter**: returns the client-area height in DIPs.
+**Getter**: returns the client-area height in logical pixels.
 
 - In the **Restored** state this equals `Window.Bounds.Height`.
 - In the **Maximized** or **Minimized** state it returns the *restored* height -- the
@@ -448,7 +446,7 @@ public double Height { get; set; }
   (whether set by your code or by the user resizing), or a value you set on
   `Height` while in the non-default presenter.
 
-**Setter**: changes the window so its client area is `value` DIPs tall. The
+**Setter**: changes the window so its client area is `value` logical pixels tall. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
 `value` to work out the window rect, using the current per-monitor DPI. Width is
 left unchanged.
@@ -481,20 +479,20 @@ affecting the live window in the meantime.
 
 ### 4.2.2. Remarks
 
-**Units and DPI.** The setter converts the requested DIP value to physical
+**Units and DPI.** The setter converts the requested logical-pixel value to physical
 pixels using the window's current per-monitor DPI:
 
 ```
-physicalPixels = round(dips * GetDpiForWindow(hwnd) / 96.0)
+physicalPixels = round(logicalPixels * GetDpiForWindow(hwnd) / 96.0)
 ```
 
 Because of integer-pixel rounding, the value you read back from the getter may
-differ from the value you passed to the setter by up to a couple of DIPs. The
-scenario tests allow a 2-DIP tolerance when comparing.
+differ from the value you passed to the setter by up to a couple of logical pixels. The
+scenario tests allow a 2-logical-pixel tolerance when comparing.
 
 **DPI changes during the window's lifetime.** If the window moves to a monitor
 with a different scale factor after you call the setter, the OS re-scales the
-window per its normal rules. The client-area size in DIPs is preserved across
+window per its normal rules. The client-area size in logical pixels is preserved across
 the move.
 
 **Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
@@ -600,7 +598,7 @@ or minimized, the live rects do not represent normal chrome, so the style-based
 calculation is used instead, with a correction that zeros out the top chrome when
 `ExtendsContentIntoTitleBar` is active.
 
-**Reading the size back.** The getter always returns the restored client-area size in DIPs.
+**Reading the size back.** The getter always returns the restored client-area size in logical pixels.
 
 - In the pre-activated state, before ShowWindow is called, the getters return the
   restored size (same as `Window.Bounds` at that point, unless the app set a new value).
@@ -653,6 +651,20 @@ that is out of scope. Setting `NaN` returns `E_INVALIDARG`.
 **Is it required the DPI mode to be per-mon-v2?** The Width and Height properties are implemented
 by calling win32 functions that are virtualized for DPI mode for the underlying HWND, so they will
 honor the DPI mode just as those functions do.
+
+**If I set `Width` and then `Height`, will the window flicker between the two sizes?**
+In practice, no. Each setter resizes the window right away, so setting both is technically two
+resizes: one frame at the new width with the old height, then the final size. But both calls run in
+the same synchronous turn, before the next frame is drawn, so that in-between size doesn't actually
+show up on screen. This matches WPF, which also resizes immediately on each setter and has worked
+this way for years.
+
+If you want a single, guaranteed atomic resize -- for example, if you set the two values across an
+`await` -- you have a couple of options:
+
+- Set `Width` and `Height` before you call `Activate`. The window isn't shown yet, so there's
+  nothing to flicker.
+- Use `AppWindow.ResizeClient(...)`, which takes both dimensions in one call (physical pixels).
 
 ## 6.5. Acknowledgements
 

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -66,23 +66,22 @@ promoted to stable.
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
-`Width` and `Height` get or set the size of the window's client area (in DIPs) in its normal,
-restored state.  This is the size it returns to when it isn't maximized, minimized, or has a special
-presenter (more detail below).
+`Width` and `Height` get or set the size of the window's client area in DIPs.  They represent the
+window's "restore size" -- the size it snaps back to when it isn't maximized, minimized, or using a
+special presenter (more detail below).
 
-These properties represent the client area of the window, in DIPs.  They match the Win32 notion of
-"client rect" except that they correct for the window's DPI.  This client area is the same area your window's
-content is hosted, so generally when the window is in a normal state, `Window.Width` equals `Window.Content.ActualWidth`
-(and same for height).
+These match the Win32 notion of "client rect" except they correct for the window's DPI.  The client
+area is where your content lives, so in the normal state `Window.Width` equals
+`Window.Content.ActualWidth` (and same for height).
 
-In the following conditions, setting the `Width` or `Height` property won't resize the window immediately:
-- When `Window.Activate` has not been called to show the window
-- When the window is maximized or minimized
-- When the `Window.AppWindow.Presenter` object is `FullScreen` or `CompactOverlay`
+Setting `Width` or `Height` won't resize the window immediately when:
+- `Window.Activate` has not been called yet
+- The window is maximized or minimized
+- The `Window.AppWindow.Presenter` is `FullScreen` or `CompactOverlay`
 
-In these cases, the new size is remembered for later as the "restore size".  The runtime resizes the window
-to the new size when the above conditions become false.  The getters return the "restore size" you set,
-so they will not always return the true "live size" of the window.
+In these cases the new size is saved as the restore size.  The runtime applies it once the window
+returns to the normal restored state.  The getters return the restore size you set, so they won't
+always match the actual live size of the window.
 
 You can set the Width and Height properties in XAML markup and in code-behind.
 
@@ -145,8 +144,8 @@ A few things to notice:
   Normal) and Win32 `Get/SetWindowPlacement` (its `rcNormalPosition`). That is
   not a coincidence: the `Width/Height` getter and setter are built on exactly
   that placement rect.
-- **Minimized state.** The APIs that operate with "live size" use "restore size" when
-  then window is minimized (rather than returning the size "0,0")
+- **Minimized state.** The APIs that report "live size" use the restore size when
+  the window is minimized (rather than returning 0,0).
 - **Read vs write.** `Window.Width/Height` is the only single member you both read
   and write. `AppWindow` splits it (a get-only property plus a separate method),
   and Win32 splits it across different functions too.
@@ -162,14 +161,12 @@ with the XAML window means you must handle the DIP/pixel conversion yourself.
 The same sizing APIs behave differently depending on which `AppWindowPresenter`
 the window is using. You pick a presenter with `AppWindow.SetPresenter(...)`.
 
-When your window is using the default `Overlapped` presenter, it behaves like a
-"normal" window, and unless it's maximized or minimized, it's resized immediately
-when you set Width or Height.
+With the default `Overlapped` presenter the window behaves normally: unless it's
+maximized or minimized, setting Width or Height resizes it immediately.
 
-If/when your app sets a non-default presenter (`FullScreen`, `CompactOverlay`) on your
-window, that window is now considered to be in a special presenter mode, and any changes
-you make to `Width` and `Height` during this time won't be honored until you set the AppWindow's
-presenter back to `Overlapped`.
+If your app switches to a non-default presenter (`FullScreen`, `CompactOverlay`),
+the setter saves the value as the restore size but won't resize the window until
+you switch back to `Overlapped`.
 
 | Presenter (`AppWindowPresenterKind`) | What it is                                   | `Window.Width/Height` **setter**                       | `Window.Width/Height` **getter** returns |
 | ------------------------------------ | -------------------------------------------- | ------------------------------------------------------ | ---------------------------------------- |
@@ -184,16 +181,14 @@ If you need to resize a window in one of these presenters, drop down to
 
 ### 2.1.2. How the Window sizing works with Window.ExtendsContentIntoTitleBar
 
-When you set `Window.ExtendsContentIntoTitleBar` to `true`, your this tells your window you want to draw the window's
-TitleBar yourself.  This effectively shifts the client area of your window ~30 DIPs upward on the y-axis. (depending on
-system settings)
+Setting `Window.ExtendsContentIntoTitleBar` to `true` tells the window you want to draw its title bar
+yourself.  This shifts the client area ~30 DIPs upward (depending on system settings).
 
-If you previously set the `Window.Height` property and then toggle the `Window.ExtendsContentIntoTitleBar` property,
-the runtime will honor the `Window.Height` value you set earlier and hold the value unchanged.  This means the physical
-size of the window will shrink slightly to account for the missing TitleBar area.  If you didn't set `Window.Height`,
-the window size will _not_ change when you toggle `ExtendsContentIntoTitleBar`.
+If you set `Window.Height` and then toggle `ExtendsContentIntoTitleBar`, the runtime keeps the
+`Height` value you set.  The physical window shrinks slightly to account for the missing title bar
+area.  If you _didn't_ set `Height`, the window size does not change when you toggle it.
 
-This means the order you set these properties in doesn't matter:
+Setting them in either order works -- either way, the window's height comes out the same:
 
 ```cs
 window.Height = 300;                      // Changes window height to 330px

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -49,6 +49,9 @@ property that returns the **client area** of the window in DIPs. The
 
 You can set the Width and Height properties in XAML markup and in code-behind.
 
+If you need the current client-area size for layout, use `Bounds` -- it always
+reflects the live size, even when the window is maximized.
+
 It's often natural to set your Window's initial size in your XAML markup near the markup for your app:
 
 ```xml

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -25,11 +25,12 @@ Table of Contents
     - [4.2.3. Errors](#423-errors)
 - [5. API Details](#5-api-details)
 - [6. Appendix](#6-appendix)
-  - [6.1. Implementation notes](#61-implementation-notes)
-  - [6.2. Design rationale](#62-design-rationale)
-  - [6.3. Open questions](#63-open-questions)
-  - [6.4. FAQ](#64-faq)
-  - [6.5. Acknowledgements](#65-acknowledgements)
+  - [6.1. Release plan](#61-release-plan)
+  - [6.2. Implementation notes](#62-implementation-notes)
+  - [6.3. Design rationale](#63-design-rationale)
+  - [6.4. Open questions](#64-open-questions)
+  - [6.5. FAQ](#65-faq)
+  - [6.6. Acknowledgements](#66-acknowledgements)
 
 
 # 1. Background
@@ -146,8 +147,8 @@ A few things to notice:
 Rule of thumb: to size the **client** area in **DIPs**, set `Window.Width/Height`.
 For **physical pixels**, use `AppWindow.ResizeClient(...)` (client) or
 `AppWindow.Resize(...)` (the window rect). Reach for raw Win32 (`SetWindowPos` and
-friends) only when you need something the WinUI surfaces do not expose; mixing it
-with the XAML window means you own the DIP/pixel conversion yourself.
+related) only when you need something the WinUI surfaces do not expose; mixing it
+with the XAML window means you must handle the DIP/pixel conversion yourself.
 
 ### 2.1.1. How the AppWindow presenter affects sizing
 
@@ -534,44 +535,20 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 
 # 5. API Details
 
-Initially the API will be **experimental**:
 ```c# (but really MIDL3)
-// For experimental release
 namespace Microsoft.UI.Xaml
 {
+  [contractversion(12)]
+  apicontract WinUIContract{};
+
   [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
   [webhosthidden]
   [contentproperty("Content")]
-  unsealed runtimeclass Window // existing type
+  unsealed runtimeclass Window
   {
-    // ...existing APIs...
-
-    // New: 
-    [contract(Microsoft.UI.Xaml.WinUIContract, 12)]   // 12 is the contract version we're using for WASDK 3.0
+    [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
     [feature(Feature_ExperimentalApi)]
     [interface_name("Microsoft.UI.Xaml.IWindowFeature_ExperimentalApi")]
-    {
-      Double Width;
-      Double Height;
-    }
-  }
-}
-```
-
-We plan for this API to be made **stable**:
-```c# (but really MIDL3)
-// For stable release
-namespace Microsoft.UI.Xaml
-{
-  [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
-  [webhosthidden]
-  [contentproperty("Content")]
-  unsealed runtimeclass Window // existing type
-  {
-    // ...existing APIs...
-
-    // New: 
-    [contract(Microsoft.UI.Xaml.WinUIContract, 12)]   // 12 is the contract version we're using for WASDK 3.0
     {
       Double Width;
       Double Height;
@@ -584,7 +561,12 @@ namespace Microsoft.UI.Xaml
 
 _(This section will not be part of public docs)_
 
-## 6.1. Implementation notes
+## 6.1. Release plan
+
+We plan to make the API experimental in WinUI3 main.  We plan to later make it stable for the WinAppSDK 3.0
+release, and possibly service it to WinAppSDK 2.x.
+
+## 6.2. Implementation notes
 
 These are implementation details, not part of the public contract. They are
 here for posterity, not for the public docs.
@@ -615,7 +597,7 @@ where the setter returns an error.
 **UWP host.** The implementation will provide basic UWP support to keep
 existing UWP tests running.
 
-## 6.2. Design rationale
+## 6.3. Design rationale
 
 The big decision was **client area vs window rect** as the unit. WinUI picked
 client area so `Width`/`Height` round-trip with `Window.Bounds`, which already
@@ -623,10 +605,9 @@ ships as the client area. The alternative (the window rect, like WPF) would have
 two different units on one Window object. See the "Porting from WPF" section for
 the user-visible impact.
 
-## 6.3. Open questions
+## 6.4. Open questions
 
-
-## 6.4. FAQ
+## 6.5. FAQ
 
 These came up as questions during design.
 
@@ -649,7 +630,11 @@ It is out of scope for now, but we expect to come back to it soon.
 **Is there a "size to content" behavior, like setting WPF's `Width` to `NaN`?** No,
 that is out of scope. Setting `NaN` returns `E_INVALIDARG`.
 
-## 6.5. Acknowledgements
+**Is it required the DPI mode to be per-mon-v2?** The Width and Height properties are implemented
+by calling win32 functions that are virtualized for DPI mode for the underlying HWND, so they will
+honor the DPI mode just as those functions do.
+
+## 6.6. Acknowledgements
 
 This API is based on community contribution
 [microsoft/microsoft-ui-xaml#11052](https://github.com/microsoft/microsoft-ui-xaml/pull/11052)

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -1,203 +1,423 @@
-<!--
-    Before submitting, delete all "<!-- TEMPLATE marked" comments in this file,
-    and the following quote banner:
--->
-> See comments in Markdown for how to use this spec template
-
-<!-- TEMPLATE
-    The purpose of this spec is to describe new APIs, in a way
-    that will transfer to docs.microsoft.com (DMC).
-
-    There are two audiences for the spec. The first are people that want to evaluate and
-    give feedback on the API, as part of the submission process.
-    When it's complete it will be incorporated into the public documentation at
-    http://docs.microsoft.com (DMC).
-    Hopefully we'll be able to copy it mostly verbatim. So the second audience is
-    everyone that reads there to learn how and why to use this API.
-    Some of this text also shows up in Visual Studio Intellisense.
-
-    For example, much of the examples and descriptions in the `RadialGradientBrush` API spec
-    (https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/RadialGradientBrush/RadialGradientBrush.md)
-    were carried over to the public API page on DMC
-    (https://docs.microsoft.com/windows/winui/api/microsoft.ui.xaml.media.radialgradientbrush?view=winui-2.5)
-
-    Once the API is on DMC, that becomes the official copy, and this spec becomes an archive.
-    For example if the description is updated, that only needs to happen on DMC and needn't
-    be duplicated here.
-
-    Examples:
-    * New class (RadialGradientBrush):
-      https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/RadialGradientBrush/RadialGradientBrush.md
-    * New member on an existing class (UIElement.ProtectedCursor):
-      https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/UIElement/ElementCursor.md
-
-    Style guide:
-    * Use second person; speak to the developer who will be learning/using this API.
-    (For example "you use this to..." rather than "the developer uses this to...")
-    * Use hard returns to keep the page width within ~100 columns.
-    (Otherwise it's more difficult to leave comments in a GitHub PR.)
-    * Talk about an API's behavior, not its implementation.
-    (Speak to the developer using this API, not to the team implementing it.)
-    * A picture is worth a thousand words.
-    * An example is worth a million words.
-    * Keep examples realistic but simple; don't add unrelated complications.
-    (An example that passes a stream needn't show the process of launching the File-Open dialog.)
-
--->
-
-Title
+Window.Width and Window.Height
 ===
 
 # Background
 
-<!-- TEMPLATE
-    Use this section to provide background context for the new API(s) 
-    in this spec. Try to briefly provide enough information to be able to read
-    the rest of the document.
+_(This section will not be part of public docs)_
 
-    This section and the appendix are the only sections that likely
-    do not get copied to DMC; they're just an aid to reading this spec.
+The WinUI 3 [Window](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window)
+class is the host for XAML content in a desktop app. Until now, the only way to
+change a Window's size from code has been to drop down to the Win32 HWND (via
+`IWindowNative`) and call `SetWindowPos`, or to go through `AppWindow.Resize(...)`,
+which works in physical pixels.
 
-    For example this is a place to provide a brief explanation of some dependent
-    area, just explanation enough to understand this new API, rather than telling
-    the reader "go read 100 pages of background information posted at ...".
+App developers keep asking for a more natural managed way to do this, the same
+way they have it in WPF. This spec adds two new properties to
+`Microsoft.UI.Xaml.Window`:
 
-    For example this section is a place to explain why you're adding this new API rather than
-    using an existing related API.
+- `Window.Width` (Double, in DIPs)
+- `Window.Height` (Double, in DIPs)
 
-    For a simple example see the spec for the UIElement.ProtectedCursor property
-    (https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/UIElement/ElementCursor.md)
-    which has some of the thinking about how this Xaml API relates to existing
-    Composition and WPF APIs. This is interesting background both for the current reader
-    and the future reader trying to understand why we designed it this way,
-    but not the kind of information
-    that would land on DMC.
--->
+These mirror what people expect from
+[`System.Windows.Window.Width`](https://learn.microsoft.com/dotnet/api/system.windows.window.width)
+and `System.Windows.Window.Height` in WPF, with a couple of important
+differences (see the WPF compare/contrast section below).
+
+These APIs ship as **experimental** first (`[feature(Feature_ExperimentalApi)]`),
+so the behavior may change based on early adopter feedback before they get
+promoted to stable.
 
 # Conceptual pages (How To)
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
-<!-- TEMPLATE
-    (Optional)
+WinUI Window already has a read-only
+[`Bounds`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window.bounds)
+property that returns the **client area** of the window in DIPs. The 
+`Width` and `Height` properties round out that surface:
 
-    All APIs have a page on DMC, some APIs or groups of APIs have an additional high level,
-    conceptual page (called a "how-to" page). This section can be used for that content.
+- The getters return the **client area** width and height in DIPs. In the
+  Normal and Fullscreen states this matches `Bounds.Width` / `Bounds.Height`.
+  In the Maximized or Minimized states the getter returns the **restore** size,
+  the size the window will have when it goes back to Normal, so that
+  `Width`/`Height` round-trip with the setter in those states. (Fullscreen is
+  the one state where they do not round-trip; see below.)
+- The setters change the **client area** size in DIPs.
 
-    For example, there are several Xaml controls for different forms of text input,
-    each with an API page, and then there's also a conceptual page that
-    discusses them collectively
-    (https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/text-controls).
+```csharp
+// Code-behind in a packaged WinUI desktop app
+public MainWindow()
+{
+    this.InitializeComponent();
 
-    Another way to use this section is as a draft of a blog post that introduces the new feature.
+    // 800 x 600 DIP client area, no matter the monitor DPI.
+    this.Width  = 800;
+    this.Height = 600;
+}
+```
 
-    Sometimes it's difficult to decide if text belongs on a how-to page or an API page.
-    It's not important to make a final decision on that in this spec; we can always
-    adjust it when copying to DMC.
--->
+You set `Width` and `Height` from code (C# or C++/WinRT), the same way you set
+`Title` or `ExtendsContentIntoTitleBar`. They are not declarable in XAML markup
+on `<Window>`. See the Bindings and XAML markup remarks on the `Window.Width` page.
+
+## A note on units: DIPs vs physical pixels
+
+There are two windowing surfaces in the platform and they use different units, so
+it is worth being clear up front:
+
+- **`Microsoft.UI.Xaml.Window`** (this class) works in **DIPs**. `Bounds`,
+  and now `Width` and `Height`, are all DIPs. The plan going forward is that
+  every size-related property on `Xaml.Window` stays in DIPs, so you do not have
+  to remember which one is which.
+- **`Microsoft.UI.Windowing.AppWindow`** and its presenters work in **physical
+  pixels** (they take `SizeInt32`). That includes `AppWindow.Size`,
+  `AppWindow.Resize(...)`, and `AppWindow.ResizeClient(...)`.
+
+So `Window.Width = 800` (DIPs) and `AppWindow.ResizeClient(new SizeInt32(800, 600))`
+(physical pixels) are NOT the same on a scaled display. To go from DIPs to
+physical pixels, multiply by `GetDpiForWindow(hwnd) / 96.0`.
+
+If you want to size the **outer** window (chrome included) instead of the client
+area, use `AppWindow.Resize(...)` (physical pixels). For a physical-pixel client
+size, use `AppWindow.ResizeClient(...)`.
+
+## WPF compare/contrast
+
+WPF developers work with the WPF `Window.Width` and `Window.Height` properties. The
+WinUI properties are meant to feel familiar but they are **not identical**.
+Here is a side-by-side:
+
+| Aspect                    | WPF `Window.Width/Height`                            | WinUI `Window.Width/Height` (this spec)         |
+| ------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| Unit                      | DIPs (1/96 inch)                                     | DIPs (1/96 inch), same                          |
+| What it measures          | **Outer** window (includes chrome)                   | **Client area** (matches `Window.Bounds`)       |
+| Default / initial value   | `Double.NaN` (auto-size to content)                  | The current actual client size (never NaN)      |
+| Setting `NaN`             | Allowed; means "size to content"                     | **Throws `E_INVALIDARG`**. No size-to-content.  |
+| Setting negative          | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
+| Setting `Infinity`        | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
+| `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
+| Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
+| Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
+| Behavior when Fullscreen  | WPF has no built-in fullscreen mode                  | **No-op** (stays fullscreen, restore not updated; subject to change) |
+| Dependency property       | Yes; bindable                                        | Plain WinRT property; not bindable              |
+
+The most important difference is **client rect vs window rect**. WPF picked window bounds
+because WPF windows draw their own chrome. WinUI Windows usually host system
+chrome (caption buttons drawn by DWM), so the client area is the more useful
+unit for laying out app content. It also means `Width`/`Height` round-trip with
+`Window.Bounds` right away:
+
+```csharp
+this.Width  = 800;
+this.Height = 600;
+Debug.Assert(this.Bounds.Width  == this.Width);
+Debug.Assert(this.Bounds.Height == this.Height);
+```
+
+That round-trip holds in Normal, Maximized, and Minimized states. In the
+Maximized and Minimized states the setter updates the *restore* bounds and the
+getter reads them back, so both directions agree on the same value even though
+the live window is a different size:
+
+```csharp
+// Window is maximized, live client area is e.g. 1920 x 1040.
+this.Width = 800;        // updates the restore width only; live window unchanged
+double w = this.Width;   // == 800 (restore width, NOT 1920)
+// The live window is still maximized at 1920 x 1040.
+// Un-maximize, then:
+double w2 = this.Width;  // == 800 (now the live width too)
+```
+
+The one exception is Fullscreen: the setter is a silent no-op and the getter
+returns the live fullscreen size, so they do not round-trip. See the per-state
+table below.
+
+## Where Width/Height equals Bounds and where it does not
+
+`Window.Bounds` always reports the **live** client area. `Width`/`Height`
+diverge from it in the Maximized and Minimized states because the getters
+return the restore size instead:
+
+| Window state | `Width`/`Height` returns | `Bounds.Width`/`Bounds.Height` returns | Same? |
+| ------------ | ------------------------ | -------------------------------------- | ----- |
+| Normal       | Live client size         | Live client size                       | Yes   |
+| Maximized    | **Restore** size         | Live maximized size                    | **No** |
+| Minimized    | **Restore** size         | Live minimized size                    | **No** |
+| Fullscreen   | Live fullscreen size     | Live fullscreen size                   | Yes   |
+| CompactOverlay | Live client size       | Live client size                       | Yes   |
+
+In short: `Width == Bounds.Width` when the window is in its "natural" state
+(Normal, Fullscreen, or CompactOverlay). In the Maximized and Minimized states,
+`Width` and `Height` tell you what the window *will be* when restored, while
+`Bounds` tells you what the window *is right now*.
+
+If you want to size by outer bounds instead, you can still call
+`AppWindow.Resize(...)` (physical pixels, not DIPs; see the units note above).
+
+## Porting from WPF: watch the unit change
+
+A WPF app that does `this.Width = 800` makes a window whose outer **window** rectangle
+is 800 DIPs wide, so the usable client area inside is something like ~784 DIPs
+after chrome. The same line in WinUI gives a **client area** of exactly 800
+DIPs, so the outer window is ~816 DIPs. Both behaviors are self-consistent; the
+cross-framework number just does not carry over 1:1.
+
+This was a deliberate choice for WinUI. `Window.Bounds` was already the client
+area, so the new setters round-trip with it right away (`Width == Bounds.Width`).
+Making the setters mean "outer window" would have produced two different units on one
+Window object, which is even more confusing.
 
 # API Pages
 
 _(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
 
-<!-- TEMPLATE
+## Window.Width property
 
-  Each of the L2 sections in this "API Pages" section corresponds to a page on DMC.
+Gets or sets the width of the Window's **client area** in device-independent
+pixels (DIPs, 1/96 inch).
 
-  It's not necessary to have a section for every class member though:
-  * If its purpose and usage is obvious from it's name/type, it's not necessary to
-    create a section for it.
-  * If its purpose and usage is fully explained by brief description, either
-      put it in a table in the "Other [class] members" section
-      put it with /// comments in the IDL section
-
-  Create an L2 section here for each API that needs more description or examples.
-  For a new class with members, the members should go in their own L2 section.
-
-  Example layout
-    ## MyClass
-    ## MyClass.Member1
-    ## MyClass.Member2
-    ## Other MyClass members
-    ## MyOtherClass
-    ## ...
-
-  Notes:
-  * The first line of each of these sections should become that first line on the DMC page,
-    which then becomes the description you see in Intellisense.
-  * Each page can have description, examples, and remarks.
-    Remarks are where the documentation calls out special considerations that the developer
-    should be aware of.
-  * It can be helpful at the top of an API page (or after the Intellisense text) to add the
-    API signature in C#
-  * Add a "_Spec note: ..._" to add a note that's useful in this spec but shouldn't go to DMC.
-  * Show _examples_, not _samples_; an example is a snippet, a sample is a full working app.
-
--->
-
-## MyExample class
-
-Brief description of this class.
-
-Introduction to one or more example usages of a MyExample class:
-
-```c#
-void SampleMethod() 
-{
-  var show = new MyExample();
-  show.SomeMembers = AndWhyItMight(be, interesting)
-}
-```
-Remarks about the MyExample class. For example,
-APIs should only throw exceptions in exceptional conditions; basically,
-only when there's a bug in the caller, such as argument exception.  But if for some
-reason it's necessary for a caller to catch an exception from an API, call that
-out with an explanation either here or in the Examples
-
-## MyExample.PropertyOne property
-
-Brief description of the MyExample.PropertyOne property.
-
-Paragraph with more detail about the property.
-
-_Spec note: internal comment about this property that won't go into the public docs._
-
-Introduction to one or more usages of the MyExample.PropertyOne property.
-
-```c#
-...
+```csharp
+public double Width { get; set; }
 ```
 
-## Other MyExample members
+**Getter**: returns the current client-area width in DIPs. In the Normal and
+Fullscreen states this equals `Window.Bounds.Width`. In the Maximized or
+Minimized state the getter returns the **restore** width, the width the window
+will have when it goes back to Normal, so the getter round-trips with the
+setter in those states.
 
-| Name | Description |
-|-|-|
-| PropertyTwo | Brief description of the PropertyTwo property (defaults to ...) |
-| MethodOne | Brief description of the MethodOne method |
+**Setter**: changes the window so its client area is `value` DIPs wide. The
+window's non-client chrome (caption, borders, and so on) gets added on top of
+`value` to work out the outer window rectangle, using the current per-monitor
+DPI. Height is left unchanged.
+
+Throws `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
+
+### Behavior by window state
+
+These four behaviors are driven by the window's show state, not directly by the
+`AppWindow` presenter. The only presenter the setter special-cases is
+`FullScreen` (see below). An `Overlapped` presenter maps to Normal / Maximized /
+Minimized based on its state, and `CompactOverlay` maps to Normal.
+
+- **Normal**: the window resizes right away to the requested client width.
+  Position is preserved.
+- **Maximized**: the live (maximized) window does not resize. The *restore*
+  bounds (the size the window snaps to when un-maximized) get updated. The other
+  axis (Height) of the restore bounds is preserved.
+- **Minimized**: same as Maximized. The *restore* bounds get updated and the
+  window stays minimized (it snaps to the new size when restored). The other
+  axis of the restore bounds is preserved.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the call is a
+  silent **no-op** for now. The live window stays fullscreen and the restore
+  bounds are not updated. We deliberately do not commit to "stash and apply on
+  exit" or "throw" yet. A silent no-op keeps us free to pick a stronger contract
+  later without breaking apps. Apps that need a specific post-fullscreen size
+  should stash it themselves and re-apply after leaving fullscreen.
+- **CompactOverlay** (picture-in-picture, via
+  `AppWindowPresenterKind.CompactOverlay`): treated the same as Normal. The
+  setter resizes the live compact-overlay window to the requested client size
+  and the getter reads it back from `Bounds`. Note the CompactOverlay presenter
+  may clamp the window to its own allowed size range, so the value you read back
+  can differ from what you set. This path is not special-cased and is currently
+  untested, so the behavior may change.
+
+### Remarks
+
+**Units and DPI.** The setter converts the requested DIP value to physical
+pixels using the window's current per-monitor DPI:
+
+```
+physicalPixels = round(dips * GetDpiForWindow(hwnd) / 96.0)
+```
+
+Because of integer-pixel rounding, the value you read back from the getter may
+differ from the value you passed to the setter by up to a couple of DIPs. The
+scenario tests allow a 2-DIP tolerance when comparing.
+
+**DPI changes during the window's lifetime.** If the window moves to a monitor
+with a different scale factor after you call the setter, the OS re-scales the
+window per its normal rules. The client-area size in DIPs is preserved across
+the move.
+
+**Interaction with ExtendsContentIntoTitleBar.**
+`Window.ExtendsContentIntoTitleBar` changes what the OS treats as "client area".
+When it is **off** (the default), DWM draws the caption bar as non-client chrome,
+so the client area starts below it. When it is **on**, the client area stretches
+up to include the caption region, so app content can render behind the caption
+buttons.
+
+Because `Width` and `Height` measure the client area, the same pixel values mean
+slightly different things in each mode:
+
+```
+  ExtendsContentIntoTitleBar = false          ExtendsContentIntoTitleBar = true
+  +---[caption / min|max|close]---+           +---[   min|max|close  ]---+
+  |                               |           |   (caption region)       |
+  +-------------------------------+           |   now part of client     |
+  |                               |           |                          |
+  |   client area                 |           |   client area            |
+  |   (Height measures this)      |           |   (Height measures       |
+  |                               |           |    ALL of this)          |
+  |                               |           |                          |
+  +-------------------------------+           +--------------------------+
+```
+
+In both modes, `Width` and `Height` equal `Bounds.Width` and `Bounds.Height` in
+the Normal state. The difference is only in how much non-client chrome sits
+outside that client rect:
+
+| Aspect                    | ECITB off (default)                  | ECITB on                                 |
+| ------------------------- | ------------------------------------ | ---------------------------------------- |
+| Top chrome                | Resize border + caption bar          | Resize border only (a few px)            |
+| Side + bottom chrome      | Resize borders                       | Resize borders (same)                    |
+| `Height = 600` means      | 600 DIPs of content below caption    | 600 DIPs including caption region        |
+| Outer window height       | 600 + caption + borders              | 600 + borders (smaller outer window)     |
+| Usable content height     | 600 DIPs (all content)               | ~570 DIPs (600 minus ~30 caption region) |
+
+The setter handles this for you. If you set `Height = 600` and then flip
+`ExtendsContentIntoTitleBar`, the OS recalculates the client area, so
+`Bounds.Height` (and the getter) will change because the boundary between client
+and non-client moved, even though the outer window size did not. If pixel-perfect
+sizing matters after toggling, call the setter again.
+
+**XAML markup.** Width and Height are settable from C# / C++/WinRT code-behind
+only. They are **not** surfaced in XAML markup on `<Window>` for this
+experimental release, so there is no markup attribute to set (and therefore no
+markup-vs-code mismatch to trip over). XAML markup support could be added later
+if there is demand and a sensible parsing order, that is, Width/Height applied
+after Activate.
+
+**Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
+take part in data binding and do not raise change notifications. This matches the
+rest of `Window`'s mutable surface (Title, ExtendsContentIntoTitleBar) and keeps
+the experimental surface small.
+
+**Threading.** You must set these properties on the thread that owns the Window
+(the dispatcher thread). Calls from other threads return the standard
+`RPC_E_WRONG_THREAD` error from the XAML framework.
+
+### Errors
+
+| Input                         | Result                              |
+| ----------------------------- | ----------------------------------- |
+| `value < 0`                   | Throws `E_INVALIDARG`               |
+| `Double.NaN`                  | Throws `E_INVALIDARG`               |
+| `Double.PositiveInfinity`     | Throws `E_INVALIDARG`               |
+| `Double.NegativeInfinity`     | Throws `E_INVALIDARG`               |
+| Window is fullscreen          | Silent no-op (the call succeeds; the live window stays fullscreen and the restore size is unchanged). Subject to change in a future release. |
+| `0`                           | Allowed. The window resizes so the client area has zero width (or height). The OS may clamp to a minimum tracking size; nothing crashes. |
+| Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
+
+## Window.Height property
+
+Gets or sets the height of the Window's **client area** in device-independent
+pixels (DIPs, 1/96 inch).
+
+```csharp
+public double Height { get; set; }
+```
+
+Same semantics as [Window.Width](#windowwidth-property), just for the
+client-area height instead of width. The getter, setter, per-state behavior,
+DPI handling, ECITB interaction, errors, and threading rules are all identical.
 
 # API Details
 
-```c# (but really MIDL3)
-namespace Microsoft.Name.Space
+```csharp
+namespace Microsoft.UI.Xaml
 {
-  runtimeclass MyExample
-  {
-      Int32 PropertyOne;
-      String PropertyTwo { get; }
-      void MethodOne();
+    [contentproperty("Content")]
+    unsealed runtimeclass Window
+    {
+        // ... existing members ...
 
-       /// Brief description of the MethodTwo method
-      void MethodTwo();
-  }
+        // New, behind Feature_ExperimentalApi:
+        Double Width;
+        Double Height;
+    }
+}
+```
+
+In MIDL3 form, matching the existing IDL in
+`dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl`:
+
+```idl
+[contract(Microsoft.UI.Xaml.WinUIContract, 10)]
+[feature(Feature_ExperimentalApi)]
+[interface_name("Microsoft.UI.Xaml.IWindowFeature_ExperimentalApi")]
+{
+    Double Width;
+    Double Height;
 }
 ```
 
 # Appendix
 
-<!-- TEMPLATE
-  Anything else that you want to write down about implementation notes and for posterity,
-  but that isn't necessary to understand the purpose and usage of the API.
+_(This section will not be part of public docs)_
 
-  This or the Background section are a good place to describe alternative designs
-  and why they were rejected.
--->
+## Implementation notes
+
+These are implementation details, not part of the public contract. They are
+here for posterity, not for DMC.
+
+**Applying the size.** The setter computes the matching *outer* window rectangle
+by adding the window's non-client chrome to the requested client size, then
+applies it with `SetWindowPos` (Normal state) or by updating `rcNormalPosition`
+via `SetWindowPlacement` (Maximized or Minimized). Fullscreen is a silent no-op.
+
+**Where the chrome comes from.** For desktop (HWND) windows in Normal state, the
+chrome is taken from the window's *observed* outer-window-minus-client delta rather than
+from a purely style-based calculation (`AdjustWindowRectExForDpi`). This is what
+makes `ExtendsContentIntoTitleBar` work correctly. When the window is Maximized
+or Minimized, the live rects do not represent normal chrome, so the style-based
+calculation is used instead, with a correction that zeros out the top chrome when
+ECITB is active.
+
+**Reading the size back.** The getter returns client-area size in DIPs. In the
+Normal and Fullscreen states it reads from `Window.Bounds`. In the Maximized or
+Minimized state it computes the restore client size from the `rcNormalPosition`
+stored in `WINDOWPLACEMENT`, subtracting the same non-client chrome and DPI scale
+the setter used. So the getter/setter round-trip in every state except
+Fullscreen.
+
+**UWP host.** When a `Window` is hosted by a UWP `CoreWindow` (legacy path), the
+setter calls `SetWindowPos` directly with physical pixels (computed once via
+`AdjustWindowRectExForDpi`). We deliberately bypass `CoreWindowWrapper::SetPosition`
+here because that wrapper takes DIPs and re-scales internally. Going through it
+would double-scale and produce a window roughly `scale^2` larger than requested.
+
+## Design rationale
+
+The big decision was **client area vs outer window** as the unit. WinUI picked
+client area so `Width`/`Height` round-trip with `Window.Bounds`, which already
+ships as the client area. The alternative (outer window bounds, like WPF) would have put
+two different units on one Window object. See the "Porting from WPF" section for
+the user-visible impact.
+
+## Open questions
+
+1. Should `Width` and `Height` become `DependencyProperty`-backed before
+   promoting out of experimental? That would enable XAML markup setters and data
+   binding, at the cost of a larger ABI commitment.
+   **No**, because Window is not a DependencyObject (unlike WPF).
+2. Should `Window.Bounds` change to track only the *desired* size (the most
+   recent setter value) rather than the actual current size? No.
+   `Window.Bounds` has shipped as the actual size and changing it would be a
+   breaking change.
+3. Do we add matching `MinWidth` / `MaxWidth` properties? Out of scope for now,
+   coming back to this soon.
+4. How should we expose "size to content" (the WPF `NaN` behavior)? Out of scope.
+5. Implementation: should we call to the AppWindow for window-related operations
+   whenever possible?
+6. Presenters: the setter only special-cases the `FullScreen` presenter.
+   `CompactOverlay`, and `Overlapped` windows configured as non-resizable
+   (`IsResizable = false`), currently flow through the normal live-resize path
+   and are untested. Should any of these be a no-op, throw, or clamp explicitly
+   instead of relying on the OS/presenter to clamp?
+
+## Acknowledgements
+
+This API is based on community contribution
+[microsoft/microsoft-ui-xaml#11052](https://github.com/microsoft/microsoft-ui-xaml/pull/11052)
+by external contributors. Thanks!

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -44,15 +44,14 @@ property that returns the **client area** of the window in DIPs. The
   `Bounds.Height`. In the Maximized or Minimized states the getter returns the
   **restore** size, the size the window will have when it goes back to Normal, so
   that `Width`/`Height` round-trip with the setter in those states. (Fullscreen
-  and CompactOverlay are the states where they do not round-trip, because the
-  setter is a no-op there; see below.)
+  and CompactOverlay return an error from the setter; see below.)
 - The setters change the **client area** size in DIPs.
 
 You can set the Width and Height properties in XAML markup and in code-behind.
 
 It's often natural to set your Window's initial size in your XAML markup near the markup for your app:
 
-```
+```xml
 <?xml version="1.0" encoding="utf-8"?>
 <Window
     x:Class="MyApp.MainWindow"
@@ -155,8 +154,8 @@ with the XAML window means you own the DIP/pixel conversion yourself.
 The same sizing APIs behave differently depending on which `AppWindowPresenter`
 the window is using. You pick a presenter with `AppWindow.SetPresenter(...)`.
 The dividing line is simple: **the default `Overlapped` presenter honors the
-setter; any non-default presenter (`FullScreen`, `CompactOverlay`) makes the
-setter a no-op.** The `Overlapped` presenter also has three show states
+setter; any non-default presenter (`FullScreen`, `CompactOverlay`) returns an
+error.** The `Overlapped` presenter also has three show states
 (Restored, Maximized, Minimized) that each behave on their own. Here is what the
 `Window.Width/Height` setter and getter do in each:
 
@@ -165,8 +164,8 @@ setter a no-op.** The `Overlapped` presenter also has three show states
 | `Overlapped` - Restored (Normal)     | Standard window: caption + borders, resizable | Resizes the **live** window now                       | Live client size                         |
 | `Overlapped` - Maximized             | Fills the monitor work area                  | Updates the **restore** size only; live window unchanged | Restore size (not the live maximized size) |
 | `Overlapped` - Minimized             | Sits in the taskbar                          | Updates the **restore** size only; window stays minimized | Restore size                          |
-| `FullScreen`                         | Borderless, covers the whole monitor         | **No-op** (does not resize)                            | Live fullscreen size                     |
-| `CompactOverlay`                     | Small always-on-top picture-in-picture window | **No-op** (does not resize)                           | Live client size                         |
+| `FullScreen`                         | Borderless, covers the whole monitor         | Returns `E_NOT_VALID_STATE`                            | Live fullscreen size                     |
+| `CompactOverlay`                     | Small always-on-top picture-in-picture window | Returns `E_NOT_VALID_STATE`                           | Live client size                         |
 
 Notes:
 
@@ -174,24 +173,20 @@ Notes:
   setter. It is also the only one with multiple show states. `Restored` is the
   "Normal" case where `Width == Bounds.Width`. Maximized and Minimized are where
   the setter/getter switch to the *restore* size instead of the live size.
-- **`FullScreen` and `CompactOverlay`** are the non-default presenters. Today the
-  setter is a silent **no-op** for both, and the getter reports the live size, so
-  `Width`/`Height` does not round-trip while you are in one of these modes. This
-  is still under discussion; see the open question in the appendix.
+- **`FullScreen` and `CompactOverlay`** are the non-default presenters. The
+  setter returns `E_NOT_VALID_STATE` for both. The getter reports the live size.
 
-For the two non-default presenters, this no-op behavior is close to, but not exactly, what
-the lower-level `AppWindow.ResizeClient(...)` already does:
+For the two non-default presenters, this error behavior differs from what
+the lower-level `AppWindow.ResizeClient(...)` does:
 
-| Presenter        | `Window.Width/Height` setter | `AppWindow.ResizeClient(...)`                                  |
-| ---------------- | ---------------------------- | -------------------------------------------------------------- |
-| `FullScreen`     | No-op                        | No-op (the presenter owns the full-monitor bounds)           |
-| `CompactOverlay` | No-op                        | May resize, but **clamped** to the presenter's allowed min/max range |
+| Presenter        | `Window.Width/Height` setter | `AppWindow.ResizeClient(...)`            |
+| ---------------- | ---------------------------- | ---------------------------------------- |
+| `FullScreen`     | Returns `E_NOT_VALID_STATE`  | Resizes the client area                  |
+| `CompactOverlay` | Returns `E_NOT_VALID_STATE`  | Resizes the client area                  |
 
-So in `FullScreen` the two surfaces agree (both do nothing). In `CompactOverlay`
-they differ: `Window.Width/Height` does nothing at all, while `ResizeClient` can
-still change the size within the presenter's limits. We chose the stricter no-op
-for `Width`/`Height` to keep one simple rule ("non-default presenter = no-op").
-If you actually need to resize a compact-overlay window, drop down to
+`Width`/`Height` fails loudly so the app knows the call had no effect, while
+`ResizeClient` actually resizes in both cases.
+If you need to resize a window in one of these presenters, drop down to
 `AppWindow.ResizeClient(...)` (physical pixels).
 
 ## Where Width/Height equals Bounds and where it does not
@@ -210,8 +205,8 @@ return the restore size instead:
 
 In short: the getter equals `Bounds` in Normal, Fullscreen, and CompactOverlay,
 but for different reasons. In **Normal** the setter actually drove the window to
-that size. In **Fullscreen** and **CompactOverlay** the setter is a no-op, so the
-getter just reflects whatever live size the presenter chose. In the **Maximized**
+that size. In **Fullscreen** and **CompactOverlay** the setter returns an error,
+so the getter just reflects whatever live size the presenter chose. In the **Maximized**
 and **Minimized** states the getter instead returns the *restore* size, so
 `Width`/`Height` tell you what the window *will be* when restored while `Bounds`
 tells you what it *is right now*.
@@ -237,14 +232,14 @@ Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 | Unit                      | DIPs (1/96 inch)                                     | DIPs (1/96 inch), same                          |
 | What it measures          | **Window rect** (includes chrome)                    | **Client area** (matches `Window.Bounds`)       |
 | Default / initial value   | `Double.NaN` (auto-size to content)                  | The current actual client size (never NaN)      |
-| Setting `NaN`             | Allowed; means "size to content"                     | **Throws `E_INVALIDARG`**. No size-to-content.  |
-| Setting negative          | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
-| Setting `Infinity`        | Throws `ArgumentException`                           | Throws `E_INVALIDARG`                           |
+| Setting `NaN`             | Allowed; means "size to content"                     | **Returns `E_INVALIDARG`**. No size-to-content.  |
+| Setting negative          | Throws `ArgumentException`                           | Returns `E_INVALIDARG`                           |
+| Setting `Infinity`        | Throws `ArgumentException`                           | Returns `E_INVALIDARG`                           |
 | `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
 | Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
 | Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
-| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes        | **No-op** in `FullScreen` and `CompactOverlay` (live window unchanged; subject to change) |
-| Dependency property       | Yes; bindable                                        | Plain WinRT property; not bindable              |
+| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Returns `E_NOT_VALID_STATE` in `FullScreen` and `CompactOverlay` |
+| Dependency property       | Yes; bindable                                        | Plain WinRT property; bindable only with x:Bind |
 
 # API Pages
 
@@ -280,8 +275,7 @@ Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
 the setter and maps to Normal / Maximized / Minimized based on its show state.
-The non-default presenters, `FullScreen` and `CompactOverlay`, both make the
-setter a **no-op**.
+The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
 
 - **Normal**: the window resizes right away to the requested client width.
   Position is preserved.
@@ -291,12 +285,11 @@ setter a **no-op**.
 - **Minimized**: same as Maximized. The *restore* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
-- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the call is a
-  silent **no-op**. The live window stays fullscreen and the getter returns the
-  live fullscreen size, so it does not round-trip in this mode.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): returns
+  `E_NOT_VALID_STATE`. The live window stays fullscreen.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, the setter is a
-  silent **no-op** and the getter returns the live size.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, returns
+  `E_NOT_VALID_STATE`.
 
 ### Remarks
 
@@ -335,7 +328,7 @@ in XAML markup.
 
 ### Errors
 
-All errors will call RoOriginateError and set an error message to help the app developer diagnose the problem.
+For all errors the runtime calls RoOriginateError with a specific error message to help the app developer diagnose the problem.
 
 | Input                         | Result                              |
 | ----------------------------- | ----------------------------------- |
@@ -343,7 +336,7 @@ All errors will call RoOriginateError and set an error message to help the app d
 | `Double.NaN`                  | Returns `E_INVALIDARG`              |
 | `Double.PositiveInfinity`     | Returns `E_INVALIDARG`              |
 | `Double.NegativeInfinity`     | Returns `E_INVALIDARG`              |
-| Window in a non-default presenter | Silent no-op (the call succeeds; the live window is unchanged) when the window uses the `FullScreen` or `CompactOverlay` presenter. Subject to change in a future release. |
+| Window in a non-default presenter | Returns `E_NOT_VALID_STATE` when the window uses the `FullScreen` or `CompactOverlay` presenter. |
 | `0`                           | Allowed. The window resizes so the client area has zero width. The OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
 
@@ -373,8 +366,7 @@ Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
 the setter and maps to Normal / Maximized / Minimized based on its show state.
-The non-default presenters, `FullScreen` and `CompactOverlay`, both make the
-setter a **no-op**.
+The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
 
 - **Normal**: the window resizes right away to the requested client height.
   Position is preserved.
@@ -384,12 +376,11 @@ setter a **no-op**.
 - **Minimized**: same as Maximized. The *restore* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
-- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the call is a
-  silent **no-op**. The live window stays fullscreen and the getter returns the
-  live fullscreen size, so it does not round-trip in this mode.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): returns
+  `E_NOT_VALID_STATE`. The live window stays fullscreen.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, the setter is a
-  silent **no-op** and the getter returns the live size.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, returns
+  `E_NOT_VALID_STATE`.
 
 ### Remarks
 
@@ -430,7 +421,7 @@ in XAML markup.
 
 ### Errors
 
-All errors will call RoOriginateError and set an error message to help the app developer diagnose the problem.
+For all errors the runtime calls RoOriginateError with a specific error message to help the app developer diagnose the problem.
 
 | Input                         | Result                              |
 | ----------------------------- | ----------------------------------- |
@@ -438,39 +429,26 @@ All errors will call RoOriginateError and set an error message to help the app d
 | `Double.NaN`                  | Returns `E_INVALIDARG`               |
 | `Double.PositiveInfinity`     | Returns `E_INVALIDARG`               |
 | `Double.NegativeInfinity`     | Returns `E_INVALIDARG`               |
-| Window in a non-default presenter | Silent no-op (the call succeeds; the live window is unchanged) when the window uses the `FullScreen` or `CompactOverlay` presenter. Subject to change in a future release. |
+| Window in a non-default presenter | Returns `E_NOT_VALID_STATE` when the window uses the `FullScreen` or `CompactOverlay` presenter. |
 | `0`                           | Allowed. The window resizes so the client area has zero height; the OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as tall as the OS allows. |
 
 # API Details
 
-```csharp
+```c# (but really MIDL3)
 namespace Microsoft.UI.Xaml
 {
-    [contentproperty("Content")]
-    unsealed runtimeclass Window
-    {
-        // ... existing members ...
+  unsealed runtimeclass Window // existing type
+  {
+    // ...existing APIs...
 
-        // New, behind Feature_ExperimentalApi:
-        Double Width;
-        Double Height;
-    }
-}
-```
-
-In MIDL3 form, matching the existing IDL in
-`dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl`:
-
-```idl
-[contract(Microsoft.UI.Xaml.WinUIContract, 10)]
-[feature(Feature_ExperimentalApi)]
-[interface_name("Microsoft.UI.Xaml.IWindowFeature_ExperimentalApi")]
-{
+    // New: 
     Double Width;
     Double Height;
+  }
 }
 ```
+
 
 # Appendix
 
@@ -485,8 +463,8 @@ here for posterity, not for the public docs.
 by adding the window's non-client chrome to the requested client size, then
 applies it with `SetWindowPos` (Normal state) or by updating `rcNormalPosition`
 via `SetWindowPlacement` (Maximized or Minimized). A non-default presenter
-(`FullScreen` or `CompactOverlay`) is a silent no-op; the setter checks the
-presenter kind up front and bails before touching the window.
+(`FullScreen` or `CompactOverlay`) returns `E_NOT_VALID_STATE`; the setter checks
+the presenter kind up front and returns the error before touching the window.
 
 **Where the chrome comes from.** For desktop (HWND) windows in Normal state, the
 chrome is taken from the window's *observed* window-rect-minus-client delta rather than
@@ -502,7 +480,7 @@ the Maximized or Minimized state it computes the restore client size from the
 `rcNormalPosition` stored in `WINDOWPLACEMENT`, subtracting the same non-client
 chrome and DPI scale the setter used. So the getter/setter round-trip in every
 state except the non-default presenters (`FullScreen` and `CompactOverlay`),
-where the setter is a no-op.
+where the setter returns an error.
 
 **UWP host.** The implementation will provide basic UWP support to keep
 existing UWP tests running.
@@ -517,27 +495,6 @@ the user-visible impact.
 
 ## Open questions
 
-1. Implementation: should we call to the AppWindow for window-related operations
-   whenever possible?
-2. Presenters and round-tripping: in a non-default presenter (`FullScreen` or
-   `CompactOverlay`) the setter currently no-ops, so `Width`/`Height` does not
-   round-trip in those modes. **Open for review, which behavior do we want?**
-   - *Option 1 (current): no-op.* Simplest to implement; the rule is "non-default
-     presenter = no-op." Cost: `Width`/`Height` does not round-trip while in one
-     of these modes.
-   - *Option 2: record and apply on return.* The setter records the desired
-     *normal* size and applies it when the window returns to `Overlapped`, the
-     way Maximized/Minimized already work. `Width`/`Height` round-trips in every
-     state and the non-default-presenter special cases go away, leaving one rule:
-     "`Width`/`Height` is the Normal-state client size; `Bounds` is the live size."
-     Cost: the size applies later, which can surprise.
-   - *Option 3: throw.* Setting in a non-default presenter throws instead of
-     silently doing nothing. Loud and honest, but apps must guard every set with
-     a presenter check.
-
-   Separately, `Overlapped` windows configured as non-resizable
-   (`IsResizable = false`) still flow through the normal live-resize path and are
-   untested; should that be a no-op, throw, or clamp explicitly?
 
 ## FAQ
 
@@ -560,7 +517,7 @@ the actual size, and changing it would be a breaking change.
 It is out of scope for now, but we expect to come back to it soon.
 
 **Is there a "size to content" behavior, like setting WPF's `Width` to `NaN`?** No,
-that is out of scope. Setting `NaN` throws `E_INVALIDARG`.
+that is out of scope. Setting `NaN` returns `E_INVALIDARG`.
 
 ## Acknowledgements
 

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -1,7 +1,38 @@
 Window.Width and Window.Height
 ===
 
-# Background
+Table of Contents
+
+- [Window.Width and Window.Height](#windowwidth-and-windowheight)
+- [1. Background](#1-background)
+- [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
+  - [2.1. Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32](#21-three-sets-of-apis-size-the-same-window-window-appwindow-and-win32)
+    - [2.1.1. How the AppWindow presenter affects sizing](#211-how-the-appwindow-presenter-affects-sizing)
+  - [2.2. Where Width/Height equals Bounds and where it does not](#22-where-widthheight-equals-bounds-and-where-it-does-not)
+  - [2.3. WPF Comparison](#23-wpf-comparison)
+- [3. Examples](#3-examples)
+  - [3.1. Set Initial Window Size in XAML Markup](#31-set-initial-window-size-in-xaml-markup)
+  - [3.2. Set Initial Window Size with x:Bind](#32-set-initial-window-size-with-xbind)
+  - [3.3. Set Window Size in Code-Behind](#33-set-window-size-in-code-behind)
+- [4. API Pages](#4-api-pages)
+  - [4.1. Window.Width property](#41-windowwidth-property)
+    - [4.1.1. Behavior by window state](#411-behavior-by-window-state)
+    - [4.1.2. Remarks](#412-remarks)
+    - [4.1.3. Errors](#413-errors)
+  - [4.2. Window.Height property](#42-windowheight-property)
+    - [4.2.1. Behavior by window state](#421-behavior-by-window-state)
+    - [4.2.2. Remarks](#422-remarks)
+    - [4.2.3. Errors](#423-errors)
+- [5. API Details](#5-api-details)
+- [6. Appendix](#6-appendix)
+  - [6.1. Implementation notes](#61-implementation-notes)
+  - [6.2. Design rationale](#62-design-rationale)
+  - [6.3. Open questions](#63-open-questions)
+  - [6.4. FAQ](#64-faq)
+  - [6.5. Acknowledgements](#65-acknowledgements)
+
+
+# 1. Background
 
 _(This section will not be part of public docs)_
 
@@ -30,7 +61,7 @@ These APIs ship as **experimental** first (`[feature(Feature_ExperimentalApi)]`)
 so the behavior may change based on early adopter feedback before they get
 promoted to stable.
 
-# Conceptual pages (How To)
+# 2. Conceptual pages (How To)
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
@@ -52,44 +83,10 @@ You can set the Width and Height properties in XAML markup and in code-behind.
 If you need the current client-area size for layout, use `Bounds` -- it always
 reflects the live size, even when the window is maximized.
 
-It's often natural to set your Window's initial size in your XAML markup near the markup for your app:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<Window
-    x:Class="MyApp.MainWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:MyApp"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Width="800"
-    Height="600"
-    Title="MyApp">
-
-    <!-- window content -->
-</Window>
-```
-
-You can also set it from code-behind:
-
-```csharp
-// Code-behind in a WinUI desktop app
-public MainWindow()
-{
-    this.InitializeComponent();
-
-    // Set client area to 800 x 600 (DIPs)
-    this.Width  = 800;
-    this.Height = 600;
-}
-```
-
 Note you can use x:bind (`{x:Bind ...}`} bindings to set the Width/Height properties, but you CAN'T use classic data binding
 (`{Binding ...}`) to set them.  This is because the Window type is not a FrameworkElement.
 
-## Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32
+## 2.1. Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32
 
 Every WinUI desktop window is, underneath, a single Win32 `HWND`. Three different
 API layers can read and size that same window, and they do **not** all agree on
@@ -152,7 +149,7 @@ For **physical pixels**, use `AppWindow.ResizeClient(...)` (client) or
 friends) only when you need something the WinUI surfaces do not expose; mixing it
 with the XAML window means you own the DIP/pixel conversion yourself.
 
-### How the AppWindow presenter affects sizing
+### 2.1.1. How the AppWindow presenter affects sizing
 
 The same sizing APIs behave differently depending on which `AppWindowPresenter`
 the window is using. You pick a presenter with `AppWindow.SetPresenter(...)`.
@@ -192,7 +189,7 @@ the lower-level `AppWindow.ResizeClient(...)` does:
 If you need to resize a window in one of these presenters, drop down to
 `AppWindow.ResizeClient(...)` (physical pixels).
 
-## Where Width/Height equals Bounds and where it does not
+## 2.2. Where Width/Height equals Bounds and where it does not
 
 `Window.Bounds` always reports the **live** client area. `Width`/`Height`
 diverge from it in the Maximized and Minimized states because the getters
@@ -217,7 +214,7 @@ tells you what it *is right now*.
 If you want to size by the window rect instead, you can still call
 `AppWindow.Resize(...)` (physical pixels, not DIPs; see the three-layers section above).
 
-## WPF Comparison
+## 2.3. WPF Comparison
 
 WPF developers work with the WPF `Window.Width` and `Window.Height` properties. The
 WinUI properties are meant to feel familiar but they are **not identical**.
@@ -244,7 +241,107 @@ Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 | Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Returns `E_NOT_VALID_STATE` in `FullScreen` and `CompactOverlay` |
 | Dependency property       | Yes; bindable                                        | Plain WinRT property; bindable only with x:Bind |
 
-# API Pages
+# 3. Examples
+
+## 3.1. Set Initial Window Size in XAML Markup
+
+It's often natural to set your Window's initial size in your XAML markup near the markup for your app.
+
+For example, Contoso's PointOfSale app defines its main window's size at development time via XAML markup:
+
+```xml
+<!-- MainWindow.xaml -->
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="PointOfSale.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:PointOfSale"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Contoso PointOfSale"
+    Width="800"
+    Height="600"
+    >
+
+    <!-- window content -->
+</Window>
+```
+
+## 3.2. Set Initial Window Size with x:Bind
+
+Here, Contoso PointOfSale binds Width/Height to code-behind:
+
+```xml
+<!-- MainWindow.xaml -->
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="PointOfSale.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:PointOfSale"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Contoso PointOfSale"
+    Width="{x:Bind InitialWindowClientWidth}"
+    Height="{x:Bind InitialWindowClientHeight}"
+    >
+
+    <!-- window content -->
+</Window>
+```
+
+In code-behind, the PointOfSale app defaults to a smaller size when a private variable `_isAppUsingCompactView`
+is set:
+
+```cs
+// MainWindow.xaml.cs
+namespace PointOfSale
+{
+    public sealed partial class MainWindow : Window
+    {
+        private bool _isAppUsingCompactView;
+
+        // ...
+
+        public double InitialWindowClientWidth => _isAppUsingCompactView ? 400 : 800;
+        public double InitialWindowClientHeight => _isAppUsingCompactView ? 200 : 600;
+    }
+}
+```
+
+## 3.3. Set Window Size in Code-Behind
+
+The PointOfSale app also has a button users can click to enter its compact view.  The app sets Window.Width and Window.Height
+in code-behind to change the window's size.
+
+
+```xml
+<!-- MainWindow.xaml -->
+  <!-- Inside the app's XAML markup -->
+  <Button Click="SwitchToCompactView_Button_Click">Switch to Compact View</Button>
+```
+
+```cs
+// MainWindow.xaml.cs
+namespace PointOfSale
+{
+    public sealed partial class MainWindow : Window
+    {
+        // ...
+        private async void SwitchToCompactView_Button_Click(object sender, RoutedEventArgs e)
+        {
+            this.Width = 400;
+            this.Height = 200;
+        }
+    }
+}
+```        
+
+
+# 4. API Pages
 
 _(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
 
@@ -252,7 +349,7 @@ _(Each of the following L2 sections correspond to a page that will be on docs.mi
 > intentionally near-identical so each can stand alone as its own docs page. If
 > you change behavior in one, make the matching change in the other.
 
-## Window.Width property
+## 4.1. Window.Width property
 
 Gets or sets the width of the Window's **client area** in device-independent
 pixels (DIPs, 1/96 inch).
@@ -274,7 +371,7 @@ DPI. Height is left unchanged.
 
 Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
-### Behavior by window state
+### 4.1.1. Behavior by window state
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
 the setter and maps to Normal / Maximized / Minimized based on its show state.
@@ -294,7 +391,7 @@ The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
   `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, returns
   `E_NOT_VALID_STATE`.
 
-### Remarks
+### 4.1.2. Remarks
 
 **Units and DPI.** The setter converts the requested DIP value to physical
 pixels using the window's current per-monitor DPI:
@@ -317,8 +414,7 @@ the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what count
 as client area, so the getter (and `Bounds`) can change even though the window
 rect did not; re-apply the setter if you need a specific size after toggling.
 
-**XAML markup.** Width and Height are settable from C++/WinRT code-behind
-AND from XAML on the `<Window>` object.
+**XAML markup.** Width and Height are settable from code-behind AND from XAML on the `<Window>` object.
 
 **Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
 take part in data binding and do not raise change notifications. (This matches the
@@ -329,7 +425,7 @@ in XAML markup.
 (the dispatcher thread). Calls from other threads return the standard
 `RPC_E_WRONG_THREAD` error from the XAML framework.
 
-### Errors
+### 4.1.3. Errors
 
 For all errors the runtime calls RoOriginateError with a specific error message to help the app developer diagnose the problem.
 
@@ -343,7 +439,7 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 | `0`                           | Allowed. The window resizes so the client area has zero width. The OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
 
-## Window.Height property
+## 4.2. Window.Height property
 
 Gets or sets the height of the Window's **client area** in device-independent
 pixels (DIPs, 1/96 inch).
@@ -365,7 +461,7 @@ left unchanged.
 
 Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
-### Behavior by window state
+### 4.2.1. Behavior by window state
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
 the setter and maps to Normal / Maximized / Minimized based on its show state.
@@ -385,7 +481,7 @@ The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
   `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, returns
   `E_NOT_VALID_STATE`.
 
-### Remarks
+### 4.2.2. Remarks
 
 **Units and DPI.** The setter converts the requested DIP value to physical
 pixels using the window's current per-monitor DPI:
@@ -422,7 +518,7 @@ in XAML markup.
 (the dispatcher thread). Calls from other threads return the standard
 `RPC_E_WRONG_THREAD` error from the XAML framework.
 
-### Errors
+### 4.2.3. Errors
 
 For all errors the runtime calls RoOriginateError with a specific error message to help the app developer diagnose the problem.
 
@@ -436,28 +532,59 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 | `0`                           | Allowed. The window resizes so the client area has zero height; the OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as tall as the OS allows. |
 
-# API Details
+# 5. API Details
 
+Initially the API will be **experimental**:
 ```c# (but really MIDL3)
+// For experimental release
 namespace Microsoft.UI.Xaml
 {
+  [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
+  [webhosthidden]
+  [contentproperty("Content")]
   unsealed runtimeclass Window // existing type
   {
     // ...existing APIs...
 
     // New: 
-    Double Width;
-    Double Height;
+    [contract(Microsoft.UI.Xaml.WinUIContract, 12)]   // 12 is the contract version we're using for WASDK 3.0
+    [feature(Feature_ExperimentalApi)]
+    [interface_name("Microsoft.UI.Xaml.IWindowFeature_ExperimentalApi")]
+    {
+      Double Width;
+      Double Height;
+    }
   }
 }
 ```
 
+We plan for this API to be made **stable**:
+```c# (but really MIDL3)
+// For stable release
+namespace Microsoft.UI.Xaml
+{
+  [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
+  [webhosthidden]
+  [contentproperty("Content")]
+  unsealed runtimeclass Window // existing type
+  {
+    // ...existing APIs...
 
-# Appendix
+    // New: 
+    [contract(Microsoft.UI.Xaml.WinUIContract, 12)]   // 12 is the contract version we're using for WASDK 3.0
+    {
+      Double Width;
+      Double Height;
+    }
+  }
+}
+```
+
+# 6. Appendix
 
 _(This section will not be part of public docs)_
 
-## Implementation notes
+## 6.1. Implementation notes
 
 These are implementation details, not part of the public contract. They are
 here for posterity, not for the public docs.
@@ -475,7 +602,7 @@ from a purely style-based calculation (`AdjustWindowRectExForDpi`). This is what
 makes `ExtendsContentIntoTitleBar` work correctly. When the window is Maximized
 or Minimized, the live rects do not represent normal chrome, so the style-based
 calculation is used instead, with a correction that zeros out the top chrome when
-ECITB is active.
+`ExtendsContentIntoTitleBar` is active.
 
 **Reading the size back.** The getter returns client-area size in DIPs. In the
 Normal, Fullscreen, and CompactOverlay states it reads from `Window.Bounds`. In
@@ -488,7 +615,7 @@ where the setter returns an error.
 **UWP host.** The implementation will provide basic UWP support to keep
 existing UWP tests running.
 
-## Design rationale
+## 6.2. Design rationale
 
 The big decision was **client area vs window rect** as the unit. WinUI picked
 client area so `Width`/`Height` round-trip with `Window.Bounds`, which already
@@ -496,10 +623,10 @@ ships as the client area. The alternative (the window rect, like WPF) would have
 two different units on one Window object. See the "Porting from WPF" section for
 the user-visible impact.
 
-## Open questions
+## 6.3. Open questions
 
 
-## FAQ
+## 6.4. FAQ
 
 These came up as questions during design.
 
@@ -522,7 +649,7 @@ It is out of scope for now, but we expect to come back to it soon.
 **Is there a "size to content" behavior, like setting WPF's `Width` to `NaN`?** No,
 that is out of scope. Setting `NaN` returns `E_INVALIDARG`.
 
-## Acknowledgements
+## 6.5. Acknowledgements
 
 This API is based on community contribution
 [microsoft/microsoft-ui-xaml#11052](https://github.com/microsoft/microsoft-ui-xaml/pull/11052)

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -66,22 +66,30 @@ promoted to stable.
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
-`Width` and `Height` get or set the size of the window's client area in DIPs.  They represent the
-window's "restore size" -- the size it snaps back to when it isn't maximized, minimized, or using a
-special presenter (more detail below).
+`Width` and `Height` get or set the size of the window's client area in DIPs.  Think of them as
+representing the window's **restore size**: the size it has (or will have) when it is in the restored state.
+This is the state when it's behaving like a "normal" window: not minimized, not maximized, not snapped, not
+full-screen, and not in another special windowing mode.
 
-These match the Win32 notion of "client rect" except they correct for the window's DPI.  The client
-area is where your content lives, so in the normal state `Window.Width` equals
-`Window.Content.ActualWidth` (and same for height).
+`Window`'s concept of restore size is like Win32's restore size, but it is not always the same value.
+See the section about AppWindow presenters below for details.
 
-Setting `Width` or `Height` won't resize the window immediately when:
-- `Window.Activate` has not been called yet
-- The window is maximized or minimized
-- The `Window.AppWindow.Presenter` is `FullScreen` or `CompactOverlay`
+The setter changes the restore size, and the getter reports it back, but user resizes update it too.
 
-In these cases the new size is saved as the restore size.  The runtime applies it once the window
-returns to the normal restored state.  The getters return the restore size you set, so they won't
-always match the actual live size of the window.
+When the window is in its restored state, the restore size is also the live size, so
+`Window.Width` equals `Window.Bounds.Width` (and same for height).  These match the Win32 notion of
+"client rect" except they work in DIPs by correcting for the window's DPI.  The client area is where your content
+lives, so in the restored state `Window.Width` usually equals `Window.Content.ActualWidth` too
+(assuming your content fills the window).
+
+Setting `Width` or `Height` defers resizing the window when:
+- **`Window.Activate` has not been called yet.** In this case, the runtime sets the new size when Window.Activate is called.
+- **The window is maximized or minimized.** In this case, the runtime sets the Win32 restore size.
+- **The `Window.AppWindow.Presenter` is `FullScreen` or `CompactOverlay`**.  In this case, the runtime remembers the
+  restore size (whether set by your code or by the user resizing) and reapplies it when the AppWindow's presenter
+  switches to `Overlapped`.
+
+In these cases the getter returns the restore size, not the actual live size of the window.
 
 You can set the Width and Height properties in XAML markup and in code-behind.
 
@@ -116,11 +124,11 @@ Because two of the three layers are in physical pixels and one is in DIPs,
 physicalPixels = dips * GetDpiForWindow(hwnd) / 96.0
 ```
 
-Here is every sizing API across the three layers, side by side:
+Here are the key sizing APIs across the three layers, side by side:
 
 | API                                         | Layer         | Unit         | Measures                  | Read / write    | Notes                              |
 | ------------------------------------------- | ------------- | ------------ | ------------------------- | --------------- | ---------------------------------- |
-| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restore size when in normal state  |
+| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restore size                       |
 | `Window.Bounds`                             | `Xaml.Window` | DIPs         | **Client** area           | get only        | Live size                          |
 | `AppWindow.ClientSize`                      | `AppWindow`   | Physical px  | **Client** area           | get only        | Live size                          |
 | `AppWindow.Size`                            | `AppWindow`   | Physical px  | **Window** rect           | get only        | Live size                          |
@@ -139,11 +147,10 @@ A few things to notice:
   your XAML content lives). `AppWindow.Size` / `AppWindow.Resize(...)`,
   `GetWindowRect`, and `SetWindowPos` / `MoveWindow` measure the **window rect**
   (caption and borders included).
-- **Live vs restore.** Almost every API reports the **live** window. The two that
-  deal in the **restore** size are `Window.Width/Height` (in any state other than
-  Normal) and Win32 `Get/SetWindowPlacement` (its `rcNormalPosition`). That is
-  not a coincidence: the `Width/Height` getter and setter are built on exactly
-  that placement rect.
+- **Live vs restore.** Almost every API reports the **live** window.
+  `Window.Width/Height` reports the window's restore size. When the window is in the restored state, that is
+  also the live size. When the window is maximized, minimized, not yet activated/shown, or using
+  another AppWindow presenter, it may differ from the live size.
 - **Minimized state.** The APIs that report "live size" use the restore size when
   the window is minimized (rather than returning 0,0).
 - **Read vs write.** `Window.Width/Height` is the only single member you both read
@@ -173,8 +180,35 @@ you switch back to `Overlapped`.
 | `Overlapped` - Restored (Normal)     | Standard window: caption + borders, resizable | Resizes the **live** window now                       | Live client size                         |
 | `Overlapped` - Maximized             | Fills the monitor work area                  | Updates the **restore** size only; live window unchanged | Restore size (not the live maximized size) |
 | `Overlapped` - Minimized             | Sits in the taskbar                          | Updates the **restore** size only; window stays minimized | Restore size                          |
-| `FullScreen`                         | Borderless, covers the whole monitor         | Updates the **restore** size only; live window unchanged | Restore size                     |
-| `CompactOverlay`                     | Small always-on-top picture-in-picture window | Updates the **restore** size only; live window unchanged | Restore size                         |
+| `FullScreen`                         | Borderless, covers the whole monitor         | Remembers the value; live window unchanged             | Restore size (see below for details) |
+| `CompactOverlay`                     | Small always-on-top picture-in-picture window | Remembers the value; live window unchanged            | Restore size (see below for details) |
+
+When the AppWindow is using a non-default Presenter, the getters return the restore size.  That's either the last size it had in the
+restored state (including user resizes), or a new value you set on `Width`/`Height` since it was last restored.
+If you've called either setter on the `Window` previously, this is also the size the runtime will set on the window
+when it goes back to using the `Overlapped` presenter.  (If you've _not_ called either setter, `Window` doesn't impose
+any size, that's handled by `AppWindow` only.  This is to avoid changing the behavior of existing apps not using this property)
+
+**Window only sets Win32 restore size when using OverlappedPresenter.**  When `Window` is using the default
+Overlapped presenter, and it is minimized or maximized, and you set `Width` or `Height`, the runtime
+sets the Win32 restore size for the HWND.  When other presenters are active, it does not.
+
+**User resize supersedes app-set size on presenter exit.**  If the app sets
+`Width`/`Height` in the restored state and the user later resizes the window
+manually, the user's size is what matters when the window comes back from a
+non-default presenter.  For example:
+
+1. App sets `Window.Width = 500` (window is now 500 DIPs wide).
+2. User drags the edge to resize to 600.
+3. App enters the `FullScreen` presenter.
+4. App exits `FullScreen` (returns to `Overlapped`).
+
+The window restores to width **600**, not 500.  This matches Win32 behavior:
+the OS tracks the restore rect based on the window's last restored geometry,
+regardless of how it got there.  The app's earlier programmatic `Width = 500`
+was applied and consumed in step 1; the user's resize in step 2 updated the
+live (and therefore the restore) geometry, and that is what the OS gives back
+in step 4.
 
 If you need to resize a window in one of these presenters, drop down to
 `AppWindow.ResizeClient(...)` (physical pixels).
@@ -191,16 +225,21 @@ area.  If you _didn't_ set `Height`, the window size does not change when you to
 Setting them in either order works -- either way, the window's height comes out the same:
 
 ```cs
-window.Height = 300;                      // Changes window height to 330px
-
-window.ExtendsContentIntoTitleBar = true; // Changes window height to 300px
+window.Height = 300;                      // Changes physical window height to ~330px 
+                                          // (depending on OS settings)
+window.ExtendsContentIntoTitleBar = true; // Changes physical window height to 300px
 ```
 versus:
 ```cs
-window.ExtendsContentIntoTitleBar = true; // Reduce window height by 30px
-
-window.Height = 300;                      // Changes window height to approx 300px
+window.ExtendsContentIntoTitleBar = true; // Reduce physical window height by ~30px
+                                          // (depending on OS settings)
+window.Height = 300;                      // Changes physical window height to approx 300px
 ```
+
+This behavior only kicks in when you've set `Width` or `Height`. If your app never sets them,
+toggling `ExtendsContentIntoTitleBar` works exactly as it always has -- the window size stays the
+same.  Setting `Width` or `Height` opts the window into keeping the client area stable across
+title bar changes.
 
 ## 2.2. WPF Comparison
 
@@ -226,7 +265,7 @@ Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 | `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
 | Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
 | Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
-| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Updates *restore* size; window unaffected       |
+| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Updates restore size; applied on return to `Overlapped` |
 | Dependency property       | Yes; bindable                                        | Plain WinRT property; bindable only with x:Bind |
 
 # 3. Examples
@@ -346,11 +385,16 @@ pixels (DIPs, 1/96 inch).
 public double Width { get; set; }
 ```
 
-**Getter**: returns the current client-area width in DIPs. In the Normal
-state this equals `Window.Bounds.Width`. In the Maximized, Minimized,
-Fullscreen, or CompactOverlay state the getter returns the **restore** width,
-the width the window will have when it goes back to Normal, so the getter
-round-trips with the setter in those states.
+**Getter**: returns the client-area width in DIPs.
+
+- In the **Restored** state this equals `Window.Bounds.Width`.
+- In the **Maximized** or **Minimized** state it returns the *restore* width -- the
+  width the window will have when it returns to the restored state. The OS tracks this
+  restore size, so it works even if you never set `Width`.
+- When the AppWindow is using a non-default presenter (`FullScreen`, `CompactOverlay`),
+  it returns the restore width -- the last width the window had in the restored state
+  (whether set by your code or by the user resizing), or a value you set on
+  `Width` while in the non-default presenter.
 
 **Setter**: changes the window so its client area is `value` DIPs wide. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
@@ -362,11 +406,12 @@ Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 ### 4.1.1. Behavior by window state
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
-the setter and maps to Normal / Maximized / Minimized based on its show state.
-The non-default presenters, `FullScreen` and `CompactOverlay`, update the
-restore size without affecting the live window.
+the setter and maps to restored / maximized / minimized based on its show state.
+The non-default presenters, `FullScreen` and `CompactOverlay`, remember the
+requested size and apply it when the window returns to `Overlapped`, without
+affecting the live window in the meantime.
 
-- **Normal**: the window resizes right away to the requested client width.
+- **Restored**: the window resizes right away to the requested client width.
   Position is preserved.
 - **Maximized**: the live (maximized) window does not resize. The *restore*
   bounds (the size the window snaps to when un-maximized) get updated. The other
@@ -374,11 +419,12 @@ restore size without affecting the live window.
 - **Minimized**: same as Maximized. The *restore* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
-- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): updates the
-  *restore* bounds only; the live window stays fullscreen.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the live window stays
+  fullscreen. The restore size is updated and applied when the window returns
+  to the `Overlapped` presenter.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. Updates the
-  *restore* bounds only; the live window is unchanged.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. The live window is
+  unchanged; the restore size is updated and applied on return to `Overlapped`.
 
 ### 4.1.2. Remarks
 
@@ -438,11 +484,16 @@ pixels (DIPs, 1/96 inch).
 public double Height { get; set; }
 ```
 
-**Getter**: returns the current client-area height in DIPs. In the Normal
-state this equals `Window.Bounds.Height`. In the Maximized, Minimized,
-Fullscreen, or CompactOverlay state the getter returns the **restore** height,
-the height the window will have when it goes back to Normal, so the getter
-round-trips with the setter in those states.
+**Getter**: returns the client-area height in DIPs.
+
+- In the **Restored** state this equals `Window.Bounds.Height`.
+- In the **Maximized** or **Minimized** state it returns the *restore* height -- the
+  height the window will have when it returns to the restored state. The OS tracks this
+  restore size, so it works even if you never set `Height`.
+- When the AppWindow is using a non-default presenter (`FullScreen`, `CompactOverlay`),
+  it returns the restore height -- the last height the window had in the restored state
+  (whether set by your code or by the user resizing), or a value you set on
+  `Height` while in the non-default presenter.
 
 **Setter**: changes the window so its client area is `value` DIPs tall. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
@@ -454,11 +505,12 @@ Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 ### 4.2.1. Behavior by window state
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
-the setter and maps to Normal / Maximized / Minimized based on its show state.
-The non-default presenters, `FullScreen` and `CompactOverlay`, update the
-restore size without affecting the live window.
+the setter and maps to restored / maximized / minimized based on its show state.
+The non-default presenters, `FullScreen` and `CompactOverlay`, remember the
+requested size and apply it when the window returns to `Overlapped`, without
+affecting the live window in the meantime.
 
-- **Normal**: the window resizes right away to the requested client height.
+- **Restored**: the window resizes right away to the requested client height.
   Position is preserved.
 - **Maximized**: the live (maximized) window does not resize. The *restore*
   bounds (the size the window snaps to when un-maximized) get updated. The other
@@ -466,11 +518,12 @@ restore size without affecting the live window.
 - **Minimized**: same as Maximized. The *restore* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
-- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): updates the
-  *restore* bounds only; the live window stays fullscreen.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the live window stays
+  fullscreen. The restore size is updated and applied when the window returns
+  to the `Overlapped` presenter.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. Updates the
-  *restore* bounds only; the live window is unchanged.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. The live window is
+  unchanged; the restore size is updated and applied on return to `Overlapped`.
 
 ### 4.2.2. Remarks
 
@@ -562,25 +615,53 @@ release, and possibly service it to WinAppSDK 2.x.
 These are implementation details, not part of the public contract. They are
 here for posterity, not for the public docs.
 
-**Applying the size.** The setter computes the matching *window rect*
-by adding the window's non-client chrome to the requested client size, then
-applies it with `SetWindowPos` (Normal state) or by updating `rcNormalPosition`
-via `SetWindowPlacement` (Maximized, Minimized, or a non-default presenter).
+**Applying the size.** The setter computes the matching *window rect* by adding the
+window's non-client chrome to the requested client size. How it applies depends on
+state:
 
-**Where the chrome comes from.** For desktop (HWND) windows in Normal state, the
+- **Restored**: `SetWindowPos` on the live window.
+- **Maximized / Minimized**: updates `rcNormalPosition` via `SetWindowPlacement`, so
+  the window snaps to the new size when it is restored.
+- **FullScreen / CompactOverlay** (presenters that don't support sizing): the value
+  is stashed in a pending field rather than applied. The implementation listens to
+  `AppWindow.Changed`; when the presenter changes back to one that supports sizing,
+  it applies the pending value through the restored-state path above. If no value was
+  ever set there is nothing pending, so a presenter change does nothing.
+
+**User resize clears pending state.** A value set via `Width`/`Height` in the
+restored state is applied immediately and has no further effect.  If the user then
+resizes the window (or the window changes size for any other reason), the
+previously-set value is not remembered or re-applied.  In particular, entering
+and exiting a non-default presenter after a user resize must restore to the
+user's size, not a stale app-set value.  The implementation achieves this because
+the restored-state setter calls `SetWindowPos` once and does not stash a pending
+value; the OS's own `WINDOWPLACEMENT` restore rect tracks whatever the window's
+last restored geometry was.
+
+**Where the chrome comes from.** For desktop (HWND) windows in the restored state, the
 chrome is taken from the window's *observed* window-rect-minus-client delta rather than
 from a purely style-based calculation (`AdjustWindowRectExForDpi`). This is what
-makes `ExtendsContentIntoTitleBar` work correctly. When the window is Maximized
-or Minimized, the live rects do not represent normal chrome, so the style-based
+makes `ExtendsContentIntoTitleBar` work correctly. When the window is maximized
+or minimized, the live rects do not represent normal chrome, so the style-based
 calculation is used instead, with a correction that zeros out the top chrome when
 `ExtendsContentIntoTitleBar` is active.
 
-**Reading the size back.** The getter returns client-area size in DIPs. In the
-Normal state it reads from `Window.Bounds`. In the Maximized, Minimized,
-Fullscreen, or CompactOverlay state it computes the restore client size from the
-`rcNormalPosition` stored in `WINDOWPLACEMENT`, subtracting the same non-client
-chrome and DPI scale the setter used. So the getter/setter round-trip in every
-state.
+**Reading the size back.** The getter always returns the restore client-area size in DIPs.
+
+- In the pre-activated state, before ShowWindow is called, the getters return the
+  restore size (same as `Window.Bounds` at that point, unless the app set a new value).
+- In the restored state, it returns the same size as `Window.Bounds`.
+- In the **Maximized / Minimized** state it computes the restore client size from the
+  `rcNormalPosition` stored in `WINDOWPLACEMENT`, subtracting the same non-client
+  chrome and DPI scale the setter used.
+- When the AppWindow is using a non-default Presenter, it returns the restore size:
+  either the last size it had in the restored state (including user resizes), or a new value
+  the app set on Width/Height while in the non-default presenter -- whichever is more recent.
+
+User resizes in the restored state update the tracked restore size. The runtime deliberately does *not* read
+`rcNormalPosition` in the FullScreen/CompactOverlay presenters: those overwrite it with
+the live (monitor or PiP) rect and keep the true restore rect private, so it would not
+be a meaningful restore size.
 
 **UWP host.** The implementation will provide basic UWP support to keep
 existing UWP tests running.

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -3,13 +3,13 @@ Window.Width and Window.Height
 
 Table of Contents
 
+
 - [Window.Width and Window.Height](#windowwidth-and-windowheight)
 - [1. Background](#1-background)
 - [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
   - [2.1. Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32](#21-three-sets-of-apis-size-the-same-window-window-appwindow-and-win32)
-    - [2.1.1. How the AppWindow presenter affects sizing](#211-how-the-appwindow-presenter-affects-sizing)
-    - [2.1.2. How the Window sizing works with Window.ExtendsContentIntoTitleBar](#212-how-the-window-sizing-works-with-windowextendscontentintotitlebar)
-  - [2.2. WPF Comparison](#22-wpf-comparison)
+  - [2.2. How Window sizing works with Window.ExtendsContentIntoTitleBar](#22-how-window-sizing-works-with-windowextendscontentintotitlebar)
+  - [2.3. WPF Comparison](#23-wpf-comparison)
 - [3. Examples](#3-examples)
   - [3.1. Set Initial Window Size in XAML Markup](#31-set-initial-window-size-in-xaml-markup)
   - [3.2. Set Initial Window Size with x:Bind](#32-set-initial-window-size-with-xbind)
@@ -28,9 +28,8 @@ Table of Contents
   - [6.1. Release plan](#61-release-plan)
   - [6.2. Implementation notes](#62-implementation-notes)
   - [6.3. Design rationale](#63-design-rationale)
-  - [6.4. Open questions](#64-open-questions)
-  - [6.5. FAQ](#65-faq)
-  - [6.6. Acknowledgements](#66-acknowledgements)
+  - [6.4. FAQ](#64-faq)
+  - [6.5. Acknowledgements](#65-acknowledgements)
 
 
 # 1. Background
@@ -66,38 +65,40 @@ promoted to stable.
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
-`Width` and `Height` get or set the size of the window's client area in DIPs.  Think of them as
-representing the window's **restore size**: the size it has (or will have) when it is in the restored state.
-This is the state when it's behaving like a "normal" window: not minimized, not maximized, not snapped, not
-full-screen, and not in another special windowing mode.
+`Width` and `Height` get or set the restored size of the window's client area in DIPs.
 
-`Window`'s concept of restore size is like Win32's restore size, but it is not always the same value.
-See the section about AppWindow presenters below for details.
+The **restored size** is conceptually the size the window is (or will be) when in the restored state -- when its
+AppWindow is using the default presenter, and it's not minimized or maximized. For the default WinUI `Window`,
+the `AppWindow.Presenter` is `Overlapped`. That's the "normal" desktop window mode.
 
-The setter changes the restore size, and the getter reports it back, but user resizes update it too.
+Setting `Width` or `Height` updates the restored size. If the Window currently has the default `Overlapped` presenter
+and is in the restored state, the runtime resizes the window immediately.
 
-When the window is in its restored state, the restore size is also the live size, so
-`Window.Width` equals `Window.Bounds.Width` (and same for height).  These match the Win32 notion of
-"client rect" except they work in DIPs by correcting for the window's DPI.  The client area is where your content
-lives, so in the restored state `Window.Width` usually equals `Window.Content.ActualWidth` too
-(assuming your content fills the window).
+Otherwise, the resize is deferred:
 
-Setting `Width` or `Height` defers resizing the window when:
-- **`Window.Activate` has not been called yet.** In this case, the runtime sets the new size when Window.Activate is called.
-- **The window is maximized or minimized.** In this case, the runtime sets the Win32 restore size.
-- **The `Window.AppWindow.Presenter` is `FullScreen` or `CompactOverlay`**.  In this case, the runtime remembers the
-  restore size (whether set by your code or by the user resizing) and reapplies it when the AppWindow's presenter
-  switches to `Overlapped`.
+- If `Window.AppWindow.Presenter` is `FullScreen` or `CompactOverlay`, the runtime remembers the
+  restored size and reapplies it when the presenter switches back to `Overlapped`.
+- If the Win32 window is minimized or maximized, the runtime updates the Win32 restored size.
 
-In these cases the getter returns the restore size, not the actual live size of the window.
+In these cases, the getters work the same way: they return the restored size, not the current size.
 
-You can set the Width and Height properties in XAML markup and in code-behind.
+**A user resize wins over an app-set size.** If your app sets `Width`/`Height` and the user later drags the
+window to a new size, the user's size is the one that sticks. For example:
 
-If you need the current client-area size for layout, use `Bounds` -- it always
-reflects the live size, except when the window is minimized.
+1. App sets `Window.Width = 500` (the window becomes 500 DIPs wide).
+2. User drags the edge to resize it to 600.
+3. App enters the `FullScreen` presenter.
+4. App exits `FullScreen` (back to `Overlapped`).
 
-Note you can use x:bind (`{x:Bind ...}`} bindings to set the Width/Height properties, but you CAN'T use classic data binding
-(`{Binding ...}`) to set them.  This is because the Window type is not a FrameworkElement.
+The window comes back at width **600**, not 500. The WinUI runtime tracks the restored size from the window's last
+size in the overlapped, restored state, no matter how it got there, so the user's resize in step 2 is what gets restored.
+
+Given that the `Width` and `Height` getters don't always return the current client size, use `Bounds` when you
+need the current client-area size for layout. `Bounds` reflects the live size except when the window is minimized.
+
+You can set the `Width` and `Height` properties in XAML markup and in code-behind. You can use
+`x:Bind` (`{x:Bind ...}`) bindings to set the `Width` and `Height` properties, but you can't use classic
+data binding (`{Binding ...}`) to set them. This is because the `Window` type is not a `FrameworkElement`.
 
 ## 2.1. Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32
 
@@ -118,17 +119,13 @@ The three layers:
 
 Because two of the three layers are in physical pixels and one is in DIPs,
 `Window.Width = 800` (DIPs) and `AppWindow.ResizeClient(new SizeInt32(800, 600))`
-(pixels) are **not** the same on a scaled display. Convert with the window's DPI:
-
-```
-physicalPixels = dips * GetDpiForWindow(hwnd) / 96.0
-```
+(pixels) are **not** the same on a scaled display.
 
 Here are the key sizing APIs across the three layers, side by side:
 
 | API                                         | Layer         | Unit         | Measures                  | Read / write    | Notes                              |
 | ------------------------------------------- | ------------- | ------------ | ------------------------- | --------------- | ---------------------------------- |
-| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restore size                       |
+| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restored size                       |
 | `Window.Bounds`                             | `Xaml.Window` | DIPs         | **Client** area           | get only        | Live size                          |
 | `AppWindow.ClientSize`                      | `AppWindow`   | Physical px  | **Client** area           | get only        | Live size                          |
 | `AppWindow.Size`                            | `AppWindow`   | Physical px  | **Window** rect           | get only        | Live size                          |
@@ -137,7 +134,7 @@ Here are the key sizing APIs across the three layers, side by side:
 | `GetClientRect(hwnd, &r)`                   | Win32         | Physical px  | **Client** area           | get only        | Live size; origin is (0,0)         |
 | `GetWindowRect(hwnd, &r)`                   | Win32         | Physical px  | **Window** rect           | get only        | Live size; screen coordinates      |
 | `SetWindowPos` / `MoveWindow`               | Win32         | Physical px  | **Window** rect           | set             | Acts on the live window            |
-| `GetWindowPlacement` / `SetWindowPlacement` | Win32         | Physical px  | **Window** rect (normal/min/max rects) | get **and** set | Reads/writes the restore rect |
+| `GetWindowPlacement` / `SetWindowPlacement` | Win32         | Physical px  | **Window** rect (normal/min/max rects) | get **and** set | Reads/writes the restored rect |
 
 A few things to notice:
 
@@ -147,11 +144,11 @@ A few things to notice:
   your XAML content lives). `AppWindow.Size` / `AppWindow.Resize(...)`,
   `GetWindowRect`, and `SetWindowPos` / `MoveWindow` measure the **window rect**
   (caption and borders included).
-- **Live vs restore.** Almost every API reports the **live** window.
-  `Window.Width/Height` reports the window's restore size. When the window is in the restored state, that is
+- **Live vs restored.** Almost every API reports the **live** window.
+  `Window.Width/Height` reports the window's restored size. When the window is in the overlapped, restored state, that is
   also the live size. When the window is maximized, minimized, not yet activated/shown, or using
   another AppWindow presenter, it may differ from the live size.
-- **Minimized state.** The APIs that report "live size" use the restore size when
+- **Minimized state.** The APIs that report "live size" use the restored size when
   the window is minimized (rather than returning 0,0).
 - **Read vs write.** `Window.Width/Height` is the only single member you both read
   and write. `AppWindow` splits it (a get-only property plus a separate method),
@@ -163,57 +160,7 @@ For **physical pixels**, use `AppWindow.ResizeClient(...)` (client) or
 related) only when you need something the WinUI surfaces do not expose; mixing it
 with the XAML window means you must handle the DIP/pixel conversion yourself.
 
-### 2.1.1. How the AppWindow presenter affects sizing
-
-The same sizing APIs behave differently depending on which `AppWindowPresenter`
-the window is using. You pick a presenter with `AppWindow.SetPresenter(...)`.
-
-With the default `Overlapped` presenter the window behaves normally: unless it's
-maximized or minimized, setting Width or Height resizes it immediately.
-
-If your app switches to a non-default presenter (`FullScreen`, `CompactOverlay`),
-the setter saves the value as the restore size but won't resize the window until
-you switch back to `Overlapped`.
-
-| Presenter (`AppWindowPresenterKind`) | What it is                                   | `Window.Width/Height` **setter**                       | `Window.Width/Height` **getter** returns |
-| ------------------------------------ | -------------------------------------------- | ------------------------------------------------------ | ---------------------------------------- |
-| `Overlapped` - Restored (Normal)     | Standard window: caption + borders, resizable | Resizes the **live** window now                       | Live client size                         |
-| `Overlapped` - Maximized             | Fills the monitor work area                  | Updates the **restore** size only; live window unchanged | Restore size (not the live maximized size) |
-| `Overlapped` - Minimized             | Sits in the taskbar                          | Updates the **restore** size only; window stays minimized | Restore size                          |
-| `FullScreen`                         | Borderless, covers the whole monitor         | Remembers the value; live window unchanged             | Restore size (see below for details) |
-| `CompactOverlay`                     | Small always-on-top picture-in-picture window | Remembers the value; live window unchanged            | Restore size (see below for details) |
-
-When the AppWindow is using a non-default Presenter, the getters return the restore size.  That's either the last size it had in the
-restored state (including user resizes), or a new value you set on `Width`/`Height` since it was last restored.
-If you've called either setter on the `Window` previously, this is also the size the runtime will set on the window
-when it goes back to using the `Overlapped` presenter.  (If you've _not_ called either setter, `Window` doesn't impose
-any size, that's handled by `AppWindow` only.  This is to avoid changing the behavior of existing apps not using this property)
-
-**Window only sets Win32 restore size when using OverlappedPresenter.**  When `Window` is using the default
-Overlapped presenter, and it is minimized or maximized, and you set `Width` or `Height`, the runtime
-sets the Win32 restore size for the HWND.  When other presenters are active, it does not.
-
-**User resize supersedes app-set size on presenter exit.**  If the app sets
-`Width`/`Height` in the restored state and the user later resizes the window
-manually, the user's size is what matters when the window comes back from a
-non-default presenter.  For example:
-
-1. App sets `Window.Width = 500` (window is now 500 DIPs wide).
-2. User drags the edge to resize to 600.
-3. App enters the `FullScreen` presenter.
-4. App exits `FullScreen` (returns to `Overlapped`).
-
-The window restores to width **600**, not 500.  This matches Win32 behavior:
-the OS tracks the restore rect based on the window's last restored geometry,
-regardless of how it got there.  The app's earlier programmatic `Width = 500`
-was applied and consumed in step 1; the user's resize in step 2 updated the
-live (and therefore the restore) geometry, and that is what the OS gives back
-in step 4.
-
-If you need to resize a window in one of these presenters, drop down to
-`AppWindow.ResizeClient(...)` (physical pixels).
-
-### 2.1.2. How the Window sizing works with Window.ExtendsContentIntoTitleBar
+## 2.2. How Window sizing works with Window.ExtendsContentIntoTitleBar
 
 Setting `Window.ExtendsContentIntoTitleBar` to `true` tells the window you want to draw its title bar
 yourself.  This shifts the client area ~30 DIPs upward (depending on system settings).
@@ -241,7 +188,7 @@ toggling `ExtendsContentIntoTitleBar` works exactly as it always has -- the wind
 same.  Setting `Width` or `Height` opts the window into keeping the client area stable across
 title bar changes.
 
-## 2.2. WPF Comparison
+## 2.3. WPF Comparison
 
 WPF developers work with the WPF `Window.Width` and `Window.Height` properties. The
 WinUI properties are meant to feel familiar but they are **not identical**.
@@ -263,10 +210,12 @@ Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 | Setting negative          | Throws `ArgumentException`                           | Returns `E_INVALIDARG`                           |
 | Setting `Infinity`        | Throws `ArgumentException`                           | Returns `E_INVALIDARG`                           |
 | `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
-| Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
-| Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
-| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Updates restore size; applied on return to `Overlapped` |
+| Behavior when Maximized   | Updates *restored* size; window stays maximized       | Updates *restored* size; window stays maximized  |
+| Behavior when Minimized   | Updates *restored* size; window stays minimized       | Updates *restored* size; window stays minimized  |
+| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Updates restored size; applied on return to `Overlapped` |
 | Dependency property       | Yes; bindable                                        | Plain WinRT property; bindable only with x:Bind |
+
+In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
 
 # 3. Examples
 
@@ -358,7 +307,7 @@ namespace PointOfSale
     public sealed partial class MainWindow : Window
     {
         // ...
-        private async void SwitchToCompactView_Button_Click(object sender, RoutedEventArgs e)
+        private void SwitchToCompactView_Button_Click(object sender, RoutedEventArgs e)
         {
             this.Width = 400;
             this.Height = 200;
@@ -373,8 +322,9 @@ namespace PointOfSale
 _(Each of the following L2 sections correspond to a page that will be on docs.microsoft.com)_
 
 > **Editor note:** The `Window.Width` and `Window.Height` sections are
-> intentionally near-identical so each can stand alone as its own docs page. If
-> you change behavior in one, make the matching change in the other.
+> intentionally almost identical so each can stand alone as its own docs page. If
+> you change behavior in one, you should probably make the same change in the other.
+> (one possible exception is that Height has extra conditions due to TitleBar special cases)
 
 ## 4.1. Window.Width property
 
@@ -388,11 +338,11 @@ public double Width { get; set; }
 **Getter**: returns the client-area width in DIPs.
 
 - In the **Restored** state this equals `Window.Bounds.Width`.
-- In the **Maximized** or **Minimized** state it returns the *restore* width -- the
+- In the **Maximized** or **Minimized** state it returns the *restored* width -- the
   width the window will have when it returns to the restored state. The OS tracks this
-  restore size, so it works even if you never set `Width`.
+  restored size, so it works even if you never set `Width`.
 - When the AppWindow is using a non-default presenter (`FullScreen`, `CompactOverlay`),
-  it returns the restore width -- the last width the window had in the restored state
+  it returns the restored width -- the last width the window had in the restored state
   (whether set by your code or by the user resizing), or a value you set on
   `Width` while in the non-default presenter.
 
@@ -402,6 +352,7 @@ window's non-client chrome (caption, borders, and so on) gets added on top of
 DPI. Height is left unchanged.
 
 Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
+In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
 
 ### 4.1.1. Behavior by window state
 
@@ -413,18 +364,18 @@ affecting the live window in the meantime.
 
 - **Restored**: the window resizes right away to the requested client width.
   Position is preserved.
-- **Maximized**: the live (maximized) window does not resize. The *restore*
+- **Maximized**: the live (maximized) window does not resize. The *restored*
   bounds (the size the window snaps to when un-maximized) get updated. The other
-  axis (Height) of the restore bounds is preserved.
-- **Minimized**: same as Maximized. The *restore* bounds get updated and the
+  axis (Height) of the restored bounds is preserved.
+- **Minimized**: same as Maximized. The *restored* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
-  axis of the restore bounds is preserved.
+  axis of the restored bounds is preserved.
 - **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the live window stays
-  fullscreen. The restore size is updated and applied when the window returns
+  fullscreen. The restored size is updated and applied when the window returns
   to the `Overlapped` presenter.
 - **CompactOverlay** (picture-in-picture, via
   `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. The live window is
-  unchanged; the restore size is updated and applied on return to `Overlapped`.
+  unchanged; the restored size is updated and applied on return to `Overlapped`.
 
 ### 4.1.2. Remarks
 
@@ -475,6 +426,8 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 | `0`                           | Allowed. The window resizes so the client area has zero width. The OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
 
+In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
+
 ## 4.2. Window.Height property
 
 Gets or sets the height of the Window's **client area** in device-independent
@@ -487,11 +440,11 @@ public double Height { get; set; }
 **Getter**: returns the client-area height in DIPs.
 
 - In the **Restored** state this equals `Window.Bounds.Height`.
-- In the **Maximized** or **Minimized** state it returns the *restore* height -- the
+- In the **Maximized** or **Minimized** state it returns the *restored* height -- the
   height the window will have when it returns to the restored state. The OS tracks this
-  restore size, so it works even if you never set `Height`.
+  restored size, so it works even if you never set `Height`.
 - When the AppWindow is using a non-default presenter (`FullScreen`, `CompactOverlay`),
-  it returns the restore height -- the last height the window had in the restored state
+  it returns the restored height -- the last height the window had in the restored state
   (whether set by your code or by the user resizing), or a value you set on
   `Height` while in the non-default presenter.
 
@@ -501,6 +454,7 @@ window's non-client chrome (caption, borders, and so on) gets added on top of
 left unchanged.
 
 Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
+In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
 
 ### 4.2.1. Behavior by window state
 
@@ -512,18 +466,18 @@ affecting the live window in the meantime.
 
 - **Restored**: the window resizes right away to the requested client height.
   Position is preserved.
-- **Maximized**: the live (maximized) window does not resize. The *restore*
+- **Maximized**: the live (maximized) window does not resize. The *restored*
   bounds (the size the window snaps to when un-maximized) get updated. The other
-  axis (Width) of the restore bounds is preserved.
-- **Minimized**: same as Maximized. The *restore* bounds get updated and the
+  axis (Width) of the restored bounds is preserved.
+- **Minimized**: same as Maximized. The *restored* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
-  axis of the restore bounds is preserved.
+  axis of the restored bounds is preserved.
 - **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): the live window stays
-  fullscreen. The restore size is updated and applied when the window returns
+  fullscreen. The restored size is updated and applied when the window returns
   to the `Overlapped` presenter.
 - **CompactOverlay** (picture-in-picture, via
   `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. The live window is
-  unchanged; the restore size is updated and applied on return to `Overlapped`.
+  unchanged; the restored size is updated and applied on return to `Overlapped`.
 
 ### 4.2.2. Remarks
 
@@ -549,10 +503,8 @@ as client area. If you previously set `Width` or `Height`, the runtime honors
 that value and holds it unchanged when you toggle `ExtendsContentIntoTitleBar`.
 If you didn't set `Width`/`Height`, the window size does not change when you
 toggle it.
-Height is the axis most affected, since the caption region is at the top of the
-window.
 
-**XAML markup.** Width and Height are settable from C++/WinRT code-behind
+**XAML markup.** Width and Height are settable from code-behind
 AND from XAML on the `<Window>` object.
 
 **Bindings.** Width and Height are not `DependencyProperty`-backed. They do not
@@ -576,6 +528,8 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 | `Double.NegativeInfinity`     | Returns `E_INVALIDARG`               |
 | `0`                           | Allowed. The window resizes so the client area has zero height; the OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as tall as the OS allows. |
+
+In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
 
 # 5. API Details
 
@@ -635,7 +589,7 @@ previously-set value is not remembered or re-applied.  In particular, entering
 and exiting a non-default presenter after a user resize must restore to the
 user's size, not a stale app-set value.  The implementation achieves this because
 the restored-state setter calls `SetWindowPos` once and does not stash a pending
-value; the OS's own `WINDOWPLACEMENT` restore rect tracks whatever the window's
+value; the OS's own `WINDOWPLACEMENT` restored rect tracks whatever the window's
 last restored geometry was.
 
 **Where the chrome comes from.** For desktop (HWND) windows in the restored state, the
@@ -646,22 +600,22 @@ or minimized, the live rects do not represent normal chrome, so the style-based
 calculation is used instead, with a correction that zeros out the top chrome when
 `ExtendsContentIntoTitleBar` is active.
 
-**Reading the size back.** The getter always returns the restore client-area size in DIPs.
+**Reading the size back.** The getter always returns the restored client-area size in DIPs.
 
 - In the pre-activated state, before ShowWindow is called, the getters return the
-  restore size (same as `Window.Bounds` at that point, unless the app set a new value).
+  restored size (same as `Window.Bounds` at that point, unless the app set a new value).
 - In the restored state, it returns the same size as `Window.Bounds`.
-- In the **Maximized / Minimized** state it computes the restore client size from the
+- In the **Maximized / Minimized** state it computes the restored client size from the
   `rcNormalPosition` stored in `WINDOWPLACEMENT`, subtracting the same non-client
   chrome and DPI scale the setter used.
-- When the AppWindow is using a non-default Presenter, it returns the restore size:
+- When the AppWindow is using a non-default Presenter, it returns the restored size:
   either the last size it had in the restored state (including user resizes), or a new value
   the app set on Width/Height while in the non-default presenter -- whichever is more recent.
 
-User resizes in the restored state update the tracked restore size. The runtime deliberately does *not* read
+User resizes in the restored state update the tracked restored size. The runtime deliberately does *not* read
 `rcNormalPosition` in the FullScreen/CompactOverlay presenters: those overwrite it with
-the live (monitor or PiP) rect and keep the true restore rect private, so it would not
-be a meaningful restore size.
+the live (monitor or PiP) rect and keep the true restored rect private, so it would not
+be a meaningful restored size.
 
 **UWP host.** The implementation will provide basic UWP support to keep
 existing UWP tests running.
@@ -671,12 +625,9 @@ existing UWP tests running.
 The big decision was **client area vs window rect** as the unit. WinUI picked
 client area so `Width`/`Height` round-trip with `Window.Bounds`, which already
 ships as the client area. The alternative (the window rect, like WPF) would have put
-two different units on one Window object. See the "Porting from WPF" section for
-the user-visible impact.
+two different units on one Window object.
 
-## 6.4. Open questions
-
-## 6.5. FAQ
+## 6.4. FAQ
 
 These came up as questions during design.
 
@@ -703,7 +654,7 @@ that is out of scope. Setting `NaN` returns `E_INVALIDARG`.
 by calling win32 functions that are virtualized for DPI mode for the underlying HWND, so they will
 honor the DPI mode just as those functions do.
 
-## 6.6. Acknowledgements
+## 6.5. Acknowledgements
 
 This API is based on community contribution
 [microsoft/microsoft-ui-xaml#11052](https://github.com/microsoft/microsoft-ui-xaml/pull/11052)

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -8,8 +8,8 @@ Table of Contents
 - [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
   - [2.1. Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32](#21-three-sets-of-apis-size-the-same-window-window-appwindow-and-win32)
     - [2.1.1. How the AppWindow presenter affects sizing](#211-how-the-appwindow-presenter-affects-sizing)
-  - [2.2. Where Width/Height equals Bounds and where it does not](#22-where-widthheight-equals-bounds-and-where-it-does-not)
-  - [2.3. WPF Comparison](#23-wpf-comparison)
+    - [2.1.2. How the Window sizing works with Window.ExtendsContentIntoTitleBar](#212-how-the-window-sizing-works-with-windowextendscontentintotitlebar)
+  - [2.2. WPF Comparison](#22-wpf-comparison)
 - [3. Examples](#3-examples)
   - [3.1. Set Initial Window Size in XAML Markup](#31-set-initial-window-size-in-xaml-markup)
   - [3.2. Set Initial Window Size with x:Bind](#32-set-initial-window-size-with-xbind)
@@ -66,23 +66,28 @@ promoted to stable.
 
 _(This is conceptual documentation that will go to docs.microsoft.com "how to" page)_
 
-WinUI Window already has a read-only
-[`Bounds`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window.bounds)
-property that returns the **client area** of the window in DIPs. The 
-`Width` and `Height` properties round out that surface:
+`Width` and `Height` get or set the size of the window's client area (in DIPs) in its normal,
+restored state.  This is the size it returns to when it isn't maximized, minimized, or has a special
+presenter (more detail below).
 
-- The getters return the **client area** width and height in DIPs. In the
-  Normal, Fullscreen, and CompactOverlay states this matches `Bounds.Width` /
-  `Bounds.Height`. In the Maximized or Minimized states the getter returns the
-  **restore** size, the size the window will have when it goes back to Normal, so
-  that `Width`/`Height` round-trip with the setter in those states. (Fullscreen
-  and CompactOverlay return an error from the setter; see below.)
-- The setters change the **client area** size in DIPs.
+These properties represent the client area of the window, in DIPs.  They match the Win32 notion of
+"client rect" except that they correct for the window's DPI.  This client area is the same area your window's
+content is hosted, so generally when the window is in a normal state, `Window.Width` equals `Window.Content.ActualWidth`
+(and same for height).
+
+In the following conditions, setting the `Width` or `Height` property won't resize the window immediately:
+- When `Window.Activate` has not been called to show the window
+- When the window is maximized or minimized
+- When the `Window.AppWindow.Presenter` object is `FullScreen` or `CompactOverlay`
+
+In these cases, the new size is remembered for later as the "restore size".  The runtime resizes the window
+to the new size when the above conditions become false.  The getters return the "restore size" you set,
+so they will not always return the true "live size" of the window.
 
 You can set the Width and Height properties in XAML markup and in code-behind.
 
 If you need the current client-area size for layout, use `Bounds` -- it always
-reflects the live size, even when the window is maximized.
+reflects the live size, except when the window is minimized.
 
 Note you can use x:bind (`{x:Bind ...}`} bindings to set the Width/Height properties, but you CAN'T use classic data binding
 (`{Binding ...}`) to set them.  This is because the Window type is not a FrameworkElement.
@@ -116,10 +121,10 @@ Here is every sizing API across the three layers, side by side:
 
 | API                                         | Layer         | Unit         | Measures                  | Read / write    | Notes                              |
 | ------------------------------------------- | ------------- | ------------ | ------------------------- | --------------- | ---------------------------------- |
-| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restore size when Max/Min          |
-| `Window.Bounds`                             | `Xaml.Window` | DIPs         | **Client** area           | get only        | Always the live size               |
-| `AppWindow.ClientSize`                      | `AppWindow`   | Physical px  | **Client** area           | get only        | Always the live size               |
-| `AppWindow.Size`                            | `AppWindow`   | Physical px  | **Window** rect           | get only        | Always the live size               |
+| `Window.Width` / `Height`                   | `Xaml.Window` | DIPs         | **Client** area           | get **and** set | Restore size when in normal state  |
+| `Window.Bounds`                             | `Xaml.Window` | DIPs         | **Client** area           | get only        | Live size                          |
+| `AppWindow.ClientSize`                      | `AppWindow`   | Physical px  | **Client** area           | get only        | Live size                          |
+| `AppWindow.Size`                            | `AppWindow`   | Physical px  | **Window** rect           | get only        | Live size                          |
 | `AppWindow.ResizeClient(sz)`                | `AppWindow`   | Physical px  | **Client** area           | set (method)    | Acts on the live window            |
 | `AppWindow.Resize(sz)`                      | `AppWindow`   | Physical px  | **Window** rect           | set (method)    | Acts on the live window            |
 | `GetClientRect(hwnd, &r)`                   | Win32         | Physical px  | **Client** area           | get only        | Live size; origin is (0,0)         |
@@ -136,10 +141,12 @@ A few things to notice:
   `GetWindowRect`, and `SetWindowPos` / `MoveWindow` measure the **window rect**
   (caption and borders included).
 - **Live vs restore.** Almost every API reports the **live** window. The two that
-  deal in the **restore** size are `Window.Width/Height` (in the Max/Min states)
-  and Win32 `Get/SetWindowPlacement` (its `rcNormalPosition`). That is not a
-  coincidence: the `Width/Height` getter and setter are built on exactly that
-  placement rect.
+  deal in the **restore** size are `Window.Width/Height` (in any state other than
+  Normal) and Win32 `Get/SetWindowPlacement` (its `rcNormalPosition`). That is
+  not a coincidence: the `Width/Height` getter and setter are built on exactly
+  that placement rect.
+- **Minimized state.** The APIs that operate with "live size" use "restore size" when
+  then window is minimized (rather than returning the size "0,0")
 - **Read vs write.** `Window.Width/Height` is the only single member you both read
   and write. `AppWindow` splits it (a get-only property plus a separate method),
   and Win32 splits it across different functions too.
@@ -154,68 +161,53 @@ with the XAML window means you must handle the DIP/pixel conversion yourself.
 
 The same sizing APIs behave differently depending on which `AppWindowPresenter`
 the window is using. You pick a presenter with `AppWindow.SetPresenter(...)`.
-The dividing line is simple: **the default `Overlapped` presenter honors the
-setter; any non-default presenter (`FullScreen`, `CompactOverlay`) returns an
-error.** The `Overlapped` presenter also has three show states
-(Restored, Maximized, Minimized) that each behave on their own. Here is what the
-`Window.Width/Height` setter and getter do in each:
+
+When your window is using the default `Overlapped` presenter, it behaves like a
+"normal" window, and unless it's maximized or minimized, it's resized immediately
+when you set Width or Height.
+
+If/when your app sets a non-default presenter (`FullScreen`, `CompactOverlay`) on your
+window, that window is now considered to be in a special presenter mode, and any changes
+you make to `Width` and `Height` during this time won't be honored until you set the AppWindow's
+presenter back to `Overlapped`.
 
 | Presenter (`AppWindowPresenterKind`) | What it is                                   | `Window.Width/Height` **setter**                       | `Window.Width/Height` **getter** returns |
 | ------------------------------------ | -------------------------------------------- | ------------------------------------------------------ | ---------------------------------------- |
 | `Overlapped` - Restored (Normal)     | Standard window: caption + borders, resizable | Resizes the **live** window now                       | Live client size                         |
 | `Overlapped` - Maximized             | Fills the monitor work area                  | Updates the **restore** size only; live window unchanged | Restore size (not the live maximized size) |
 | `Overlapped` - Minimized             | Sits in the taskbar                          | Updates the **restore** size only; window stays minimized | Restore size                          |
-| `FullScreen`                         | Borderless, covers the whole monitor         | Returns `E_NOT_VALID_STATE`                            | Live fullscreen size                     |
-| `CompactOverlay`                     | Small always-on-top picture-in-picture window | Returns `E_NOT_VALID_STATE`                           | Live client size                         |
+| `FullScreen`                         | Borderless, covers the whole monitor         | Updates the **restore** size only; live window unchanged | Restore size                     |
+| `CompactOverlay`                     | Small always-on-top picture-in-picture window | Updates the **restore** size only; live window unchanged | Restore size                         |
 
-Notes:
-
-- **`Overlapped`** is the default presenter and the only one that honors the
-  setter. It is also the only one with multiple show states. `Restored` is the
-  "Normal" case where `Width == Bounds.Width`. Maximized and Minimized are where
-  the setter/getter switch to the *restore* size instead of the live size.
-- **`FullScreen` and `CompactOverlay`** are the non-default presenters. The
-  setter returns `E_NOT_VALID_STATE` for both. The getter reports the live size.
-
-For the two non-default presenters, this error behavior differs from what
-the lower-level `AppWindow.ResizeClient(...)` does:
-
-| Presenter        | `Window.Width/Height` setter | `AppWindow.ResizeClient(...)`            |
-| ---------------- | ---------------------------- | ---------------------------------------- |
-| `FullScreen`     | Returns `E_NOT_VALID_STATE`  | Resizes the client area                  |
-| `CompactOverlay` | Returns `E_NOT_VALID_STATE`  | Resizes the client area                  |
-
-`Width`/`Height` fails loudly so the app knows the call had no effect, while
-`ResizeClient` actually resizes in both cases.
 If you need to resize a window in one of these presenters, drop down to
 `AppWindow.ResizeClient(...)` (physical pixels).
 
-## 2.2. Where Width/Height equals Bounds and where it does not
+### 2.1.2. How the Window sizing works with Window.ExtendsContentIntoTitleBar
 
-`Window.Bounds` always reports the **live** client area. `Width`/`Height`
-diverge from it in the Maximized and Minimized states because the getters
-return the restore size instead:
+When you set `Window.ExtendsContentIntoTitleBar` to `true`, your this tells your window you want to draw the window's
+TitleBar yourself.  This effectively shifts the client area of your window ~30 DIPs upward on the y-axis. (depending on
+system settings)
 
-| Window state | `Width`/`Height` returns | `Bounds.Width`/`Bounds.Height` returns | Same? |
-| ------------ | ------------------------ | -------------------------------------- | ----- |
-| Normal       | Live client size         | Live client size                       | Yes   |
-| Maximized    | **Restore** size         | Live maximized size                    | **No** |
-| Minimized    | **Restore** size         | Live minimized size                    | **No** |
-| Fullscreen   | Live fullscreen size     | Live fullscreen size                   | Yes   |
-| CompactOverlay | Live client size       | Live client size                       | Yes   |
+If you previously set the `Window.Height` property and then toggle the `Window.ExtendsContentIntoTitleBar` property,
+the runtime will honor the `Window.Height` value you set earlier and hold the value unchanged.  This means the physical
+size of the window will shrink slightly to account for the missing TitleBar area.  If you didn't set `Window.Height`,
+the window size will _not_ change when you toggle `ExtendsContentIntoTitleBar`.
 
-In short: the getter equals `Bounds` in Normal, Fullscreen, and CompactOverlay,
-but for different reasons. In **Normal** the setter actually drove the window to
-that size. In **Fullscreen** and **CompactOverlay** the setter returns an error,
-so the getter just reflects whatever live size the presenter chose. In the **Maximized**
-and **Minimized** states the getter instead returns the *restore* size, so
-`Width`/`Height` tell you what the window *will be* when restored while `Bounds`
-tells you what it *is right now*.
+This means the order you set these properties in doesn't matter:
 
-If you want to size by the window rect instead, you can still call
-`AppWindow.Resize(...)` (physical pixels, not DIPs; see the three-layers section above).
+```cs
+window.Height = 300;                      // Changes window height to 330px
 
-## 2.3. WPF Comparison
+window.ExtendsContentIntoTitleBar = true; // Changes window height to 300px
+```
+versus:
+```cs
+window.ExtendsContentIntoTitleBar = true; // Reduce window height by 30px
+
+window.Height = 300;                      // Changes window height to approx 300px
+```
+
+## 2.2. WPF Comparison
 
 WPF developers work with the WPF `Window.Width` and `Window.Height` properties. The
 WinUI properties are meant to feel familiar but they are **not identical**.
@@ -239,7 +231,7 @@ Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 | `MinWidth` / `MaxWidth`   | Exists and is enforced                               | Not part of this spec (may follow later)        |
 | Behavior when Maximized   | Updates *restore* size; window stays maximized       | Updates *restore* size; window stays maximized  |
 | Behavior when Minimized   | Updates *restore* size; window stays minimized       | Updates *restore* size; window stays minimized  |
-| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Returns `E_NOT_VALID_STATE` in `FullScreen` and `CompactOverlay` |
+| Behavior in non-default presenter | WPF has no built-in fullscreen/PiP modes     | Updates *restore* size; window unaffected       |
 | Dependency property       | Yes; bindable                                        | Plain WinRT property; bindable only with x:Bind |
 
 # 3. Examples
@@ -359,11 +351,11 @@ pixels (DIPs, 1/96 inch).
 public double Width { get; set; }
 ```
 
-**Getter**: returns the current client-area width in DIPs. In the Normal,
-Fullscreen, and CompactOverlay states this equals `Window.Bounds.Width`. In the
-Maximized or Minimized state the getter returns the **restore** width, the width
-the window will have when it goes back to Normal, so the getter round-trips with
-the setter in those states.
+**Getter**: returns the current client-area width in DIPs. In the Normal
+state this equals `Window.Bounds.Width`. In the Maximized, Minimized,
+Fullscreen, or CompactOverlay state the getter returns the **restore** width,
+the width the window will have when it goes back to Normal, so the getter
+round-trips with the setter in those states.
 
 **Setter**: changes the window so its client area is `value` DIPs wide. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
@@ -376,7 +368,8 @@ Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
 the setter and maps to Normal / Maximized / Minimized based on its show state.
-The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
+The non-default presenters, `FullScreen` and `CompactOverlay`, update the
+restore size without affecting the live window.
 
 - **Normal**: the window resizes right away to the requested client width.
   Position is preserved.
@@ -386,11 +379,11 @@ The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
 - **Minimized**: same as Maximized. The *restore* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
-- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): returns
-  `E_NOT_VALID_STATE`. The live window stays fullscreen.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): updates the
+  *restore* bounds only; the live window stays fullscreen.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, returns
-  `E_NOT_VALID_STATE`.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. Updates the
+  *restore* bounds only; the live window is unchanged.
 
 ### 4.1.2. Remarks
 
@@ -412,8 +405,10 @@ the move.
 
 **Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
 the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what counts
-as client area, so the getter (and `Bounds`) can change even though the window
-rect did not; re-apply the setter if you need a specific size after toggling.
+as client area. If you previously set `Width` or `Height`, the runtime honors
+that value and holds it unchanged when you toggle `ExtendsContentIntoTitleBar`.
+If you didn't set `Width`/`Height`, the window size does not change when you
+toggle it.
 
 **XAML markup.** Width and Height are settable from code-behind AND from XAML on the `<Window>` object.
 
@@ -436,7 +431,6 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 | `Double.NaN`                  | Returns `E_INVALIDARG`              |
 | `Double.PositiveInfinity`     | Returns `E_INVALIDARG`              |
 | `Double.NegativeInfinity`     | Returns `E_INVALIDARG`              |
-| Window in a non-default presenter | Returns `E_NOT_VALID_STATE` when the window uses the `FullScreen` or `CompactOverlay` presenter. |
 | `0`                           | Allowed. The window resizes so the client area has zero width. The OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as large as the OS allows. |
 
@@ -449,11 +443,11 @@ pixels (DIPs, 1/96 inch).
 public double Height { get; set; }
 ```
 
-**Getter**: returns the current client-area height in DIPs. In the Normal,
-Fullscreen, and CompactOverlay states this equals `Window.Bounds.Height`. In the
-Maximized or Minimized state the getter returns the **restore** height, the height
-the window will have when it goes back to Normal, so the getter round-trips with
-the setter in those states.
+**Getter**: returns the current client-area height in DIPs. In the Normal
+state this equals `Window.Bounds.Height`. In the Maximized, Minimized,
+Fullscreen, or CompactOverlay state the getter returns the **restore** height,
+the height the window will have when it goes back to Normal, so the getter
+round-trips with the setter in those states.
 
 **Setter**: changes the window so its client area is `value` DIPs tall. The
 window's non-client chrome (caption, borders, and so on) gets added on top of
@@ -466,7 +460,8 @@ Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 
 These behaviors split by presenter. The default `Overlapped` presenter honors
 the setter and maps to Normal / Maximized / Minimized based on its show state.
-The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
+The non-default presenters, `FullScreen` and `CompactOverlay`, update the
+restore size without affecting the live window.
 
 - **Normal**: the window resizes right away to the requested client height.
   Position is preserved.
@@ -476,11 +471,11 @@ The non-default presenters, `FullScreen` and `CompactOverlay`, return an error.
 - **Minimized**: same as Maximized. The *restore* bounds get updated and the
   window stays minimized (it snaps to the new size when restored). The other
   axis of the restore bounds is preserved.
-- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): returns
-  `E_NOT_VALID_STATE`. The live window stays fullscreen.
+- **Fullscreen** (via `AppWindowPresenterKind.FullScreen`): updates the
+  *restore* bounds only; the live window stays fullscreen.
 - **CompactOverlay** (picture-in-picture, via
-  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen, returns
-  `E_NOT_VALID_STATE`.
+  `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. Updates the
+  *restore* bounds only; the live window is unchanged.
 
 ### 4.2.2. Remarks
 
@@ -502,8 +497,10 @@ the move.
 
 **Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
 the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what counts
-as client area, so the getter (and `Bounds`) can change even though the window
-rect did not; re-apply the setter if you need a specific size after toggling.
+as client area. If you previously set `Width` or `Height`, the runtime honors
+that value and holds it unchanged when you toggle `ExtendsContentIntoTitleBar`.
+If you didn't set `Width`/`Height`, the window size does not change when you
+toggle it.
 Height is the axis most affected, since the caption region is at the top of the
 window.
 
@@ -529,7 +526,6 @@ For all errors the runtime calls RoOriginateError with a specific error message 
 | `Double.NaN`                  | Returns `E_INVALIDARG`               |
 | `Double.PositiveInfinity`     | Returns `E_INVALIDARG`               |
 | `Double.NegativeInfinity`     | Returns `E_INVALIDARG`               |
-| Window in a non-default presenter | Returns `E_NOT_VALID_STATE` when the window uses the `FullScreen` or `CompactOverlay` presenter. |
 | `0`                           | Allowed. The window resizes so the client area has zero height; the OS may apply a minimum size. |
 | Very large value (> screen)   | Allowed. The OS clamps to its tracking-size maximum; the window grows as tall as the OS allows. |
 
@@ -574,9 +570,7 @@ here for posterity, not for the public docs.
 **Applying the size.** The setter computes the matching *window rect*
 by adding the window's non-client chrome to the requested client size, then
 applies it with `SetWindowPos` (Normal state) or by updating `rcNormalPosition`
-via `SetWindowPlacement` (Maximized or Minimized). A non-default presenter
-(`FullScreen` or `CompactOverlay`) returns `E_NOT_VALID_STATE`; the setter checks
-the presenter kind up front and returns the error before touching the window.
+via `SetWindowPlacement` (Maximized, Minimized, or a non-default presenter).
 
 **Where the chrome comes from.** For desktop (HWND) windows in Normal state, the
 chrome is taken from the window's *observed* window-rect-minus-client delta rather than
@@ -587,12 +581,11 @@ calculation is used instead, with a correction that zeros out the top chrome whe
 `ExtendsContentIntoTitleBar` is active.
 
 **Reading the size back.** The getter returns client-area size in DIPs. In the
-Normal, Fullscreen, and CompactOverlay states it reads from `Window.Bounds`. In
-the Maximized or Minimized state it computes the restore client size from the
+Normal state it reads from `Window.Bounds`. In the Maximized, Minimized,
+Fullscreen, or CompactOverlay state it computes the restore client size from the
 `rcNormalPosition` stored in `WINDOWPLACEMENT`, subtracting the same non-client
 chrome and DPI scale the setter used. So the getter/setter round-trip in every
-state except the non-default presenters (`FullScreen` and `CompactOverlay`),
-where the setter returns an error.
+state.
 
 **UWP host.** The implementation will provide basic UWP support to keep
 existing UWP tests running.

--- a/specs/Window/window-width-height-spec.md
+++ b/specs/Window/window-width-height-spec.md
@@ -10,6 +10,7 @@ Table of Contents
   - [2.1. Three sets of APIs size the same window: `Window`, `AppWindow`, and Win32](#21-three-sets-of-apis-size-the-same-window-window-appwindow-and-win32)
   - [2.2. How Window sizing works with Window.ExtendsContentIntoTitleBar](#22-how-window-sizing-works-with-windowextendscontentintotitlebar)
   - [2.3. WPF Comparison](#23-wpf-comparison)
+  - [2.4. Sizing properties after the window closes](#24-sizing-properties-after-the-window-closes)
 - [3. Examples](#3-examples)
   - [3.1. Set Initial Window Size in XAML Markup](#31-set-initial-window-size-in-xaml-markup)
   - [3.2. Set Initial Window Size with x:Bind](#32-set-initial-window-size-with-xbind)
@@ -71,11 +72,13 @@ The **restored size** is conceptually the size the window is (or will be) when i
 AppWindow is using the default presenter, and it's not minimized or maximized. For the default WinUI `Window`,
 the `AppWindow.Presenter` is `Overlapped`. That's the "normal" desktop window mode.
 
-Setting `Width` or `Height` updates the restored size. If the Window currently has the default `Overlapped` presenter
-and is in the restored state, the runtime resizes the window immediately.
+While the window is open, setting `Width` or `Height` updates the restored size. After first activation,
+if the window has the default `Overlapped` presenter and is restored, it resizes immediately.
 
 Otherwise, the resize is deferred:
 
+- Before first activation, the runtime stores the request and applies it on activation if the
+  presenter supports sizing.
 - If `Window.AppWindow.Presenter` is `FullScreen` or `CompactOverlay`, the runtime remembers the
   restored size and reapplies it when the presenter switches back to `Overlapped`.
 - If the Win32 window is minimized or maximized, the runtime updates the Win32 restored size.
@@ -93,8 +96,12 @@ window to a new size, the user's size is the one that sticks. For example:
 The window comes back at width **600**, not 500. The WinUI runtime tracks the restored size from the window's last
 size in the overlapped, restored state, no matter how it got there, so the user's resize in step 2 is what gets restored.
 
-Given that the `Width` and `Height` getters don't always return the current client size, use `Bounds` when you
-need the current client-area size for layout. `Bounds` reflects the live size except when the window is minimized.
+Given that the `Width` and `Height` getters don't always return the current client size, use `Bounds`
+while the window is open when you need the current client-area size for layout. `Bounds` reflects the
+live size except when the window is minimized.
+
+After the window closes, valid assignments to `Width` and `Height` have no effect. Their getters return
+the values preserved at close. See [Sizing properties after the window closes](#24-sizing-properties-after-the-window-closes).
 
 You can set the `Width` and `Height` properties in XAML markup and in code-behind. You can use
 `x:Bind` (`{x:Bind ...}`) bindings to set the `Width` and `Height` properties, but you can't use classic
@@ -163,30 +170,34 @@ with the XAML window means you must handle the logical/physical pixel conversion
 ## 2.2. How Window sizing works with Window.ExtendsContentIntoTitleBar
 
 Setting `Window.ExtendsContentIntoTitleBar` to `true` tells the window you want to draw its title bar
-yourself.  This shifts the client area ~30 logical pixels upward (depending on system settings).
+yourself. The area occupied by the standard title bar becomes part of the client area.
 
-If you set `Window.Height` and then toggle `ExtendsContentIntoTitleBar`, the runtime keeps the
-`Height` value you set.  The physical window shrinks slightly to account for the missing title bar
-area.  If you _didn't_ set `Height`, the window size does not change when you toggle it.
+While the window is in the overlapped, restored state, if your app has explicitly set `Window.Height`,
+toggling `ExtendsContentIntoTitleBar` preserves the current client height. The outer window height
+adjusts to account for the change in non-client area. This preserves a subsequent user resize, not
+necessarily the last height assigned by your app.
 
-Setting them in either order works -- either way, the window's height comes out the same:
+If your app has not set `Height`, toggling `ExtendsContentIntoTitleBar` leaves the outer window size
+unchanged, so the client height changes instead. Setting `Width` alone does not opt into client-height
+preservation.
+
+Both examples assume the window is already displayed in its normal desktop state, not minimized,
+maximized, full screen, or compact overlay. They show that you can set these properties in either order.
+In each example, the app has not previously set `Height`. Either order produces the same client height:
 
 ```cs
-window.Height = 300;                      // Changes physical window height to ~330px 
-                                          // (depending on OS settings)
-window.ExtendsContentIntoTitleBar = true; // Changes physical window height to 300px
+window.Height = 300;                      // Requests a client height of 300 logical pixels.
+window.ExtendsContentIntoTitleBar = true; // Preserves that client height; reduces the outer height.
 ```
 versus:
 ```cs
-window.ExtendsContentIntoTitleBar = true; // Reduce physical window height by ~30px
-                                          // (depending on OS settings)
-window.Height = 300;                      // Changes physical window height to approx 300px
+window.ExtendsContentIntoTitleBar = true; // Changes the client area without resizing the outer window.
+window.Height = 300;                      // Requests a client height of 300 logical pixels.
 ```
 
-This behavior only kicks in when you've set `Width` or `Height`. If your app never sets them,
-toggling `ExtendsContentIntoTitleBar` works exactly as it always has -- the window size stays the
-same.  Setting `Width` or `Height` opts the window into keeping the client area stable across
-title bar changes.
+Before first activation, a pending `Height` request uses the title-bar configuration in effect when
+the request is applied. Toggling `ExtendsContentIntoTitleBar` while minimized, maximized, or using a non-default
+presenter does not itself preserve the restored client height.
 
 ## 2.3. WPF Comparison
 
@@ -216,6 +227,40 @@ Here is a side-by-side breakdown of more WPF vs WinUI behavior:
 | Dependency property       | Yes; bindable                                        | Plain WinRT property; bindable only with x:Bind |
 
 In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
+
+## 2.4. Sizing properties after the window closes
+
+Closing a window freezes its `Width` and `Height` values. Valid assignments after close are ignored:
+they do not change the preserved values, create a pending resize, raise `SizeChanged`, or reopen the
+window. The getters remain available on the owning thread.
+
+Each preserved value is the value its getter would have returned after the `Closed` handlers complete
+without canceling and immediately before native teardown, not necessarily the last value assigned by your app:
+
+- If the user resized the restored window, preserve the resulting client size.
+- If the window is minimized or maximized, preserve the restored size, not the live size.
+- If a request is still pending, such as before first activation or while using a non-default
+  presenter, preserve that request.
+
+For example, this code runs on the owning thread and assumes no `Closed` handler cancels closing:
+
+```csharp
+window.Close();
+double closedWidth = window.Width;
+double closedHeight = window.Height;
+
+window.Width = 800;  // Ignored. Width still returns closedWidth.
+window.Height = 600; // Ignored. Height still returns closedHeight.
+```
+
+The `Closed` event is raised before native teardown, and a handler can cancel closing by setting
+`Handled` to `true`. During those handlers, the sizing properties retain their normal open-window
+behavior. A canceled close does not freeze them.
+
+Closing alone is not an error for these properties. Argument validation and thread affinity still
+apply: invalid sizes return `E_INVALIDARG`, and access from another thread returns
+`RPC_E_WRONG_THREAD`. A valid post-close assignment succeeds without changing either preserved value.
+This behavior does not change the closed-state contract of other members, such as `Bounds`.
 
 # 3. Examples
 
@@ -334,9 +379,11 @@ Gets or sets the width of the Window's **client area** in logical pixels.
 public double Width { get; set; }
 ```
 
-**Getter**: returns the client-area width in logical pixels.
+**Getter**: returns the restored client-area width in logical pixels.
 
-- In the **Restored** state this equals `Window.Bounds.Width`.
+- Before first activation, a pending `Width` request is returned as supplied. Without a pending
+  request, the getter uses the current presenter's restored-width behavior described below.
+- In the **Restored** state after activation this equals `Window.Bounds.Width`.
 - In the **Maximized** or **Minimized** state it returns the *restored* width -- the
   width the window will have when it returns to the restored state. The OS tracks this
   restored size, so it works even if you never set `Width`.
@@ -344,11 +391,13 @@ public double Width { get; set; }
   it returns the restored width -- the last width the window had in the restored state
   (whether set by your code or by the user resizing), or a value you set on
   `Width` while in the non-default presenter.
+- After the window closes, it returns the width preserved immediately before native teardown.
+  Subsequent assignments do not change this value.
 
-**Setter**: changes the window so its client area is `value` logical pixels wide. The
-window's non-client chrome (caption, borders, and so on) gets added on top of
+**Setter**: while the window is open, requests a client width of `value` logical pixels.
+The window's non-client chrome (caption, borders, and so on) gets added on top of
 `value` to work out the window rect, using the current per-monitor
-DPI. Height is left unchanged.
+DPI. Height is left unchanged. After close, a valid assignment has no effect.
 
 Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
@@ -361,7 +410,9 @@ The non-default presenters, `FullScreen` and `CompactOverlay`, remember the
 requested size and apply it when the window returns to `Overlapped`, without
 affecting the live window in the meantime.
 
-- **Restored**: the window resizes right away to the requested client width.
+- **Before first activation**: the requested width is stored and returned by the getter. It is
+  applied on activation if the presenter supports sizing, or when it subsequently does.
+- **Restored, after activation**: the window resizes right away to the requested client width.
   Position is preserved.
 - **Maximized**: the live (maximized) window does not resize. The *restored*
   bounds (the size the window snaps to when un-maximized) get updated. The other
@@ -375,6 +426,8 @@ affecting the live window in the meantime.
 - **CompactOverlay** (picture-in-picture, via
   `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. The live window is
   unchanged; the restored size is updated and applied on return to `Overlapped`.
+- **Closed**: valid assignments are ignored. The getter returns its preserved pre-teardown value.
+  No pending resize or size-change event is created. A canceled close leaves normal behavior intact.
 
 ### 4.1.2. Remarks
 
@@ -394,12 +447,10 @@ with a different scale factor after you call the setter, the OS re-scales the
 window per its normal rules. The client-area size in logical pixels is preserved across
 the move.
 
-**Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
-the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what counts
-as client area. If you previously set `Width` or `Height`, the runtime honors
-that value and holds it unchanged when you toggle `ExtendsContentIntoTitleBar`.
-If you didn't set `Width`/`Height`, the window size does not change when you
-toggle it.
+**Interaction with ExtendsContentIntoTitleBar.** Setting `Width` alone does not opt into preserving
+client height when the title-bar configuration changes. Only an explicit assignment to `Height`
+enables that behavior while the window is overlapped and restored. See
+[How Window sizing works with Window.ExtendsContentIntoTitleBar](#22-how-window-sizing-works-with-windowextendscontentintotitlebar).
 
 **XAML markup.** Width and Height are settable from code-behind AND from XAML on the `<Window>` object.
 
@@ -408,13 +459,16 @@ take part in data binding and do not raise change notifications. (This matches t
 rest of `Window`'s API surface).  You can, however, use `x:Bind` to set them
 in XAML markup.
 
-**Threading.** You must set these properties on the thread that owns the Window
-(the dispatcher thread). Calls from other threads return the standard
+**Threading.** You must read and write this property on the thread that owns the Window
+(the dispatcher thread), including after close. Calls from other threads return the standard
 `RPC_E_WRONG_THREAD` error from the XAML framework.
 
 ### 4.1.3. Errors
 
 For all errors the runtime calls RoOriginateError with a specific error message to help the app developer diagnose the problem.
+
+Argument validation applies both before and after close. Closing alone does not cause an error.
+The resizing effects below apply only while the window is open; valid post-close assignments are ignored.
 
 | Input                         | Result                              |
 | ----------------------------- | ----------------------------------- |
@@ -435,9 +489,11 @@ Gets or sets the height of the Window's **client area** in logical pixels.
 public double Height { get; set; }
 ```
 
-**Getter**: returns the client-area height in logical pixels.
+**Getter**: returns the restored client-area height in logical pixels.
 
-- In the **Restored** state this equals `Window.Bounds.Height`.
+- Before first activation, a pending `Height` request is returned as supplied. Without a pending
+  request, the getter uses the current presenter's restored-height behavior described below.
+- In the **Restored** state after activation this equals `Window.Bounds.Height`.
 - In the **Maximized** or **Minimized** state it returns the *restored* height -- the
   height the window will have when it returns to the restored state. The OS tracks this
   restored size, so it works even if you never set `Height`.
@@ -445,11 +501,13 @@ public double Height { get; set; }
   it returns the restored height -- the last height the window had in the restored state
   (whether set by your code or by the user resizing), or a value you set on
   `Height` while in the non-default presenter.
+- After the window closes, it returns the height preserved immediately before native teardown.
+  Subsequent assignments do not change this value.
 
-**Setter**: changes the window so its client area is `value` logical pixels tall. The
-window's non-client chrome (caption, borders, and so on) gets added on top of
+**Setter**: while the window is open, requests a client height of `value` logical pixels.
+The window's non-client chrome (caption, borders, and so on) gets added on top of
 `value` to work out the window rect, using the current per-monitor DPI. Width is
-left unchanged.
+left unchanged. After close, a valid assignment has no effect.
 
 Returns `E_INVALIDARG` for negative, `NaN`, or `Infinity` values.
 In .NET an `E_INVALIDARG` error is thrown as an `ArgumentException`.
@@ -462,7 +520,9 @@ The non-default presenters, `FullScreen` and `CompactOverlay`, remember the
 requested size and apply it when the window returns to `Overlapped`, without
 affecting the live window in the meantime.
 
-- **Restored**: the window resizes right away to the requested client height.
+- **Before first activation**: the requested height is stored and returned by the getter. It is
+  applied on activation if the presenter supports sizing, or when it subsequently does.
+- **Restored, after activation**: the window resizes right away to the requested client height.
   Position is preserved.
 - **Maximized**: the live (maximized) window does not resize. The *restored*
   bounds (the size the window snaps to when un-maximized) get updated. The other
@@ -476,6 +536,8 @@ affecting the live window in the meantime.
 - **CompactOverlay** (picture-in-picture, via
   `AppWindowPresenterKind.CompactOverlay`): same as Fullscreen. The live window is
   unchanged; the restored size is updated and applied on return to `Overlapped`.
+- **Closed**: valid assignments are ignored. The getter returns its preserved pre-teardown value.
+  No pending resize or size-change event is created. A canceled close leaves normal behavior intact.
 
 ### 4.2.2. Remarks
 
@@ -495,12 +557,12 @@ with a different scale factor after you call the setter, the OS re-scales the
 window per its normal rules. The client-area size in logical pixels is preserved across
 the move.
 
-**Interaction with ExtendsContentIntoTitleBar.** Because `Width`/`Height` measure
-the client area, toggling `Window.ExtendsContentIntoTitleBar` changes what counts
-as client area. If you previously set `Width` or `Height`, the runtime honors
-that value and holds it unchanged when you toggle `ExtendsContentIntoTitleBar`.
-If you didn't set `Width`/`Height`, the window size does not change when you
-toggle it.
+**Interaction with ExtendsContentIntoTitleBar.** If your app has explicitly set `Height`, toggling
+`Window.ExtendsContentIntoTitleBar` while the window is overlapped and restored preserves its current
+client height, including subsequent user resizes. If your app has set only `Width`, or neither
+property, the outer window size stays unchanged and the client height changes instead. See
+[How Window sizing works with Window.ExtendsContentIntoTitleBar](#22-how-window-sizing-works-with-windowextendscontentintotitlebar)
+for behavior before activation and in other window states.
 
 **XAML markup.** Width and Height are settable from code-behind
 AND from XAML on the `<Window>` object.
@@ -510,8 +572,8 @@ take part in data binding and do not raise change notifications. (This matches t
 rest of `Window`'s API surface).  You can, however, use `x:Bind` to set them
 in XAML markup.
 
-**Threading.** You must set these properties on the thread that owns the Window
-(the dispatcher thread). Calls from other threads return the standard
+**Threading.** You must read and write this property on the thread that owns the Window
+(the dispatcher thread), including after close. Calls from other threads return the standard
 `RPC_E_WRONG_THREAD` error from the XAML framework.
 
 ### 4.2.3. Errors
@@ -571,7 +633,8 @@ here for posterity, not for the public docs.
 window's non-client chrome to the requested client size. How it applies depends on
 state:
 
-- **Restored**: `SetWindowPos` on the live window.
+- **Before first activation**: retain the request until activation with a sizing-capable presenter.
+- **Restored, after activation**: `SetWindowPos` on the live window.
 - **Maximized / Minimized**: updates `rcNormalPosition` via `SetWindowPlacement`, so
   the window snaps to the new size when it is restored.
 - **FullScreen / CompactOverlay** (presenters that don't support sizing): the value
@@ -579,6 +642,8 @@ state:
   `AppWindow.Changed`; when the presenter changes back to one that supports sizing,
   it applies the pending value through the restored-state path above. If no value was
   ever set there is nothing pending, so a presenter change does nothing.
+- **Closed**: validate the argument and return success without changing sizing state or accessing
+  native window resources.
 
 **User resize clears pending state.** A value set via `Width`/`Height` in the
 restored state is applied immediately and has no further effect.  If the user then
@@ -598,7 +663,8 @@ or minimized, the live rects do not represent normal chrome, so the style-based
 calculation is used instead, with a correction that zeros out the top chrome when
 `ExtendsContentIntoTitleBar` is active.
 
-**Reading the size back.** The getter always returns the restored client-area size in logical pixels.
+**Reading the size back.** While the window is open, the getter returns the restored client-area
+size in logical pixels. After close, it returns the preserved pre-teardown value.
 
 - In the pre-activated state, before ShowWindow is called, the getters return the
   restored size (same as `Window.Bounds` at that point, unless the app set a new value).
@@ -653,7 +719,8 @@ by calling win32 functions that are virtualized for DPI mode for the underlying 
 honor the DPI mode just as those functions do.
 
 **If I set `Width` and then `Height`, will the window flicker between the two sizes?**
-In practice, no. Each setter resizes the window right away, so setting both is technically two
+For an open, activated window in the restored state, each setter resizes the window right away,
+so setting both is technically two
 resizes: one frame at the new width with the old height, then the final size. But both calls run in
 the same synchronous turn, before the next frame is drawn, so that in-between size doesn't actually
 show up on screen. This matches WPF, which also resizes immediately on each setter and has worked


### PR DESCRIPTION
This is an API spec for Window.Width and Window.Height properties.

This is to support this contribution from @dotMorten : https://github.com/microsoft/microsoft-ui-xaml/pull/11052 Adds Width and Height properties to the Window class


Thanks!