### PR TITLE
pr7: Check out the WinUIGallery submodule in GitHub PR validation

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -73,7 +73,7 @@ extends:
     platform:
       name: 'windows_undocked'
     git:
-      submodules: false
+      submodules: true
     globalsdl:
       tsa:
         enabled: false


### PR DESCRIPTION
`Samples/WinUIGallery` is a committed submodule on `winui3/main` (github.com/microsoft/WinUI-Gallery @ `29f62479`), but `build/WinUI-GitHub-PR.yml` pins `git.submodules` to `false`, so PR builds get an empty directory. The internal `WinUI-PR.yml` sets no `git:` block at all and inherits the OneBranch default — which is exactly why `MUXControls.Test`'s `GenerateWinUIGalleryTestData` target worked internally only.

## Change

```diff
     git:
-      submodules: false
+      submodules: true
```

The lightweight `ValidateGitHubPrContext` job keeps `checkout: self / submodules: false` — it does no build and does not need the Gallery clone.

## Validation

Reproduced locally in a `winui3/main` worktree with the submodule initialized and the paired csproj change applied:

| Check | Result |
| --- | --- |
| `msb /restore controls\test\MUXControls.Test\MUXControls.Test.csproj` (`IsInternalWinUIBuild` = false) | Build succeeded; `BuildOutput\bin\amd64chk\Test\WinUIGalleryTestData.xml` produced — 44,897 bytes, 19 tables / 120 rows, byte-identical to the internal build |
| Same build with `ControlInfoData.json` removed | Build succeeded, target skipped, no error |
| `WinUI-GitHub-PR.yml` YAML parse | OK (`git: {submodules: True}`) |

## Notes

- `git.submodules` is global to this pipeline, so every job now clones WinUI-Gallery. Acceptable — it is a public, moderately sized repo.
- This PR self-validates: it targets `winui3/main`, which triggers the very pipeline being edited.
- Paired with internal PR 16290751, which re-gates the MSBuild target on `Exists(...)` instead of `IsInternalWinUIBuild`. Order does not matter; each is inert without the other.

AB#62718749

