### PR TITLE
Add `XamlChangeId.SkipWindowRedirectionSurface` to skip the window's GDI redirection surface

### DIFF
--- a/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
+++ b/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
@@ -64,6 +64,9 @@ namespace MUXControlsTestApp.Utilities
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.OptimizeApplyStyles));
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.DefaultStyleOptimizations));
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.DeferContextFlyoutInit));
+            // SkipWindowRedirectionSurface is deliberately not enabled here. It changes how every test window
+            // paints (no GDI redirection surface at all), so it is opted into per test through the
+            // Data:XamlOptionalChanges test property rather than turned on for the whole suite.
         }
 
         public void UpdateXamlOptionalChanges()
@@ -169,6 +172,10 @@ namespace MUXControlsTestApp.Utilities
                         else if (string.Equals(name, "DeferContextFlyoutInit", StringComparison.OrdinalIgnoreCase))
                         {
                             changeId = XamlChangeId.DeferContextFlyoutInit;
+                        }
+                        else if (string.Equals(name, "SkipWindowRedirectionSurface", StringComparison.OrdinalIgnoreCase))
+                        {
+                            changeId = XamlChangeId.SkipWindowRedirectionSurface;
                         }
 
                         Verify.AreNotEqual(changeId, XamlChangeId._Reserved, "Unknown XamlChangeId: " + name);

