### PR TITLE
Make arm64 a first-class build host (auto-detect host arch)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -79,6 +79,34 @@ jobs:
           fetch-depth: 1
           show-progress: false
 
+      # The windows-11-arm runner image ships most VS components but is missing
+      # some the repo requires (notably VC.Runtimes.x86.x64.Spectre, needed even
+      # for arm64-target builds because the codegen tools compile as x86/x64).
+      # Apply the repo's .vsconfig so the installed toolchain matches what the
+      # build expects. windows-2022 already includes these, so gate to arm64.
+      - name: Ensure required VS components (arm64 runner parity)
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $installerDir = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
+          $vsPath = & "$installerDir\vswhere.exe" -latest -property installationPath
+          Write-Host "Applying .vsconfig to $vsPath"
+          # Quote the space-containing paths: Start-Process joins -ArgumentList
+          # with spaces and does not quote elements itself.
+          $installArgs = @(
+            'modify', '--installPath', "`"$vsPath`"",
+            '--config', "`"${{ github.workspace }}\.vsconfig`"",
+            '--quiet', '--norestart', '--nocache', '--force'
+          )
+          $p = Start-Process -FilePath "$installerDir\vs_installer.exe" `
+            -ArgumentList $installArgs -Wait -PassThru -NoNewWindow
+          # vs_installer can return before its child finishes; wait those out too.
+          Get-Process -Name 'vs_installer', 'setup', 'vs_installerservice' -ErrorAction SilentlyContinue |
+            Wait-Process -Timeout 1800 -ErrorAction SilentlyContinue
+          Write-Host "vs_installer exit code: $($p.ExitCode)"
+          if ($p.ExitCode -notin @(0, 3010)) { throw "vs_installer failed with exit code $($p.ExitCode)" }
+
       - name: Initialize build environment and build
         shell: pwsh
         run: |

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -32,12 +32,16 @@ permissions:
 
 jobs:
   build:
-    name: Build (${{ matrix.flavor }})
-    runs-on: windows-2022
+    name: Build (${{ matrix.os }} / ${{ matrix.flavor }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
+        # Build every flavor on both an x64 host (windows-2022) and a native
+        # arm64 host (windows-11-arm) to keep host-toolchain parity across both.
+        os: [windows-2022, windows-11-arm]
+        flavor: [x86chk, x86fre, x64chk, x64fre, arm64chk, arm64fre]
         include:
           - flavor: x86chk
             platform: x86
@@ -87,7 +91,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: binlogs-${{ matrix.flavor }}
+          name: binlogs-${{ matrix.os }}-${{ matrix.flavor }}
           path: BuildOutput/**/*.binlog
           if-no-files-found: ignore
           retention-days: 7
@@ -95,7 +99,7 @@ jobs:
       - name: Upload product runtime payload
         uses: actions/upload-artifact@v6
         with:
-          name: winui-product-${{ matrix.flavor }}
+          name: winui-product-${{ matrix.os }}-${{ matrix.flavor }}
           path: |
             BuildOutput/packaging/${{ matrix.configuration }}/runtimes-framework/win-${{ matrix.platform }}/**
           if-no-files-found: warn

--- a/build/DownloadDotNetCoreSdk.ps1
+++ b/build/DownloadDotNetCoreSdk.ps1
@@ -17,8 +17,13 @@ $dotNetSdkVNextChannel  = $versionPropsFileProject.SelectSingleNode('//dotNetSdk
 
 Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile $dotnetInstallScript
 
-$x64InstallDir  = $repoInstallDir
-$x86InstallDir  = "$x64InstallDir\x86"
+# Install the primary SDK for the native host architecture so dotnet.exe runs
+# natively (not emulated). Falls back to x64 for any host that is neither arm64
+# nor amd64. The x86 SDK is always installed side-by-side (used by GenXbf etc.).
+$primaryArch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { 'arm64' } else { 'x64' }
+
+$primaryInstallDir = $repoInstallDir
+$x86InstallDir     = "$primaryInstallDir\x86"
 
 
 
@@ -33,8 +38,8 @@ $x86InstallDir  = "$x64InstallDir\x86"
 if (-not [string]::IsNullOrEmpty($version)) 
 {
     # ignore quality and channel
-    . $dotnetInstallScript -Version $version -InstallDir $x64InstallDir -Architecture x64
-    Write-Host "Installed SDK (x64) with Version $version to $x64InstallDir." -ForegroundColor green
+    . $dotnetInstallScript -Version $version -InstallDir $primaryInstallDir -Architecture $primaryArch
+    Write-Host "Installed SDK ($primaryArch) with Version $version to $primaryInstallDir." -ForegroundColor green
 
     . $dotnetInstallScript -Version $version -InstallDir $x86InstallDir -Architecture x86
     Write-Host "Installed SDK (x86) with Version $version to $x86InstallDir." -ForegroundColor green    
@@ -51,8 +56,8 @@ elseif (-not [string]::IsNullOrEmpty($quality))
         # use channel and quality
         Write-Host "Using channel: $channel and quality: $quality"
 
-        . $dotnetInstallScript -channel $channel -quality $quality -InstallDir $x64InstallDir -Architecture x64
-        Write-Host "Installed SDK (x64) with channel $channel and quality $quality to $x64InstallDir." -ForegroundColor green
+        . $dotnetInstallScript -channel $channel -quality $quality -InstallDir $primaryInstallDir -Architecture $primaryArch
+        Write-Host "Installed SDK ($primaryArch) with channel $channel and quality $quality to $primaryInstallDir." -ForegroundColor green
     
         . $dotnetInstallScript -channel $channel -quality $quality -InstallDir $x86InstallDir -Architecture x86
         Write-Host "Installed SDK (x86) with channel $channel and version $quality to $x86InstallDir." -ForegroundColor green 
@@ -63,8 +68,8 @@ elseif (-not [string]::IsNullOrEmpty($channel))
     # use only channel
     Write-Host "Using channel: $channel"
 
-    . $dotnetInstallScript -channel $channel -InstallDir $x64InstallDir -Architecture x64
-    Write-Host "Installed SDK (x64) with channel $channel to $x64InstallDir." -ForegroundColor green
+    . $dotnetInstallScript -channel $channel -InstallDir $primaryInstallDir -Architecture $primaryArch
+    Write-Host "Installed SDK ($primaryArch) with channel $channel to $primaryInstallDir." -ForegroundColor green
 
     . $dotnetInstallScript -channel $channel -InstallDir $x86InstallDir -Architecture x86
     Write-Host "Installed SDK (x86) with channel $channel to $x86InstallDir." -ForegroundColor green
@@ -81,8 +86,8 @@ else
         $backupChannel = $dotNetSdkVNextChannel
     }    
 
-    . $dotnetInstallScript -channel $backupChannel -InstallDir $x64InstallDir -Architecture x64
-    Write-Host "Installed SDK (x64) from Version.props with channel $backupChannel to $x64InstallDir." -ForegroundColor green
+    . $dotnetInstallScript -channel $backupChannel -InstallDir $primaryInstallDir -Architecture $primaryArch
+    Write-Host "Installed SDK ($primaryArch) from Version.props with channel $backupChannel to $primaryInstallDir." -ForegroundColor green
 
     . $dotnetInstallScript -channel $backupChannel -InstallDir $x86InstallDir -Architecture x86
     Write-Host "Installed SDK (x86) from Version.props with channel $backupChannel to $x86InstallDir." -ForegroundColor green

--- a/controls/dev/dll/Microsoft.UI.Xaml.Common.props
+++ b/controls/dev/dll/Microsoft.UI.Xaml.Common.props
@@ -35,8 +35,10 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <!-- Use 64-bit compilers because 32-bit compilers run out of heap space -->
-    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+    <!-- Use 64-bit compilers because 32-bit compilers run out of heap space.
+         Prefer the native host arch (arm64 on an arm64 host) to avoid emulation. -->
+    <PreferredToolArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'Arm64'">x64</PreferredToolArchitecture>
+    <PreferredToolArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">arm64</PreferredToolArchitecture>
     <ScriptPath>..\..\tools\</ScriptPath>
     <ForceMuiRes>true</ForceMuiRes>
     <Use64BitLinker>true</Use64BitLinker>

--- a/controls/environment.props
+++ b/controls/environment.props
@@ -22,8 +22,10 @@
     <PlatformTarget Condition="'$(PlatformTarget)' == '' and '$(Platform)' == 'Win32'">x86</PlatformTarget>
     <PlatformTarget Condition="'$(PlatformTarget)' == ''">$(Platform)</PlatformTarget>
     <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
-    <!-- Use 64-bit compilers because 32-bit compilers run out of heap space -->
-    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+    <!-- Use 64-bit compilers because 32-bit compilers run out of heap space.
+         Prefer the native host arch (arm64 on an arm64 host) to avoid emulation. -->
+    <PreferredToolArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'Arm64'">x64</PreferredToolArchitecture>
+    <PreferredToolArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">arm64</PreferredToolArchitecture>
 
     <!-- We're generating our own AppX manifest files, so we don't care that we're referencing WinMDs without providing reference DLLs. -->
     <MSBuildWarningsAsMessages>APPX1707</MSBuildWarningsAsMessages>

--- a/eng/BuildGenXbfForMSBuild/BuildGenXbfForMSBuild.csproj
+++ b/eng/BuildGenXbfForMSBuild/BuildGenXbfForMSBuild.csproj
@@ -30,5 +30,12 @@
     <ProjectReference Include="$(XamlSourcePath)\xcp\tools\GenXbfDLL\GenXbf.vcxproj">
       <Properties>Configuration=$(Configuration);Platform=x64;CurrentSolutionConfigurationContents=;ShouldUnsetParentConfigurationAndPlatform=false</Properties>
     </ProjectReference>
+    <!-- On an arm64 build host, MSBuild - and the managed XamlCompiler.exe it launches - runs
+         arm64, so it loads GenXbf.dll from the arm64 folder regardless of the product target arch.
+         Build it explicitly (mirrors the always-x64 reference above); otherwise x86/x64-target
+         builds on an arm64 host fail with "Cannot resolve 'GenXbf.dll' under ...\GenXbf\arm64". -->
+    <ProjectReference Include="$(XamlSourcePath)\xcp\tools\GenXbfDLL\GenXbf.vcxproj" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">
+      <Properties>Configuration=$(Configuration);Platform=arm64;CurrentSolutionConfigurationContents=;ShouldUnsetParentConfigurationAndPlatform=false</Properties>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/eng/sdkconfig.props
+++ b/eng/sdkconfig.props
@@ -26,7 +26,11 @@
     <UseWindowsSdk Condition="'$(UseWindowsSdk)'=='' and '$(UsingMicrosoftNetSdk)'=='true'">false</UseWindowsSdk>
     <!-- Default projects to using the Windows SDK nuget packages -->
     <UseWindowsSdk Condition="'$(UseWindowsSdk)'==''">true</UseWindowsSdk>
-    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+    <!-- Run the native 64-bit host toolchain (VC cl/link + Windows SDK tools such
+         as midlrt/mc/rc) instead of an emulated one: arm64-hosted tools on an arm64
+         host, otherwise x64 (also covers x86 hosts and future arches). -->
+    <PreferredToolArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'Arm64'">x64</PreferredToolArchitecture>
+    <PreferredToolArchitecture Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">arm64</PreferredToolArchitecture>
 
     <SdkCppArchitectureNeutralPropsFile>$(NugetPackageDirectory)\$(WindowsSdkNugetPackageName).cpp.$(MicrosoftWindowsSDKCppNugetPackageVersion)\build\native\$(WindowsSdkNugetPackageName).cpp.props</SdkCppArchitectureNeutralPropsFile>
     <SdkCppArchitectureSpecificPropsFile>$(NugetPackageDirectory)\$(WindowsSdkNugetPackageName).cpp.$(WindowsSdkArch).$(MicrosoftWindowsSDKCppNugetPackageVersion)\build\native\$(WindowsSdkNugetPackageName).cpp.$(WindowsSdkArch).props</SdkCppArchitectureSpecificPropsFile>

--- a/init.cmd
+++ b/init.cmd
@@ -66,6 +66,7 @@ set fre=
 set chk=
 set _BuildArch=
 set _BuildType=
+set _HostArch=
 set _DotNetMoniker=net8.0
 set _archIsSet=
 set _noPgo=
@@ -224,6 +225,11 @@ if "%fre%"=="1" if not "%_noPgo%"=="1" if not "%ARM64EC%"=="1" (
 )
 set _noPgo=
 
+rem Detect the native host architecture (_HostArch: amd64 | arm64) so we run the
+rem native build toolchain instead of an emulated one. Falls back to amd64 for
+rem any host that is neither arm64 nor amd64.
+call "%RepoRoot%\scripts\init\SetHostArch.cmd"
+
 if "%DevEnvDir%" == "" goto :NeedDevCmd
 where msbuild >nul 2>&1
 if errorlevel 1 goto :NeedDevCmd
@@ -231,21 +237,21 @@ goto :SkipDevCmd
 :NeedDevCmd
     echo DevEnvDir environment variable not set or msbuild unavailable. Running DevCmd.cmd to get a developer command prompt...
     if "%ARM64EC%"=="1" (
-        call %RepoRoot%\DevCmd.cmd /PreserveContext /prerelease -arch=amd64 -host_arch=amd64
+        call %RepoRoot%\DevCmd.cmd /PreserveContext /prerelease -arch=amd64 -host_arch=%_HostArch%
     ) else if "%ARM64%"=="1" (
-        call %RepoRoot%\DevCmd.cmd /PreserveContext /prerelease -arch=arm64 -host_arch=amd64
+        call %RepoRoot%\DevCmd.cmd /PreserveContext /prerelease -arch=arm64 -host_arch=%_HostArch%
     ) else (
-        call %RepoRoot%\DevCmd.cmd /PreserveContext /prerelease -arch=%_BuildArch% -host_arch=amd64
+        call %RepoRoot%\DevCmd.cmd /PreserveContext /prerelease -arch=%_BuildArch% -host_arch=%_HostArch%
     )
     if errorlevel 1 (echo Could not set up a developer command prompt && exit /b %ERRORLEVEL%)
 :SkipDevCmd
 
 if "%VisualStudioVersion%" == "16.0" (echo Visual Studio 2019 is not supported. && exit /b /1)
 
-set PATH=%RepoRoot%\.buildtools\MSBuild\Current\Bin\amd64;%RepoRoot%\.tools;%RepoRoot%\.tools\VSS.NuGet.AuthHelper;%RepoRoot%\tools;%RepoRoot%\dxaml\scripts;%PATH%
+set PATH=%RepoRoot%\.buildtools\MSBuild\Current\Bin\%_HostArch%;%RepoRoot%\.tools;%RepoRoot%\.tools\VSS.NuGet.AuthHelper;%RepoRoot%\tools;%RepoRoot%\dxaml\scripts;%PATH%
 
 rem If we have init'd from a VS developer command prompt, we should use its tooling instead of the VS build tools installed with the repo
-call :AddPathIfExists "%VSINSTALLDIR%\MSBuild\Current\Bin\amd64"
+call :AddPathIfExists "%VSINSTALLDIR%\MSBuild\Current\Bin\%_HostArch%"
 
 call :SetEnviromentVariable BuildArtifactsDir "%RepoRoot%\BuildOutput"
 

--- a/perf/pgo/Microsoft.WinUI.PGO.props
+++ b/perf/pgo/Microsoft.WinUI.PGO.props
@@ -24,8 +24,19 @@
 
   <Import Project="$(PkgMicrosoft_PGO_Helpers_Cpp)\build\Microsoft.PGO-Helpers.Cpp.props" />
 
-  <!-- Since we are running on a x64 machine, use x64 version of pgomger.exe -->
-  <PropertyGroup Condition="'$(PGOPlatformShortName)' == 'ARM64' or '$(PGOPlatformShortName)' == 'ARM'">
+  <!--
+      pgomgr.exe (PGO profile merge) is a host tool: it only needs to run on the
+      build machine, and pgomgr /merge is target-agnostic (e.g. an x64 pgomgr can
+      merge ARM64 profile data - see the non-arm64 case below). So select it by the
+      native HOST architecture to run it natively instead of emulated.
+  -->
+  <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">
+    <PGOMgrToolPath>$(VCToolsInstallDir)bin\Hostarm64\arm64\pgomgr.exe</PGOMgrToolPath>
+  </PropertyGroup>
+
+  <!-- On a non-arm64 (x64) build machine there is no runnable ARM/ARM64 pgomgr, so
+       use the native x64 pgomgr to merge ARM/ARM64 target profile data. -->
+  <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' != 'Arm64' and ('$(PGOPlatformShortName)' == 'ARM64' or '$(PGOPlatformShortName)' == 'ARM')">
     <PGOMgrToolPath>$(VCToolsInstallDir)bin\Hostx64\x64\pgomgr.exe</PGOMgrToolPath>
   </PropertyGroup>
 

--- a/scripts/PostInit.ps1
+++ b/scripts/PostInit.ps1
@@ -50,6 +50,15 @@ if (($buildPlatform -ne "x86") -and ($buildPlatform -ne "x64"))
     $mainPkgs.Add("packages.$buildPlatform.config")
 }
 
+# On an arm64 build host we also build an arm64 GenXbf.dll (see BuildGenXbfForMSBuild.csproj),
+# which links against the arm64 Windows SDK. Restore it even for x86/x64 product targets so
+# that GenXbf link step can find the arm64 SDK libs (e.g. kernel32.lib).
+if (([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) -and
+    (-not ($mainPkgs -contains "packages.arm64.config")))
+{
+    $mainPkgs.Add("packages.arm64.config")
+}
+
 Write-Host "Restoring packages for build platform $buildPlatform..." -NoNewline
 $installed = 0
 foreach ($pkg in $mainPkgs)

--- a/scripts/init/Initialize-InstallMSBuild.ps1
+++ b/scripts/init/Initialize-InstallMSBuild.ps1
@@ -9,6 +9,11 @@ param(
 
 Import-Module -Name $PSScriptRoot\..\MSBuildFunctions.psm1 -DisableNameChecking
 
+# Select the MSBuild that matches the native host architecture so we run it
+# natively instead of emulated. Falls back to amd64 for any host that is neither
+# arm64 nor amd64 (e.g. x86, or a future architecture such as RISC-V).
+$hostArch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { 'arm64' } else { 'amd64' }
+
 #is VS installed on this machine?
 if (Test-Path -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\") {
     $msBuildInstallations = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -requires Microsoft.Component.MSBuild -property InstallationPath -prerelease
@@ -17,7 +22,7 @@ if (Test-Path -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\") {
     Write-Host
 
     foreach ($msBuildInstallation in $msBuildInstallations) {
-        $msBuildPath = (Join-Path $msBuildInstallation "MSBuild\Current\Bin\amd64\msbuild.exe")
+        $msBuildPath = (Join-Path $msBuildInstallation "MSBuild\Current\Bin\$hostArch\msbuild.exe")
         if (Test-Path $msBuildPath) {
             $msBuildVersion = & $msBuildPath -version -noLogo
             Write-Host "$msBuildPath (v$msBuildVersion)"
@@ -53,7 +58,7 @@ else {
     }
 
     # Check if global VS is valid
-    $msbuildUpToDate = Test-MSBuild (Join-Path $vsInstallDir "MSBuild\Current\Bin\amd64\msbuild.exe")
+    $msbuildUpToDate = Test-MSBuild (Join-Path $vsInstallDir "MSBuild\Current\Bin\$hostArch\msbuild.exe")
 }
 
 # If globally installed VS is out of date, or we're ignoring it, switch to using VS build tools
@@ -61,7 +66,7 @@ if (-not $msbuildUpToDate) {
     $useVsBuildTools = $true
     $vsInstallDir = $installDir;
     # Check if VS build tools is valid
-    $msbuildUpToDate = Test-MSBuild (Join-Path $vsInstallDir "MSBuild\Current\Bin\amd64\msbuild.exe")
+    $msbuildUpToDate = Test-MSBuild (Join-Path $vsInstallDir "MSBuild\Current\Bin\$hostArch\msbuild.exe")
 }
 
 if ($useVsBuildTools) {

--- a/scripts/init/SetHostArch.cmd
+++ b/scripts/init/SetHostArch.cmd
@@ -1,0 +1,38 @@
+@echo off
+rem =============================================================================
+rem SetHostArch.cmd
+rem
+rem Detects the native host processor architecture and exposes it as _HostArch,
+rem using the naming convention the build uses for toolchain folders:
+rem     amd64 | arm64
+rem
+rem This selects which *native* build toolchain (MSBuild, VC compilers, VsDevCmd
+rem host tools) to run. It is independent of the *target* architecture being
+rem built (_BuildArch / Platform).
+rem
+rem We fall back to amd64 for any host that is neither arm64 nor amd64 (e.g. x86,
+rem or a future architecture such as RISC-V) so the build keeps working via
+rem emulation rather than failing outright.
+rem
+rem Detection order (most authoritative first):
+rem   1. The machine-level PROCESSOR_ARCHITECTURE in the registry. This always
+rem      reflects the true OS architecture even when init runs from an emulated
+rem      shell (e.g. an x64 process on an arm64 OS), where the process-level
+rem      environment variables would otherwise report the emulated architecture.
+rem   2. PROCESSOR_ARCHITEW6432 - set only in an emulated process, where it holds
+rem      the true host architecture.
+rem   3. PROCESSOR_ARCHITECTURE - the process (possibly emulated) architecture.
+rem =============================================================================
+
+set _HostArch=amd64
+set _detectedHostArch=
+
+for /f "tokens=3" %%a in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v PROCESSOR_ARCHITECTURE 2^>nul ^| findstr /i "REG_SZ"') do set _detectedHostArch=%%a
+
+if not defined _detectedHostArch set _detectedHostArch=%PROCESSOR_ARCHITEW6432%
+if not defined _detectedHostArch set _detectedHostArch=%PROCESSOR_ARCHITECTURE%
+
+if /i "%_detectedHostArch%"=="ARM64" set _HostArch=arm64
+
+set _detectedHostArch=
+exit /b 0

--- a/scripts/init/SetMSBuildVars.cmd
+++ b/scripts/init/SetMSBuildVars.cmd
@@ -1,1 +1,2 @@
-set PATH=%1\MSBuild\Current\Bin\amd64;%PATH%
+call "%~dp0SetHostArch.cmd"
+set PATH=%1\MSBuild\Current\Bin\%_HostArch%;%PATH%

--- a/src/XamlCompiler/runtests.cmd
+++ b/src/XamlCompiler/runtests.cmd
@@ -82,7 +82,8 @@ set "OBJ=%REPO%\BuildOutput\obj\%CONFIG%\src\XamlCompiler\Tests\UnitTests"
 set "PROD=%REPO%\BuildOutput\bin\%CONFIG%\Product"
 set "EXE=%REPO%\BuildOutput\obj\%CONFIG%\src\XamlCompiler\Exe\Microsoft.UI.Xaml.Markup.Compiler.Executable"
 set "DST=%REPO%\src\XamlCompiler\Tests\UnitTests\UnitTestingBin"
-set "MSB=%REPO%\.buildtools\MSBuild\Current\Bin\amd64\MSBuild.exe"
+call "%REPO%\scripts\init\SetHostArch.cmd"
+set "MSB=%REPO%\.buildtools\MSBuild\Current\Bin\%_HostArch%\MSBuild.exe"
 
 echo [INFO] Repo:     %REPO%
 echo [INFO] Config:   %CONFIG%   (Platform=%PLATFORM%, Flavor=%FLAVOR%)


### PR DESCRIPTION
## Fixes 

<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

Fixes #11249

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

The build scripts hardcoded `amd64` for the **host** toolchain, so on a native arm64 machine everything ran x64-emulated. This auto-detects the native host architecture and selects the matching native toolchain, falling back to `amd64` for any host that is neither arm64 nor amd64 (x86, or a future arch such as RISC-V). Independent of the **target** architecture being built.

While arm64 devices can run x64 tools like cl.exe and MSBuild.exe under emulation, Visual Studio 2022 and later offers native arm64 versions of these build tools as well, which significantly speeds up the build process.

<!-- Describe your changes in detail. -->

### Current Behavior
<!-- How does this work today? -->

The `.\Build.cmd` script always invokes amd64/x64 host tools, even on arm64 devices

### New Behavior
<!-- How will it work after this PR? -->

The `.\Build.cmd` script auto-detects the host architecture and uses native arm64 build tools on arm64 devices, such as the Surface Pro X.

## Customer Impact

<!-- How does this change affect end users? Is it user-facing or infra changes? -->

Just build-related changes for users who want to contribute to this repository.

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

Also, here's a successful CI build on both an x64 and arm64 host: https://github.com/dennisameling/microsoft-ui-xaml/actions/runs/29587060879

## Screenshots (if appropriate)

<!-- If you are making visual changes, include before/after screenshots. -->