### PR TITLE
Add /needs-repro maintainer comment command

### DIFF
--- a/.github/workflows/needs-repro-command.yml
+++ b/.github/workflows/needs-repro-command.yml
@@ -1,0 +1,70 @@
+name: /needs-repro command
+
+# Lets maintainers request a reproduction by commenting `/needs-repro` on an
+# issue. The bot posts a message asking for a minimal repro (code snippet or,
+# ideally, a small self-contained WinUI project) and applies the needs-repro
+# and needs-author-feedback labels.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  needs-repro:
+    # Only run on issues (not PRs), when the comment contains the command, and
+    # only when the commenter is a maintainer/collaborator of the repo.
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/needs-repro') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge the command
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -H "Accept: application/vnd.github+json" \
+            -f content='eyes' || true
+
+      - name: Add labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue edit "$NUMBER" --repo "$REPO" \
+            --add-label "needs-repro" \
+            --add-label "needs-author-feedback"
+
+      - name: Post repro request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          gh issue comment "$NUMBER" --repo "$REPO" --body "$(cat <<EOF
+          Hi @$AUTHOR, thanks for filing this! To investigate we need to be able to reproduce the behavior on our side.
+
+          Could you please share a **minimal reproduction**? In order of preference:
+
+          1. **A small, self-contained WinUI 3 project** that builds and runs, and demonstrates the bug when launched — ideally a link to a GitHub repo, or a \`.zip\` attached to this issue (drag-and-drop into a comment). Please strip it down to the smallest project that still shows the problem.
+          2. **A minimal XAML + code-behind snippet** we can drop into a blank WinUI app to reproduce it.
+
+          Please also confirm:
+
+          - Exact **steps to reproduce** (what you click/do), and the **expected vs. actual** behavior.
+          - **Windows App SDK / WinUI version** and **Windows version** (e.g. \`winver\`).
+          - Whether it repros in a **clean, unpackaged and packaged** app, if known.
+
+          Once you add the repro, this issue will be re-triaged automatically. If we don't hear back within a reasonable time, the issue may be closed for housekeeping — but you're always welcome to comment to reopen the discussion. Thanks! 🙏
+          EOF
+          )"

--- a/.github/workflows/needs-repro-command.yml
+++ b/.github/workflows/needs-repro-command.yml
@@ -12,10 +12,15 @@ on:
 permissions:
   issues: write
 
+concurrency:
+  group: needs-repro-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   needs-repro:
-    # Only run on issues (not PRs), when the comment contains the command, and
-    # only when the commenter is a maintainer/collaborator of the repo.
+    # Coarse gate: only on issues (not PRs), when the comment mentions the
+    # command, and only for maintainers/collaborators. The exact-match check
+    # below rejects loose matches (quoted replies, inline mentions, suffixes).
     if: >-
       github.event.issue.pull_request == null &&
       contains(github.event.comment.body, '/needs-repro') &&
@@ -24,7 +29,23 @@ jobs:
        github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
+      - name: Detect command
+        id: detect
+        env:
+          # Passed via env (not inlined into the script) to avoid injection.
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # Only treat it as the command if some line is exactly "/needs-repro"
+          # (ignoring surrounding whitespace). This rejects quoted replies
+          # ("> /needs-repro"), inline mentions, and suffixes ("/needs-repro-x").
+          if printf '%s' "$BODY" | grep -qE '^[[:space:]]*/needs-repro[[:space:]]*$'; then
+            echo "match=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "match=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Acknowledge the command
+        if: steps.detect.outputs.match == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -34,17 +55,8 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -f content='eyes' || true
 
-      - name: Add labels
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
-        run: |
-          gh issue edit "$NUMBER" --repo "$REPO" \
-            --add-label "needs-repro" \
-            --add-label "needs-author-feedback"
-
       - name: Post repro request
+        if: steps.detect.outputs.match == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -68,3 +80,14 @@ jobs:
           Once you add the repro, this issue will be re-triaged automatically. If we don't hear back within a reasonable time, the issue may be closed for housekeeping — but you're always welcome to comment to reopen the discussion. Thanks! 🙏
           EOF
           )"
+
+      - name: Add labels
+        if: steps.detect.outputs.match == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue edit "$NUMBER" --repo "$REPO" \
+            --add-label "needs-repro" \
+            --add-label "needs-author-feedback" || true


### PR DESCRIPTION
## What

Adds a **`/needs-repro`** maintainer command. When a maintainer/collaborator comments `/needs-repro` on an issue, a GitHub Action:

- Adds the **`needs-repro`** label (and **`needs-author-feedback`**, so the existing policy bot auto-swaps it to `needs-triage` once the author replies).
- Posts a message asking the author for a **minimal reproduction** — ideally a small self-contained WinUI 3 project (repo link or attached `.zip`) that runs and shows the bug, or a minimal XAML + code-behind snippet — plus steps, expected/actual, and Windows App SDK / Windows version.
- Reacts to the command comment with 👀 to acknowledge it.

## Why

Triagers frequently need a runnable repro to investigate WinUI bugs. This standardizes the ask and the label in one comment.

## Guardrails

- Runs only on **issues** (not PRs).
- Only fires when the commenter's `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR` — so random users can't trigger it.
- The `needs-repro` label already exists in this repo.

## Notes

- `needs-author-feedback` is included so the round-trip integrates with existing automation in `resourceManagement.yml`. Happy to drop it if you'd prefer only `needs-repro`.
- Message wording is easy to tweak — see the `Post repro request` step.