### PR TITLE
[Validation]Test Dcpp.Edge restore from an external fork PR

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -19,154 +19,102 @@ pr:
 
 name: WinUI-GitHub-PR_$(Date:yyyyMMdd)$(Rev:.r)
 
-parameters:
-- name: runFullValidation
-  displayName: "Run full WinUI PR validation stages"
-  type: boolean
-  default: true
-- name: MUXFinalRelease
-  type: boolean
-  default: false
-- name: runArm64Tests
-  displayName: "Enable running tests on arm64"
-  type: boolean
-  default: true
-- name: runStaticAnalysis
-  displayName: "Run Static Analysis (e.g., PREFast, APIScan)"
-  type: boolean
-  default: false
-
 variables:
-- template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
-- template: build\AzurePipelinesTemplates\WinUI-BuildVariables.yml@WinUIInternal
-- group: WinUI-Variable-Library
-- name: WindowsContainerImage
-  value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
+- name: DcppPackageName
+  value: 'Microsoft.UI.DCPP.Dependencies.Edge'
+- name: DcppPackageVersion
+  value: '144.0.3719.82'
+- name: DcppFeedUri
+  value: 'https://microsoft.pkgs.visualstudio.com/_packaging/WinUI.Dependencies/nuget/v3/index.json'
 
-resources:
-  repositories:
-    - repository: templates
-      type: git
-      name: OneBranch.Pipelines/GovernedTemplates
-      ref: refs/heads/main
-    - repository: WinUIInternal
-      type: git
-      name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
-    - repository: WindowsAppSDKConfig
-      type: git
-      name: ProjectReunion/WindowsAppSDKConfig
-      ref: refs/heads/main
-    - repository: WindowsAppSDKVersionConfig
-      type: git
-      name: ProjectReunion/WindowsAppSDKConfig
-      ref: refs/heads/main
+pool:
+  vmImage: windows-2022
 
-extends:
-  template: v2/Microsoft.NonOfficial.yml@templates
-  parameters:
-    featureFlags:
-      EnableCDPxPAT: false
-      WindowsHostVersion:
-        Version: 2022
-        Network: KS3
-    platform:
-      name: 'windows_undocked'
-    git:
-      submodules: false
-    globalsdl:
-      tsa:
-        enabled: false
-      enableXFGCheck: false
-      codeql:
-        tsandjs:
-          enabled: true
-        python:
-          enabled: false
-        psscriptanalyzer:
-          enable: true
-      prefast:
-        ${{ if eq(parameters.runStaticAnalysis, 'true') }}:
-          enabled: true
-        ${{ else }}:
-          enabled: false
-        break: true
-      apiscan:
-        enabled: false
-        break: false
-      binskim:
-        enabled: true
-        analyzeTargetGlob: $(BinskimExclusion)
-        break: true
+steps:
+- checkout: self
+  submodules: false
+  fetchDepth: 1
+  fetchTags: false
 
-    stages:
-    - stage: ValidateGitHubPrContext
-      displayName: Validate GitHub PR context
-      jobs:
-      - job: ValidateGitHubPrContext
-        displayName: Validate GitHub PR context
-        pool:
-          type: windows
-        variables:
-          ob_outputDirectory: '$(Build.SourcesDirectory)\out'
-        steps:
-        - checkout: self
-          submodules: false
-          fetchDepth: 1
-          fetchTags: false
+- task: PowerShell@2
+  displayName: Log GitHub PR context
+  inputs:
+    targetType: inline
+    script: |
+      $ErrorActionPreference = 'Stop'
 
-        - task: PowerShell@2
-          displayName: Validate GitHub PR context
-          inputs:
-            targetType: inline
-            script: |
-              $ErrorActionPreference = 'Stop'
+      Write-Host "Build.Reason=$env:BUILD_REASON"
+      Write-Host "Build.Repository.Provider=$env:BUILD_REPOSITORY_PROVIDER"
+      Write-Host "Build.Repository.Name=$env:BUILD_REPOSITORY_NAME"
+      Write-Host "Build.SourceBranch=$env:BUILD_SOURCEBRANCH"
+      Write-Host "System.PullRequest.IsFork=$env:SYSTEM_PULLREQUEST_ISFORK"
+      Write-Host "System.PullRequest.SourceBranch=$env:SYSTEM_PULLREQUEST_SOURCEBRANCH"
+      Write-Host "System.PullRequest.SourceRepositoryURI=$env:SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI"
+      Write-Host "System.PullRequest.TargetBranch=$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
 
-              Write-Host "Build.Reason=$env:BUILD_REASON"
-              Write-Host "Build.Repository.Provider=$env:BUILD_REPOSITORY_PROVIDER"
-              Write-Host "Build.Repository.Name=$env:BUILD_REPOSITORY_NAME"
-              Write-Host "Build.SourceBranch=$env:BUILD_SOURCEBRANCH"
-              Write-Host "System.PullRequest.TargetBranch=$env:SYSTEM_PULLREQUEST_TARGETBRANCH"
+      if ($env:BUILD_REPOSITORY_PROVIDER -notin @('GitHub', 'GitHubEnterprise')) {
+        throw "Expected a GitHub-backed Azure Pipelines run, but Build.Repository.Provider was '$env:BUILD_REPOSITORY_PROVIDER'."
+      }
 
