### PR TITLE
Handle MaxWidth bounds in non-clipping tree logic

### DIFF
--- a/dxaml/xcp/core/core/elements/uielement.cpp
+++ b/dxaml/xcp/core/core/elements/uielement.cpp
@@ -3939,11 +3939,22 @@ CUIElement::Measure(XSIZEF availableSize)
 
     pLayoutManager->PushCurrentLayoutElement(this);
 
+    bool hasMaxWidth = false;
+
+    // lets check if the element has width bounds
+	if (this->OfTypeByIndex<KnownTypeIndex::FrameworkElement>())
+	{
+		CFrameworkElement* parent = static_cast<CFrameworkElement*>(this);
+		XFLOAT maxWidth = parent->m_pLayoutProperties->m_eMaxWidth;
+
+		hasMaxWidth = !DirectUI::FloatUtil::IsNaN(maxWidth);
+	}
+
     // remember whether we need to set this value back
     wasInNonClippingTree = pLayoutManager->GetIsInNonClippingTree();
-    // once entering a tree that is non-clipping, we don't get out of it
+    // once entering a tree that is non-clipping, we don't get out of it until there is a width bounds
     // remember this for down-stream
-    pLayoutManager->SetIsInNonClippingTree(GetIsNonClippingSubtree() || wasInNonClippingTree);
+    pLayoutManager->SetIsInNonClippingTree((GetIsNonClippingSubtree() || wasInNonClippingTree) && !hasMaxWidth);
 
     SetIsOnMeasureStack(TRUE);
     SetIsAncestorDirty(FALSE);


### PR DESCRIPTION
## Fixes


Fixes #9860

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

This pull request updates the layout measurement logic in the `CUIElement::Measure` method to better handle elements with maximum width constraints in `ListView`. The main improvement is that elements with a defined `MaxWidth` are now excluded from being marked as part of a "non-clipping" layout tree, which can affect downstream layout behavior.

### Current Behavior
`CUIElement::Measure` inside the `ListView` can mark an element as part of a “non-clipping” layout tree even when the element has a defined MaxWidth. This means elements with maximum width constraints may be treated as if they are unconstrained for downstream layout decisions.

### New Behavior
`CUIElement::Measure` now excludes elements with a defined MaxWidth from being marked as part of a “non-clipping” layout tree inside the `ListView`. This ensures that maximum width constraints are respected when determining layout behavior.

## Customer Impact

Customers should see more accurate layout behavior for UI elements inside the `ListView` that specify MaxWidth. This may prevent elements from measuring or arranging as though they can expand without clipping, reducing visual issues such as incorrect sizing, overflow, or layout inconsistencies in constrained containers.

This issue was observed in [WinUI.TableView](https://github.com/w-ahmad/WinUI.TableView), which is built on top of ListView. In that scenario, TableView cells measured under the subtree could exceed the expected MaxWidth, causing clipping and incorrect rendering.

## Regression Potential

This change affects layout measurement behavior, so related layout scenarios should be validated, especially around ListView, scrolling, and elements with explicit MaxWidth.

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)

- **Before Fix**

https://github.com/user-attachments/assets/3f8edac8-75b3-40b1-bacd-7e054e5648ea

- **After Fix**

https://github.com/user-attachments/assets/9e9c5b0b-a839-4fb0-90f0-f8603b8131ee

