### PR TITLE
[Do Not Review] Validate OSS-pinned WinUI dependencies

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -154,6 +154,14 @@ extends:
           buildProductOnly: true
           dependsOn: ValidateGitHubPrContext
 
+      - template: build\AzurePipelinesTemplates\WinUI-TestWinUIComponentPackageUpdate-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: GitHubPR
+          buildScenarioApps: false
+          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+          dependsOn: ValidateGitHubPrContext
+
     - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
         parameters:

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/user/hmishra/gh-ado-oss-pinned-winui-deps
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
@@ -147,7 +147,7 @@ extends:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
         parameters:
           pipelineKind: GitHubPR
-          buildScenarioApps: false
+          buildScenarioApps: true
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'


### PR DESCRIPTION
Validation-only PR for the WinUI validation restoration effort.

This keeps changes limited to `build/WinUI-GitHub-PR.yml` and:
- points `WinUIInternal` at ADO branch `user/hmishra/gh-ado-oss-pinned-winui-deps` (commit `bcbb7f10cf`), and
- enables `buildScenarioApps: true` for the GitHub PR product build so sample app validation consumes the generated `Microsoft.WindowsAppSDK.WinUI` package with OSS-pinned dependency overrides.

Do not review or merge.