### PR TITLE
[WinUI OSS] Enable PGO Optimize on the GitHub PR validation (diagnostic)

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,9 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      # TEMPORARY (PGO diagnostic): repoint to the lift branch carrying the enablePgo
+      # template param. Revert to refs/heads/main before merge.
+      ref: refs/heads/user/gpaskaleva/gh-ado-public-validation-pgo
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
@@ -150,7 +152,7 @@ extends:
           buildScenarioApps: false
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
-          pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
+          enablePgo: true
           buildProductOnly: false
           dependsOn: ValidateGitHubPrContext
 


### PR DESCRIPTION
## Description

### Summary

Enables Profile-Guided Optimization (PGO) on the  GitHubPR build stage of the GitHub-facing PR validation wrapper so the release ( fre ) legs build with  PGOBuildMode=Optimize instead of Off.

### Changes

 build/WinUI-GitHub-PR.yml :

1.  GitHubPR  stage — added  enablePgo: true and removed the hardcoded  pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off' . Removing the literal lets the shared build-stage template's default ( /p:PGOBuildMode=$(pgoBuildMode) ) apply, so the pipeline's "Enable PGO" step drives the build mode. With  enablePgo: true , the  fre  x86/x64/arm64 legs opt into PGO ( arm64ec  and Debug legs remain off).
2.  WinUIInternal  pipeline resource (temporary) — repointed  ref  from  refs/heads/main  to the branch that carries the new  enablePgo  template parameter. The wrapper consumes the build templates via this Azure Repos resource, so the parameter isn't visible until that template change reaches  main .

The  Build_MUXFinalRelease  stage is intentionally left unchanged.