### PR TITLE
fix: make `XamlGeneratedProgram` and `XamlGeneratedMain` internal

### DIFF
--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.cs
@@ -45,7 +45,7 @@ namespace Microsoft.UI.Xaml.Markup.Compiler.CodeGen
 namespace ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.CodeInfo.ClassName.Namespace));
             this.Write("\r\n{\r\n    /// <summary>\r\n    /// Program class\r\n    /// </summary>\r\n#if !DISABLE_X" +
-                    "AML_GENERATED_MAIN\r\n    public static class Program\r\n#else\r\n    public static cl" +
+                    "AML_GENERATED_MAIN\r\n    public static class Program\r\n#else\r\n    internal static cl" +
                     "ass XamlGeneratedProgram\r\n#endif\r\n    {\r\n        ");
             this.Write(this.ToStringHelper.ToStringWithCulture(GeneratedCodeAttribute));
             this.Write("\r\n        ");
@@ -55,7 +55,7 @@ namespace ");
             this.Write("        [global::System.STAThreadAttribute]\r\n");
   } 
             this.Write("#if !DISABLE_XAML_GENERATED_MAIN\r\n        static void Main(string[] args)\r\n#else\r" +
-                    "\n        public static void XamlGeneratedMain(string[] args)\r\n#endif\r\n        {\r\n");
+                    "\n        internal static void XamlGeneratedMain(string[] args)\r\n#endif\r\n        {\r\n");
   if (ProjectInfo.UsingCSWinRT) { 
             this.Write("            global::WinRT.ComWrappersSupport.InitializeComWrappers();\r\n");
   }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.cs
@@ -55,7 +55,7 @@ namespace ");
             this.Write("        [global::System.STAThreadAttribute]\r\n");
   } 
             this.Write("#if !DISABLE_XAML_GENERATED_MAIN\r\n        static void Main(string[] args)\r\n#else\r" +
-                    "\n        static void XamlGeneratedMain(string[] args)\r\n#endif\r\n        {\r\n");
+                    "\n        public static void XamlGeneratedMain(string[] args)\r\n#endif\r\n        {\r\n");
   if (ProjectInfo.UsingCSWinRT) { 
             this.Write("            global::WinRT.ComWrappersSupport.InitializeComWrappers();\r\n");
   }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.cs
@@ -55,7 +55,7 @@ namespace ");
             this.Write("        [global::System.STAThreadAttribute]\r\n");
   } 
             this.Write("#if !DISABLE_XAML_GENERATED_MAIN\r\n        static void Main(string[] args)\r\n#else\r" +
-                    "\n        internal static void XamlGeneratedMain(string[] args)\r\n#endif\r\n        {\r\n");
+                    "\n        internal static void XamlGeneratedMain()\r\n#endif\r\n        {\r\n");
   if (ProjectInfo.UsingCSWinRT) { 
             this.Write("            global::WinRT.ComWrappersSupport.InitializeComWrappers();\r\n");
   }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.tt
@@ -33,7 +33,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 #if !DISABLE_XAML_GENERATED_MAIN
         static void Main(string[] args)
 #else
-        internal static void XamlGeneratedMain(string[] args)
+        internal static void XamlGeneratedMain()
 #endif
         {
 <#  if (ProjectInfo.UsingCSWinRT) { #>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.tt
@@ -22,7 +22,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 #if !DISABLE_XAML_GENERATED_MAIN
     public static class Program
 #else
-    public static class XamlGeneratedProgram
+    internal static class XamlGeneratedProgram
 #endif
     {
         <#=GeneratedCodeAttribute#>
@@ -33,7 +33,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 #if !DISABLE_XAML_GENERATED_MAIN
         static void Main(string[] args)
 #else
-        public static void XamlGeneratedMain(string[] args)
+        internal static void XamlGeneratedMain(string[] args)
 #endif
         {
 <#  if (ProjectInfo.UsingCSWinRT) { #>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpAppPass1.tt
@@ -33,7 +33,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 #if !DISABLE_XAML_GENERATED_MAIN
         static void Main(string[] args)
 #else
-        static void XamlGeneratedMain(string[] args)
+        public static void XamlGeneratedMain(string[] args)
 #endif
         {
 <#  if (ProjectInfo.UsingCSWinRT) { #>


### PR DESCRIPTION
## Fixes

<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

Fixes #11245 

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

`XamlGeneratedMain` is generated as a private method, so a custom Main() cannot invoke it.

### New Behavior

`XamlGeneratedMain` is now accessible from a custom entry point, allowing it to delegate to the generated startup implementation.

## Customer Impact

Applications can configure options such as `XamlOptionalChanges` before XAML initialization without duplicating the generated startup logic.

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

Verified by building a C# WinUI project with `DISABLE_XAML_GENERATED_MAIN` and invoking `XamlGeneratedProgram.XamlGeneratedMain(args)` from a custom `Main()`.

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

## Screenshots (if appropriate)

Not applicable.