### PR TITLE
Use soft border mode for the SystemBackdropElement placement visual

### DIFF
--- a/controls/dev/SystemBackdropElement/SystemBackdropElement.cpp
+++ b/controls/dev/SystemBackdropElement/SystemBackdropElement.cpp
@@ -174,6 +174,8 @@ void SystemBackdropElement::UpdatePlacementVisualClip()
     
     // Apply the clip to the placement visual
     m_backdropLink.PlacementVisual().Clip(m_clip);
+
+    m_backdropLink.ExternalBackdropBorderMode(winrt::Microsoft::UI::Composition::CompositionBorderMode::Soft);
 }
 
 void SystemBackdropElement::EnsureCompositionResources()


### PR DESCRIPTION
Rounded corners came out jagged because the backdrop link defaults to a hard border. Switching it to Soft brings proper anti-aliasing on the edges.

## Fixes

https://github.com/microsoft/microsoft-ui-xaml/issues/11086

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

I simply added a call to set the border type to soft:

```c++
m_backdropLink.PlacementVisual().Clip(m_clip);
// Added this line:
m_backdropLink.ExternalBackdropBorderMode(winrt::Microsoft::UI::Composition::CompositionBorderMode::Soft);
```

### Current Behavior
Rounded corners look jagged with `SystemBackdropElement`

### New Behavior
Rounded corners look nice and smooth

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

## Screenshots

### Old

<img width="362" height="117" alt="image" src="https://github.com/user-attachments/assets/bb8d485e-c370-4d3d-9112-a2b28da31442" />

### New

<img width="373" height="150" alt="image" src="https://github.com/user-attachments/assets/3a1c85ac-d5ad-4ee7-8ac8-eeb822a5600d" />