-              if ($env:BUILD_REPOSITORY_PROVIDER -notin @('GitHub', 'GitHubEnterprise')) {
-                throw "Expected a GitHub-backed Azure Pipelines run, but Build.Repository.Provider was '$env:BUILD_REPOSITORY_PROVIDER'."
-              }
+- task: NuGetAuthenticate@1
+  displayName: Authenticate to WinUI.Dependencies
 
-              if ($env:BUILD_REASON -eq 'PullRequest') {
-                $targetBranch = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-                $allowedExactTargetBranches = @('main', 'winui3/main', 'refs/heads/main', 'refs/heads/winui3/main')
-                $isAllowedFeatureBranch = $targetBranch -like 'feature/*' -or $targetBranch -like 'refs/heads/feature/*'
-                if (($allowedExactTargetBranches -notcontains $targetBranch) -and -not $isAllowedFeatureBranch) {
-                  throw "Unexpected GitHub PR target branch '$env:SYSTEM_PULLREQUEST_TARGETBRANCH'."
-                }
-              }
+- task: NuGetCommand@2
+  displayName: Restore Dcpp.Edge package
+  inputs:
+    command: custom
+    arguments: >
+      restore "$(Build.SourcesDirectory)\build\packages.webview2.config"
+      -Source "$(DcppFeedUri)"
+      -PackagesDirectory "$(Pipeline.Workspace)\dcpp-edge-artifact\packages"
+      -NonInteractive
+      -Verbosity detailed
+    includeNuGetOrg: false
 
-              Write-Host "GitHub PR context validation completed."
+- task: PowerShell@2
+  displayName: Verify restored package
+  env:
+    PACKAGE_RESTORE_DIRECTORY: $(Pipeline.Workspace)\dcpp-edge-artifact\packages
+    DCPP_PACKAGE_NAME: $(DcppPackageName)
+    DCPP_PACKAGE_VERSION: $(DcppPackageVersion)
+  inputs:
+    targetType: inline
+    script: |
+      $ErrorActionPreference = 'Stop'
 
-    - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
-        parameters:
-          pipelineKind: GitHubPR
-          buildScenarioApps: false
-          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
-          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
-          pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: true
-          dependsOn: ValidateGitHubPrContext
+      $packageDirectory = Join-Path `
+        $env:PACKAGE_RESTORE_DIRECTORY `
+        "$($env:DCPP_PACKAGE_NAME).$($env:DCPP_PACKAGE_VERSION)"
 
-    - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
-        parameters:
-          stageName: Build_MUXFinalRelease
-          pipelineKind: PR-2
-          buildScenarioApps: false
-          MUXFinalRelease: true
-          runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
-          pgoBuildModeMSBuildArg: '/p:PGOBuildMode=Off'
-          buildProductOnly: true
-          dependsOn: ValidateGitHubPrContext
+      if (-not (Test-Path -LiteralPath $packageDirectory -PathType Container)) {
+        throw "Expected restored package directory was not found: $packageDirectory"
+      }
 
-    - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
-        parameters:
-          MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+      $files = Get-ChildItem -LiteralPath $packageDirectory -File -Recurse
+      if ($files.Count -eq 0) {
+        throw "The restored package directory is empty: $packageDirectory"
+      }
+
+      $manifestPath = Join-Path `
+        (Split-Path $env:PACKAGE_RESTORE_DIRECTORY -Parent) `
+        'restored-package-manifest.txt'
+
+      @(
+        "Package=$env:DCPP_PACKAGE_NAME"
+        "Version=$env:DCPP_PACKAGE_VERSION"
+        "Directory=$packageDirectory"
+        "FileCount=$($files.Count)"
+        ""
+        "Files:"
+        $files.FullName
+      ) | Set-Content -LiteralPath $manifestPath
+
+      Write-Host "Verified $env:DCPP_PACKAGE_NAME version $env:DCPP_PACKAGE_VERSION."
+      Write-Host "Package artifact directory: $packageDirectory"
+      Write-Host "Manifest: $manifestPath"
+
+- task: PublishPipelineArtifact@1
+  displayName: Publish restored Dcpp.Edge package
+  inputs:
+    targetPath: '$(Pipeline.Workspace)\dcpp-edge-artifact'
+    artifactName: dcpp-edge-restore

--- a/build/packages.webview2.config
+++ b/build/packages.webview2.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.UI.DCPP.Dependencies.Edge" version="144.0.3719.82" />
+</packages>


### PR DESCRIPTION
This is a temporary validation PR to check whether a GitHub PR raised from a non-Microsoft fork can restore Microsoft.UI.DCPP.Dependencies.Edge from the internal WinUI.Dependencies feed.

The GitHub PR pipeline has been simplified for this experiment to:

- Log the non-sensitive PR context, including System.PullRequest.IsFork
- Run NuGetAuthenticate@1
- Restore Dcpp.Edge from WinUI.Dependencies
- Save the restored package as a pipeline artifact for verification

PGO, product builds and tests are disabled for this initial validation.

This PR is for pipeline testing only and is not intended to be merged.
