### PR TITLE
Test: Add temporary failing API test to probe GitHub PR test gating

### DIFF
--- a/controls/dev/AnimatedIcon/APITests/AnimatedIconTests.cs
+++ b/controls/dev/AnimatedIcon/APITests/AnimatedIconTests.cs
@@ -25,6 +25,15 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
     [TestClass]
     public class AnimatedIconTests : ApiTestBase
     {
+        // TEMPORARY infrastructure probe. WinUI-GitHub-PR.yml passes failOnTestFailure: false
+        // to WinUI-RunTests-Stage.yml, so a failing test is expected to be published but not to
+        // fail the pipeline. Revert once the result is recorded.
+        [TestMethod]
+        public void BuildTypeCoverageProbe_IntentionalFailure()
+        {
+            Verify.AreEqual(1, 2, "Intentional failure - GitHub PR test gating probe");
+        }
+
         [TestMethod]
         public void SettingStateOnParentPropagatesToChildAnimatedIcon()
         {


### PR DESCRIPTION
## PR Type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): Failing test for testing purposes

## Description
Temporary infrastructure probe. WinUI-GitHub-PR.yml passes failOnTestFailure: false to WinUI-RunTests-Stage.yml, so a failing test is expected to be published but not to fail the pipeline. Will be closed once the result is recorded.
