### PR TITLE
[WinUI OSS] Enable fresh-clone builds from Visual Studio

### DIFF
--- a/Microsoft.UI.Xaml-VisualStudio.sln
+++ b/Microsoft.UI.Xaml-VisualStudio.sln
@@ -1,0 +1,42 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinUI Visual Studio Build", "eng\VisualStudioBuild\WinUI.VisualStudioBuild.vcxproj", "{3B1BD177-3446-467F-9D5C-FB51E355E4C5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|ARM64EC = Debug|ARM64EC
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|ARM64 = Release|ARM64
+		Release|ARM64EC = Release|ARM64EC
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|ARM64.Build.0 = Debug|ARM64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|ARM64EC.Build.0 = Debug|ARM64EC
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|Win32.ActiveCfg = Debug|Win32
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|Win32.Build.0 = Debug|Win32
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|x64.ActiveCfg = Debug|x64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Debug|x64.Build.0 = Debug|x64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|ARM64.ActiveCfg = Release|ARM64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|ARM64.Build.0 = Release|ARM64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|ARM64EC.ActiveCfg = Release|ARM64EC
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|ARM64EC.Build.0 = Release|ARM64EC
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|Win32.ActiveCfg = Release|Win32
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|Win32.Build.0 = Release|Win32
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|x64.ActiveCfg = Release|x64
+		{3B1BD177-3446-467F-9D5C-FB51E355E4C5}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {06CB8105-D014-4B66-BBA4-23E665411800}
+	EndGlobalSection
+EndGlobal

--- a/eng/VisualStudioBuild/WinUI.VisualStudioBuild.vcxproj
+++ b/eng/VisualStudioBuild/WinUI.VisualStudioBuild.vcxproj
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64EC">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64EC</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64EC">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64EC</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3B1BD177-3446-467F-9D5C-FB51E355E4C5}</ProjectGuid>
+    <Keyword>MakeFileProj</Keyword>
+    <ProjectName>WinUI Visual Studio Build</ProjectName>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Makefile</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <NMakeBuildCommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(ProjectDir)..\..\scripts\Build-FromVisualStudio.ps1" -Configuration "$(Configuration)" -Platform "$(Platform)" -Action Build</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(ProjectDir)..\..\scripts\Build-FromVisualStudio.ps1" -Configuration "$(Configuration)" -Platform "$(Platform)" -Action Rebuild</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(ProjectDir)..\..\scripts\Build-FromVisualStudio.ps1" -Configuration "$(Configuration)" -Platform "$(Platform)" -Action Clean</NMakeCleanCommandLine>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/scripts/Build-FromVisualStudio.ps1
+++ b/scripts/Build-FromVisualStudio.ps1
@@ -1,0 +1,83 @@
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+
+    [ValidateSet("Win32", "x86", "x64", "ARM64", "ARM64EC")]
+    [string]$Platform = "x64",
+
+    [ValidateSet("Build", "Rebuild", "Clean")]
+    [string]$Action = "Build"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Windows PowerShell can inherit PowerShell 7's module path when launched from
+# another terminal. Prefer the modules that belong to the current host.
+$hostModules = Join-Path $PSHOME "Modules"
+$modulePaths = @($hostModules) + @($env:PSModulePath -split [IO.Path]::PathSeparator | Where-Object { $_ -and $_ -ne $hostModules })
+$env:PSModulePath = $modulePaths -join [IO.Path]::PathSeparator
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+$architecture = switch ($Platform)
+{
+    "Win32" { "x86" }
+    "x86" { "x86" }
+    "x64" { "amd64" }
+    "ARM64" { "arm64" }
+    "ARM64EC" { "arm64ec" }
+}
+
+$flavor = if ($Configuration -eq "Debug") { "chk" } else { "fre" }
+$buildFlavor = "$architecture$flavor"
+$initScript = Join-Path $repoRoot "init.ps1"
+$initializationMarker = Join-Path $repoRoot ".tools\VisualStudioBuild.initialized"
+
+if ($Action -eq "Clean")
+{
+    if (-not (Test-Path $initializationMarker))
+    {
+        Write-Host "The WinUI repository has not been initialized; there is nothing to clean."
+        exit 0
+    }
+
+    & $initScript $buildFlavor /envcheck /notitle
+    if ($LASTEXITCODE -ne 0)
+    {
+        exit $LASTEXITCODE
+    }
+    & (Join-Path $repoRoot "tools\clean.cmd") /all
+    exit $LASTEXITCODE
+}
+
+$requiresFullInit = -not (Test-Path (Join-Path $repoRoot ".tools")) -or
+                    -not (Test-Path (Join-Path $repoRoot "packages")) -or
+                    -not (Test-Path $initializationMarker)
+
+if ($requiresFullInit)
+{
+    Write-Host "Preparing the WinUI repository for the first build..."
+    & $initScript $buildFlavor /notitle
+    if ($LASTEXITCODE -ne 0)
+    {
+        exit $LASTEXITCODE
+    }
+    New-Item -ItemType File -Path $initializationMarker -Force | Out-Null
+}
+else
+{
+    & $initScript $buildFlavor /envcheck /notitle
+    if ($LASTEXITCODE -ne 0)
+    {
+        exit $LASTEXITCODE
+    }
+}
+
+$buildArguments = @("product", "/restore")
+if ($Action -eq "Rebuild")
+{
+    $buildArguments += "/c"
+}
+
+& (Join-Path $repoRoot "Build.cmd") @buildArguments
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

Adds a lightweight Visual Studio coordinator solution that initializes a fresh WinUI checkout and runs the existing product build flow when the developer selects **Build Solution**.

## Problem

`Microsoft.UI.Xaml-Product.sln` cannot build directly from a fresh clone because its projects require restored packages and generated prerequisite files during project evaluation.

Visual Studio evaluates those projects before a setup or pre-build step can run, so initialization cannot safely be added directly to the existing product solution.

## Changes

- Added `Microsoft.UI.Xaml-VisualStudio.sln` as the Visual Studio entry point.
- Added an isolated Makefile project:
  `eng\VisualStudioBuild\WinUI.VisualStudioBuild.vcxproj`
- Added `scripts\Build-FromVisualStudio.ps1` to:
  - Map Visual Studio configurations to WinUI build flavors.
  - Run full repository initialization when required.
  - Restore required packages.
  - Delegate to the existing `Build.cmd product` flow.
  - Support Build, Rebuild, and Clean operations.
  - Detect and recover from incomplete initialization.

## Developer experience

From a fresh clone:

1. Open `Microsoft.UI.Xaml-VisualStudio.sln`.
2. Select the required configuration and platform, such as `Debug | x64`.
3. Select **Build → Build Solution**.

The coordinator runs:

```text
Repository initialization
    → package restoration
    → XAML compiler prerequisites
    → WinUI product build

Compatibility

The existing  init.ps1 ,  Build.cmd , product solution, and terminal workflow are unchanged. The coordinator only delegates to the existing build process.

Validation

Validated from a clean checkout based on the latest  winui3/main  after removing:

•  .tools 
•  .dotnet 
•  packages 
•  BuildOutput 

The build completed without Azure Artifacts authentication prompts or  401  errors:

BUILD SUCCEEDED
Build: 1 succeeded, 0 failed
Total Visual Studio time: 32:29

Addresses #11411.
```