### PR TITLE
TitleBar: avoid AppWindow.Title() getter reads that can fail-fast the process (#11214)

### DIFF
--- a/controls/dev/TitleBar/TitleBar.cpp
+++ b/controls/dev/TitleBar/TitleBar.cpp
@@ -486,15 +486,6 @@ void TitleBar::UpdateTitle()
 
     TITLEBAR_TRACE_VERBOSE(*this, TRACE_MSG_METH_STR, METH_NAME, this, titleText.c_str());
 
-    const auto appWindow = TryGetAppWindow();
-
-    // Capture default title once.
-    if (appWindow && !m_hasDefaultAppWindowTitle)
-    {
-        m_defaultAppWindowTitle = appWindow.Title();
-        m_hasDefaultAppWindowTitle = true;
-    }
-
     if (titleText.empty())
     {
         // Do not set appWindow.Title here. Reset is handled by ResetTitle via OnPropertyChanged.
@@ -502,41 +493,31 @@ void TitleBar::UpdateTitle()
         return;
     }
 
-    // Only set the window title if it actually needs to change.
-    if (appWindow)
+    // Mirror the TitleBar's Title into the window title.
+    //
+    // Note: we intentionally do NOT read AppWindow.Title() back first (neither to capture a
+    // "default" title nor to skip a redundant set). Reading the window title during a deferred
+    // layout pass can fault inside the windowing layer's AppWindow.Title getter when the native
+    // title is momentarily empty (E_INVALIDARG fail-fast; see #11214). Setting the title
+    // unconditionally is cheap and avoids the read entirely.
+    if (const auto appWindow = TryGetAppWindow())
     {
-        const auto currentTitle = appWindow.Title();
-        if (currentTitle != titleText)
-        {
-            appWindow.Title(titleText);
-        }
+        appWindow.Title(titleText);
     }
 
     GoToState(s_titleTextVisibleVisualStateName, false);
 }
 
-void TitleBar::ResetTitle(winrt::hstring const& lastAppliedTitle)
+void TitleBar::ResetTitle(winrt::hstring const& /*lastAppliedTitle*/)
 {
     TITLEBAR_TRACE_INFO(nullptr, TRACE_MSG_METH, METH_NAME, nullptr);
 
-    if (!m_hasDefaultAppWindowTitle)
-    {
-        return;
-    }
-
-    const auto appWindow = TryGetAppWindow();
-    if (!appWindow)
-    {
-        return;
-    }
-
-    // Restore only if the current title matches what we previously applied
-    const auto currentTitle = appWindow.Title();
-    if (lastAppliedTitle == currentTitle && currentTitle != m_defaultAppWindowTitle)
-    {
-        appWindow.Title(m_defaultAppWindowTitle);
-        m_hasDefaultAppWindowTitle = false;
-    }
+    // Previously this restored the window's original title by reading AppWindow.Title() back
+    // and comparing. That getter can fault inside the windowing layer when the native title is
+    // momentarily empty (E_INVALIDARG fail-fast; see #11214), so the read is removed and the
+    // TitleBar no longer auto-restores a previously-captured window title. Apps that need a
+    // specific window title after clearing TitleBar.Title should set Window.Title /
+    // AppWindow.Title directly.
 }
 
 void TitleBar::UpdateSubtitle()

--- a/controls/dev/TitleBar/TitleBar.h
+++ b/controls/dev/TitleBar/TitleBar.h
@@ -75,7 +75,6 @@ private:
 
     winrt::event_token m_inputActivationChangedToken{};
     winrt::event_token m_windowRectChangedToken{};
-    winrt::hstring m_defaultAppWindowTitle{};
     winrt::Button::Click_revoker m_backButtonClickRevoker{};
     winrt::Button::Click_revoker m_paneToggleButtonClickRevoker{};
     winrt::FrameworkElement::SizeChanged_revoker m_sizeChangedRevoker;
@@ -103,7 +102,6 @@ private:
 
     double m_compactModeThresholdWidth{ 0.0 };
     bool m_isCompact{ false };
-    bool m_hasDefaultAppWindowTitle{ false };
 
     static constexpr std::wstring_view s_leftPaddingColumnName{ L"LeftPaddingColumn"sv };
     static constexpr std::wstring_view s_rightPaddingColumnName{ L"RightPaddingColumn"sv };


### PR DESCRIPTION
> **Draft / discussion** — a WinUI-side mitigation for #11214. Not yet built/validated locally; opening to discuss the approach.

## Problem

`TitleBar::UpdateTitle` and `TitleBar::ResetTitle` read back `AppWindow.Title` (three getter calls) to capture/restore a "default" window title and to skip redundant sets. During a deferred layout pass at startup, that getter can fault **inside the windowing layer** when the native window title is momentarily empty, terminating the process with an `E_INVALIDARG (0x80070057)` fail-fast. Full root cause in #11214.

A `try/catch` in the control cannot help here — the failure is a fail-fast *inside* the windowing callee, not a returnable HRESULT — so the only WinUI-side mitigation is to **not perform the getter reads**.

## Change

- `UpdateTitle`: set `AppWindow.Title` unconditionally; stop reading it back (removes both the default-capture read and the redundant-set read).
- `ResetTitle`: no longer reads `AppWindow.Title`, and no longer auto-restores a previously-captured window title.
- Remove the now-unused `m_defaultAppWindowTitle` / `m_hasDefaultAppWindowTitle` members.

## Tradeoff (why this is a draft)

This drops the automatic "restore the window's original title when `TitleBar.Title` is cleared" behavior. Apps that relied on it would set `Window.Title` / `AppWindow.Title` themselves.

The **preferred** fix is in the windowing layer — make the `AppWindow.Title` getter treat an empty title as valid (it's a wrapper over `GetWindowTextLengthW`, which returns 0 for an empty title and does not reset the last-error). This PR is a middle-layer mitigation for discussion: should WinUI take it in the meantime, or rely solely on the platform fix?

Related app-side workaround: microsoft/PowerToys#49069.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
