### PR TITLE
Reduce retained memory in XamlOptimizedNodeList via shrink_to_fit on Close

### DIFF
--- a/dxaml/xcp/core/Parser/XamlOptimizedNodeList.cpp
+++ b/dxaml/xcp/core/Parser/XamlOptimizedNodeList.cpp
@@ -607,6 +607,18 @@ XamlOptimizedNodeList::ReserveBasedOn(const std::shared_ptr<XamlOptimizedNodeLis
 void XamlOptimizedNodeList::Close()
 {
     m_fReadMode = true;
+
+    // This node list is write-once / read-many and is retained for the lifetime of the
+    // cached template, cached node stream, or deferred dictionary that owns it. The
+    // append path grows m_bytes from reserve(128), and ReserveBasedOn() pre-sizes the
+    // vectors from a sibling list, so both routinely leave excess capacity. Now that
+    // writing is done, reclaim that overshoot so the retained buffers only commit what
+    // they actually hold. shrink_to_fit() changes capacity only, not contents, so the
+    // size()-based read paths are unaffected.
+    m_bytes.shrink_to_fit();
+    m_values.shrink_to_fit();
+    m_strings.shrink_to_fit();
+    m_unknownNamespaces.shrink_to_fit();
 }
 
 

--- a/dxaml/xcp/core/core/elements/TemplateContent.cpp
+++ b/dxaml/xcp/core/core/elements/TemplateContent.cpp
@@ -721,6 +721,14 @@ CTemplateContent::LoadXbfVersion2(
     if (bTryOptimizeContent && !m_bContentAlreadyOptimized)
     {
         m_bContentAlreadyOptimized = true;
+
+        // The cache is populated only on this first optimization pass (via emplace_back,
+        // which grows capacity geometrically); every later template expansion only reads
+        // it by index. Now that it is sealed, reclaim the growth overshoot so this
+        // CShareableDependencyObject-retained buffer commits only what it holds.
+        // shrink_to_fit() changes capacity only, not contents, so the size()-based read
+        // paths in GenerateOptimizedNode() are unaffected.
+        m_cachedTemplateContentObjects.shrink_to_fit();
     }
 
     return S_OK;


### PR DESCRIPTION
## Summary
`XamlOptimizedNodeList` is the in-memory compiled-XAML representation retained for cached control templates, cached node streams, and deferred resource dictionaries. It is **write-once / read-many**: its four backing `std::vector` buffers (`m_bytes`, `m_values`, `m_strings`, `m_unknownNamespaces`) are populated during parse and then held immutable for the object''s lifetime.

This change calls `shrink_to_fit()` on those four vectors in `XamlOptimizedNodeList::Close()` — the definitive end-of-writing boundary, where `m_fReadMode` is set to `true`.

## Why this reduces the memory footprint
The append paths over-allocate capacity on purpose for speed:
- The first append does `reserve(128)`.
- Subsequent growth uses overshoot-based `ReserveBasedOn(...)` (grows by more than one element at a time to amortize reallocation cost).

As a result, when writing finishes a node list typically has **`capacity > size`** — i.e. it holds heap memory it will never use again. Because these objects are retained for the lifetime of every cached template / deferred dictionary, that slack is **permanently committed** dead memory that scales with the number of cached node lists.

`shrink_to_fit()` at `Close()` releases the unused tail capacity back to the native heap allocator. Concretely:
- Native heap (the CRT heap where these `std::vector`s live) retains less committed memory.
- That surfaces as a reduction in the process **Private Bytes** / **Committed** memory (the private, non-shareable per-process footprint).

The savings scale with XAML and template complexity: the more cached templates / deferred dictionaries an app instantiates, the more retained capacity slack is reclaimed.

## Why it is safe (behavior-preserving)
- `shrink_to_fit()` changes only **capacity**, never `size()` or the element contents.
- It runs at the read-mode transition in `Close()`, after all writing is complete; nothing appends afterward, so there is no reallocation churn from re-growing.
- All read paths index by `size()`, so the shrunk-but-identical contents are read exactly as before.

## Measurement note (honest caveat)
For a single small app this is a modest win — realistically kilobytes to low-single-digit MB, dominated by how many templates are cached. A single before/after snapshot of committed memory is **not** a reliable attribution because run-to-run variance (GC timing, JIT, thread-pool sizing, heap fragmentation, ASLR) can move committed memory by several MB on its own. Proper attribution requires a controlled A/B (same navigation script, steady state, forced GC, averaged over multiple runs, swapping only the dll). The value here is a correct, contained, retained-memory reduction that grows with real-world XAML complexity.!
## Fixes

<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->


## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### New Behavior
Less memory footprint



## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## Screenshots (if appropriate)

Before

<img width="427" height="466" alt="Screenshot 2026-08-18 163448" src="https://github.com/user-attachments/assets/f1d8a574-3cc2-47e0-905f-949ee85fddc0" />

After
<img width="422" height="456" alt="Screenshot 2026-08-18 173313" src="https://github.com/user-attachments/assets/9bb3790a-77d9-4f45-ba4d-46552394adf8" />
