### PR TITLE
[WinUI OSS] Enable internal PGO restores for  GitHub Nightly and Official builds

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-BuildMUXProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildMUXProject-Steps.yml
@@ -11,6 +11,7 @@ parameters:
   projectCaching: false
   buildProductOnly: false
   pgoBuildModeMSBuildArg: '/p:PGOBuildMode=$(pgoBuildMode)'
+  useInternalPgoFeed: false
 
 steps:
   - task: NuGetAuthenticate@1
@@ -27,14 +28,61 @@ steps:
       # PublishAot must be specified at restore, as it conditionally generates nuget.g.* imports
       $publishAot = $env:buildConfiguration -eq "Release" -and $env:buildPlatform -ne "x86"
       Write-Host "##vso[task.setvariable variable=publishAotValue;]$publishAot"
+      Write-Host "##vso[task.setvariable variable=pgoNuGetConfigMSBuildArg;]"
 
-      if ($env:BUILD_REPOSITORY_PROVIDER -in @("GitHub", "GitHubEnterprise"))
+      $isGitHub = $env:BUILD_REPOSITORY_PROVIDER -in @("GitHub", "GitHubEnterprise")
+      $useInternalPgoFeed = $env:USE_INTERNAL_PGO_FEED -ieq "true"
+
+      if ($isGitHub -and $useInternalPgoFeed)
+      {
+        if ($env:BUILD_REPOSITORY_NAME -ne "microsoft/microsoft-ui-xaml")
+        {
+          throw "Internal PGO dependencies are only allowed for microsoft/microsoft-ui-xaml."
+        }
+
+        if ($env:SYSTEM_PULLREQUEST_ISFORK -eq "True")
+        {
+          throw "Internal PGO dependencies are not available to forked pull requests."
+        }
+      }
+      elseif ($isGitHub)
       {
         Write-Host "Disabling PGO for GitHub-backed validation."
         Write-Host "##vso[task.setvariable variable=PGODisable;]true"
         Write-Host "##vso[task.setvariable variable=pgoBuildMode;]Off"
       }
     displayName: Set computed variables
