### PR TITLE
Gate InkCanvas system compositor path

### DIFF
--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -445,23 +445,18 @@ void InkCanvas::DetachFromVisualLink()
     }
 }
 
-// Compositor-engine detection: true when the process runs on the system composition engine.
-// CompositionEngine::GetForSystemEngine returns a non-null system object only on a system-backed
-// compositor, so it selects the system splice (AttachToSystemCompositor) over the lifted
-// ContentExternalOutputLink path (AttachToLiftedCompositor). Evaluated once per process on first
-// use, so every InkCanvas on the thread agrees for the process lifetime.
+// Compositor-engine detection: true when the process exposes the system-compositor splice interop.
+// QueryInterface is used as the gate so public builds that do not project newer CompositionEngine
+// APIs still compile and naturally fall back to the lifted ContentExternalOutputLink path. Evaluated
+// once per process on first use, so every InkCanvas on the thread agrees for the process lifetime.
 bool InkCanvas::IsSystemCompositor()
 {
     static bool isSystemCompositor = [] {
         auto compositor = winrt::CompositionTarget::GetCompositorForCurrentThread();
-        // GetForSystemEngine takes any composition object (IInspectable); pass the compositor
-        // directly rather than allocating a throwaway visual just to probe the engine.
-        // CompositionEngine lives in the Microsoft.UI.Composition namespace (it was promoted out of
-        // the Experimental namespace in the InteractiveExperiences transport), so reference it there.
-        return winrt::Microsoft::UI::Composition::CompositionEngine::GetForSystemEngine(compositor) != nullptr;
+        winrt::com_ptr<ABI::Microsoft::UI::Composition::Experimental::IExpCompositorInterop2> interop;
+        return SUCCEEDED(winrt::get_unknown(compositor)->QueryInterface(IID_PPV_ARGS(interop.put())));
     }();
     return isSystemCompositor;
 }
-
 
 

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -46,10 +46,10 @@ private:
     void AttachToVisualLink();
     void DetachFromVisualLink();
 
-    // Compositor fork: IsSystemCompositor() detects (via CompositionEngine::GetForSystemEngine)
-    // whether the process runs on the system composition engine. A system-backed process splices the
-    // ink visual under a lifted MUC visual (AttachToSystemCompositor); a lifted process bridges it
-    // into the XAML tree via ContentExternalOutputLink (AttachToLiftedCompositor).
+    // Compositor fork: IsSystemCompositor() detects whether the system-compositor splice interop is
+    // exposed. A system-backed process splices the ink visual under a lifted MUC visual
+    // (AttachToSystemCompositor); other processes bridge it into the XAML tree via
+    // ContentExternalOutputLink (AttachToLiftedCompositor).
     void EnsureCompositionDevice();
     bool IsSystemCompositor();
     void AttachToSystemCompositor();


### PR DESCRIPTION
## Summary

Gate the InkCanvas system-compositor path using the existing `IExpCompositorInterop2` `QueryInterface` check instead of referencing `CompositionEngine::GetForSystemEngine` directly.

This keeps builds that do not project the newer IXP `CompositionEngine` API compiling, while still using the system-compositor splice when the interop is available. Other builds fall back to the existing `ContentExternalOutputLink` path.

## Validation

- Ran `git diff --check`.
- Confirmed `InkCanvas.cpp` no longer references `CompositionEngine::GetForSystemEngine`.