### PR TITLE
Ignore repository-local build tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,5 +274,7 @@ HelixPayload/
 UnreliableTestReport.csv
 
 # tools
+/.dotnet/
+/.tools/
 src/.dotnet/
 src/.tools/


### PR DESCRIPTION
## Description
Ignore the repository-local `.dotnet` and `.tools` directories generated by the build initialization scripts.

The existing rules only covered these directories under the former `src` layout.
