### PR TITLE
Fix Init.ps1 failing in PowerShell 7 (pwsh) due to Get-FileHash not found

### DIFF
--- a/scripts/init/Initialize-NuGet.ps1
+++ b/scripts/init/Initialize-NuGet.ps1
@@ -17,15 +17,16 @@ $nuget_exe = . "$PSScriptRoot\Initialize-DownloadLatest.ps1" -OutDir $toolsDir -
 Write-Progress "Downloading the Azure Artifacts Credential Provider"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-# If this is PowerShell 5, remove PowerShell 7 module paths from PSModulePath to avoid module loading conflicts.
-# The pwsh7 path can cause an error inside the credprovider install via missing Get-FileHash command.
+# If this is PowerShell 5, remove PowerShell 7+ module paths from PSModulePath to avoid module loading conflicts.
+# The pwsh module path can cause an error inside the credprovider install via missing Get-FileHash command,
+# because the PowerShell 7 Microsoft.PowerShell.Utility module is not compatible with PowerShell 5.
 $originalPSModulePath = $env:PSModulePath
-if ($PSVersionTable.PSVersion.Major -eq 5)
+if ($PSVersionTable.PSVersion.Major -eq 5 -and $env:PSModulePath)
 {
-    if ($env:PSModulePath -like "*powershell\7\Modules*")
+    if ($env:PSModulePath -match '\\PowerShell\\\d+')
     {
         $paths = $env:PSModulePath -split ';'
-        $filteredPaths = $paths | Where-Object { $_ -notlike "*powershell\7\Modules*" }
+        $filteredPaths = $paths | Where-Object { $_ -notmatch '\\PowerShell\\\d+(?:-preview)?\\Modules' }
         $env:PSModulePath = $filteredPaths -join ';'
     }
 }


### PR DESCRIPTION
## Bug

When running .\init.ps1 from a PowerShell 7 (pwsh) console, the Azure Artifacts Credential Provider installation fails with:

> The term 'Get-FileHash' is not recognized as the name of a cmdlet

## Root Cause

The init flow is: pwsh -> init.ps1 -> Invoke-CmdScript -> init.cmd -> powershell.exe (spawned Windows PowerShell 5.1) -> Initialize-Restore.ps1 -> Initialize-NuGet.ps1.

The spawned powershell.exe inherits PSModulePath from the pwsh parent process, which includes PowerShell 7 module paths (e.g., C:\Program Files\PowerShell\7\Modules). When the installcredprovider.ps1 script tries to use Get-FileHash (from Microsoft.PowerShell.Utility), the presence of PowerShell 7 module paths in PSModulePath causes module resolution to find the incompatible PowerShell 7 version of the module, resulting in the cmdlet not being found.

## Existing Workaround

The code in Initialize-NuGet.ps1 (lines 20-31) already attempted to filter out PowerShell 7 paths from PSModulePath, but used `-like "*powershell\7\Modules*"` which only matched version 7 exactly and was not robust enough for all PowerShell 7 installation variants.

## Fix

Changed the PSModulePath filtering to use regex instead of -like, broadening the pattern to match any PowerShell version (>=\d+) with optional preview suffix:

- `-match '\\PowerShell\\\d+'` detects ANY PowerShell version (7, 7-preview, 8, ...) paths in PSModulePath
- `-notmatch '\\PowerShell\\\d+(?:-preview)?\\Modules'` filters out matching paths
- Added null guard for PSModulePath being empty

This correctly handles:
- Standard PowerShell 7: `C:\Program Files\PowerShell\7\Modules` (filtered)
- PowerShell Preview: `C:\Program Files\PowerShell\7-preview\Modules` (filtered)
- Future versions: `C:\Program Files\PowerShell\8\Modules` (filtered)
- User module path: `C:\Users\<user>\Documents\PowerShell\Modules` (kept - no version number)

Closes #11163
