### PR TITLE
Restore MUXFinalRelease GitHub validation stage

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/user/hmishra/muxfinalrelease-restore-clean
+      ref: refs/heads/main
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/user/hmishra/muxfinalrelease-restore-clean
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
@@ -152,3 +152,16 @@ extends:
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
           buildProductOnly: true
+          dependsOn: ValidateGitHubPrContext
+
+    - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
+      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+        parameters:
+          stageName: Build_MUXFinalRelease
+          pipelineKind: PR-2
+          buildScenarioApps: false
+          MUXFinalRelease: true
+          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+          pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
+          buildProductOnly: true
+          dependsOn: ValidateGitHubPrContext


### PR DESCRIPTION
## Fixes

N/A

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

GitHub-backed PR validation runs the reduced product-only build stage and does not run the MUXFinalRelease build stage.

### New Behavior

The GitHub PR wrapper adds the MUXFinalRelease build stage while keeping the rest of the GitHub validation graph reduced-scope.

The wrapper now consumes the build templates from `refs/heads/main`.

## Customer Impact

No direct product/customer-facing impact. This restores CI coverage for the MUXFinalRelease build path in GitHub-backed PR validation.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The change only affects GitHub PR validation.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

- GitHub PR validation passed with the matching template change before the wrapper ref was switched back to `main`.

## Screenshots (if appropriate)

N/A
