### PR TITLE
Fix pending WrapPanel layout bugs

### DIFF
--- a/controls/dev/WrapPanel/APITests/WrapPanelTests.cs
+++ b/controls/dev/WrapPanel/APITests/WrapPanelTests.cs
@@ -174,6 +174,93 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        public void VerifyItemsStretchLastWithInfinitePrimaryMeasure()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                foreach (var orientation in new[] { Orientation.Horizontal, Orientation.Vertical })
+                {
+                    Log.Comment("Verify finite measurement for {0} orientation", orientation);
+
+                    var panel = new WrapPanel
+                    {
+                        Orientation = orientation,
+                        ItemsStretch = WrapPanelItemsStretch.Last
+                    };
+                    var child1 = new Border { Width = 40, Height = 20 };
+                    var child2 = new Border { Width = 40, Height = 20 };
+
+                    panel.Children.Add(child1);
+                    panel.Children.Add(child2);
+
+                    var availableSize = orientation == Orientation.Horizontal ?
+                        new Size(float.PositiveInfinity, 100) :
+                        new Size(100, float.PositiveInfinity);
+
+                    panel.Measure(availableSize);
+
+                    Verify.IsTrue(
+                        !double.IsInfinity(panel.DesiredSize.Width) && !double.IsNaN(panel.DesiredSize.Width) &&
+                        !double.IsInfinity(panel.DesiredSize.Height) && !double.IsNaN(panel.DesiredSize.Height),
+                        "WrapPanel DesiredSize should remain finite.");
+
+                    panel.Arrange(new Rect(0, 0, panel.DesiredSize.Width, panel.DesiredSize.Height));
+
+                    var expectedLastChildLayoutSlot = orientation == Orientation.Horizontal ?
+                        new Rect(40, 0, 40, 20) :
+                        new Rect(0, 20, 40, 20);
+                    Verify.AreEqual(
+                        expectedLastChildLayoutSlot,
+                        LayoutInformation.GetLayoutSlot(child2),
+                        "The last child should retain its desired primary-axis size.");
+                }
+            });
+        }
+
+        [TestMethod]
+        public void VerifyZeroSizedLastChildWrapsAndStretchesToFullLine()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                foreach (var orientation in new[] { Orientation.Horizontal, Orientation.Vertical })
+                {
+                    Log.Comment("Verify full-line wrapping for {0} orientation", orientation);
+
+                    var panel = new WrapPanel
+                    {
+                        Orientation = orientation,
+                        ItemsStretch = WrapPanelItemsStretch.Last
+                    };
+
+                    for (int i = 0; i < 3; i++)
+                    {
+                        panel.Children.Add(new Border { Width = 44, Height = 44 });
+                    }
+
+                    var lastChild = orientation == Orientation.Horizontal ?
+                        new Border { Height = 44 } :
+                        new Border { Width = 44 };
+                    panel.Children.Add(lastChild);
+
+                    var panelSize = orientation == Orientation.Horizontal ?
+                        new Size(132, 88) :
+                        new Size(88, 132);
+
+                    panel.Measure(panelSize);
+                    panel.Arrange(new Rect(0, 0, panelSize.Width, panelSize.Height));
+
+                    var expectedLastChildLayoutSlot = orientation == Orientation.Horizontal ?
+                        new Rect(0, 44, 132, 44) :
+                        new Rect(44, 0, 44, 132);
+                    Verify.AreEqual(
+                        expectedLastChildLayoutSlot,
+                        LayoutInformation.GetLayoutSlot(lastChild),
+                        "The zero-desired-size last child should wrap and stretch across the new line.");
+                }
+            });
+        }
+
+        [TestMethod]
         public void VerifyItemsStretchNone()
         {
             RunOnUIThread.Execute(() =>

--- a/controls/dev/WrapPanel/APITests/WrapPanelTests.cs
+++ b/controls/dev/WrapPanel/APITests/WrapPanelTests.cs
@@ -228,7 +228,10 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
                     var panel = new WrapPanel
                     {
                         Orientation = orientation,
-                        ItemsStretch = WrapPanelItemsStretch.Last
+                        ItemsStretch = WrapPanelItemsStretch.Last,
+                        Padding = orientation == Orientation.Horizontal ?
+                            new Thickness(0, 0, 10, 0) :
+                            new Thickness(0, 0, 0, 10)
                     };
 
                     for (int i = 0; i < 3; i++)
@@ -242,15 +245,15 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
                     panel.Children.Add(lastChild);
 
                     var panelSize = orientation == Orientation.Horizontal ?
-                        new Size(132, 88) :
-                        new Size(88, 132);
+                        new Size(142, 88) :
+                        new Size(88, 142);
 
                     panel.Measure(panelSize);
                     panel.Arrange(new Rect(0, 0, panelSize.Width, panelSize.Height));
 
                     var expectedLastChildLayoutSlot = orientation == Orientation.Horizontal ?
-                        new Rect(0, 44, 132, 44) :
-                        new Rect(44, 0, 44, 132);
+                        new Rect(0, 44, 142, 44) :
+                        new Rect(44, 0, 44, 142);
                     Verify.AreEqual(
                         expectedLastChildLayoutSlot,
                         LayoutInformation.GetLayoutSlot(lastChild),

--- a/controls/dev/WrapPanel/APITests/WrapPanelTests.cs
+++ b/controls/dev/WrapPanel/APITests/WrapPanelTests.cs
@@ -180,8 +180,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 foreach (var orientation in new[] { Orientation.Horizontal, Orientation.Vertical })
                 {
-                    Log.Comment("Verify finite measurement for {0} orientation", orientation);
-
+                    Log.Comment("Verify finite DesiredSize for {0} orientation when measured with an infinite primary axis", orientation);
                     var panel = new WrapPanel
                     {
                         Orientation = orientation,

--- a/controls/dev/WrapPanel/WrapPanel.cpp
+++ b/controls/dev/WrapPanel/WrapPanel.cpp
@@ -109,7 +109,7 @@ winrt::Size WrapPanel::UpdateRows(winrt::Size availableSize)
             }
 
             UvMeasure desiredMeasure(orientation, child.DesiredSize());
-            if ((desiredMeasure.U + position.U + paddingEnd.U) > parentMeasure.U)
+            if ((desiredMeasure.U + position.U + paddingEnd.U) > parentMeasure.U || position.U >= parentMeasure.U)
             {
                 // next row!
                 position.U = paddingStart.U;
@@ -119,7 +119,7 @@ winrt::Size WrapPanel::UpdateRows(winrt::Size availableSize)
             }
 
             // Stretch the last item to fill the available space
-            if (isLast)
+            if (isLast && std::isfinite(parentMeasure.U))
             {
                 desiredMeasure.U = parentMeasure.U - position.U;
             }

--- a/controls/dev/WrapPanel/WrapPanel.cpp
+++ b/controls/dev/WrapPanel/WrapPanel.cpp
@@ -109,7 +109,7 @@ winrt::Size WrapPanel::UpdateRows(winrt::Size availableSize)
             }
 
             UvMeasure desiredMeasure(orientation, child.DesiredSize());
-            if ((desiredMeasure.U + position.U + paddingEnd.U) > parentMeasure.U || position.U >= parentMeasure.U)
+            if ((desiredMeasure.U + position.U + paddingEnd.U) > parentMeasure.U || (position.U + paddingEnd.U) >= parentMeasure.U)
             {
                 // next row!
                 position.U = paddingStart.U;


### PR DESCRIPTION
## Description

Ports the two remaining Community Toolkit WrapPanel fixes that were identified during the WinUI API-review follow-up but were still pending in the WinUI implementation:

- Avoid stretching the last item to an infinite size when the panel is measured with an unconstrained primary axis.
- Start a new line when the current line exactly fills the available primary-axis space, allowing a zero-desired-size final item to wrap and stretch correctly.

The API naming updates from #10858 were already completed; this PR closes the remaining behavioral gaps from the original Community Toolkit implementation:

- [CommunityToolkit/Windows#703 — WrapPanel with infinity width crashes trying to stretch its last item](https://github.com/CommunityToolkit/Windows/issues/703), fixed by [CommunityToolkit/Windows#704](https://github.com/CommunityToolkit/Windows/pull/704).
- [CommunityToolkit/Windows#743 — New row not created for last child when `StretchChild=Last`](https://github.com/CommunityToolkit/Windows/issues/743), fixed by [CommunityToolkit/Windows#759](https://github.com/CommunityToolkit/Windows/pull/759).

Both original fixes and their tests were authored by [@AndrewKeepCoding](https://github.com/AndrewKeepCoding). This WinUI port retains that attribution in the commit metadata.

## Testing

Added API regression coverage for both horizontal and vertical orientations, covering infinite primary-axis measurement and exact-boundary wrapping with `ItemsStretch="Last"`.