### PR TITLE
Add Run Tests Stage to WinUI-GitHub-PR

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -167,6 +167,13 @@ extends:
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
+      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: PR
+          # Test results are published but do not gate the pipeline yet.
+          failOnTestFailure: false
+
+    - ${{ if eq(parameters.runFullValidation, true) }}:
       - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
         parameters:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}


### PR DESCRIPTION
Adds the **Run Tests Stage** to `WinUI-GitHub-PR`, at full parity with `WinUI-Xaml-PR`: all three OS
legs (Win11-25H2, Win11-23H2, Win10-RS5) with the default 20 slices each, plus the auto-injected
`postRunTests*` jobs.

**7 lines, one file, pure addition.** `winui3/main` already carries `buildProductOnly: false` on both
build stages, so the build already produces the test binaries — only the stage itself was missing.

```yaml
- template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
  parameters:
    pipelineKind: PR
    # Test results are published but do not gate the pipeline yet.
    failOnTestFailure: false
```

## Why tests are non-gating for now

`failOnTestFailure: false` means results are still collected and published to the Tests tab, they
just do not fail the pipeline. Only the test-result gate is relaxed; the `Run Tests` step keeps
`errorActionPreference: stop`, so genuine infrastructure failures still surface.

Both known failure clusters are pre-existing and unrelated to this change:

- **Win11-25H2 Graphics / WPF** — image-sensitive tests that also fail on the internal pipeline. ADO
  build `153192339` had 161 WPF failures on its own 25H2 leg; the same binaries are 100% green on 23H2.
- **Win10-RS5 WebView2** — the runtime installer ships in an internal-only package that
  `WinUI-InstallDependencies-Steps.yml` already skips restoring on GitHub. Windows 11 carries the
  runtime in the OS; Win10 RS5 does not, so 55 of 56 WebView2 tests fail there against **0 of 55 on
  each Win11 leg**.

## Validation

Build [`153202059`](https://dev.azure.com/microsoft/WinUI/_build/results?buildId=153202059) built the
full solutions on a GitHub-backed leg in **63.4 min** and ran the complete suite:

| | Result |
|---|---|
| Build (5 flavors) | succeeded, 63.4m |
| CreateTestPayload 25H2 / 23H2 / RS5 | 3/3 |
| RunTests23H2 + postRunTests23H2 | **20/20 and 20/20 green** |
| **Tests** | **19,597 run, 19,399 passed (99.0%)** |

All three OS images — including `Win11-23H2` and `Win10-2019-LTSC`, previously unexercised by this
definition — acquired agents without issue.

## Dependency

Requires **PR 16301291** in `microsoft-ui-xaml-lift`, which adds the `failOnTestFailure` parameter
and removes a dead `Build.Repository.Provider` guard from the stage condition (2 files, 8 insertions).
**That must merge first.**

Supersedes #11335.
