### PR TITLE
[WinUI OSS] Restore MUXControls GitHub PR validation

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -151,7 +151,7 @@ extends:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: true
+          buildProductOnly: false
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
@@ -163,7 +163,7 @@ extends:
           MUXFinalRelease: true
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: true
+          buildProductOnly: false
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:


### PR DESCRIPTION
Fixes: https://github.com/microsoft/microsoft-ui-xaml/issues/11287

## Description

Restores MUXControls coverage in the GitHub-backed validation pipeline by running the full WinUI build path from the public GitHub wrapper.

The required internal pipeline support has already landed, so this PR now only updates the public wrapper to pass `buildProductOnly: false` for both the normal build stage and the MUXFinalRelease stage.

## Validation

A fresh GitHub-backed validation run has been queued for this PR.
