### PR TITLE
[Do Not Review] Validate scenario app tests restoration

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/user/sakshishar/restore-scenario-app-tests
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig
@@ -147,12 +147,18 @@ extends:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
         parameters:
           pipelineKind: GitHubPR
-          buildScenarioApps: false
+          buildScenarioApps: true
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: true
+          buildProductOnly: false
           dependsOn: ValidateGitHubPrContext
+
+      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: GitHubPR
+          dependsOn: Build
+          runArm64Tests: ${{ parameters.runArm64Tests }}
 
     - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
@@ -163,7 +169,7 @@ extends:
           MUXFinalRelease: true
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: true
+          buildProductOnly: false
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:

--- a/test/CreateTestPayload.ps1
+++ b/test/CreateTestPayload.ps1
@@ -18,6 +18,8 @@ param(
 
     [switch]$SkipSymbols,
 
+    [switch]$SkipWinUIGallery,
+
     [switch]$Clean,
 
     [switch]$Quiet
@@ -67,6 +69,7 @@ function Print-Config
     Write-Host "Platform:                          $Platform"
     Write-Host "Configuration:                     $Configuration"
     Write-Host "Skip Symbols:                      $SkipSymbols"
+    Write-Host "Skip WinUIGallery:                 $SkipWinUIGallery"
     Write-Host "Show Payload:                      $ShowPayload"
     Write-Host "Mode set (manually set by -mode):  $Mode"
     Write-Host "Modes not set [X] :                $modes"
@@ -227,25 +230,30 @@ if ($Mode -eq "ScenarioTestSuite")
         Publish-Item "$binpath\Samples\WinUICsDesktopSampleApp_Test\*.msix*" "$outpath\Test\"
         Publish-Item "$binpath\Samples\WinUICppDesktopSampleApp_Test\*.msix*" "$outpath\Test\"
     }
-    # The Windows App SDK MSIX tooling stamps platform/version/config into the test-package directory name,
-    # e.g. WinUIGallery_x86_1.0.0.0_Debug_Test. Discover it dynamically rather than hard-coding the suffix.
-    $galleryTestDir = Get-ChildItem -Path "$binpath\Samples" -Directory -Filter "WinUIGallery*Test" -ErrorAction SilentlyContinue | Select-Object -First 1
-    if (-not $galleryTestDir)
+    if (-not $SkipWinUIGallery)
     {
-        throw "WinUIGallery test package directory not found under '$binpath\Samples' (expected a folder matching 'WinUIGallery*Test')."
-    }
-    Publish-Item "$($galleryTestDir.FullName)\WinUIGallery*.msix*" "$outpath\Test\"
-    Get-ChildItem -Path "$outpath\Test" -Filter "WinUIGallery*.msix*" -File -ErrorAction SilentlyContinue |
-        Where-Object { $_.Extension -in @(".msix", ".msixbundle") } |
-        ForEach-Object {
-            $target = Join-Path $_.DirectoryName ("WinUIGallery$($_.Extension)")
-            if ($_.FullName -ne $target) { Move-Item -Path $_.FullName -Destination $target -Force }
+        # The Windows App SDK MSIX tooling stamps platform/version/config into the test-package directory name,
+        # e.g. WinUIGallery_x86_1.0.0.0_Debug_Test. Discover it dynamically rather than hard-coding the suffix.
+        $galleryTestDir = Get-ChildItem -Path "$binpath\Samples" -Directory -Filter "WinUIGallery*Test" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $galleryTestDir)
+        {
+            throw "WinUIGallery test package directory not found under '$binpath\Samples' (expected a folder matching 'WinUIGallery*Test')."
         }
+
+        Publish-Item "$($galleryTestDir.FullName)\WinUIGallery*.msix*" "$outpath\Test\"
+        Get-ChildItem -Path "$outpath\Test" -Filter "WinUIGallery*.msix*" -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Extension -in @(".msix", ".msixbundle") } |
+            ForEach-Object {
+                $target = Join-Path $_.DirectoryName ("WinUIGallery$($_.Extension)")
+                if ($_.FullName -ne $target) { Move-Item -Path $_.FullName -Destination $target -Force }
+            }
+
+        Publish-Item "$binpath\Test\WinUIGalleryTestData.xml" "$outpath\Test\"
+    }
 
     Publish-Item "$binpath\Test\MUXControls.Test.dll" "$outpath\Test\"
     Publish-Item "$binpath\Test\MUXTestInfra.dll" "$outpath\Test\"
     Publish-Item "$binpath\Test\Microsoft.Windows.Apps.Test.*.dll" "$outpath\Test\"
-    Publish-Item "$binpath\Test\WinUIGalleryTestData.xml" "$outpath\Test\"
 
     # TODO: Remove below check
     if (-not ($env:BUILD_DEFINITIONNAME -and ($env:BUILD_DEFINITIONNAME.Contains("ValidateReunion") -or $env:BUILD_DEFINITIONNAME.Contains("WindowsAppSDK"))))
@@ -254,7 +262,7 @@ if ($Mode -eq "ScenarioTestSuite")
     }
 
     # TODO: Remove below check
-    if ($env:BUILD_DEFINITIONNAME -and ($env:BUILD_DEFINITIONNAME.Contains("ValidateReunion") -or $env:BUILD_DEFINITIONNAME.Contains("WindowsAppSDK")))
+    if ((-not $SkipWinUIGallery) -and $env:BUILD_DEFINITIONNAME -and ($env:BUILD_DEFINITIONNAME.Contains("ValidateReunion") -or $env:BUILD_DEFINITIONNAME.Contains("WindowsAppSDK")))
     {
         Publish-Item "$($galleryTestDir.FullName)\Dependencies\$redistPlatform\*.msix" "$outpath\Test\"
     }


### PR DESCRIPTION
## Description

Validation-only PR for ADO task 62750646 and GitHub issue #11286.

This validates restoration of Scenario App Tests for GitHub-backed Azure Pipelines PR validation.

## Validation setup

- ADO branch: `user/sakshishar/restore-scenario-app-tests`
- Enables scenario and sample app builds
- Enables the `RunScenarioTests` stage for `GitHubPR`
- Validates C# and C++ desktop scenario tests
- Validates scenario app unit tests
- Uses the main build artifact for GitHub scenario unit tests

## Current scope

WinUIGallery scenario tests remain excluded because their GitHub build and generated test-data prerequisites are not currently available.

## Important

This PR is for validation only and must not be reviewed or merged.
