### PR TITLE
[Do Not Review] Validate GitHub pipeline guard audit

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -52,7 +52,7 @@ resources:
     - repository: WinUIInternal
       type: git
       name: WinUI/microsoft-ui-xaml-lift
-      ref: refs/heads/main
+      ref: refs/heads/user/sakshishar/audit-github-pipeline-guards
     - repository: WindowsAppSDKConfig
       type: git
       name: ProjectReunion/WindowsAppSDKConfig


### PR DESCRIPTION
## Summary

Validation-only PR for ADO PR [16490220](https://dev.azure.com/microsoft/WinUI/_git/microsoft-ui-xaml-lift/pullrequest/16490220).

This points the public GitHub validation wrapper at the ADO branch `user/sakshishar/audit-github-pipeline-guards` so the GitHub-backed OneBranch pipeline validates the internal changes without duplicating them in this PR.

## What this validates

- `GenerateVersionInfo` runs for GitHub-backed validation.
- Azure Maps token injection no longer depends on the repository provider while fork protection remains.
- Peak system-memory diagnostics run before and after MSBuild.
- Existing PGO and later infrastructure-dependent behavior remains unchanged.

## Important

This PR is for validation only and must not be reviewed or merged.