### PR TITLE
Bump OSS IXP package to 2.1.4-experimental

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -55,12 +55,12 @@
     <!-- OSS builds currently pin to last-known-good versions. -->
     <FoundationTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationTransportPackageVersion>
     <FrameworkUdkPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">3.0.0-experimental-27300.1893.260705-0915.0</FrameworkUdkPackageVersion>
-    <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IxpTransportPackageVersion>
+    <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IxpTransportPackageVersion>
     <BasePackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.3-experimental1</BasePackageVersion>
     <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260625.0</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
-    <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>
+    <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IXPPackageVersion>
     <!-- ====================================================================================== -->
     <!-- It is at this point that we might want our non-product code to be able to use a package version different than the primary configuration -->
     <!-- If so, this would probably be the point at which we would override the above version with what is configured for the app                 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260625.0</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
-    <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IXPPackageVersion>
+    <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>
     <!-- ====================================================================================== -->
     <!-- It is at this point that we might want our non-product code to be able to use a package version different than the primary configuration -->
     <!-- If so, this would probably be the point at which we would override the above version with what is configured for the app                 -->


### PR DESCRIPTION
## Summary

Bumps the OSS Interactive Experiences package pins to `2.1.4-experimental`.

This package version includes the `Microsoft.UI.Composition.CompositionEngine::GetForSystemEngine` projection used by InkCanvas.

## Validation

- Restored `eng\Microsoft.MaestroRestore.csproj` with the updated package pins.
