### PR TITLE
Modifying build-pr script to work with LMR present

### DIFF
--- a/.github/scripts/build-pr.ps1
+++ b/.github/scripts/build-pr.ps1
@@ -22,19 +22,11 @@ if (-not (Test-Path $binlogDir)) { New-Item -ItemType Directory -Force -Path $bi
 
 $commonArgs = "/restore /m /ds:false"
 
-$lmrSentinel = "src\XamlCompiler\BuildTasks\Microsoft\Lmr\XamlTypeUniverse.cs"
-if (Test-Path $lmrSentinel) {
-    Write-Host "LMR present - building XamlCompilerPrerequisites.sln"
-    $prereqSteps = @(
-        "msbuild XamlCompilerPrerequisites.sln /p:Platform=$Platform /p:Configuration=$Configuration $commonArgs /binaryLogger:$binlogDir\XamlCompilerPrerequisites.$Platform.$Configuration.binlog"
-    )
-} else {
-    Write-Host "OSS path - using XamlCompilerPublic.csproj + BuildGenXbfForMSBuild.csproj"
-    $prereqSteps = @(
-        "msbuild XamlCompilerPublic.csproj                              /p:Platform=$Platform /p:Configuration=$Configuration $commonArgs /binaryLogger:$binlogDir\XamlCompilerPublic.$Platform.$Configuration.binlog",
-        "msbuild eng\BuildGenXbfForMSBuild\BuildGenXbfForMSBuild.csproj /p:Platform=$Platform /p:Configuration=$Configuration $commonArgs /binaryLogger:$binlogDir\BuildGenXbfForMSBuild.$Platform.$Configuration.binlog"
-    )
-}
+# Build the XAML compiler from source. XamlCompilerPrerequisites.sln also builds
+# GenXbf (via the BuildGenXbfForMSBuild project it contains), so no separate step is needed.
+$prereqSteps = @(
+    "msbuild XamlCompilerPrerequisites.sln /p:Platform=$Platform /p:Configuration=$Configuration $commonArgs /binaryLogger:$binlogDir\XamlCompilerPrerequisites.$Platform.$Configuration.binlog"
+)
 
 $sequence = $prereqSteps + @(
     "msbuild Microsoft.UI.Xaml-Product.sln                       /p:Platform=$Platform /p:Configuration=$Configuration $commonArgs /binaryLogger:$binlogDir\Microsoft.UI.Xaml-Product.$Platform.$Configuration.binlog",


### PR DESCRIPTION
## PR Type

- [x] Build related changes

## Description

The PR build script (`.github/scripts/build-pr.ps1`) previously detected whether the LMR (XAML compiler) sources were present in the repo by probing for a sentinel file (`src\XamlCompiler\BuildTasks\Microsoft\Lmr\XamlTypeUniverse.cs`). Based on that check it branched between two prerequisite build paths:

- **LMR present:** build `XamlCompilerPrerequisites.sln`
- **OSS path (LMR absent):** build `XamlCompilerPublic.csproj` + `eng\BuildGenXbfForMSBuild\BuildGenXbfForMSBuild.csproj`

Now that LMR is present in the repo, the fallback OSS path is no longer needed. This PR removes the sentinel check and the conditional, so the script always builds the XAML compiler from source via `XamlCompilerPrerequisites.sln`. That solution already builds GenXbf (through the `BuildGenXbfForMSBuild` project it contains), so no separate GenXbf step is required.

### Current Behavior
The script probes for the LMR sentinel file and picks between the LMR prerequisite solution and the OSS `XamlCompilerPublic` + `BuildGenXbfForMSBuild` steps.

### New Behavior
The script unconditionally builds `XamlCompilerPrerequisites.sln`, which compiles the XAML compiler and GenXbf together.

## Customer Impact

Infrastructure/CI only. No user-facing or runtime behavior change.

## Regression Potential

- [x] Low risk — isolated change, limited scope

Only the PR build script is affected. The removed OSS branch is obsolete now that LMR is always present.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] Existing tests pass locally

Validated via the PR build pipeline running `build-pr.ps1`.