### PR TITLE
Restore packaging fusion GitHub validation

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/user/hmishra/gh-ado-packaging-fusion-fullbuild
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig


### PR DESCRIPTION
## Description

Validation-only GitHub PR for restoring the packaging, fusion manifest, and symbol artifact portions of GitHub-backed WinUI PR validation.

This points the public GitHub wrapper at the ADO branch `user/hmishra/gh-ado-packaging-fusion-fullbuild` and uses the full-build path that was proven by the MUXControls validation work.

## Validation target

- ADO branch: `user/hmishra/gh-ado-packaging-fusion-fullbuild`
- ADO task: 62750651
- ADO validation run: https://dev.azure.com/microsoft/WinUI/_build/results?buildId=152804993

## Notes

This PR is for scheduling and proving GitHub-backed ADO validation. It should not be completed until the corresponding internal ADO branch is ready.
