### PR TITLE
Add missing Windows versions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -56,6 +56,9 @@ body:
       multiple: true
       options:
         - "Windows Insider Build (xxxxx)"
+        - "Windows 11 (26H1): Build 28000"
+        - "Windows 11 (25H2): Build 26200"
+        - "Windows 11 (24H2): Build 26120"
         - "Windows 11 (24H2): Build 26100"
         - "Windows 11 (23H2): Build 22631"
         - "Windows 11 (22H2): Build 22621"


### PR DESCRIPTION
## Summary

Adds missing Windows version options to the bug report issue template dropdown.

### Added versions:
- **Windows 11 (26H1): Build 28000** — released Feb 2026 for new hardware
- **Windows 11 (25H2): Build 26200** — broad rollout Sept 2025
- **Windows 11 (24H2): Build 26120** — updated 24H2 builds

These are inserted in descending order. The `Windows Insider Build (xxxxx)` catch-all remains for bleeding-edge/unreleased builds.

Fixes #10622