### PR TITLE
Disable GitHub PR build matrix on winui3/main

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -30,6 +30,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  DISABLE_PR_BUILD_MATRIX_VALIDATION: 'true'
+
 jobs:
   build:
     name: Build (${{ matrix.flavor }})
@@ -69,13 +72,20 @@ jobs:
       CL: '/MP2'
 
     steps:
+      - name: Skip disabled PR Build validation
+        if: env.DISABLE_PR_BUILD_MATRIX_VALIDATION == 'true'
+        shell: pwsh
+        run: Write-Host "PR Build matrix validation is disabled by DISABLE_PR_BUILD_MATRIX_VALIDATION."
+
       - name: Checkout
+        if: env.DISABLE_PR_BUILD_MATRIX_VALIDATION != 'true'
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
           show-progress: false
 
       - name: Initialize build environment and build
+        if: env.DISABLE_PR_BUILD_MATRIX_VALIDATION != 'true'
         shell: pwsh
         run: |
           & "${{ github.workspace }}/.github/scripts/build-pr.ps1" `
@@ -84,7 +94,7 @@ jobs:
             -Configuration $env:WINUI_BUILD_CONFIGURATION
 
       - name: Upload MSBuild binlogs
-        if: failure()
+        if: failure() && env.DISABLE_PR_BUILD_MATRIX_VALIDATION != 'true'
         uses: actions/upload-artifact@v6
         with:
           name: binlogs-${{ matrix.flavor }}
@@ -93,6 +103,7 @@ jobs:
           retention-days: 7
 
       - name: Upload product runtime payload
+        if: env.DISABLE_PR_BUILD_MATRIX_VALIDATION != 'true'
         uses: actions/upload-artifact@v6
         with:
           name: winui-product-${{ matrix.flavor }}


### PR DESCRIPTION
# Disable automatic GitHub PR Build matrix on winui3/main

## Summary
- Added `DISABLE_PR_BUILD_MATRIX_VALIDATION` to `.github/workflows/pr-build.yml`.
- Kept the existing `pull_request` and `workflow_dispatch` triggers intact.
- Added a no-op skip step and gated checkout, build, and artifact upload steps so the six PR Build matrix jobs complete without running product builds while the switch is enabled.

## Notes
This ports the effective workflow change from #11347 to the `winui3/main` branch.

This stops the six `PR Build / Build (...)` matrix validations from running product builds automatically on new PRs:
- `PR Build / Build (x86chk)`
- `PR Build / Build (x86fre)`
- `PR Build / Build (x64chk)`
- `PR Build / Build (x64fre)`
- `PR Build / Build (arm64chk)`
- `PR Build / Build (arm64fre)`

After this merges, remove those six checks from the required status checks in the GitHub ruleset/branch protection settings and keep `github-pr-xaml` required.

## Validation
- Confirmed the expected workflow guard, skip step, and gated build/artifact steps are present.