+    env:
+      USE_INTERNAL_PGO_FEED: ${{ parameters.useInternalPgoFeed }}
+
+  - task: PowerShell@2
+    displayName: Configure internal PGO package source
+    condition: and(succeeded(), eq(variables['shouldPgo'], 'true'), ${{ eq(parameters.useInternalPgoFeed, true) }}, or(eq(variables['Build.Repository.Provider'], 'GitHub'), eq(variables['Build.Repository.Provider'], 'GitHubEnterprise')))
+    inputs:
+      targetType: inline
+      script: |
+        $ErrorActionPreference = 'Stop'
+
+        if ([string]::IsNullOrWhiteSpace($env:WINUI_LKG_DEPENDENCIES_FEED_URI))
+        {
+          throw "WinUILKGDependenciesFeedUri is required for trusted GitHub PGO builds."
+        }
+
+        $configPath = Join-Path $env:AGENT_TEMPDIRECTORY 'WinUI.PGO.nuget.config'
+        $escapedFeedUri = [System.Security.SecurityElement]::Escape($env:WINUI_LKG_DEPENDENCIES_FEED_URI)
+        @"
+        <?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+          <packageSources>
+            <clear />
+            <add key="WinUI.Dependencies" value="$escapedFeedUri" />
+          </packageSources>
+        </configuration>
+        "@ | Set-Content -Path $configPath -Encoding UTF8
+
+        Write-Host "##vso[task.setvariable variable=pgoNuGetConfigMSBuildArg;]/p:PGONuGetConfigPath=`"$configPath`""
+    env:
+      WINUI_LKG_DEPENDENCIES_FEED_URI: $(WinUILKGDependenciesFeedUri)
 
   # Cleans anything left over from previous builds (including VS build tools) and installs NuGet
   - template: WinUI-InitializeMachineState-Steps.yml
@@ -65,7 +113,7 @@ steps:
 
   - script: |
       echo ##vso[task.setvariable variable=pgoBuildMode]Optimize
-    condition: and(eq(variables['shouldPgo'], 'true'), ne(variables['PGODisable'], 'true'), ne(variables['Build.Repository.Provider'], 'GitHub'), ne(variables['Build.Repository.Provider'], 'GitHubEnterprise'))
+    condition: and(eq(variables['shouldPgo'], 'true'), ne(variables['PGODisable'], 'true'))
     displayName: Enable PGO
 
   - template: WinUI-InstallDependencies-Steps.yml
@@ -126,7 +174,7 @@ steps:
       solutionName: XamlCompilerPrerequisites.sln
       solutionPath: $(Build.SourcesDirectory)
       nugetConfigPath: nuget.config
-      msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /m ${{parameters.additionalMSBuildOptions}}'
+      msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} $(pgoNuGetConfigMSBuildArg) /m ${{parameters.additionalMSBuildOptions}}'
       msbuildInstallDir: $(_buildToolsDirectory)
       projectCaching: ${{ parameters.projectCaching }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -138,7 +186,7 @@ steps:
         solutionName: Microsoft.UI.Xaml.sln
         solutionPath: $(Build.SourcesDirectory)\dxaml
         nugetConfigPath: nuget.config
-        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:WinUIVersion=$(versionFinal) /m ${{parameters.additionalMSBuildOptions}} /p:PublishAot=$(publishAotValue)'
+        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} $(pgoNuGetConfigMSBuildArg) /p:WinUIVersion=$(versionFinal) /m ${{parameters.additionalMSBuildOptions}} /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -150,7 +198,7 @@ steps:
         solutionName: Microsoft.UI.Xaml-Product.sln
         solutionPath: $(Build.SourcesDirectory)
         nugetConfigPath: nuget.config
-        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:WinUIVersion=$(versionFinal) /m ${{parameters.additionalMSBuildOptions}} /p:PublishAot=$(publishAotValue)'
+        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} $(pgoNuGetConfigMSBuildArg) /p:WinUIVersion=$(versionFinal) /m ${{parameters.additionalMSBuildOptions}} /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -197,7 +245,7 @@ steps:
         solutionName: MUXControls.sln
         solutionPath: $(Build.SourcesDirectory)\controls
         nugetConfigPath: nuget.config
-        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:DisableWarnForInvalidRestoreProjects=true ${{parameters.additionalMSBuildOptions}} /p:WinUIVersion=$(versionFinal) /p:PublishAot=$(publishAotValue)'
+        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} $(pgoNuGetConfigMSBuildArg) /p:DisableWarnForInvalidRestoreProjects=true ${{parameters.additionalMSBuildOptions}} /p:WinUIVersion=$(versionFinal) /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -214,7 +262,7 @@ steps:
         solutionName: MUXControlsTabular.sln
         solutionPath: $(Build.SourcesDirectory)\controls
         nugetConfigPath: nuget.config
-        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:DisableWarnForInvalidRestoreProjects=true ${{parameters.additionalMSBuildOptions}} /p:WinUIVersion=$(versionFinal) /p:PublishAot=$(publishAotValue)'
+        msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} $(pgoNuGetConfigMSBuildArg) /p:DisableWarnForInvalidRestoreProjects=true ${{parameters.additionalMSBuildOptions}} /p:WinUIVersion=$(versionFinal) /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}

--- a/build/AzurePipelinesTemplates/WinUI-BuildWinUI-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildWinUI-Stage.yml
@@ -9,6 +9,7 @@ parameters:
   runStaticAnalysis: true
   projectCaching: false
   pgoBuildModeMSBuildArg: '/p:PGOBuildMode=$(pgoBuildMode)'
+  useInternalPgoFeed: false
   buildProductOnly: false
   dependsOn: ''
 
@@ -159,6 +160,7 @@ stages:
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
         projectCaching: ${{ parameters.projectCaching }}
         pgoBuildModeMSBuildArg: ${{ parameters.pgoBuildModeMSBuildArg }}
+        useInternalPgoFeed: ${{ parameters.useInternalPgoFeed }}
         buildProductOnly: ${{ parameters.buildProductOnly }}
 
     - ${{ if eq(parameters.pipelineKind, 'Nightly') }}:

--- a/build/WinUI-Nightly.yml
+++ b/build/WinUI-Nightly.yml
@@ -96,6 +96,7 @@ extends:
         signOutput: ${{ parameters.SignOutput }}
         MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+        useInternalPgoFeed: true
 
     - template: AzurePipelinesTemplates\WinUI-BuildScenarioApps-Stage.yml
       parameters:

--- a/build/WinUI-Official.yml
+++ b/build/WinUI-Official.yml
@@ -89,6 +89,7 @@ extends:
         signOutput: true
         MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
+        useInternalPgoFeed: true
 
     - template: AzurePipelinesTemplates\WinUI-BuildScenarioApps-Stage.yml
       parameters:


### PR DESCRIPTION
## Summary

Enable PGO package restoration for trusted GitHub-backed WinUI Nightly and Official builds.

## Context

GitHub-backed Release builds attempted to use PGO but searched the public `shine-oss` feed. The required `Microsoft.WinUI.PGO` profile packages are available from the internal WinUI feed, causing builds to fail with:

`Could not find matching PGO package.`

## Changes

- Added an opt-in switch for trusted internal PGO restoration.
- Enabled it only for WinUI Nightly and Official pipelines.
- Generated the internal NuGet configuration temporarily on the build agent.
- Restricted internal PGO access to `microsoft/microsoft-ui-xaml`.
- Blocked internal PGO access for forked pull requests.
- Limited internal-feed usage to Release jobs that enable PGO.
- Left the GitHub PR pipeline unchanged.

## Validation

- Confirmed Nightly and Official are the only pipelines opting into internal PGO restoration.
- Confirmed the GitHub PR pipeline remains unchanged with PGO disabled.
- Confirmed the generated NuGet configuration preserves the feed URI without committing it to GitHub.
- Confirmed all PGO-enabled MSBuild paths receive the temporary internal NuGet configuration.
