### PR TITLE
[WinUI OSS] pr4: Add Samples/WinUIGallery submodule on winui3/main (RestorePaths strategy)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Samples/WinUIGallery"]
+	path = Samples/WinUIGallery
+	url = https://github.com/microsoft/WinUI-Gallery.git


### PR DESCRIPTION
## Summary
PR 4 in the WinUIGallery open-sourcing workstream (RestorePaths strategy).

Adds the `Samples/WinUIGallery` submodule to **`winui3/main`** so the branch itself carries the gitlink and `.gitmodules`:
- gitlink `Samples/WinUIGallery` @ `29f62479d5c046a0b854a5868e5a7cd484572d87` (current WinUI-Gallery `main` tip)
- root `.gitmodules` -> `https://github.com/microsoft/WinUI-Gallery.git`

## Validation
- Commit contains a valid `160000` gitlink + resolvable `.gitmodules`.
- Post-merge: trigger a `winui3/main` source-mirror run and confirm the submodule (folder@sha) + `.gitmodules` persist in the public repo.