### PR TITLE
Fix PowerShell 7 initialization failure (#11411)

### DIFF
--- a/scripts/init/Initialize-NuGet.ps1
+++ b/scripts/init/Initialize-NuGet.ps1
@@ -17,16 +17,15 @@ $nuget_exe = . "$PSScriptRoot\Initialize-DownloadLatest.ps1" -OutDir $toolsDir -
 Write-Progress "Downloading the Azure Artifacts Credential Provider"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-# If this is PowerShell 5, remove PowerShell 7 module paths from PSModulePath to avoid module loading conflicts.
-# The pwsh7 path can cause an error inside the credprovider install via missing Get-FileHash command.
+# If this is Windows PowerShell 5, prefer its built-in modules over inherited PowerShell 7 modules.
+# PowerShell 7 paths can otherwise resolve an incompatible Microsoft.PowerShell.Utility module.
 $originalPSModulePath = $env:PSModulePath
 if ($PSVersionTable.PSVersion.Major -eq 5)
 {
-    if ($env:PSModulePath -like "*powershell\7\Modules*")
+    $systemModulePath = Join-Path $PSHOME "Modules"
+    if ($env:PSModulePath -notlike "$systemModulePath*")
     {
-        $paths = $env:PSModulePath -split ';'
-        $filteredPaths = $paths | Where-Object { $_ -notlike "*powershell\7\Modules*" }
-        $env:PSModulePath = $filteredPaths -join ';'
+        $env:PSModulePath = "$systemModulePath;$env:PSModulePath"
     }
 }
 


### PR DESCRIPTION

## Summary

Fixes `init.ps1` failing when launched from a Microsoft Store installation of PowerShell 7.

Windows PowerShell 5 inherits `PSModulePath` from PowerShell 7. This can cause it to load an incompatible `Microsoft.PowerShell.Utility` module, resulting in `Get-FileHash` not being recognized.

## Changes

- Prioritize Windows PowerShell 5's built-in module directory during Azure Artifacts Credential Provider installation.
- Support PowerShell 7 installations from MSI, Microsoft Store/MSIX, and other locations.
- Restore the original `PSModulePath` after installation.

## Validation

Successfully ran repository initialization from:

- PowerShell 7.6.4 installed through Microsoft Store
- Windows PowerShell 5.1
- Command Prompt