### PR TITLE
[Feat]: Add AcrylicBrush noise toggle

### DIFF
--- a/controls/dev/Materials/Acrylic/APITests/AcrylicBrushTests.cs
+++ b/controls/dev/Materials/Acrylic/APITests/AcrylicBrushTests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
                 Log.Comment("Verifying AcrylicBrush default property values");
                 Verify.AreEqual(acrylicBrush.FallbackColor, Microsoft.UI.ColorHelper.FromArgb(0, 255, 255, 255));
                 Verify.AreEqual(acrylicBrush.AlwaysUseFallback, false);
+                Verify.AreEqual(acrylicBrush.IsNoiseEnabled, true);
                 Verify.AreEqual(acrylicBrush.TintColor, Microsoft.UI.ColorHelper.FromArgb(204, 255, 255, 255));
                 Verify.AreEqual(acrylicBrush.TintOpacity, 1.0);
                 Verify.AreEqual(acrylicBrush.Opacity, 1.0);

--- a/controls/dev/Materials/Acrylic/AcrylicBrush.cpp
+++ b/controls/dev/Materials/Acrylic/AcrylicBrush.cpp
@@ -180,6 +180,13 @@ void AcrylicBrush::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
             __RP_Marker_ClassMemberById(RuntimeProfiler::ProfId_Acrylic, RuntimeProfiler::ProfMemberId_Acrylic_TintLuminosityOpacity_Changed);
         }
     }
