### PR TITLE
[Do Not Review] Validate WinUIGallery scenario tests on GitHub PR (#11478)

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/user/sakshishar/enable-gallery-scenario-tests-lift
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig


### PR DESCRIPTION
## Summary

Validation-only PR to confirm the **WinUIGallery scenario tests run end-to-end
on GitHub PR validation** (WinUI OSS #11478), now that the Gallery build
prerequisites are in place. This is throwaway scaffolding — it will be dropped
and the real change rebased onto a clean `winui3/main` once the dependent PRs merge.

## What this validates

- The `Samples/WinUIGallery` submodule source is checked out on GitHub PR builds.
- `WinUIGallery.slnx` builds and produces the `WinUIGallery*Test` package.
- The scenario test payload includes the Gallery test package (no longer skipped).
- The WinUIGallery scenario tests execute on the GitHub leg.

## Temporary scaffolding (removed before the real PR)

- **`WinUIInternal` ref pinned** to `user/sakshishar/enable-gallery-scenario-tests-lift`
  so the Gallery skip-removal templates are consumed from the lift branch.
  Reverts to `refs/heads/main` once that lift change merges and mirrors.

## The real change (lands via lift → public mirror)

Removal of the temporary `-SkipWinUIGallery` scaffolding across the internal
templates, so the WinUIGallery scenario test package is always included in the
payload. This lives in the lift repo and arrives via the mirror, so it is not
part of this PR's file diff.

## Dependencies

- #11350 — Restore WinUIGallery build validation (submodule checkout). **Open.**
- Lift PR for `user/sakshishar/enable-gallery-scenario-tests-lift`. **Open.**

## Validation

Run `WinUI-GitHub-PR` (OneBranch) via `/azp run`.

**Expected:** Gallery submodule checks out → Gallery sample builds → payload created
**with** the WinUIGallery test package → the Run Scenario App Tests stage executes
the Gallery scenario tests.
