### PR TITLE
Enable GitHub-to-ADO source mirroring

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-MirrorGitHubToInternal-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-MirrorGitHubToInternal-Stage.yml
@@ -1,0 +1,62 @@
+parameters:
+- name: sourceBranchName
+  displayName: GitHub source branch to mirror
+  type: string
+  default: winui3/main
+- name: targetBranchName
+  displayName: Internal ADO target branch to update
+  type: string
+  default: user/hmishra/winui3/main
+
+stages:
+- stage: Source
+  dependsOn: []
+  jobs:
+  - job: MirrorGitHubToInternal
+    pool:
+      type: windows
+    timeoutInMinutes: 60
+    variables:
+      ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+      ob_git_skip_checkout_none: true
+      sourceRepoRelativePath: 's\source'
+      targetRepoRelativePath: 's\target'
+    steps:
+    - checkout: self
+      submodules: false
+      persistCredentials: false
+      fetchDepth: 0
+      fetchTags: false
+      path: '$(sourceRepoRelativePath)'
+      displayName: Checkout GitHub source repository '$(sourceRepoRelativePath)'
+    - checkout: targetRepository
+      submodules: false
+      persistCredentials: true
+      fetchDepth: 0
+      path: '$(targetRepoRelativePath)'
+      displayName: Checkout internal target repository '$(targetRepoRelativePath)'
+
+    - script: set
+      displayName: Display machine environment variables
+
+    # This keeps Guardian happy by allowing it to find the TSA config.
+    - task: CopyFiles@2
+      displayName: Copy `.config\` to `$(Build.SourcesDirectory)`
+      inputs:
+        SourceFolder: '$(Pipeline.Workspace)\$(sourceRepoRelativePath)'
+        TargetFolder: '$(Build.SourcesDirectory)'
+        Contents: |
+          .config\**
+
+    - task: PowerShell@2
+      displayName: Mirror GitHub source to internal repository
+      inputs:
+        workingDirectory: '$(Pipeline.Workspace)'
+        filePath: '$(Pipeline.Workspace)\$(sourceRepoRelativePath)\scripts\MirrorGitRepositoryWithHistory.ps1'
+        arguments: >
+          -SourceRepositoryDirectory $(sourceRepoRelativePath)
+          -SourceBranchName '${{ parameters.sourceBranchName }}'
+          -TargetRepositoryDirectory $(targetRepoRelativePath)
+          -TargetBranchName '${{ parameters.targetBranchName }}'
+          -SourceRemoteUrlPattern '$(GitHubToAdoMirrorSourceRemoteUrlPattern)'
+          -TargetRemoteUrlPattern '$(GitHubToAdoMirrorTargetRemoteUrlPattern)'

--- a/build/WinUI-MirrorGitHubToInternal-Official.yml
+++ b/build/WinUI-MirrorGitHubToInternal-Official.yml
@@ -1,0 +1,56 @@
+# Mirrors the public GitHub source branch to an internal Azure Repos user branch.
+#
+# This is intentionally history-preserving and fast-forward-only. The target
+# branch must not contain ADO-only commits or files; exact mirrors cannot
+# preserve target-only content. For validation, the defaults mirror GitHub
+# winui3/main into an ADO user branch, not ADO main. This pipeline publishes
+# when run. The pipeline is defined from the public GitHub repository, so its
+# CI trigger runs directly when winui3/main advances.
+
+trigger:
+  branches:
+    include:
+    - winui3/main
+pr: none
+
+parameters:
+- name: sourceBranchName
+  displayName: GitHub source branch to mirror
+  type: string
+  default: winui3/main
+
+variables:
+- group: WinUI-InternalFeed
+- template: AzurePipelinesTemplates\WinUI-BuildVariables.yml
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    - repository: targetRepository
+      type: git
+      name: WinUI/microsoft-ui-xaml-lift
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.Official.yml@templates
+  parameters:
+    featureFlags:
+      EnableCDPxPAT: false
+      ensureArtifactsDirExists: true
+      WindowsHostVersion:
+        Version: 2022
+        Network: KS3
+    platform:
+      name: 'windows_undocked'
+    git:
+      submodules: false
+      persistCredentials: true
+
+    stages:
+    - template: AzurePipelinesTemplates\WinUI-MirrorGitHubToInternal-Stage.yml@self
+      parameters:
+        sourceBranchName: ${{ parameters.sourceBranchName }}
+        targetBranchName: user/hmishra/winui3/main

--- a/scripts/MirrorGitRepositoryWithHistory.ps1
+++ b/scripts/MirrorGitRepositoryWithHistory.ps1
@@ -1,0 +1,293 @@
+<#
+.SYNOPSIS
+Mirrors one Git branch to another repository while preserving commit history.
+
+.DESCRIPTION
+This script is intended for Azure Pipelines scenarios where a public GitHub
+branch is the source of truth and an Azure Repos branch is an exact mirror.
+It performs a fast-forward-only push from the source branch to the target
+branch when the target branch already exists. If the target branch does not
+exist, the push creates it at the source commit. It never force-pushes,
+rewrites commits, or attempts to preserve target-only files.
+
+Target-only files are not compatible with an exact history-preserving mirror:
+the target branch must be treated as a pure mirror of the source branch.
+
+.PARAMETER SourceRepositoryDirectory
+Path to the local clone of the source repository.
+
+.PARAMETER SourceBranchName
+Name of the branch in the source repository to mirror.
+
+.PARAMETER TargetRepositoryDirectory
+Path to the local clone of the target repository.
+
+.PARAMETER TargetBranchName
+Name of the branch in the target repository to update.
+
+.PARAMETER SourceRemoteName
+Name of the source repository remote. Defaults to the only configured remote.
+
+.PARAMETER TargetRemoteName
+Name of the target repository remote. Defaults to the only configured remote.
+
+.PARAMETER SourceRemoteUrlPattern
+Optional regular expression that the source remote URL must match.
+
+.PARAMETER TargetRemoteUrlPattern
+Optional regular expression that the target remote URL must match.
+
+#>
+
+param(
+    [parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$SourceRepositoryDirectory,
+
+    [parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$SourceBranchName,
+
+    [parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TargetRepositoryDirectory,
+
+    [parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TargetBranchName,
+
+    [parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$SourceRemoteName,
+
+    [parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TargetRemoteName,
+
+    [parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$SourceRemoteUrlPattern,
+
+    [parameter(Mandatory=$false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TargetRemoteUrlPattern
+)
+
+$ErrorActionPreference = "Stop"
+$global:LASTEXITCODE = 0
+
+function Invoke-GitCommand {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory,
+
+        [parameter(Mandatory=$true)]
+        [string[]]$Arguments
+    )
+
+    Write-Host -ForegroundColor Blue "##[command]git -C '$RepositoryDirectory' $($Arguments -join ' ')"
+    & git -C $RepositoryDirectory @Arguments
+    $exitCode = $global:LASTEXITCODE
+
+    if ($exitCode) {
+        throw "Command 'git -C $RepositoryDirectory $($Arguments -join ' ')' terminated with error code '$exitCode'"
+    }
+}
+
+function Get-GitCommandOutput {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory,
+
+        [parameter(Mandatory=$true)]
+        [string[]]$Arguments
+    )
+
+    Write-Host -ForegroundColor Blue "##[command]git -C '$RepositoryDirectory' $($Arguments -join ' ')"
+    $output = & git -C $RepositoryDirectory @Arguments
+    $exitCode = $global:LASTEXITCODE
+
+    if ($exitCode) {
+        throw "Command 'git -C $RepositoryDirectory $($Arguments -join ' ')' terminated with error code '$exitCode'"
+    }
+
+    return ($output -join "`n").Trim()
+}
+
+function Get-GitCommandOutputWithExitCode {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory,
+
+        [parameter(Mandatory=$true)]
+        [string[]]$Arguments
+    )
+
+    Write-Host -ForegroundColor Blue "##[command]git -C '$RepositoryDirectory' $($Arguments -join ' ')"
+    $output = & git -C $RepositoryDirectory @Arguments
+    $exitCode = $global:LASTEXITCODE
+
+    return @{
+        ExitCode = $exitCode
+        Output = ($output -join "`n").Trim()
+    }
+}
+
+function Resolve-GitRemoteName {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory,
+
+        [parameter(Mandatory=$false)]
+        [string]$RemoteNameParameter,
+
+        [parameter(Mandatory=$true)]
+        [string]$ParameterName
+    )
+
+    if ($RemoteNameParameter) {
+        return $RemoteNameParameter
+    }
+
+    $remotes = @((Get-GitCommandOutput $RepositoryDirectory @("remote")) -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($remotes.Count -ne 1) {
+        throw "Parameter '$ParameterName' was not supplied and repository '$RepositoryDirectory' has $($remotes.Count) remotes. Supply '$ParameterName' explicitly."
+    }
+
+    return $remotes[0]
+}
+
+function Assert-CleanWorktree {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory
+    )
+
+    $status = Get-GitCommandOutput $RepositoryDirectory @("status", "--porcelain")
+    if (-not [string]::IsNullOrWhiteSpace($status)) {
+        throw "Repository '$RepositoryDirectory' has uncommitted changes and cannot be used for mirroring.`n$status"
+    }
+}
+
+function Assert-RemoteUrlMatches {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory,
+
+        [parameter(Mandatory=$true)]
+        [string]$RemoteName,
+
+        [parameter(Mandatory=$false)]
+        [string]$RemoteUrlPattern,
+
+        [parameter(Mandatory=$true)]
+        [string]$RemoteDescription
+    )
+
+    $remoteUrl = Get-GitCommandOutput $RepositoryDirectory @("remote", "get-url", $RemoteName)
+    Write-Host "##[debug]$RemoteDescription remote URL: $remoteUrl"
+
+    if ($RemoteUrlPattern -and $remoteUrl -notmatch $RemoteUrlPattern) {
+        throw "$RemoteDescription remote '$RemoteName' URL '$remoteUrl' does not match expected pattern '$RemoteUrlPattern'."
+    }
+}
+
+function Assert-ValidBranchName {
+    param(
+        [parameter(Mandatory=$true)]
+        [string]$RepositoryDirectory,
+
+        [parameter(Mandatory=$true)]
+        [string]$BranchName,
+
+        [parameter(Mandatory=$true)]
+        [string]$ParameterName
+    )
+
+    if ($BranchName.StartsWith("refs/heads/")) {
+        throw "Parameter '$ParameterName' should be a branch name like 'winui3/main', not a full ref like '$BranchName'."
+    }
+
+    Write-Host -ForegroundColor Blue "##[command]git -C '$RepositoryDirectory' check-ref-format --branch '$BranchName'"
+    & git -C $RepositoryDirectory check-ref-format --branch $BranchName | Out-Null
+    $exitCode = $global:LASTEXITCODE
+
+    if ($exitCode) {
+        throw "Parameter '$ParameterName' value '$BranchName' is not a valid Git branch name."
+    }
+}
+
+$SourceRepositoryDirectoryFullPath = [IO.Path]::Combine($pwd, $SourceRepositoryDirectory)
+if (-not (Test-Path $SourceRepositoryDirectoryFullPath)) {
+    throw "Parameter 'SourceRepositoryDirectory' does not point to a valid path"
+}
+
+$TargetRepositoryDirectoryFullPath = [IO.Path]::Combine($pwd, $TargetRepositoryDirectory)
+if (-not (Test-Path $TargetRepositoryDirectoryFullPath)) {
+    throw "Parameter 'TargetRepositoryDirectory' does not point to a valid path"
+}
+
+$SourceRemoteName = Resolve-GitRemoteName $SourceRepositoryDirectoryFullPath $SourceRemoteName "SourceRemoteName"
+$TargetRemoteName = Resolve-GitRemoteName $TargetRepositoryDirectoryFullPath $TargetRemoteName "TargetRemoteName"
+
+Write-Host "##[group]Validating repositories"
+Assert-ValidBranchName $SourceRepositoryDirectoryFullPath $SourceBranchName "SourceBranchName"
+Assert-ValidBranchName $TargetRepositoryDirectoryFullPath $TargetBranchName "TargetBranchName"
+Assert-CleanWorktree $SourceRepositoryDirectoryFullPath
+Assert-CleanWorktree $TargetRepositoryDirectoryFullPath
+Assert-RemoteUrlMatches $SourceRepositoryDirectoryFullPath $SourceRemoteName $SourceRemoteUrlPattern "Source"
+Assert-RemoteUrlMatches $TargetRepositoryDirectoryFullPath $TargetRemoteName $TargetRemoteUrlPattern "Target"
+Write-Host "##[endgroup]"
+
+Write-Host "##[group]Fetching source and target branches"
+Invoke-GitCommand $SourceRepositoryDirectoryFullPath @("fetch", "--prune", $SourceRemoteName, "+refs/heads/$SourceBranchName`:refs/remotes/$SourceRemoteName/$SourceBranchName")
+
+$sourceTrackingRef = "refs/remotes/$SourceRemoteName/$SourceBranchName"
+$sourceCommit = Get-GitCommandOutput $SourceRepositoryDirectoryFullPath @("rev-parse", "--verify", "$sourceTrackingRef^{commit}")
+Write-Host "##[debug]Source $SourceRemoteName/$SourceBranchName commit: $sourceCommit"
+Write-Host "##[endgroup]"
+
+Write-Host "##[group]Importing source commit into target repository"
+$sourceRefInTargetRepository = "refs/remotes/sourceRepository/$SourceBranchName"
+Invoke-GitCommand $TargetRepositoryDirectoryFullPath @("fetch", "--no-tags", $SourceRepositoryDirectoryFullPath, "+$sourceTrackingRef`:$sourceRefInTargetRepository")
+$sourceCommitInTargetRepository = Get-GitCommandOutput $TargetRepositoryDirectoryFullPath @("rev-parse", "--verify", "$sourceRefInTargetRepository^{commit}")
+
+if ($sourceCommitInTargetRepository -ne $sourceCommit) {
+    throw "Source commit imported into target repository as '$sourceCommitInTargetRepository', expected '$sourceCommit'."
+}
+Write-Host "##[endgroup]"
+
+Write-Host "##[group]Validating fast-forward mirror"
+$targetBranchRef = "refs/heads/$TargetBranchName"
+$targetBranchSearch = Get-GitCommandOutputWithExitCode $TargetRepositoryDirectoryFullPath @("ls-remote", "--exit-code", $TargetRemoteName, $targetBranchRef)
+$targetBranchExists = $targetBranchSearch.ExitCode -eq 0
+
+if ($targetBranchExists) {
+    Invoke-GitCommand $TargetRepositoryDirectoryFullPath @("fetch", "--prune", $TargetRemoteName, "+$targetBranchRef`:refs/remotes/$TargetRemoteName/$TargetBranchName")
+    $targetTrackingRef = "refs/remotes/$TargetRemoteName/$TargetBranchName"
+    $targetCommit = Get-GitCommandOutput $TargetRepositoryDirectoryFullPath @("rev-parse", "--verify", "$targetTrackingRef^{commit}")
+    Write-Host "##[debug]Target $TargetRemoteName/$TargetBranchName commit: $targetCommit"
+
+    Write-Host -ForegroundColor Blue "##[command]git -C '$TargetRepositoryDirectoryFullPath' merge-base --is-ancestor $targetCommit $sourceCommitInTargetRepository"
+    & git -C $TargetRepositoryDirectoryFullPath merge-base --is-ancestor $targetCommit $sourceCommitInTargetRepository
+    $exitCode = $global:LASTEXITCODE
+
+    if ($exitCode -eq 1) {
+        throw "Refusing to mirror because target '$TargetBranchName' ($targetCommit) is not an ancestor of source '$SourceBranchName' ($sourceCommitInTargetRepository). This would require rewriting target history."
+    } elseif ($exitCode) {
+        throw "Fast-forward validation failed with error code '$exitCode'."
+    }
+
+    Write-Host "Target branch '$TargetBranchName' can fast-forward from $targetCommit to $sourceCommitInTargetRepository."
+} elseif ($targetBranchSearch.ExitCode -eq 2) {
+    Write-Host "Target branch '$TargetBranchName' does not exist on '$TargetRemoteName'. It will be created at $sourceCommitInTargetRepository."
+} else {
+    throw "Unable to query target branch '$TargetBranchName'. 'git ls-remote' failed with error code '$($targetBranchSearch.ExitCode)'."
+}
+Write-Host "##[endgroup]"
+
+Write-Host "##[group]Publishing mirror"
+Invoke-GitCommand $TargetRepositoryDirectoryFullPath @("push", $TargetRemoteName, "$sourceRefInTargetRepository`:refs/heads/$TargetBranchName")
+Write-Host "##[endgroup]"
+
+exit 0


### PR DESCRIPTION
Enables the GitHub-first source flow by introducing automated mirroring from `winui3/main` to the internal WinUI repository.

The initial rollout targets a validation branch ahead of the production cutover.
