### PR TITLE
[Validation] Restore non-Gallery scenario and sample app builds

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -147,7 +147,7 @@ extends:
       - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
         parameters:
           pipelineKind: GitHubPR
-          buildScenarioApps: false
+          buildScenarioApps: true
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
           runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
           pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'


### PR DESCRIPTION
## Summary

Enables the existing scenario and sample app validation path for GitHub pull requests.

This expands pull request coverage beyond the core product build so changes are also validated against the non-Gallery sample applications that consume the produced WinUI package.

## Scope

- Enables scenario and sample app builds in the GitHub pull request pipeline.
- Uses the standard sample restore and build flow.
- Covers the supported build architectures and configurations.
- Keeps WinUIGallery excluded because its validation is being restored separately.

## Why

These sample applications exercise important package-consumption and XAML compiler scenarios that are not fully represented by the core product build alone. Running them for GitHub pull requests helps detect integration regressions before changes are merged.