--- a/docs/design-notes/xaml-window.md
+++ b/docs/design-notes/xaml-window.md
@@ -4,6 +4,7 @@
 
 - [Overview](#overview)
 - [How Window works](#how-window-works)
+- [The window's redirection surface](#the-windows-redirection-surface)
 - [What is AppWindow and how does it relate to Xaml Window?](#what-is-appwindow-and-how-does-it-relate-to-xaml-window)
 
 ## Overview
@@ -59,8 +60,36 @@ Microsoft_UI_Xaml!BaseWindow<DirectUI::DesktopWindowImpl>::WndProc
 Microsoft_UI_Xaml!directui::DesktopWindowImpl::OnMessage
 ```
 
-## What is AppWindow and how does it relate to Xaml Window?
+## The window's redirection surface
 
+By default every top-level window gets a GDI redirection surface: a full-window bitmap that GDI painting on the
+HWND lands in, which the compositor then composes as part of the window. A Xaml `Window` barely uses it. The
+content island covers the whole client area and renders through the compositor, so the only thing the surface
+really shows is the themed background painted on `WM_ERASEBKGND`, which exists to stop the window flashing
+unpainted content before the island's first frame.
+
+That surface is not free. It costs one 32-bit bitmap the size of the window, and the compositor blends it on
+every frame even though it contributes nothing once the island is up. The memory is charged to the compositor
+process rather than to the app, so it doesn't show up in the app's own memory counters.
+
+`WS_EX_NOREDIRECTIONBITMAP` tells the system not to create the surface at all. Xaml passes it when
+`XamlChangeId.SkipWindowRedirectionSurface` is enabled:
+
+``` cpp
+// DesktopWindowImpl.cpp
+const DWORD extendedStyle = OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled() ? WS_EX_NOREDIRECTIONBITMAP : 0;
+```
+
+Two things make this opt-in rather than the default:
+
+* **The window can no longer paint with GDI.** The `WM_ERASEBKGND` themed fill stops having any effect, as does
+  any GDI painting an app does on the Xaml HWND. That is a behavior change as much as an optimization, so it is
+  a `XamlChangeId` and is deliberately not folded into the general perf opt-in.
+* **It has to be decided when the window is created.** The style is only honored when passed to
+  `CreateWindowEx`; adding it afterwards through `SetWindowLongPtr` is silently dropped, and the style bit
+  doesn't even read back as set. So it cannot be turned on later in response to anything the app does.
+
+## What is AppWindow and how does it relate to Xaml Window?
 Microsoft.UI.Windowing.AppWindow is an interesting type.  You can create one to create a standalone top-level window
 (similar to Xaml Window).  OR, you can use it to wrap an _existing_ HWND.
 

--- a/dxaml/test/infra/client/lib/WindowHelper.cpp
+++ b/dxaml/test/infra/client/lib/WindowHelper.cpp
@@ -2108,6 +2108,10 @@ std::vector<std::pair<xaml_settings::XamlChangeId, bool>> GetXamlOptionalChanges
             {
                 changeId = xaml_settings::XamlChangeId_DeferContextFlyoutInit;
             }
+            else if (_wcsicmp(name.c_str(), L"SkipWindowRedirectionSurface") == 0)
+            {
+                changeId = xaml_settings::XamlChangeId_SkipWindowRedirectionSurface;
+            }
 
             if (changeId == xaml_settings::XamlChangeId__Reserved)
             {
@@ -2188,6 +2192,9 @@ void WindowHelper::InitializeXamlCore(_In_ xaml_markup::IXamlMetadataProvider* c
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_OptimizeApplyStyles, &mutated);
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_DefaultStyleOptimizations, &mutated);
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_DeferContextFlyoutInit, &mutated);
+        // SkipWindowRedirectionSurface is deliberately not enabled here. It changes how every test window
+        // paints (no GDI redirection surface at all), so it is opted into per test through the
+        // Data:XamlOptionalChanges test property rather than turned on for the whole suite.
 
         // Apply per-test overrides from XamlOptionalChanges test data.
         for (const auto& [changeId, enabled] : changeOverrides)

--- a/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
+++ b/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
@@ -2212,6 +2212,7 @@ namespace DirectUI
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
     };
     DEFINE_ENUM_FLAG_OPERATORS(XamlChangeId);
 

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
@@ -28,6 +28,7 @@ namespace OptionalChangeState
     constexpr int BitIndex_OptimizeApplyStyles = 1;
     constexpr int BitIndex_DefaultStyleOptimizations = 2;
     constexpr int BitIndex_DeferContextFlyoutInit = 3;
+    constexpr int BitIndex_SkipWindowRedirectionSurface = 4;
 
     inline bool IsOptionalChangeEnabled(int bitIndex)
     {
@@ -53,5 +54,13 @@ namespace OptionalChangeState
     inline bool IsDeferContextFlyoutInitEnabled()
     {
         return IsOptionalChangeEnabled(BitIndex_DeferContextFlyoutInit) || IsPerfOptInEnabled();
+    }
+
+    // Note: deliberately not folded into IsPerfOptInEnabled(). Skipping the redirection surface is a
+    // behavior change as much as an optimization - the window stops being able to paint with GDI - so it
+    // stays an explicit opt-in.
+    inline bool IsSkipWindowRedirectionSurfaceEnabled()
+    {
+        return IsOptionalChangeEnabled(BitIndex_SkipWindowRedirectionSurface);
     }
 }

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
@@ -520,6 +520,7 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
     };
 }
 

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -25,6 +25,7 @@
 #include "Microsoft.UI.Windowing.h"
 #include <FrameworkUdk/Theming.h>
 #include <Microsoft.UI.Interop.h>
+#include <OptionalChangeState.h>
 
 #pragma warning(disable:4267) //'var' : conversion from 'size_t' to 'type', possible loss of data
 
@@ -1252,6 +1253,13 @@ LRESULT DesktopWindowImpl::OnMessage(
             return LResultFromHResult(OnNonClientRegionButtonUp(wParam, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
         case WM_ERASEBKGND:
         {
+            // Without a redirection surface there is nothing to erase: GDI painting on this window goes
+            // nowhere, so the themed fill below would have no effect. See CreateDesktopWindow.
+            if (OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled())
+            {
+                return 1;
+            }
+
             Theming::Theme appTheme = Theming::Theme::None;
             ctl::ComPtr<xaml::IUIElement> content;
             if(!m_bIsClosed && SUCCEEDED(get_ContentImpl(&content)) && content)
@@ -1667,8 +1675,19 @@ void DesktopWindowImpl::RegisterDesktopWindowClass()
 
 void DesktopWindowImpl::CreateDesktopWindow()
 {
+    // WS_EX_NOREDIRECTIONBITMAP tells the system not to give this window a GDI redirection surface at all.
+    // Xaml barely uses it: the content island covers the client area, so the surface only really shows before
+    // the island's first frame - but DWM still allocates it and blends it every frame, at the cost of one
+    // full-window 32-bit bitmap. Skipping it drops both.
+    //
+    // The catch is that the window can no longer paint with GDI, which is a behavior change rather than a pure
+    // optimization, so it is opt-in through XamlChangeId::SkipWindowRedirectionSurface. The style is only
+    // honored here - adding it later with SetWindowLongPtr is silently dropped - so the decision has to be made
+    // for the window as a whole, before the app can set anything on it.
+    const DWORD extendedStyle = OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled() ? WS_EX_NOREDIRECTIONBITMAP : 0;
+
     _CreateWindow(
-        0,                                 // Extended Style
+        extendedStyle,                     // Extended Style
         s_windowClassName,                 // name of window class
         s_defaultWindowTitle,              // title-bar string
         WS_OVERLAPPEDWINDOW | WS_VISIBLE,  // top-level window

--- a/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
@@ -44,6 +44,8 @@ static int GetBitIndex(xaml_settings::XamlChangeId id)
         return OptionalChangeState::BitIndex_DefaultStyleOptimizations;
     case xaml_settings::XamlChangeId_DeferContextFlyoutInit:
         return OptionalChangeState::BitIndex_DeferContextFlyoutInit;
+    case xaml_settings::XamlChangeId_SkipWindowRedirectionSurface:
+        return OptionalChangeState::BitIndex_SkipWindowRedirectionSurface;
     default:
         return -1;
     }

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
@@ -20,6 +20,7 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
     }
 
     // Provides static methods to opt in to or out of individual breaking or


### PR DESCRIPTION
## Fixes

Fixes #11523

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Adds `XamlChangeId.SkipWindowRedirectionSurface`, an opt-in that creates the Xaml `Window`'s top-level HWND with `WS_EX_NOREDIRECTIONBITMAP` so it has no GDI redirection surface.

### Current Behavior

Every Xaml `Window` gets a GDI redirection surface, and there is no way for an app to avoid it.

Xaml barely uses that surface. The content island covers the client area and renders through the compositor, so the only thing the surface really shows is the themed `WM_ERASEBKGND` fill, which exists to stop the window flashing unpainted content before the island's first frame.

It is not free, though. It costs one 32-bit bitmap the size of the window, and the compositor blends it on every frame even though it contributes nothing once the island is up.

### New Behavior

When the change is enabled, the window is created with `WS_EX_NOREDIRECTIONBITMAP` and no surface is allocated. `WM_ERASEBKGND` returns early, since GDI painting on the window would go nowhere.

Nothing changes unless an app opts in:

```csharp
XamlOptionalChanges.Enable(XamlChangeId.SkipWindowRedirectionSurface);
```

The enum value follows the existing convention in `XamlChangeId`, where each value is the tracking ID for the change.

## Customer Impact

Apps that opt in save one full-window 32-bit bitmap per window, and the compositor stops blending a surface that contributes nothing.

Measured per window on Windows 11 24H2 (build 26667), as the change in the compositor's GPU-committed memory across a batch of 40 identically sized windows, against the process's own idle baseline:

| window size | one BGRA bitmap | before | after |
| ---: | ---: | ---: | ---: |
| 1600 × 1000 | 6.10 MB | 6.11 MB | **0.00 MB** |
| 1920 × 1080 | 7.91 MB | 7.91 MB | **0.00 MB** |

Stable across repeated runs, and matching one bitmap of the window's size to within 0.01 MB, which is what identifies what is being freed.

Worth knowing when reading those numbers: the surface is allocated and owned by the compositor process, not by the app that owns the window, so this does not show up in the app's own memory counters either before or after.

Two things an app gives up by opting in:

* **The window can no longer paint with GDI.** The themed `WM_ERASEBKGND` fill stops having any effect, as does any GDI painting an app does on the Xaml HWND. In practice the visible consequence is that a window may show unpainted content for the moment before the island's first frame.
* **It cannot be turned on later.** The style is only honored when passed to `CreateWindowEx`; adding it afterwards through `SetWindowLongPtr` is silently dropped, and the style bit does not even read back as set. So the decision is made once, when the window is created.

Because it is a behavior change as much as an optimization, `IsSkipWindowRedirectionSurfaceEnabled()` is deliberately **not** folded into `IsPerfOptInEnabled()` the way most of the other change IDs are. It has to be asked for by name.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

Every code path added is behind `IsSkipWindowRedirectionSurfaceEnabled()`, which is off unless an app enables it explicitly, and which is not reachable through the general perf opt-in. With the change disabled the window is created with the same extended style as before (`0`) and `WM_ERASEBKGND` runs exactly as it does today.

The risk that remains is scoped to apps that opt in, and is the documented trade-off above rather than an unintended effect.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

Validation done:

* **Builds clean.** `Microsoft.ui.xaml.vcxproj` builds with 0 errors and 0 warnings with the change applied.
* **Measured, not assumed.** The numbers above come from an isolated benchmark that creates batches of windows in one process and differences the compositor's GPU-committed memory around them, with the extended style as the only variable.
* **Checked the obvious cheaper theory first, and it was wrong.** `CreateOrGetRedirectionBitmap` reads like it allocates lazily, which would mean a window that never paints would not pay for a surface, and no new API would be needed. Measured, a window with no class background brush that claims `WM_ERASEBKGND` without ever taking a device context still costs the full 7.91 MB at 1080p. The allocation follows from the window being redirected at all, not from anything drawing into it, so the extended style really is the only lever.
* **Confirmed the style is creation-time only** by applying it with `SetWindowLong` after creation: the surface is not released, and the bit does not read back as set.

No automated test is added. The observable effect is the presence or absence of a surface owned by another process, which is measurable in a benchmark but not assertable from the existing API test harness. The test harnesses do learn the new name, so the change can be enabled by name in test runs.

## Screenshots (if appropriate)

Not applicable, there is no intended visual change.