### PR TITLE
Ignore build and test artifacts (TestPayload, .buildtools, MSBuildCache, etc.) in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,49 @@ UnreliableTestReport.csv
 /.tools/
 src/.dotnet/
 src/.tools/
+.buildtools/
+
+# Test payload folder produced by test\CreateTestPayload.ps1
+TestPayload*
+
+# Files created by init.cmd and SetupDotNetFiles.cmd to target different .NET versions
+dxaml/test/infra/taefhostappnetcore/WinRT.Host.runtimeconfig.json
+
+# Build logs and outputs
+build*.err
+build*.wrn
+msbuild-install-logs/
+*.ProjectImports.zip
+*.sln.metaproj
+
+# MSBuildCache
+MSBuildCache/
+MSBuildCacheLogs/
+
+# Code coverage results
+*.coverage
+*.coveragexml
+
+# Additional compiler/tool intermediates
+*.iobj
+*.ipdb
+*.ndf
+*.jfm
+*.e2e
+*.sap
+*.vbw
+*.nvuser
+CppProperties.json
+
+# JetBrains Rider
+.idea/
+*.sln.iml
+
+# Python
+__pycache__/
+*.pyc
+
+# perf results
+perf/results
+perf/scenarios/**/x64/**/*
+perf/scenarios/**/x86/**/*


### PR DESCRIPTION
## Fixes
Fixes #11537 

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Current Behavior
After a normal `init.cmd` + build + test cycle, generated output shows up as candidates
to commit. Most visibly:

- `TestPayload/` — created by `test\CreateTestPayload.ps1`
- `dxaml\test\infra\taefhostappnetcore\WinRT.Host.runtimeconfig.json` — rewritten by
  `scripts\init\SetupDotNetFiles.cmd` on every `init.cmd`

This makes `git status` noisy and risks accidentally committing build output.

### New Behavior
`.gitignore` now covers the in-repo generated artifacts:

- `TestPayload*`
- `dxaml/test/infra/taefhostappnetcore/WinRT.Host.runtimeconfig.json`
- `.buildtools/` (repo-local VS install from `Initialize-InstallMSBuild.ps1`)
- `MSBuildCache/`, `MSBuildCacheLogs/`, `msbuild-install-logs/`
- `*.sln.metaproj`, `*.ProjectImports.zip`, `build*.err`, `build*.wrn`
- `*.coverage`, `*.coveragexml`
- `*.iobj`, `*.ipdb`, `*.ndf`, `*.jfm`, `*.e2e`, `*.sap`, `*.vbw`, `*.nvuser`, `CppProperties.json`
- `.idea/`, `*.sln.iml`, `__pycache__/`, `*.pyc`
- `perf/results`, `perf/scenarios/**/{x86,x64}/**`

## Customer Impact
None for end users of WinUI. This is a developer/infra-only change that keeps
`git status` clean for contributors and reduces the chance of build output being
committed.

## Regression Potential

`.gitignore` only affects untracked files; already-tracked files are unaffected, so no
build, runtime, or API behavior changes. Patterns were kept scoped to generated output
and verified not to shadow any checked-in source.

- [X] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

Verified with `git status` before/after and `git check-ignore -v` that the previously
untracked generated files (`TestPayload`, `WinRT.Host.runtimeconfig.json`) are now
ignored, and that `git status` reports no tracked files being newly ignored.

- [X] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [X] Existing tests pass locally

## Screenshots (if appropriate)
N/A