### PR TITLE
API spec: Window showing and activation

### DIFF
--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -3,22 +3,13 @@ Window showing and activation
 
 - [Window showing and activation](#window-showing-and-activation)
 - [1. Background](#1-background)
-    - [1.1. WPF behavior](#11-wpf-behavior)
-    - [1.2. Win32 behavior](#12-win32-behavior)
-    - [1.3. API summary](#13-api-summary)
-    - [1.4. Goals](#14-goals)
-    - [1.5. Non-goals](#15-non-goals)
+  - [1.1. WPF behavior](#11-wpf-behavior)
+  - [1.2. Win32 behavior](#12-win32-behavior)
+  - [1.3. API summary](#13-api-summary)
+  - [1.4. Goals](#14-goals)
+  - [1.5. Non-goals](#15-non-goals)
 - [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
 - [3. Examples](#3-examples)
-- [4. API Pages](#4-api-pages)
-    - [4.1. Window.Show](#41-windowshow)
-    - [4.2. Window.ShowActivated](#42-windowshowactivated)
-    - [4.3. Window.TrySetForeground](#43-windowtrysetforeground)
-    - [4.4. Window.Activate](#44-windowactivate)
-- [5. API Details](#5-api-details)
-- [6. Appendix](#6-appendix)
-    - [6.1. Alternatives considered](#61-alternatives-considered)
-    - [6.2. API review status](#62-api-review-status)
 
 
 # 1. Background
@@ -140,20 +131,22 @@ The new surface keeps activation and foreground as separate, clearly named opera
 # 2. Conceptual pages (How To)
 
 _Note: This is conceptual documentation that WILL go to the online "how to"
-page on learn.microsoft.com._
-A WinUI `Window` does two separate jobs: showing a window, and taking the
-foreground. These new APIs keep those jobs apart, so you can pick the behavior
-you want.
+page on learn.microsoft.com. It may extend, for example, the 
+[Manage app windows](https://learn.microsoft.com/windows/apps/develop/ui/manage-app-windows)
+conceptual page rather than starting a new one._
 
-- Call `Show()` to display a window. By default it also activates the window,
-  just like WPF.
+A WinUI `Window` represents a top-level window on the desktop. Showing that
+window and bringing it to the foreground are two separate operations, and these
+new APIs keep them apart so you can pick the behavior you want.
+
+- Call `Show()` to display a window. By default it also activates the window.
 - Set `ShowActivated = false` before `Show()` when you do not want the window
   to steal focus. This is the right choice for non-interrupting windows such as
   overlays, toasts, splash screens, search palettes, and tool windows.
 - Call `TrySetForeground()` to ask Windows to bring an already-shown window to the
   foreground. Windows can say no, so treat the return value as "maybe".
-- `Activate()` is the old call that did both jobs at once. It still works, but
-  it is deprecated. New code should use `Show()`.
+- `Activate()` is the old call that showed the window and activated it together.
+  It still works, but it is deprecated. New code should use `Show()`.
 
 # 3. Examples
 

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -1,12 +1,37 @@
 Window showing and activation
 ===
 
-> **STATUS: DRAFT FOR API REVIEW**
->
-> This proposal is intentionally open for design feedback. The API shape and
-> behavior are not approved.
+- [Window showing and activation](#window-showing-and-activation)
+- [1. Background](#1-background)
+    - [1.1. WPF behavior](#11-wpf-behavior)
+    - [1.2. Win32 behavior](#12-win32-behavior)
+    - [1.3. API summary](#13-api-summary)
+    - [1.4. Goals](#14-goals)
+    - [1.5. Non-goals](#15-non-goals)
+- [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
+- [3. Examples](#3-examples)
+- [4. API Pages](#4-api-pages)
+    - [4.1. Window.Show](#41-windowshow)
+    - [4.2. Window.ShowActivated](#42-windowshowactivated)
+    - [4.3. Window.TrySetForeground](#43-windowtrysetforeground)
+    - [4.4. Window.Activate](#44-windowactivate)
+- [5. API Details](#5-api-details)
+- [6. Appendix](#6-appendix)
+    - [6.1. Alternatives considered](#61-alternatives-considered)
+    - [6.2. API review status](#62-api-review-status)
 
-# Background
+
+# 1. Background
+
+_Note: This section is background to help you read the spec. It does NOT go to
+the online docs._
+
+**TL;DR**: The plan in this doc is:
+- Add **Show()**  (match WPF)
+- Add **ShowActivated** prop  (match WPF)
+- Add **TrySetForeground()**  (works like WPF's "Activate")
+- Deprecate **Activate()**
+
 
 [Issue #7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595)
 reports that `Window.Activate()` does not bring a background WinUI window to
@@ -42,7 +67,7 @@ This proposal separates those jobs. It adds WPF-style APIs for showing a
 window, adds an explicit fallible foreground request, and keeps the existing
 `Activate()` behavior for compatibility.
 
-## WPF behavior
+## 1.1. WPF behavior
 
 WPF has three relevant members:
 
@@ -53,7 +78,7 @@ WPF has three relevant members:
 | [`Window.Activate()`](https://learn.microsoft.com/dotnet/api/system.windows.window.activate) | Attempts to bring an existing window to the foreground and activate it. It returns whether activation succeeded and follows the Win32 `SetForegroundWindow` rules. |
 
 
-## Win32 behavior
+## 1.2. Win32 behavior
 
 Win32 also separates showing, thread activation, and foreground activation:
 
@@ -87,7 +112,18 @@ button instead. A WinUI API that requests foreground activation must preserve
 these rules, must not promise success, and should expose denial as a normal
 outcome rather than an exceptional failure.
 
-# Goals
+## 1.3. API summary
+
+The new surface keeps activation and foreground as separate, clearly named operations:
+
+| API | Win32 call | What it does | Can Windows deny it? |
+| --- | --- | --- | --- |
+| `Show()` with `ShowActivated = true` | `ShowWindow` (`SW_SHOW` family) | Shows the window and activates it at show time | No explicit foreground request |
+| `Show()` with `ShowActivated = false` | `ShowWindow` (`SW_SHOWNOACTIVATE` family) | Shows the window without activating it | n/a |
+| `TrySetForeground()` | `SetForegroundWindow` | Requests system-wide foreground for an already-shown window | Yes, returns `false` if denied |
+| `Activate()` (legacy) | `ShowWindow` + `SetActiveWindow` | Shows and selects the thread's active window | No, but cannot take foreground from another app |
+
+## 1.4. Goals
 
 - Give WinUI apps a clear way to show a window without taking focus.
 - Give WinUI apps a clear way to request foreground activation.
@@ -95,43 +131,69 @@ outcome rather than an exceptional failure.
 - Preserve Windows foreground-lock behavior.
 - Preserve the existing `Window.Activate()` behavior for compatibility.
 
-# Non-goals
+## 1.5. Non-goals
 
 - Do not bypass Windows foreground-lock rules.
 - Do not guarantee that a background window becomes foreground.
 - Do not change the behavior of `Window.Activate()`.
 
-# Proposed API
+# 2. Conceptual pages (How To)
 
-Add the missing WPF-style show surface and a separate foreground request:
+_Note: This is conceptual documentation that WILL go to the online "how to"
+page on learn.microsoft.com._
+A WinUI `Window` does two separate jobs: showing a window, and taking the
+foreground. These new APIs keep those jobs apart, so you can pick the behavior
+you want.
+
+- Call `Show()` to display a window. By default it also activates the window,
+  just like WPF.
+- Set `ShowActivated = false` before `Show()` when you do not want the window
+  to steal focus. This is the right choice for non-interrupting windows such as
+  overlays, toasts, splash screens, search palettes, and tool windows.
+- Call `TrySetForeground()` to ask Windows to bring an already-shown window to the
+  foreground. Windows can say no, so treat the return value as "maybe".
+- `Activate()` is the old call that did both jobs at once. It still works, but
+  it is deprecated. New code should use `Show()`.
+
+# 3. Examples
+
+_Note: These examples WILL go to the online "how to" page on
+learn.microsoft.com._
+
+Show a window the normal way. It activates by default:
+
+````csharp
+Window window = new();
+window.Show();
+```
+
+Show a tool window without stealing focus:
 
 ```csharp
-namespace Microsoft.UI.Xaml
-{
-    unsealed runtimeclass Window
-    {
-        Boolean ShowActivated { get; set; };
-        void Show();
-        Boolean TryActivate();
+Window toolWindow = new();
+toolWindow.ShowActivated = false;
+toolWindow.Show();
+```
 
-        // Existing, will be deprecated.  Behavior does not change.
-        void Activate();
-    }
+Ask Windows to bring an existing window to the foreground, and handle the case
+where Windows keeps the current foreground window:
+
+```csharp
+window.Show();
+
+if (!window.TrySetForeground())
+{
+    // Windows kept the current foreground window.
+    // For example, you could flash the taskbar button instead.
 }
 ```
 
-These APIs handle two different points in the window lifecycle:
+# 4. API Pages
 
-- `ShowActivated` controls whether showing a hidden window also activates it.
-- `TryActivate()` asks Windows to activate a window after it has been shown.
+_Note: Each of the following sections WILL become a page on
+learn.microsoft.com._
 
-The show-time option is needed for non-interrupting windows such as overlays,
-toasts, splash screens, search palettes, and tool windows. Public WPF apps use
-`ShowActivated = false` for these scenarios.
-
-# API behavior
-
-## Window.Show
+## 4.1. Window.Show
 
 Shows the window and returns immediately.
 
@@ -145,7 +207,7 @@ window-state APIs.
 Calling `Show()` after the window has closed produces the same error behavior
 as calling `Activate()` after close.
 
-## Window.ShowActivated
+## 4.2. Window.ShowActivated
 
 Gets or sets whether `Show()` activates the window.
 
@@ -155,21 +217,26 @@ activate or deactivate a window that is already visible, but the new value is
 used after a later `Hide()` and `Show()` sequence. As in WPF, the value is also
 used when a minimized window is restored through the window-state APIs.
 
+ShowActivated only chooses the `ShowWindow` activation flag (an `SW_SHOW`-family
+flag when true, an `SW_SHOWNOACTIVATE`-family flag when false). It does not call
+`SetForegroundWindow`, which is why showing and foreground activation are named
+differently.
+
 ```csharp
 Window toolWindow = new();
 toolWindow.ShowActivated = false;
 toolWindow.Show();
 ```
 
-## Window.TryActivate
+## 4.3. Window.TrySetForeground
 
-Asks Windows to make the window foreground and active.
+Asks Windows to make the window the foreground window.
 
 WinUI calls `SetForegroundWindow` and returns `true` when Windows accepts the
 request. It returns `false` when Windows denies the request under its normal
 foreground-lock rules.
 
-`TryActivate()` does not bypass Windows restrictions and does not treat a
+`TrySetForeground()` does not bypass Windows restrictions and does not treat a
 denied request as an exception. It does not show or restore the window. Apps
 should show a hidden window or restore a minimized window through the
 appropriate window API before calling it.
@@ -177,13 +244,13 @@ appropriate window API before calling it.
 ```csharp
 window.Show();
 
-if (!window.TryActivate())
+if (!window.TrySetForeground())
 {
     // Windows kept the current foreground window.
 }
 ```
 
-## Window.Activate
+## 4.4. Window.Activate
 
 `Window.Activate()` keeps its existing `ShowWindow`, `UpdateWindow`, and
 `SetActiveWindow` behavior.
@@ -191,23 +258,53 @@ if (!window.TryActivate())
 The API is deprecated. New code can safely switch to use `Show()`.
 
 
-# Appendix: Alternatives considered
+# 5. API Details
 
-- **Change `Window.Activate()` to call `SetForegroundWindow`.** This matches
-  the name and WPF behavior, but then WinUI apps do not have the ability to
-  show a window normally or quietly without jumping to the foreground.
+_Note: This is the API definition (MIDL). The doc comments in it feed
+Intellisense and the online docs, but the block itself is a spec reference and
+does NOT go to the online docs as-is._
 
-- **Add `Window.SetForeground()`.** This directly represents
-  `SetForegroundWindow`, but the operation can be denied during normal use and
-  "foreground" exposes Win32 terminology that WPF presents as activation. This
-  proposal uses `TryActivate()` to make the fallibility clear while staying
-  closer to WPF naming.
+```csharp
+namespace Microsoft.UI.Xaml
+{
+    unsealed runtimeclass Window
+    {
+        Boolean ShowActivated { get; set; };
+        void Show();
+        Boolean TrySetForeground();
 
-- **Add only `Window.Show()`.** This is simpler, but it does not give apps a
-  framework-level way to show tool windows, palettes, or notifications without
-  activation. WPF and Win32 both support that scenario.
+        // Existing, will be deprecated.  Behavior does not change.
+        void Activate();
+    }
+}
+```
 
-# API review status
+# 6. Appendix
+
+_Note: This section is a spec aid for design notes. It does NOT go to the
+online docs._
+
+## 6.1. Alternatives considered
+
+- **Keep `TryActivate()`.** This stays closest to WPF's `Window.Activate()`
+  name, but it collides with WinUI's existing `Activate()` (which only does
+  thread-level `SetActiveWindow`). Developers would read `TryActivate()` as a
+  bool-returning `Activate()`, when it actually adds the fallible cross-process
+  `SetForegroundWindow`. Same word, stronger behavior, right next to each other.
+
+- **Change `Window.Activate()` to call `SetForegroundWindow`.** This matches WPF
+  behavior, but it silently changes shipped WinUI behavior and removes the
+  ability to show a window quietly.
+
+- **Add only `Window.Show()`.** Simpler, but it gives apps no framework-level
+  way to request foreground for a window that is already shown.
+
+We chose `TrySetForeground()` because it names the exact Win32 operation
+(`SetForegroundWindow`), the `Try`/`bool` shape makes denial a normal outcome,
+and it keeps 'foreground' distinct from the thread-level 'activate' vocabulary.
+
+## 6.2. API review status
 
 This API is not approved. This draft is meant to gather public feedback before
 the implementation or API shape is finalized.
+````

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -12,25 +12,35 @@ Window showing and activation
 reports that `Window.Activate()` does not bring a background WinUI window to
 the foreground unless the window is minimized.
 
-The current WinUI implementation uses this sequence:
+Today, an app creates a WinUI `Window` and calls `Window.Activate()` to show
+it. In response, WinUI calls `ShowWindow` to show or restore the backing HWND,
+`UpdateWindow` to paint it, and `SetActiveWindow` to make it the active window
+for the calling thread.
 
-1. `ShowWindow` to make the HWND visible or restore it.
-2. `UpdateWindow` to paint it.
-3. `SetActiveWindow` to activate it within the calling thread.
+The important distinction is between an *active window* and the *foreground
+window*.
 
-This works when the app is already the foreground app, but
 [`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow)
-does not bring a background app to the foreground.
+only activates a window attached to the calling thread's message queue. If the
+app is already the foreground app, Windows also brings that window to the top
+of the foreground app's Z-order. If another app is foreground,
+`SetActiveWindow` does not move the calling app to the foreground. This is why
+the current WinUI `Window.Activate()` can select a window within the WinUI app,
+but cannot take foreground from another process.
 
-The first implementation considered changing `Window.Activate()` to call
-`SetForegroundWindow`, then pivoted to a separate `Window.SetForeground()`
-method. Neither choice fully accounts for the fact that WinUI currently uses
-`Activate()` for two different jobs:
+[`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow)
+is the Win32 request that can cross that process boundary. If Windows allows
+the request, it makes the target window foreground, activates it, and directs
+keyboard input to it. The request is not guaranteed to succeed.
+
+WinUI currently uses `Activate()` for two different jobs:
 
 - Showing a window for the first time.
 - Asking an existing window to become active.
 
-Those jobs are separate in WPF and in Win32.
+This proposal separates those jobs. It adds WPF-style APIs for showing a
+window, adds an explicit fallible foreground request, and keeps the existing
+`Activate()` behavior for compatibility.
 
 ## WPF behavior
 
@@ -42,13 +52,6 @@ WPF has three relevant members:
 | [`Window.ShowActivated`](https://learn.microsoft.com/dotnet/api/system.windows.window.showactivated) | Controls whether the window is activated when it is first shown. The default is `true`. Apps set it to `false` before `Show()` to show without activation. |
 | [`Window.Activate()`](https://learn.microsoft.com/dotnet/api/system.windows.window.activate) | Attempts to bring an existing window to the foreground and activate it. It returns whether activation succeeded and follows the Win32 `SetForegroundWindow` rules. |
 
-This split lets a WPF app show a window without activation while keeping
-`Activate()` focused on foreground activation.
-
-WinUI has no public `Window.Show()` API or `ShowActivated` property. Apps call
-`Window.Activate()` to show a newly created window. Changing that method to
-always request foreground activation could cause existing secondary windows,
-tool windows, and palettes to take focus when an app only meant to show them.
 
 ## Win32 behavior
 
@@ -57,13 +60,32 @@ Win32 also separates showing, thread activation, and foreground activation:
 | API | Behavior |
 | --- | --- |
 | [`ShowWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-showwindow) | Changes the window's show state. Flags such as `SW_SHOW` activate the window, while `SW_SHOWNOACTIVATE` and `SW_SHOWNA` show it without activation. |
-| [`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow) | Activates a window attached to the calling thread's message queue. It does not bring a background application to the foreground. |
-| [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) | Requests foreground activation. Windows can deny the request under its foreground-lock rules. |
+| [`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow) | Selects the active window for the calling thread's message queue. It brings the window to the top only when the calling app is already foreground. |
+| [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) | Asks Windows to make the window foreground and active, even if another app is currently foreground. Windows can deny the request. |
 
-An app cannot force foreground activation while the user is working in
-another app. If Windows denies `SetForegroundWindow`, it can flash the taskbar
+Windows limits foreground changes so a background app cannot freely interrupt
+the user. According to the `SetForegroundWindow` documentation, all of these
+conditions must be true:
+
+- The caller is a desktop app.
+- The foreground process has not called `LockSetForegroundWindow` to block the
+  request.
+- No menus are active.
+
+At least one of these conditions must also be true:
+
+- The foreground-lock timeout has expired.
+- The calling process is already foreground.
+- The foreground process started the calling process.
+- There is no foreground process.
+- The calling process received the last input event.
+- Either the calling process or foreground process is being debugged.
+
+Windows may still deny the request even when these conditions appear to be
+met. When foreground activation is denied, Windows can flash the app's taskbar
 button instead. A WinUI API that requests foreground activation must preserve
-these rules and must not promise success.
+these rules, must not promise success, and should expose denial as a normal
+outcome rather than an exceptional failure.
 
 # Goals
 
@@ -71,20 +93,17 @@ these rules and must not promise success.
 - Give WinUI apps a clear way to request foreground activation.
 - Align with WPF where that produces a usable and compatible WinUI API.
 - Preserve Windows foreground-lock behavior.
-- Avoid changing existing app behavior without an explicit compatibility plan.
+- Preserve the existing `Window.Activate()` behavior for compatibility.
 
 # Non-goals
 
 - Do not bypass Windows foreground-lock rules.
 - Do not guarantee that a background window becomes foreground.
-- Do not silently change `Window.Activate()` until the compatibility impact is
-  understood.
-- Do not approve a final API shape in this initial draft.
+- Do not change the behavior of `Window.Activate()`.
 
-# Proposed direction
+# Proposed API
 
-The current direction is to add the missing WPF-style show surface before
-changing foreground activation behavior:
+Add the missing WPF-style show surface and a separate foreground request:
 
 ```csharp
 namespace Microsoft.UI.Xaml
@@ -93,58 +112,22 @@ namespace Microsoft.UI.Xaml
     {
         Boolean ShowActivated { get; set; };
         void Show();
+        Boolean TryActivate();
+
+        // Existing, will be deprecated.  Behavior does not change.
+        void Activate();
     }
 }
 ```
 
-`ShowActivated` would default to `true`. Apps could set it to `false` before
-the first call to `Show()` to display a window without activating it.
+These APIs handle two different points in the window lifecycle:
 
-This gives WinUI a dedicated show operation and removes the main reason that
-apps must use `Activate()` for first-time display.
+- `ShowActivated` controls whether showing a hidden window also activates it.
+- `TryActivate()` asks Windows to activate a window after it has been shown.
 
-The exact future of `Window.Activate()` remains an API review question. Options
-include:
-
-1. Keep its current behavior for compatibility and add a separate fallible
-   foreground API.
-2. Change it in a future compatibility boundary to follow WPF and
-   `SetForegroundWindow`.
-3. Deprecate it after adding clearer show and foreground APIs.
-
-# Alternatives considered
-
-## Change Window.Activate
-
-Change the existing method to call `SetForegroundWindow`.
-
-This matches the name and WPF behavior, but it can break apps that currently
-call `Activate()` only because WinUI lacks `Show()`. Those apps could start
-taking focus unexpectedly.
-
-## Add Window.SetForeground
-
-Add a method that directly represents `SetForegroundWindow` and returns
-whether Windows accepted the request.
-
-```csharp
-Boolean SetForeground();
-```
-
-This is explicit and preserves the current `Activate()` behavior. However,
-WPF does not expose this API shape, and adding it without first addressing
-WinUI's missing show API moves the frameworks further apart.
-
-If this option is selected, `TrySetForeground` may be a clearer name because
-failure is a normal result under Windows foreground-lock rules.
-
-## Add only Window.Show
-
-Add `Show()` but no `ShowActivated` property.
-
-This is simpler, but it does not give apps a framework-level way to show tool
-windows, palettes, or notifications without activation. WPF and Win32 both
-support that scenario.
+The show-time option is needed for non-interrupting windows such as overlays,
+toasts, splash screens, search palettes, and tool windows. Public WPF apps use
+`ShowActivated = false` for these scenarios.
 
 # API behavior
 
@@ -152,8 +135,12 @@ support that scenario.
 
 Shows the window and returns immediately.
 
-On the first show, WinUI uses `ShowActivated` to decide whether to request
-activation. Later calls show or restore the window using the same setting.
+When `Show()` changes a hidden window to visible, WinUI uses the current
+`ShowActivated` value to decide whether the operation should activate it.
+
+If the window is already visible, `Show()` does nothing. This includes a
+minimized window, which is still visible and must be restored through the
+window-state APIs.
 
 Calling `Show()` after the window has closed produces the same error behavior
 as calling `Activate()` after close.
@@ -162,8 +149,11 @@ as calling `Activate()` after close.
 
 Gets or sets whether `Show()` activates the window.
 
-The default value is `true`. The property must be set before the first call to
-`Show()`. Changing it after the window is first shown has no effect.
+The default value is `true`. Set it to `false` before calling `Show()` to show
+the window without activation. Changing the property does not retroactively
+activate or deactivate a window that is already visible, but the new value is
+used after a later `Hide()` and `Show()` sequence. As in WPF, the value is also
+used when a minimized window is restored through the window-state APIs.
 
 ```csharp
 Window toolWindow = new();
@@ -171,21 +161,51 @@ toolWindow.ShowActivated = false;
 toolWindow.Show();
 ```
 
-# Open questions
+## Window.TryActivate
 
-- Should WinUI match WPF exactly by adding both `Show()` and `ShowActivated`?
-- Should `ShowActivated` apply only to the first show, like WPF, or to every
-  call to `Show()`?
-- Should `Window.Activate()` eventually use `SetForegroundWindow`, remain
-  unchanged, or be deprecated?
-- If compatibility prevents changing `Activate()`, should the foreground API
-  be named `SetForeground`, `TrySetForeground`, or `TryActivate`?
-- How should the API report foreground denial without treating normal Windows
-  behavior as an exception?
-- Should a foreground API restore or show a hidden or minimized window, or
-  only operate on an already visible window?
-- Are `Show()` and `ShowActivated` desktop-only, or can they have meaningful
-  behavior for UWP?
+Asks Windows to make the window foreground and active.
+
+WinUI calls `SetForegroundWindow` and returns `true` when Windows accepts the
+request. It returns `false` when Windows denies the request under its normal
+foreground-lock rules.
+
+`TryActivate()` does not bypass Windows restrictions and does not treat a
+denied request as an exception. It does not show or restore the window. Apps
+should show a hidden window or restore a minimized window through the
+appropriate window API before calling it.
+
+```csharp
+window.Show();
+
+if (!window.TryActivate())
+{
+    // Windows kept the current foreground window.
+}
+```
+
+## Window.Activate
+
+`Window.Activate()` keeps its existing `ShowWindow`, `UpdateWindow`, and
+`SetActiveWindow` behavior.
+
+The API is deprecated. New code can safely switch to use `Show()`.
+
+
+# Appendix: Alternatives considered
+
+- **Change `Window.Activate()` to call `SetForegroundWindow`.** This matches
+  the name and WPF behavior, but then WinUI apps do not have the ability to
+  show a window normally or quietly without jumping to the foreground.
+
+- **Add `Window.SetForeground()`.** This directly represents
+  `SetForegroundWindow`, but the operation can be denied during normal use and
+  "foreground" exposes Win32 terminology that WPF presents as activation. This
+  proposal uses `TryActivate()` to make the fallibility clear while staying
+  closer to WPF naming.
+
+- **Add only `Window.Show()`.** This is simpler, but it does not give apps a
+  framework-level way to show tool windows, palettes, or notifications without
+  activation. WPF and Win32 both support that scenario.
 
 # API review status
 

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -11,8 +11,13 @@ Window showing and activation
 - [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
 - [3. Examples](#3-examples)
 - [4. API Pages](#4-api-pages)
+  - [4.1. Window.TrySetForeground](#41-windowtrysetforeground)
+  - [4.2. Window.Activate](#42-windowactivate)
 - [5. API Details](#5-api-details)
 - [6. Appendix](#6-appendix)
+  - [6.1. Alternatives considered](#61-alternatives-considered)
+  - [6.2. Future directions](#62-future-directions)
+  - [6.3. API review status](#63-api-review-status)
 
 
 # 1. Background
@@ -26,7 +31,6 @@ the online docs._
 
 (An earlier draft also added `Show()` and a `ShowActivated` property to match
 WPF. We cut those to keep this change small and low-risk. See the appendix.)
-
 
 [Issue #7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595)
 reports that `Window.Activate()` does not bring a background WinUI window to
@@ -71,8 +75,15 @@ WPF has three relevant members:
 | [`Window.ShowActivated`](https://learn.microsoft.com/dotnet/api/system.windows.window.showactivated) | Controls whether the window is activated when it is first shown. The default is `true`. Apps set it to `false` before `Show()` to show without activation. |
 | [`Window.Activate()`](https://learn.microsoft.com/dotnet/api/system.windows.window.activate) | Attempts to bring an existing window to the foreground and activate it. It returns whether activation succeeded and follows the Win32 `SetForegroundWindow` rules. |
 
-Only `Window.Activate()` is in scope for this proposal. `Show()` and
-`ShowActivated` are listed under future directions in the appendix.
+WPF's names are a little inside-out. `ShowActivated` is the property that is
+really about activation, while `Activate()` is really about taking the
+foreground: under the hood it calls `SetForegroundWindow`. So the method named
+"activate" is the one that pulls the window to the front.
+
+WinUI's `Activate()` looks the same but only does thread-level activation
+(`SetActiveWindow`), so it cannot pull a window forward across processes. Same
+name, less power. That gap is what `TrySetForeground()` fills. See section 1.2
+for the two levels of "activate" in Win32.
 
 ## 1.2. Win32 behavior
 

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -1,13 +1,13 @@
 Window showing and activation
 ===
 
+> **Status: Placeholder**.  This API has not yet been reviewed and approved.
+
 - [Window showing and activation](#window-showing-and-activation)
 - [1. Background](#1-background)
   - [1.1. WPF behavior](#11-wpf-behavior)
   - [1.2. Win32 behavior](#12-win32-behavior)
   - [1.3. API summary](#13-api-summary)
-  - [1.4. Goals](#14-goals)
-  - [1.5. Non-goals](#15-non-goals)
 - [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
 - [3. Examples](#3-examples)
 - [4. API Pages](#4-api-pages)
@@ -17,7 +17,6 @@ Window showing and activation
 - [6. Appendix](#6-appendix)
   - [6.1. Alternatives considered](#61-alternatives-considered)
   - [6.2. Future directions](#62-future-directions)
-  - [6.3. API review status](#63-api-review-status)
 
 
 # 1. Background
@@ -26,44 +25,44 @@ _Note: This section is background to help you read the spec. It does NOT go to
 the online docs._
 
 **TL;DR**: The plan in this doc is:
-- Add **TrySetForeground()**  (works like WPF's "Activate")
-- Keep **Activate()** exactly as it is today
+- Add **TrySetForeground()** for the case where an already-shown window needs to
+  come forward, such as a single-instance relaunch. It asks Windows for the
+  foreground, and Windows can still say no.
+- Keep **Activate()** exactly as it is today, because existing apps rely on how
+  it behaves now.
 
 (An earlier draft also added `Show()` and a `ShowActivated` property to match
 WPF. We cut those to keep this change small and low-risk. See the appendix.)
 
 [Issue #7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595)
 reports that `Window.Activate()` does not bring a background WinUI window to
-the foreground unless the window is minimized.
+the foreground unless the window is minimized. It is a long-standing request,
+open since 2022.
 
-Today, an app creates a WinUI `Window` and calls `Window.Activate()` to show
-it. In response, WinUI calls `ShowWindow` to show or restore the backing HWND,
-`UpdateWindow` to paint it, and `SetActiveWindow` to make it the active window
-for the calling thread.
+The main scenario is **single-instancing**. A single-instance app wants a second
+launch to bring the already-running window forward. The Windows App SDK already
+has most of the plumbing for this. The second instance calls
+[`AppInstance.RedirectActivationToAsync`](https://learn.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-instancing),
+which is designed to grant foreground rights to the running instance (it calls
+`AllowSetForegroundWindow` under the hood) before it raises that instance's
+`Activated` event. (You can see this in the WindowsAppSDK source,
+`dev/AppLifecycle/AppInstance.cpp`.)
 
-The important distinction is between an *active window* and the *foreground
-window*.
+That makes the running instance's `Activated` handler the right place to come
+forward. The missing piece is a WinUI call that actually does it. `Activate()`
+will not: it calls `SetActiveWindow`, which only activates a window on the
+calling thread and cannot pull the foreground from another thread or process,
+which is exactly the single-instance case. There is no WinUI API that crosses
+that boundary, and `AppWindow` has no foreground method either. So Microsoft's
+own
+[single-instance walkthrough](https://learn.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-single-instance)
+drops to a raw Win32 `SetForegroundWindow` P/Invoke to finish the job.
+Sections 1.1 and 1.2 have the details.
 
-[`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow)
-only activates a window attached to the calling thread's message queue. If the
-app is already the foreground app, Windows also brings that window to the top
-of the foreground app's Z-order. If another app is foreground,
-`SetActiveWindow` does not move the calling app to the foreground. This is why
-the current WinUI `Window.Activate()` can select a window within the WinUI app,
-but cannot take foreground from another process.
-
-[`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow)
-is the Win32 request that can cross that process boundary. If Windows allows
-the request, it makes the target window foreground, activates it, and directs
-keyboard input to it. The request is not guaranteed to succeed.
-
-There is no WinUI API that asks Windows to bring an already-shown window to the
-foreground across the process boundary. `Activate()` only does thread-level
-activation, and `AppWindow` has no foreground method either.
-
-This proposal adds one explicit, fallible foreground request,
-`TrySetForeground()`, and leaves the existing `Activate()` behavior exactly as
-it is today.
+This proposal adds that one missing call: `TrySetForeground()`, the managed API
+for that same `SetForegroundWindow`. Put it in the `Activated` handler instead of
+the P/Invoke. It is still a request that Windows can deny, so it returns a
+`bool`. `Activate()` stays exactly as it is today.
 
 ## 1.1. WPF behavior
 
@@ -75,15 +74,13 @@ WPF has three relevant members:
 | [`Window.ShowActivated`](https://learn.microsoft.com/dotnet/api/system.windows.window.showactivated) | Controls whether the window is activated when it is first shown. The default is `true`. Apps set it to `false` before `Show()` to show without activation. |
 | [`Window.Activate()`](https://learn.microsoft.com/dotnet/api/system.windows.window.activate) | Attempts to bring an existing window to the foreground and activate it. It returns whether activation succeeded and follows the Win32 `SetForegroundWindow` rules. |
 
-WPF's names are a little inside-out. `ShowActivated` is the property that is
-really about activation, while `Activate()` is really about taking the
-foreground: under the hood it calls `SetForegroundWindow`. So the method named
-"activate" is the one that pulls the window to the front.
+WPF's naming is a little odd: `Activate()` actually calls `SetForegroundWindow`,
+so the method named "activate" is the one that pulls the window to the front.
 
 WinUI's `Activate()` looks the same but only does thread-level activation
-(`SetActiveWindow`), so it cannot pull a window forward across processes. Same
-name, less power. That gap is what `TrySetForeground()` fills. See section 1.2
-for the two levels of "activate" in Win32.
+(`SetActiveWindow`), so it cannot pull the foreground from another thread or
+process. Same name as WPF, less power. That gap is what `TrySetForeground()`
+fills. Section 1.2 has the two levels of "activate" in Win32.
 
 ## 1.2. Win32 behavior
 
@@ -92,8 +89,8 @@ Win32 also separates showing, thread activation, and foreground activation:
 | API | Behavior |
 | --- | --- |
 | [`ShowWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-showwindow) | Changes the window's show state. Flags such as `SW_SHOW` activate the window, while `SW_SHOWNOACTIVATE` and `SW_SHOWNA` show it without activation. |
-| [`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow) | Selects the active window for the calling thread's message queue. It brings the window to the top only when the calling app is already foreground. |
-| [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) | Asks Windows to make the window foreground and active, even if another app is currently foreground. Windows can deny the request. |
+| [`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow) | Selects the active window for the calling thread's message queue. It cannot take the foreground for a background app; the window comes to the top only when the app is already in the foreground. |
+| [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) | Asks Windows to make the window foreground and active, even when the current foreground window is on another thread or process. Windows can deny the request. |
 
 Windows limits foreground changes so a background app cannot freely interrupt
 the user. Roughly, the request is allowed when the calling app already has some
@@ -112,26 +109,11 @@ should treat denial as a normal outcome rather than an error.
 The new API names the foreground request as its own operation, separate from the
 existing thread-level activate:
 
-| API | Win32 call | What it does | Can Windows deny it? |
+| API | Win32 call | What it does | Foreground request? |
 | --- | --- | --- | --- |
-| `TrySetForeground()` | `SetForegroundWindow` | Requests system-wide foreground for an already-shown window | Yes, returns `false` if denied |
-| `Activate()` (unchanged) | `ShowWindow` + `SetActiveWindow` | Shows and selects the thread's active window | No, but cannot take foreground from another app |
+| `TrySetForeground()` | `SetForegroundWindow` | Requests system-wide foreground for an already-shown window | Yes. Windows can deny it, and it returns `false`. |
+| `Activate()` (unchanged) | `ShowWindow` + `SetActiveWindow` | Shows the window and sets it active on its own thread | No. It does not request foreground, so it cannot pull the window in front of another app. |
 
-## 1.4. Goals
-
-- Give WinUI apps a clear way to request foreground activation.
-- Preserve Windows foreground-lock behavior.
-- Preserve the existing `Window.Activate()` behavior for compatibility.
-- Keep the change small and low-risk.
-
-## 1.5. Non-goals
-
-- Do not bypass Windows foreground-lock rules.
-- Do not guarantee that a background window becomes foreground.
-- Do not change the behavior of `Window.Activate()`.
-- Do not add `Show()` or a `ShowActivated` property in this proposal.
-  `AppWindow.Show(Boolean)` already shows a window with or without activation, so
-  that story is deferred. See the appendix.
 
 # 2. Conceptual pages (How To)
 
@@ -141,34 +123,88 @@ page on learn.microsoft.com. It may extend, for example, the
 conceptual page rather than starting a new one._
 
 A WinUI `Window` represents a top-level window on the desktop. Showing a window
-and bringing it to the foreground are two separate operations.
+and bringing it to the foreground are two separate operations, and neither one
+is guaranteed to leave your window active and in front. Windows has the final
+say.
 
-- Call `Activate()` to show and activate a window, the same as always.
-- Call `TrySetForeground()` to ask Windows to bring an already-shown window to
-  the foreground. Windows can say no, so treat the return value as "maybe". This
-  is what you want when a background window needs the user's attention, which is
-  the case WinUI's thread-level `Activate()` cannot handle on its own.
+**`Activate()`** calls the Win32
+[`ShowWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-showwindow)
+and
+[`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow)
+functions to show the window and mark it active on its own thread. What
+the user sees depends on who has the foreground:
+
+- If your app already has the foreground, the window comes up front and active,
+  the way you would expect.
+- If another process has the foreground, `Activate()` does not pull your window
+  in front of it. The window still shows, but it stays behind the active app and
+  does not steal focus. So "activate" does not always mean "comes to the front."
+
+**`TrySetForeground()`** calls the Win32
+[`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow)
+function to ask Windows to make the window the foreground window.
+Windows grants it only when your app has a claim to the foreground, for example
+it is already foreground, it launched the current foreground app, it got the
+last input event, or a single-instance redirect just handed it foreground
+rights.
+
+When Windows says no:
+
+- The foreground does not change and your window stays where it was.
+- Windows flashes your taskbar button to signal that you want attention.
+- The call returns `false`.
+
+`TrySetForeground()` also does nothing to a hidden or minimized window on its
+own. Call `Activate()` to show a hidden window, or use the window's
+[`OverlappedPresenter.Restore()`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.overlappedpresenter.restore)
+to bring back a minimized one, then call `TrySetForeground()`.
+
+A key scenario for `TrySetForeground()` is when an app is a single-instance app:
+after a second launch redirects to it, the running instance calls
+`TrySetForeground()` to come forward. See the
+[single-instance walkthrough](https://learn.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-single-instance)
+for the redirect pattern.
+
+These behaviors come straight from the Win32 functions underneath. See the
+[`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow)
+and
+[`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow)
+reference pages for more detail.
 
 # 3. Examples
 
 _Note: These examples WILL go to the online "how to" page on
 learn.microsoft.com._
 
-Show and activate a window the normal way:
+**Bring a single-instance app forward.** A single-instance app redirects a
+second launch to the instance that is already running (see the
+[single-instance walkthrough](https://learn.microsoft.com/windows/apps/windows-app-sdk/applifecycle/applifecycle-single-instance)).
+The redirect grants foreground rights to the running instance, then raises its
+`Activated` event. That handler is the right place to come forward. Restore the
+window first if it is minimized, then call `TrySetForeground()`. Windows can
+still deny it, so check the return value:
 
 ```csharp
-Window window = new();
-window.Activate();
+private void OnActivated(object sender, AppActivationArguments args)
+{
+    // The user launched a second copy, and it redirected here.
+    // The redirect granted us foreground rights, but Windows can still say no.
+    if (!_mainWindow.TrySetForeground())
+    {
+        // Windows kept the current foreground window.
+    }
+}
 ```
 
-Later, ask Windows to bring that window to the foreground, and handle the case
-where Windows keeps the current foreground window:
+**Handle a denied request.** Windows can keep the current foreground window, so
+check the return value:
 
 ```csharp
 if (!window.TrySetForeground())
 {
-    // Windows kept the current foreground window.
-    // For example, you could flash the taskbar button instead.
+    // Windows kept the current foreground window and flashed our taskbar
+    // button to signal that we want attention. There is usually nothing
+    // more to do here.
 }
 ```
 
@@ -179,16 +215,23 @@ learn.microsoft.com._
 
 ## 4.1. Window.TrySetForeground
 
-Asks Windows to make the window the foreground window.
+Asks Windows to make the window the foreground window. You can call it on any
+window that is already shown, but calling it does not guarantee success. Whether
+Windows grants the request is up to the
+[`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow)
+rules: your app needs a current claim to the foreground, so a call out of the
+blue while another app is in front will be denied. A common case where the
+request is granted is right after `AppInstance.RedirectActivationToAsync`, which
+hands the running instance foreground rights before it raises the `Activated`
+event.
 
 WinUI calls `SetForegroundWindow` and returns `true` when Windows accepts the
-request. It returns `false` when Windows denies the request under its normal
-foreground-lock rules.
+request. It returns `false` when Windows denies it under the normal
+foreground-lock rules, the same rules any `SetForegroundWindow` caller follows.
+A denied request is a normal outcome, not an exception.
 
-`TrySetForeground()` does not bypass Windows restrictions and does not treat a
-denied request as an exception. It does not show or restore the window. Apps
-should show a hidden window or restore a minimized window through the
-appropriate window API before calling it.
+`TrySetForeground()` does not show or restore the window. Show a hidden window or
+restore a minimized one through the appropriate window API before calling it.
 
 ```csharp
 if (!window.TrySetForeground())
@@ -237,17 +280,13 @@ online docs._
   tempting one, because WPF's `Window.Activate()` already calls
   `SetForegroundWindow` and returns a `bool`. Matching WPF here would fix
   [#7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595) with no new
-  API. We rejected it because it silently changes the behavior of every existing
-  WinUI `Activate()` call, including the one in every default project template,
-  and because `Activate()` returns `void` so it still could not report a denied
-  request. `TrySetForeground()` honors the same intent (a fallible foreground
-  request) without changing a shipped method.
+  API. We rejected it because (a) it's complicated to change the behavior
+  of an existing API and (b) aligning the concepts of "Activate" and "Foreground"
+  with Win32 is the simplest model long-term.
 
 - **Keep `TryActivate()`.** This stays closest to WPF's `Window.Activate()`
-  name, but it collides with WinUI's existing `Activate()` (which only does
-  thread-level `SetActiveWindow`). Developers would read `TryActivate()` as a
-  bool-returning `Activate()`, when it actually adds the fallible cross-process
-  `SetForegroundWindow`. Same word, stronger behavior, right next to each other.
+  name, and avoids the compat issue, but again doesn't match the function at the
+  Win32 level.
 
 We chose `TrySetForeground()` because it names the exact Win32 operation
 (`SetForegroundWindow`), the `Try`/`bool` shape makes denial a normal outcome,
@@ -273,7 +312,8 @@ Out of scope here, but natural follow-ups:
   this. If there is demand for it directly on `Window`, it can be its own
   proposal.
 
-## 6.3. API review status
-
-This API is not approved. This draft is meant to gather public feedback before
-the implementation or API shape is finalized.
+  Open question if we ever build it: match WPF with a `ShowActivated` property, or
+  take the activated flag as a parameter (`Show(Boolean activated)`)? A parameter
+  reads more clearly than a separate property you have to set first, and
+  `AppWindow.Show(Boolean)` already uses that shape. WPF likely used a property so
+  the common case (`ShowActivated = true`) needs no argument at the `Show()` call.

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -10,6 +10,9 @@ Window showing and activation
   - [1.5. Non-goals](#15-non-goals)
 - [2. Conceptual pages (How To)](#2-conceptual-pages-how-to)
 - [3. Examples](#3-examples)
+- [4. API Pages](#4-api-pages)
+- [5. API Details](#5-api-details)
+- [6. Appendix](#6-appendix)
 
 
 # 1. Background
@@ -18,10 +21,11 @@ _Note: This section is background to help you read the spec. It does NOT go to
 the online docs._
 
 **TL;DR**: The plan in this doc is:
-- Add **Show()**  (match WPF)
-- Add **ShowActivated** prop  (match WPF)
 - Add **TrySetForeground()**  (works like WPF's "Activate")
-- Deprecate **Activate()**
+- Keep **Activate()** exactly as it is today
+
+(An earlier draft also added `Show()` and a `ShowActivated` property to match
+WPF. We cut those to keep this change small and low-risk. See the appendix.)
 
 
 [Issue #7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595)
@@ -49,14 +53,13 @@ is the Win32 request that can cross that process boundary. If Windows allows
 the request, it makes the target window foreground, activates it, and directs
 keyboard input to it. The request is not guaranteed to succeed.
 
-WinUI currently uses `Activate()` for two different jobs:
+There is no WinUI API that asks Windows to bring an already-shown window to the
+foreground across the process boundary. `Activate()` only does thread-level
+activation, and `AppWindow` has no foreground method either.
 
-- Showing a window for the first time.
-- Asking an existing window to become active.
-
-This proposal separates those jobs. It adds WPF-style APIs for showing a
-window, adds an explicit fallible foreground request, and keeps the existing
-`Activate()` behavior for compatibility.
+This proposal adds one explicit, fallible foreground request,
+`TrySetForeground()`, and leaves the existing `Activate()` behavior exactly as
+it is today.
 
 ## 1.1. WPF behavior
 
@@ -105,75 +108,62 @@ outcome rather than an exceptional failure.
 
 ## 1.3. API summary
 
-The new surface keeps activation and foreground as separate, clearly named operations:
+The new API names the foreground request as its own operation, separate from the
+existing thread-level activate:
 
 | API | Win32 call | What it does | Can Windows deny it? |
 | --- | --- | --- | --- |
-| `Show()` with `ShowActivated = true` | `ShowWindow` (`SW_SHOW` family) | Shows the window and activates it at show time | No explicit foreground request |
-| `Show()` with `ShowActivated = false` | `ShowWindow` (`SW_SHOWNOACTIVATE` family) | Shows the window without activating it | n/a |
 | `TrySetForeground()` | `SetForegroundWindow` | Requests system-wide foreground for an already-shown window | Yes, returns `false` if denied |
-| `Activate()` (legacy) | `ShowWindow` + `SetActiveWindow` | Shows and selects the thread's active window | No, but cannot take foreground from another app |
+| `Activate()` (unchanged) | `ShowWindow` + `SetActiveWindow` | Shows and selects the thread's active window | No, but cannot take foreground from another app |
 
 ## 1.4. Goals
 
-- Give WinUI apps a clear way to show a window without taking focus.
 - Give WinUI apps a clear way to request foreground activation.
-- Align with WPF where that produces a usable and compatible WinUI API.
 - Preserve Windows foreground-lock behavior.
 - Preserve the existing `Window.Activate()` behavior for compatibility.
+- Keep the change small and low-risk.
 
 ## 1.5. Non-goals
 
 - Do not bypass Windows foreground-lock rules.
 - Do not guarantee that a background window becomes foreground.
 - Do not change the behavior of `Window.Activate()`.
+- Do not add `Show()` or a `ShowActivated` property in this proposal.
+  `AppWindow.Show(Boolean)` already shows a window with or without activation, so
+  that story is deferred. See the appendix.
 
 # 2. Conceptual pages (How To)
 
 _Note: This is conceptual documentation that WILL go to the online "how to"
-page on learn.microsoft.com. It may extend, for example, the 
+page on learn.microsoft.com. It may extend, for example, the
 [Manage app windows](https://learn.microsoft.com/windows/apps/develop/ui/manage-app-windows)
 conceptual page rather than starting a new one._
 
-A WinUI `Window` represents a top-level window on the desktop. Showing that
-window and bringing it to the foreground are two separate operations, and these
-new APIs keep them apart so you can pick the behavior you want.
+A WinUI `Window` represents a top-level window on the desktop. Showing a window
+and bringing it to the foreground are two separate operations.
 
-- Call `Show()` to display a window. By default it also activates the window.
-- Set `ShowActivated = false` before `Show()` when you do not want the window
-  to steal focus. This is the right choice for non-interrupting windows such as
-  overlays, toasts, splash screens, search palettes, and tool windows.
-- Call `TrySetForeground()` to ask Windows to bring an already-shown window to the
-  foreground. Windows can say no, so treat the return value as "maybe".
-- `Activate()` is the old call that showed the window and activated it together.
-  It still works, but it is deprecated. New code should use `Show()`.
+- Call `Activate()` to show and activate a window, the same as always.
+- Call `TrySetForeground()` to ask Windows to bring an already-shown window to
+  the foreground. Windows can say no, so treat the return value as "maybe". This
+  is what you want when a background window needs the user's attention, which is
+  the case WinUI's thread-level `Activate()` cannot handle on its own.
 
 # 3. Examples
 
 _Note: These examples WILL go to the online "how to" page on
 learn.microsoft.com._
 
-Show a window the normal way. It activates by default:
-
-````csharp
-Window window = new();
-window.Show();
-```
-
-Show a tool window without stealing focus:
+Show and activate a window the normal way:
 
 ```csharp
-Window toolWindow = new();
-toolWindow.ShowActivated = false;
-toolWindow.Show();
+Window window = new();
+window.Activate();
 ```
 
-Ask Windows to bring an existing window to the foreground, and handle the case
+Later, ask Windows to bring that window to the foreground, and handle the case
 where Windows keeps the current foreground window:
 
 ```csharp
-window.Show();
-
 if (!window.TrySetForeground())
 {
     // Windows kept the current foreground window.
@@ -186,42 +176,7 @@ if (!window.TrySetForeground())
 _Note: Each of the following sections WILL become a page on
 learn.microsoft.com._
 
-## 4.1. Window.Show
-
-Shows the window and returns immediately.
-
-When `Show()` changes a hidden window to visible, WinUI uses the current
-`ShowActivated` value to decide whether the operation should activate it.
-
-If the window is already visible, `Show()` does nothing. This includes a
-minimized window, which is still visible and must be restored through the
-window-state APIs.
-
-Calling `Show()` after the window has closed produces the same error behavior
-as calling `Activate()` after close.
-
-## 4.2. Window.ShowActivated
-
-Gets or sets whether `Show()` activates the window.
-
-The default value is `true`. Set it to `false` before calling `Show()` to show
-the window without activation. Changing the property does not retroactively
-activate or deactivate a window that is already visible, but the new value is
-used after a later `Hide()` and `Show()` sequence. As in WPF, the value is also
-used when a minimized window is restored through the window-state APIs.
-
-ShowActivated only chooses the `ShowWindow` activation flag (an `SW_SHOW`-family
-flag when true, an `SW_SHOWNOACTIVATE`-family flag when false). It does not call
-`SetForegroundWindow`, which is why showing and foreground activation are named
-differently.
-
-```csharp
-Window toolWindow = new();
-toolWindow.ShowActivated = false;
-toolWindow.Show();
-```
-
-## 4.3. Window.TrySetForeground
+## 4.1. Window.TrySetForeground
 
 Asks Windows to make the window the foreground window.
 
@@ -235,20 +190,20 @@ should show a hidden window or restore a minimized window through the
 appropriate window API before calling it.
 
 ```csharp
-window.Show();
-
 if (!window.TrySetForeground())
 {
     // Windows kept the current foreground window.
 }
 ```
 
-## 4.4. Window.Activate
+## 4.2. Window.Activate
 
 `Window.Activate()` keeps its existing `ShowWindow`, `UpdateWindow`, and
-`SetActiveWindow` behavior.
+`SetActiveWindow` behavior. This proposal does not change it and does not
+deprecate it.
 
-The API is deprecated. New code can safely switch to use `Show()`.
+Use `TrySetForeground()` when you need to request foreground for a window that
+is already shown.
 
 
 # 5. API Details
@@ -262,11 +217,9 @@ namespace Microsoft.UI.Xaml
 {
     unsealed runtimeclass Window
     {
-        Boolean ShowActivated { get; set; };
-        void Show();
         Boolean TrySetForeground();
 
-        // Existing, will be deprecated.  Behavior does not change.
+        // Existing.  Behavior does not change and it is not deprecated.
         void Activate();
     }
 }
@@ -279,18 +232,28 @@ online docs._
 
 ## 6.1. Alternatives considered
 
+- **Change `Window.Activate()` to call `SetForegroundWindow`.** This is the
+  tempting one, because WPF's `Window.Activate()` already calls
+  `SetForegroundWindow` and returns a `bool`. Matching WPF here would fix
+  [#7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595) with no new
+  API. We rejected it because it silently changes the behavior of every existing
+  WinUI `Activate()` call, including the one in every default project template,
+  and because `Activate()` returns `void` so it still could not report a denied
+  request. `TrySetForeground()` honors the same intent (a fallible foreground
+  request) without changing a shipped method.
+
 - **Keep `TryActivate()`.** This stays closest to WPF's `Window.Activate()`
   name, but it collides with WinUI's existing `Activate()` (which only does
   thread-level `SetActiveWindow`). Developers would read `TryActivate()` as a
   bool-returning `Activate()`, when it actually adds the fallible cross-process
   `SetForegroundWindow`. Same word, stronger behavior, right next to each other.
 
-- **Change `Window.Activate()` to call `SetForegroundWindow`.** This matches WPF
-  behavior, but it silently changes shipped WinUI behavior and removes the
-  ability to show a window quietly.
-
-- **Add only `Window.Show()`.** Simpler, but it gives apps no framework-level
-  way to request foreground for a window that is already shown.
+- **Also add `Show()` and a `ShowActivated` property (match WPF).** An earlier
+  draft did this to give apps a WPF-style way to show a window without taking
+  focus. We deferred it because `Microsoft.UI.Windowing.AppWindow` already has
+  `Show()` and `Show(Boolean)`, so the show-without-activate story is largely
+  covered. It can be a separate proposal if there is demand for it on `Window`
+  directly.
 
 We chose `TrySetForeground()` because it names the exact Win32 operation
 (`SetForegroundWindow`), the `Try`/`bool` shape makes denial a normal outcome,
@@ -300,4 +263,3 @@ and it keeps 'foreground' distinct from the thread-level 'activate' vocabulary.
 
 This API is not approved. This draft is meant to gather public feedback before
 the implementation or API shape is finalized.
-````

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -1,0 +1,193 @@
+Window showing and activation
+===
+
+> **STATUS: DRAFT FOR API REVIEW**
+>
+> This proposal is intentionally open for design feedback. The API shape and
+> behavior are not approved.
+
+# Background
+
+[Issue #7595](https://github.com/microsoft/microsoft-ui-xaml/issues/7595)
+reports that `Window.Activate()` does not bring a background WinUI window to
+the foreground unless the window is minimized.
+
+The current WinUI implementation uses this sequence:
+
+1. `ShowWindow` to make the HWND visible or restore it.
+2. `UpdateWindow` to paint it.
+3. `SetActiveWindow` to activate it within the calling thread.
+
+This works when the app is already the foreground app, but
+[`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow)
+does not bring a background app to the foreground.
+
+The first implementation considered changing `Window.Activate()` to call
+`SetForegroundWindow`, then pivoted to a separate `Window.SetForeground()`
+method. Neither choice fully accounts for the fact that WinUI currently uses
+`Activate()` for two different jobs:
+
+- Showing a window for the first time.
+- Asking an existing window to become active.
+
+Those jobs are separate in WPF and in Win32.
+
+## WPF behavior
+
+WPF has three relevant members:
+
+| API | Behavior |
+| --- | --- |
+| [`Window.Show()`](https://learn.microsoft.com/dotnet/api/system.windows.window.show) | Shows a modeless window. |
+| [`Window.ShowActivated`](https://learn.microsoft.com/dotnet/api/system.windows.window.showactivated) | Controls whether the window is activated when it is first shown. The default is `true`. Apps set it to `false` before `Show()` to show without activation. |
+| [`Window.Activate()`](https://learn.microsoft.com/dotnet/api/system.windows.window.activate) | Attempts to bring an existing window to the foreground and activate it. It returns whether activation succeeded and follows the Win32 `SetForegroundWindow` rules. |
+
+This split lets a WPF app show a window without activation while keeping
+`Activate()` focused on foreground activation.
+
+WinUI has no public `Window.Show()` API or `ShowActivated` property. Apps call
+`Window.Activate()` to show a newly created window. Changing that method to
+always request foreground activation could cause existing secondary windows,
+tool windows, and palettes to take focus when an app only meant to show them.
+
+## Win32 behavior
+
+Win32 also separates showing, thread activation, and foreground activation:
+
+| API | Behavior |
+| --- | --- |
+| [`ShowWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-showwindow) | Changes the window's show state. Flags such as `SW_SHOW` activate the window, while `SW_SHOWNOACTIVATE` and `SW_SHOWNA` show it without activation. |
+| [`SetActiveWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setactivewindow) | Activates a window attached to the calling thread's message queue. It does not bring a background application to the foreground. |
+| [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) | Requests foreground activation. Windows can deny the request under its foreground-lock rules. |
+
+An app cannot force foreground activation while the user is working in
+another app. If Windows denies `SetForegroundWindow`, it can flash the taskbar
+button instead. A WinUI API that requests foreground activation must preserve
+these rules and must not promise success.
+
+# Goals
+
+- Give WinUI apps a clear way to show a window without taking focus.
+- Give WinUI apps a clear way to request foreground activation.
+- Align with WPF where that produces a usable and compatible WinUI API.
+- Preserve Windows foreground-lock behavior.
+- Avoid changing existing app behavior without an explicit compatibility plan.
+
+# Non-goals
+
+- Do not bypass Windows foreground-lock rules.
+- Do not guarantee that a background window becomes foreground.
+- Do not silently change `Window.Activate()` until the compatibility impact is
+  understood.
+- Do not approve a final API shape in this initial draft.
+
+# Proposed direction
+
+The current direction is to add the missing WPF-style show surface before
+changing foreground activation behavior:
+
+```csharp
+namespace Microsoft.UI.Xaml
+{
+    unsealed runtimeclass Window
+    {
+        Boolean ShowActivated { get; set; };
+        void Show();
+    }
+}
+```
+
+`ShowActivated` would default to `true`. Apps could set it to `false` before
+the first call to `Show()` to display a window without activating it.
+
+This gives WinUI a dedicated show operation and removes the main reason that
+apps must use `Activate()` for first-time display.
+
+The exact future of `Window.Activate()` remains an API review question. Options
+include:
+
+1. Keep its current behavior for compatibility and add a separate fallible
+   foreground API.
+2. Change it in a future compatibility boundary to follow WPF and
+   `SetForegroundWindow`.
+3. Deprecate it after adding clearer show and foreground APIs.
+
+# Alternatives considered
+
+## Change Window.Activate
+
+Change the existing method to call `SetForegroundWindow`.
+
+This matches the name and WPF behavior, but it can break apps that currently
+call `Activate()` only because WinUI lacks `Show()`. Those apps could start
+taking focus unexpectedly.
+
+## Add Window.SetForeground
+
+Add a method that directly represents `SetForegroundWindow` and returns
+whether Windows accepted the request.
+
+```csharp
+Boolean SetForeground();
+```
+
+This is explicit and preserves the current `Activate()` behavior. However,
+WPF does not expose this API shape, and adding it without first addressing
+WinUI's missing show API moves the frameworks further apart.
+
+If this option is selected, `TrySetForeground` may be a clearer name because
+failure is a normal result under Windows foreground-lock rules.
+
+## Add only Window.Show
+
+Add `Show()` but no `ShowActivated` property.
+
+This is simpler, but it does not give apps a framework-level way to show tool
+windows, palettes, or notifications without activation. WPF and Win32 both
+support that scenario.
+
+# API behavior
+
+## Window.Show
+
+Shows the window and returns immediately.
+
+On the first show, WinUI uses `ShowActivated` to decide whether to request
+activation. Later calls show or restore the window using the same setting.
+
+Calling `Show()` after the window has closed produces the same error behavior
+as calling `Activate()` after close.
+
+## Window.ShowActivated
+
+Gets or sets whether `Show()` activates the window.
+
+The default value is `true`. The property must be set before the first call to
+`Show()`. Changing it after the window is first shown has no effect.
+
+```csharp
+Window toolWindow = new();
+toolWindow.ShowActivated = false;
+toolWindow.Show();
+```
+
+# Open questions
+
+- Should WinUI match WPF exactly by adding both `Show()` and `ShowActivated`?
+- Should `ShowActivated` apply only to the first show, like WPF, or to every
+  call to `Show()`?
+- Should `Window.Activate()` eventually use `SetForegroundWindow`, remain
+  unchanged, or be deprecated?
+- If compatibility prevents changing `Activate()`, should the foreground API
+  be named `SetForeground`, `TrySetForeground`, or `TryActivate`?
+- How should the API report foreground denial without treating normal Windows
+  behavior as an exception?
+- Should a foreground API restore or show a hidden or minimized window, or
+  only operate on an already visible window?
+- Are `Show()` and `ShowActivated` desktop-only, or can they have meaningful
+  behavior for UWP?
+
+# API review status
+
+This API is not approved. This draft is meant to gather public feedback before
+the implementation or API shape is finalized.

--- a/docs/api-specs/Window-Activation-spec.md
+++ b/docs/api-specs/Window-Activation-spec.md
@@ -71,6 +71,8 @@ WPF has three relevant members:
 | [`Window.ShowActivated`](https://learn.microsoft.com/dotnet/api/system.windows.window.showactivated) | Controls whether the window is activated when it is first shown. The default is `true`. Apps set it to `false` before `Show()` to show without activation. |
 | [`Window.Activate()`](https://learn.microsoft.com/dotnet/api/system.windows.window.activate) | Attempts to bring an existing window to the foreground and activate it. It returns whether activation succeeded and follows the Win32 `SetForegroundWindow` rules. |
 
+Only `Window.Activate()` is in scope for this proposal. `Show()` and
+`ShowActivated` are listed under future directions in the appendix.
 
 ## 1.2. Win32 behavior
 
@@ -83,28 +85,16 @@ Win32 also separates showing, thread activation, and foreground activation:
 | [`SetForegroundWindow`](https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setforegroundwindow) | Asks Windows to make the window foreground and active, even if another app is currently foreground. Windows can deny the request. |
 
 Windows limits foreground changes so a background app cannot freely interrupt
-the user. According to the `SetForegroundWindow` documentation, all of these
-conditions must be true:
+the user. Roughly, the request is allowed when the calling app already has some
+claim to the foreground (for example it is already foreground, it launched the
+current foreground app, or it received the last input event) and no app has
+locked the foreground. The `SetForegroundWindow` documentation has the full list
+of conditions.
 
-- The caller is a desktop app.
-- The foreground process has not called `LockSetForegroundWindow` to block the
-  request.
-- No menus are active.
-
-At least one of these conditions must also be true:
-
-- The foreground-lock timeout has expired.
-- The calling process is already foreground.
-- The foreground process started the calling process.
-- There is no foreground process.
-- The calling process received the last input event.
-- Either the calling process or foreground process is being debugged.
-
-Windows may still deny the request even when these conditions appear to be
-met. When foreground activation is denied, Windows can flash the app's taskbar
-button instead. A WinUI API that requests foreground activation must preserve
-these rules, must not promise success, and should expose denial as a normal
-outcome rather than an exceptional failure.
+Even when the conditions look right, Windows can still deny the request, and it
+may flash the app's taskbar button instead. So a WinUI API that requests
+foreground activation must follow these rules, must not promise success, and
+should treat denial as a normal outcome rather than an error.
 
 ## 1.3. API summary
 
@@ -248,18 +238,31 @@ online docs._
   bool-returning `Activate()`, when it actually adds the fallible cross-process
   `SetForegroundWindow`. Same word, stronger behavior, right next to each other.
 
-- **Also add `Show()` and a `ShowActivated` property (match WPF).** An earlier
-  draft did this to give apps a WPF-style way to show a window without taking
-  focus. We deferred it because `Microsoft.UI.Windowing.AppWindow` already has
-  `Show()` and `Show(Boolean)`, so the show-without-activate story is largely
-  covered. It can be a separate proposal if there is demand for it on `Window`
-  directly.
-
 We chose `TrySetForeground()` because it names the exact Win32 operation
 (`SetForegroundWindow`), the `Try`/`bool` shape makes denial a normal outcome,
 and it keeps 'foreground' distinct from the thread-level 'activate' vocabulary.
 
-## 6.2. API review status
+## 6.2. Future directions
+
+Out of scope here, but natural follow-ups:
+
+- **A `Show()` method and a `ShowActivated` property on `Window` (match WPF).**
+  This would give a WPF-style way to show a window and choose whether it
+  activates. Setting `ShowActivated = false` before `Show()` would show a window
+  without stealing focus, which suits overlays, toasts, splash screens, and tool
+  windows:
+
+  ```csharp
+  Window toolWindow = new();
+  toolWindow.ShowActivated = false;
+  toolWindow.Show();
+  ```
+
+  We left it out for now because `AppWindow.Show(Boolean)` already covers most of
+  this. If there is demand for it directly on `Window`, it can be its own
+  proposal.
+
+## 6.3. API review status
 
 This API is not approved. This draft is meant to gather public feedback before
 the implementation or API shape is finalized.


### PR DESCRIPTION
Related to #7595.

## PR Type

- [x] Documentation content changes
- [ ] Other: Public API design review

## Description

This describes a proposed API change to make it easier for app code to bring a WinUI window to the foreground (calling Win32 SetForegroundWindow).

This is a "placeholder" for now, I'm not sure we'll do the implementation soon.  But I wanted to write down some notes and get feedback.