### PR TITLE
Fix typo in API review process documentation

### DIFF
--- a/docs/api-specs/public-api-review-process.md
+++ b/docs/api-specs/public-api-review-process.md
@@ -56,7 +56,7 @@ The start and end dates will be outlined in the spec and in the [API Specs Revie
 
 ## Handle Feedback 
 
-We are commited to respond to all feedback in different manners depending on the feedback category.
+We are committed to respond to all feedback in different manners depending on the feedback category.
 
 **Feedback categorization:** In general, feedback will be prioritized into the categories below based on relevance, impact, and feasibility. 
 

--- a/specs/public-api-review-process.md
+++ b/specs/public-api-review-process.md
@@ -54,7 +54,7 @@ The start and end dates will be outlined in the spec and in the [API Specs Revie
 
 ## Handle Feedback 
 
-We are commited to respond to all feedback in different manners depending on the feedback category.
+We are committed to respond to all feedback in different manners depending on the feedback category.
 
 **Feedback categorization:** In general, feedback will be prioritized into the categories below based on relevance, impact, and feasibility. 
 


### PR DESCRIPTION
## Summary

Correct the spelling of \committed\ in both copies of the API review process documentation.

## Validation

Documentation-only change; verified both copies remain consistent.