### PR TITLE
[WinUI OSS] Restore MUXFinalRelease validation signal

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -163,7 +163,7 @@ extends:
           MUXFinalRelease: true
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: false
+          buildProductOnly: true
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:


### PR DESCRIPTION
### Summary

Restores the MUXFinalRelease build validation signal on GitHub PRs by setting `buildProductOnly: true` on the Build_MUXFinalRelease stage in build/WinUI-GitHub-PR.yml .

### Context

 MUXFinalRelease  validates that the WinUI product compiles cleanly in final-release mode — without the prerelease defines toggled in eng/muxfinalrelease.props (Build.cmd /muxfinal  →  /p:MUXFinalRelease=true). It runs as an independent stage on GitHub PRs, giving early signal that the shipping build configuration is intact.

This stage had stopped producing that signal. It was configured with  buildProductOnly: false, which expands the build to additional solutions and dependencies that aren't part of the product build available in this repo's PR environment. As a result the stage failed before it could exercise the MUXFinalRelease configuration, so the intended signal was never produced.

### Change

With `buildProductOnly: true`, the stage builds Microsoft.UI.Xaml-Product.sln with /p:MUXFinalRelease=true — exactly the intended signal — scoped to what's buildable in the GitHub PR environment.

The  Build_MUXFinalRelease stage runs independently (dependsOn: ValidateGitHubPrContext), so this restores its signal without affecting other stages.

### Validation

• Confirmed only the Build_MUXFinalRelease stage changed; other stages are untouched.
• The stage now builds the product in final-release mode, matching what the GitHub PR environment supports.