+    else if (property == s_IsNoiseEnabledProperty)
+    {
+        if (m_brush && (m_isUsingAcrylicBrush || m_isWaitingForFallbackAnimationComplete))
+        {
+            m_brush.Properties().InsertScalar(NoiseOpacityOpacity, IsNoiseEnabled() ? sc_noiseOpacity : 0.0f);
+        }
+    }
     else if (property == s_AlwaysUseFallbackProperty)
     {
         UpdateAcrylicBrush();
@@ -539,6 +546,7 @@ winrt::CompositionEffectFactory AcrylicBrush::CreateAcrylicBrushCompositionEffec
     auto noiseOpacityEffect = winrt::make_self<Microsoft::UI::Private::Composition::Effects::OpacityEffect>();
     noiseOpacityEffect->Name(L"NoiseOpacity");
     noiseOpacityEffect->Opacity(sc_noiseOpacity);
+    animatedProperties.push_back(winrt::hstring{ NoiseOpacityOpacity });
     noiseOpacityEffect->Source(*noiseBorderEffect);
 
     // Blend noise on top of tint
@@ -633,6 +641,7 @@ void AcrylicBrush::CreateAcrylicBrush(bool useCrossFadeEffect, bool forceCreateA
         MUX_ASSERT(m_noiseBrush);
         acrylicBrush.SetSourceParameter(L"Noise", m_noiseBrush);
         acrylicBrush.Properties().InsertColor(TintColorColor, tintColor);
+        acrylicBrush.Properties().InsertScalar(NoiseOpacityOpacity, IsNoiseEnabled() ? sc_noiseOpacity : 0.0f);
 
         if (!m_isUsingOpaqueBrush)
         {

--- a/controls/dev/Materials/Acrylic/AcrylicBrush.h
+++ b/controls/dev/Materials/Acrylic/AcrylicBrush.h
@@ -60,6 +60,7 @@ private:
     static constexpr auto LuminosityColorColor{ L"LuminosityColor.Color"sv };
     static constexpr auto FallbackColorColor{ L"FallbackColor.Color"sv };
     static constexpr auto OpaqueFallbackColorColor{ L"OpaqueFallbackColor.Color"sv };
+    static constexpr auto NoiseOpacityOpacity{ L"NoiseOpacity.Opacity"sv };
 
     static constexpr float sc_blurRadius = 30.0f;
     static constexpr float sc_noiseOpacity = 0.02f;

--- a/controls/dev/Materials/Acrylic/AcrylicBrush.idl
+++ b/controls/dev/Materials/Acrylic/AcrylicBrush.idl
@@ -22,6 +22,9 @@ unsealed runtimeclass AcrylicBrush : Microsoft.UI.Xaml.Media.XamlCompositionBrus
 
     Boolean AlwaysUseFallback { get; set; };
 
+    [MUX_DEFAULT_VALUE("true")]
+    Boolean IsNoiseEnabled { get; set; };
+
     [MUX_PUBLIC]
     {
         [MUX_PROPERTY_VALIDATION_CALLBACK("CoerceToZeroOneRange_Nullable")]
@@ -32,6 +35,7 @@ unsealed runtimeclass AcrylicBrush : Microsoft.UI.Xaml.Media.XamlCompositionBrus
     static Microsoft.UI.Xaml.DependencyProperty TintOpacityProperty { get; };
     static Microsoft.UI.Xaml.DependencyProperty TintTransitionDurationProperty { get; };
     static Microsoft.UI.Xaml.DependencyProperty AlwaysUseFallbackProperty { get; };
+    static Microsoft.UI.Xaml.DependencyProperty IsNoiseEnabledProperty { get; };
 
     [MUX_PUBLIC]
     {

--- a/controls/dev/Materials/Acrylic/TestUI/AcrylicBrushPage.xaml
+++ b/controls/dev/Materials/Acrylic/TestUI/AcrylicBrushPage.xaml
@@ -78,6 +78,7 @@
                     <ToggleButton x:Name="TintColorButton" Content="TintColor Chooser" Checked="TintColorButton_Checked" Unchecked="TintColorButton_Unchecked"/>
                     <ToggleButton x:Name="FallbackColorButton" Content="FallbackColor [-> Orange]" Checked="FallbackColorButton_Checked" Unchecked="FallbackColorButton_Unchecked"/>
                     <ToggleButton x:Name="AlwaysUseFallbackButton" Content="AlwaysUseFallback [-> True]" Checked="AlwaysUseFallbackButton_Checked" Unchecked="AlwaysUseFallbackButton_Unchecked"/>
+                    <ToggleButton x:Name="IsNoiseEnabledButton" IsChecked="True" Content="IsNoiseEnabled" Checked="IsNoiseEnabledButton_IsCheckedChanged" Unchecked="IsNoiseEnabledButton_IsCheckedChanged"/>
                     <ToggleButton x:Name="AnimateBackgroundButton" Content="Animate Background" Checked="AnimateBackgroundButton_Checked" Unchecked="AnimateBackgroundButton_Unchecked"/>
 
                 <StackPanel Orientation="Vertical">

--- a/controls/dev/Materials/Acrylic/TestUI/AcrylicBrushPage.xaml.cs
+++ b/controls/dev/Materials/Acrylic/TestUI/AcrylicBrushPage.xaml.cs
@@ -98,6 +98,14 @@ namespace MUXControlsTestApp
             _acrylicBrush.AlwaysUseFallback = false;
         }
 
+        private void IsNoiseEnabledButton_IsCheckedChanged(object sender, RoutedEventArgs e)
+        {
+            if (_acrylicBrush != null)
+            {
+                _acrylicBrush.IsNoiseEnabled = IsNoiseEnabledButton.IsChecked == true;
+            }
+        }
+
         private void TintOpacity_ValueChanged(object sender, Microsoft.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
         {
             if (_acrylicBrush != null)


### PR DESCRIPTION
## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

This PR adds an opt-out option for the noise layer used by `AcrylicBrush`.

The existing acrylic effect pipeline always composites the built-in noise texture on top of the blurred and tinted backdrop. This change allows applications to disable that noise layer while preserving the rest of the acrylic effect, including backdrop blur, tint, and luminosity processing.

The default behavior remains unchanged, so existing applications continue to use the current acrylic appearance unless they explicitly disable noise.

### Current Behavior

`AcrylicBrush` always includes the built-in noise texture as the final stage of the acrylic effect pipeline.

Applications can customize properties such as `TintColor`, `TintOpacity`, and `TintLuminosityOpacity`, but there is currently no way to use the standard acrylic blur, tint, and luminosity recipe without also applying the noise texture.

As a result, applications that prefer a cleaner translucent surface must either use a different brush implementation or reimplement the acrylic effect pipeline themselves.

### New Behavior

`AcrylicBrush` now exposes an option to disable the noise layer.

When noise is enabled, the brush behaves exactly as it does today.

When noise is disabled, the acrylic effect still applies the existing backdrop blur, luminosity processing, and tint, but skips compositing the noise texture onto the final output.

The new option defaults to the existing behavior, preserving compatibility with current applications and theme resources.

## Customer Impact

This gives applications more control over the visual appearance of acrylic surfaces without requiring them to reimplement the acrylic effect pipeline.

Applications can create a smoother, noise-free acrylic surface while retaining the standard WinUI acrylic blur, tint, and luminosity behavior.

Existing applications are unaffected because the new option preserves the current noise-enabled behavior by default.


## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)
Default (Enable/Before):<img width="40" height="295" alt="effect_before" src="https://github.com/user-attachments/assets/d7eead94-bf82-4f68-9191-83e59cdc0174" />Disable (PR After)<img width="34" height="408" alt="image" src="https://github.com/user-attachments/assets/bc9ca984-d3eb-4daf-b23b-fc4d2c08f0fb" />

<!-- If you are making visual changes, include before/after screenshots. -->