### PR TITLE
Run XamlCompiler.exe as ARM64-native on Windows on ARM

### DIFF
--- a/src/XamlCompiler/Exe/Microsoft.UI.Xaml.Markup.Compiler.Executable.csproj
+++ b/src/XamlCompiler/Exe/Microsoft.UI.Xaml.Markup.Compiler.Executable.csproj
@@ -7,6 +7,10 @@
     <TargetFrameworks>net472</TargetFrameworks>
     <TargetDestination>$(MarkupCompilerDestinationPath).Executable</TargetDestination>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <!-- Embed an application manifest that declares supportedArchitectures (amd64 arm64) so this
+         AnyCPU .NET Framework executable launches ARM64-native on Windows on ARM instead of under
+         x64 emulation. See https://github.com/microsoft/microsoft-ui-xaml/issues/11237 -->
+    <ApplicationManifest>XamlCompiler.manifest</ApplicationManifest>
     <NoWarn>$(NoWarn);0419;1570;1572;1573;1574;1591;3021;0618;0672;0436;0108;SYSLIB0003;SYSLIB0005;SYSLIB0012;SYSLIB0019;SYSLIB0021;CA2002;CA1060;CA1063;CA2229;CA1001;CA1033;CA1416;CA2101;CA2213;CA2231</NoWarn>
     <!-- USE_CLR_V4 is only for the LMR code -->
     <DefineConstants>$(DefineConstants);USE_CLR_V4;NET40PLUS;Debug;SYSTEM_XAML</DefineConstants>

--- a/src/XamlCompiler/Exe/XamlCompiler.manifest
+++ b/src/XamlCompiler/Exe/XamlCompiler.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity type="win32" name="Microsoft.UI.Xaml.Markup.Compiler.XamlCompiler" version="1.0.0.0" processorArchitecture="*" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <asmv3:application>
+    <!--
+      XamlCompiler.exe is an IL-only (AnyCPU) .NET Framework executable. On Windows on ARM,
+      AnyCPU binaries launch under x64 emulation by default, which makes the XAML compiler the
+      dominant cost of a WinUI build. Declaring the native architectures the app supports lets
+      the loader launch it ARM64-native instead of emulated (Windows 11, version 24H2 and later),
+      removing the emulation tax without the per-machine IFEO 'PreferredMachine' registry hack.
+      See https://github.com/microsoft/microsoft-ui-xaml/issues/11237 and
+      https://learn.microsoft.com/windows/win32/sbscs/application-manifests#supportedarchitectures
+    -->
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">
+      <supportedArchitectures>amd64 arm64</supportedArchitectures>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
Fixes #11237

## Problem

`XamlCompiler.exe` is an **AnyCPU / IL-only .NET Framework** executable. On Windows on ARM, AnyCPU IL-only images launch under **x64 emulation** by default. Since the XAML compiler dominates WinUI build time, this emulation tax makes ARM64 builds much slower than they need to be. Issue #11237 measured the compiler at ~76% of build time, and forcing it ARM64-native via a per-machine registry hack gave a ~3.4× compiler speedup.

## Fix

Declare the native architectures the compiler supports via an application manifest, and reference it from the project:

- New `src/XamlCompiler/Exe/XamlCompiler.manifest` with:
  ```xml
  <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">
    <supportedArchitectures>amd64 arm64</supportedArchitectures>
  </asmv3:windowsSettings>
  ```
- `Microsoft.UI.Xaml.Markup.Compiler.Executable.csproj`: `<ApplicationManifest>XamlCompiler.manifest</ApplicationManifest>`

On **Windows 11, version 24H2 and later**, the loader then launches the compiler ARM64-native instead of x64-emulated — no per-machine Image File Execution Options `PreferredMachine` registry workaround needed. This was the approach suggested by @driver1998 in the issue.

See the [`supportedArchitectures` documentation](https://learn.microsoft.com/windows/win32/sbscs/application-manifests#supportedarchitectures).

## Verification

Measured on the **actual shipped `XamlCompiler.exe`** (from the `microsoft.windowsappsdk.winui` package — PE32 / `ILONLY` / AnyCPU) on Windows 11 ARM64 (build 26200). Architecture read at image-load time via `GetProcessInformation(ProcessMachineTypeInfo)` from an ARM64-native parent process (representing the ARM64 build host):

| Binary | Launch architecture |
|---|---|
| `XamlCompiler.exe` as shipped (no `supportedArchitectures`) | **x64 EMULATED** |
| Same binary with this manifest injected | **ARM64 NATIVE** |

Notes:
- `IsWow64Process2` is unreliable for detecting x64-on-ARM64 on current builds (it reports `processMachine=UNKNOWN` for a verified-x64 image); `GetProcessInformation` / Task Manager's *Architecture* column are the reliable signals.
- Process architecture is inherited, so the manifest delivers ARM64-native when the process launching the compiler is itself ARM64-native (the normal arm64 .NET SDK build) — which is exactly the scenario in #11237.
- `amd64 arm64` (rather than `arm64` alone) keeps x64 hosts running the compiler x64-native.
