### PR TITLE
Validate Non-Gallery scenario app test restore (#11286)

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -179,3 +179,9 @@ extends:
       - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
         parameters:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+
+    - ${{ if eq(parameters.runFullValidation, true) }}:
+      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
+        parameters:
+          pipelineKind: GitHubPR
+          dependsOn: Build


### PR DESCRIPTION
## Summary

Enable the Scenario App Tests stage on GitHub PR validation. The scenario app tests (non-Gallery) now run as part of GitHub PR builds. WinUIGallery is intentionally skipped for now and tracked separately.

## Change

- `build/WinUI-GitHub-PR.yml` — add the `RunScenarioTests` stage to the GitHub PR pipeline (`pipelineKind: GitHubPR`, `dependsOn: Build`), guarded by `runFullValidation` to stay consistent with the other stages.

## Note

- WinUIGallery scenario coverage on GitHub is deferred and tracked in a separate issue.