### PR TITLE
Make `MicaBackdrop` work when the process uses the system composition engine

### DIFF
--- a/controls/MUXControls.sln
+++ b/controls/MUXControls.sln
@@ -198,6 +198,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AcrylicBrush_TestUI", "dev\
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AcrylicBrush_ApiTests", "dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.shproj", "{593E15D8-F6F9-4ABA-BA65-C6927C178DBD}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MicaBackdrop_APITests", "dev\Materials\MicaBackdrop\APITests\MicaBackdrop_APITests.shproj", "{C3ECF03A-9210-42BA-9FC6-094649AF0D72}"
+EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AcrylicBrush_InteractionTests", "dev\Materials\Acrylic\InteractionTests\AcrylicBrush_InteractionTests.shproj", "{F601284A-00C1-49F9-99B3-70D45585F784}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Reveal_InteractionTests", "dev\Materials\Reveal\InteractionTests\Reveal_InteractionTests\Reveal_InteractionTests.shproj", "{1F2872E7-28C9-4C01-88ED-73C43EE1C9A4}"
@@ -1458,6 +1460,7 @@ Global
 		{76353825-06F5-4EA2-BB96-D6A9BB8B6545} = {96707BBD-8D2A-4715-8DDA-3A60E4AF9914}
 		{CC231572-D8DB-4D9D-A687-1690F9E8B169} = {0BEED10A-70BC-4103-8BC8-84D83A14EF75}
 		{71ABD2F5-1AE8-45E9-814C-F8362FE1AD33} = {AAEE68EF-8CB5-40D2-8BC8-9A00FB0A1B6A}
+		{C3ECF03A-9210-42BA-9FC6-094649AF0D72} = {AAEE68EF-8CB5-40D2-8BC8-9A00FB0A1B6A}
 		{CE762527-4CC8-4604-A0DD-9EA4CB29C4A9} = {414D2AE4-5B65-43E1-9C11-D94817835B3D}
 		{4993A99D-57AE-4EE7-A3C1-0840ED127608} = {CE762527-4CC8-4604-A0DD-9EA4CB29C4A9}
 		{73E823BC-5485-4F26-9B09-8B83C133EE6B} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
@@ -1871,6 +1874,7 @@ Global
 		dev\MapControl\TestUI\MapControl_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\Materials\Acrylic\TestUI\AcrylicBrush_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
+		dev\Materials\MicaBackdrop\APITests\MicaBackdrop_APITests.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\Materials\Reveal\APITests\Reveal_APITests.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\Materials\Reveal\TestUI\Reveal_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\MenuBar\MenuBar_TestUI\MenuBar_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
@@ -1940,6 +1944,7 @@ Global
 		dev\MenuBar\MenuBar_TestUI\MenuBar_TestUI.projitems*{55cb08ca-19fe-4db9-8160-a4ec47984b95}*SharedItemsImports = 13
 		dev\Breadcrumb\Breadcrumb.vcxitems*{563fe343-c6b0-447b-831a-b0ce3aa7a688}*SharedItemsImports = 9
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{593e15d8-f6f9-4aba-ba65-c6927c178dbd}*SharedItemsImports = 13
+		dev\Materials\MicaBackdrop\APITests\MicaBackdrop_APITests.projitems*{c3ecf03a-9210-42ba-9fc6-094649af0d72}*SharedItemsImports = 13
 		dev\Materials\Reveal\TestUI\Reveal_TestUI.projitems*{5bf80ae9-29df-4be9-858a-f095c8073473}*SharedItemsImports = 13
 		dev\PersonPicture\PersonPicture.vcxitems*{5fdf2501-aa3d-4082-ad45-d1f2a94c1213}*SharedItemsImports = 9
 		dev\ProgressRing\ProgressRing.vcxitems*{64447efa-19b4-4bf2-9d63-618635c483ec}*SharedItemsImports = 9

--- a/controls/MUXControlsInnerLoop.sln
+++ b/controls/MUXControlsInnerLoop.sln
@@ -181,6 +181,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AcrylicBrush_TestUI", "dev\
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AcrylicBrush_ApiTests", "dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.shproj", "{593E15D8-F6F9-4ABA-BA65-C6927C178DBD}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MicaBackdrop_APITests", "dev\Materials\MicaBackdrop\APITests\MicaBackdrop_APITests.shproj", "{C3ECF03A-9210-42BA-9FC6-094649AF0D72}"
+EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "AcrylicBrush_InteractionTests", "dev\Materials\Acrylic\InteractionTests\AcrylicBrush_InteractionTests.shproj", "{F601284A-00C1-49F9-99B3-70D45585F784}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Reveal_InteractionTests", "dev\Materials\Reveal\InteractionTests\Reveal_InteractionTests\Reveal_InteractionTests.shproj", "{1F2872E7-28C9-4C01-88ED-73C43EE1C9A4}"
@@ -1029,6 +1031,7 @@ Global
 		dev\MenuBar\MenuBar_TestUI\MenuBar_TestUI.projitems*{55cb08ca-19fe-4db9-8160-a4ec47984b95}*SharedItemsImports = 13
 		dev\Breadcrumb\Breadcrumb.vcxitems*{563fe343-c6b0-447b-831a-b0ce3aa7a688}*SharedItemsImports = 9
 		dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems*{593e15d8-f6f9-4aba-ba65-c6927c178dbd}*SharedItemsImports = 13
+		dev\Materials\MicaBackdrop\APITests\MicaBackdrop_APITests.projitems*{c3ecf03a-9210-42ba-9fc6-094649af0d72}*SharedItemsImports = 13
 		dev\Materials\Reveal\TestUI\Reveal_TestUI.projitems*{5bf80ae9-29df-4be9-858a-f095c8073473}*SharedItemsImports = 13
 		dev\PersonPicture\PersonPicture.vcxitems*{5fdf2501-aa3d-4082-ad45-d1f2a94c1213}*SharedItemsImports = 9
 		dev\ProgressRing\ProgressRing.vcxitems*{64447efa-19b4-4bf2-9d63-618635c483ec}*SharedItemsImports = 9

--- a/controls/dev/Common/Common.vcxitems
+++ b/controls/dev/Common/Common.vcxitems
@@ -23,6 +23,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ColorConversion.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)CornerRadiusFilterConverter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LifetimeHandler.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)SystemCompositionEngine.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\CornerRadiusFilterConverter.properties.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)CornerRadiusToThicknessConverter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\CornerRadiusToThicknessConverter.properties.cpp" />
@@ -35,6 +36,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)LifetimeHandler.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PointerInfo.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PointerInfoRevokers.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)SystemCompositionEngine.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="$(MSBuildThisFileDirectory)CornerRadiusToThicknessConverter.idl" />

--- a/controls/dev/Common/Common.vcxitems
+++ b/controls/dev/Common/Common.vcxitems
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)ColorConversion.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)CornerRadiusFilterConverter.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)DwmSystemBackdrop.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LifetimeHandler.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SystemCompositionEngine.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Generated\CornerRadiusFilterConverter.properties.cpp" />
@@ -32,6 +33,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ColorConversion.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)CornerRadiusFilterConverter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)CornerRadiusToThicknessConverter.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)DwmSystemBackdrop.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Flags_Enum.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)LifetimeHandler.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PointerInfo.h" />

--- a/controls/dev/Common/DwmSystemBackdrop.cpp
+++ b/controls/dev/Common/DwmSystemBackdrop.cpp
@@ -24,6 +24,20 @@ namespace
         return SUCCEEDED(DwmSetWindowAttribute(windowHandle, DWMWA_SYSTEMBACKDROP_TYPE, &backdropType, sizeof(backdropType)));
     }
 
+    // Reads whether DWM currently draws 'windowHandle' dark. This selects the light or dark variant of the
+    // backdrop material as well as the window's frame, and DWM defaults it to light for every window - it has
+    // no knowledge of the Xaml theme, and doesn't follow the system one either.
+    bool TryGetWindowDarkMode(HWND windowHandle, BOOL& useDarkMode)
+    {
+        useDarkMode = FALSE;
+        return SUCCEEDED(DwmGetWindowAttribute(windowHandle, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDarkMode, sizeof(useDarkMode)));
+    }
+
+    bool TrySetWindowDarkMode(HWND windowHandle, BOOL useDarkMode)
+    {
+        return SUCCEEDED(DwmSetWindowAttribute(windowHandle, DWMWA_USE_IMMERSIVE_DARK_MODE, &useDarkMode, sizeof(useDarkMode)));
+    }
+
     // Returns the handle of the Xaml Window whose backdrop 'systemBackdrop' is, given that it was just connected
     // to 'target' inside 'xamlRoot'. Returns null for every other way a SystemBackdrop can be attached.
     //
@@ -87,7 +101,8 @@ namespace
     const winrt::Microsoft::UI::Xaml::Media::SystemBackdrop& systemBackdrop,
     const winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop& target,
     const winrt::Microsoft::UI::Xaml::XamlRoot& xamlRoot,
-    DWM_SYSTEMBACKDROP_TYPE backdropType)
+    DWM_SYSTEMBACKDROP_TYPE backdropType,
+    bool useDarkMode)
 {
     const HWND windowHandle = TryGetXamlWindowForTarget(systemBackdrop, target, xamlRoot);
     if (!windowHandle)
@@ -104,13 +119,31 @@ namespace
         return nullptr;
     }
 
-    return std::unique_ptr<DwmSystemBackdrop>(new DwmSystemBackdrop(windowHandle, previousBackdropType, backdropType));
+    // The material is the point of this object, so it is what decides whether we could attach at all. The
+    // light/dark variant is taken on separately and only when the window lets us read it back, because an
+    // attribute we can't read is one we can't tell apart from an app's own later write.
+    const BOOL appliedDarkMode = useDarkMode ? TRUE : FALSE;
+    BOOL previousDarkMode = FALSE;
+    const bool ownsDarkMode = TryGetWindowDarkMode(windowHandle, previousDarkMode) &&
+                              TrySetWindowDarkMode(windowHandle, appliedDarkMode);
+
+    return std::unique_ptr<DwmSystemBackdrop>(new DwmSystemBackdrop(
+        windowHandle, previousBackdropType, backdropType, ownsDarkMode, previousDarkMode, appliedDarkMode));
 }
 
-DwmSystemBackdrop::DwmSystemBackdrop(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE previousBackdropType, DWM_SYSTEMBACKDROP_TYPE backdropType)
+DwmSystemBackdrop::DwmSystemBackdrop(
+    HWND windowHandle,
+    DWM_SYSTEMBACKDROP_TYPE previousBackdropType,
+    DWM_SYSTEMBACKDROP_TYPE backdropType,
+    bool ownsDarkMode,
+    BOOL previousDarkMode,
+    BOOL appliedDarkMode)
     : m_windowHandle(windowHandle)
     , m_previousBackdropType(previousBackdropType)
     , m_appliedBackdropType(backdropType)
+    , m_ownsDarkMode(ownsDarkMode)
+    , m_previousDarkMode(previousDarkMode)
+    , m_appliedDarkMode(appliedDarkMode)
 {
 }
 
@@ -120,6 +153,11 @@ DwmSystemBackdrop::~DwmSystemBackdrop()
     if (IsLastWriter())
     {
         TrySetWindowBackdropType(m_windowHandle, m_previousBackdropType);
+    }
+
+    if (IsLastDarkModeWriter())
+    {
+        TrySetWindowDarkMode(m_windowHandle, m_previousDarkMode);
     }
 }
 
@@ -133,8 +171,26 @@ void DwmSystemBackdrop::BackdropType(DWM_SYSTEMBACKDROP_TYPE backdropType)
     }
 }
 
+void DwmSystemBackdrop::DarkMode(bool useDarkMode)
+{
+    const BOOL darkMode = useDarkMode ? TRUE : FALSE;
+
+    if (darkMode != m_appliedDarkMode && IsLastDarkModeWriter() && TrySetWindowDarkMode(m_windowHandle, darkMode))
+    {
+        m_appliedDarkMode = darkMode;
+    }
+}
+
 bool DwmSystemBackdrop::IsLastWriter() const
 {
     DWM_SYSTEMBACKDROP_TYPE currentBackdropType = DWMSBT_AUTO;
     return TryGetWindowBackdropType(m_windowHandle, currentBackdropType) && currentBackdropType == m_appliedBackdropType;
+}
+
+bool DwmSystemBackdrop::IsLastDarkModeWriter() const
+{
+    BOOL currentDarkMode = FALSE;
+    return m_ownsDarkMode &&
+           TryGetWindowDarkMode(m_windowHandle, currentDarkMode) &&
+           currentDarkMode == m_appliedDarkMode;
 }

--- a/controls/dev/Common/DwmSystemBackdrop.cpp
+++ b/controls/dev/Common/DwmSystemBackdrop.cpp
@@ -116,10 +116,8 @@ DwmSystemBackdrop::DwmSystemBackdrop(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE 
 
 DwmSystemBackdrop::~DwmSystemBackdrop()
 {
-    // Undo only our own configuration. If the app has written the attribute behind our back it is the last
-    // writer and gets to keep what it asked for.
-    DWM_SYSTEMBACKDROP_TYPE currentBackdropType = DWMSBT_AUTO;
-    if (TryGetWindowBackdropType(m_windowHandle, currentBackdropType) && currentBackdropType == m_appliedBackdropType)
+    // Undo only our own configuration, so that an app that took the attribute over keeps what it asked for.
+    if (IsLastWriter())
     {
         TrySetWindowBackdropType(m_windowHandle, m_previousBackdropType);
     }
@@ -127,8 +125,16 @@ DwmSystemBackdrop::~DwmSystemBackdrop()
 
 void DwmSystemBackdrop::BackdropType(DWM_SYSTEMBACKDROP_TYPE backdropType)
 {
-    if (backdropType != m_appliedBackdropType && TrySetWindowBackdropType(m_windowHandle, backdropType))
+    // Same ownership rule as the destructor: once an app has written the attribute behind our back it is the
+    // last writer, and a later Kind change must not take the window back off it.
+    if (backdropType != m_appliedBackdropType && IsLastWriter() && TrySetWindowBackdropType(m_windowHandle, backdropType))
     {
         m_appliedBackdropType = backdropType;
     }
+}
+
+bool DwmSystemBackdrop::IsLastWriter() const
+{
+    DWM_SYSTEMBACKDROP_TYPE currentBackdropType = DWMSBT_AUTO;
+    return TryGetWindowBackdropType(m_windowHandle, currentBackdropType) && currentBackdropType == m_appliedBackdropType;
 }

--- a/controls/dev/Common/DwmSystemBackdrop.cpp
+++ b/controls/dev/Common/DwmSystemBackdrop.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "DwmSystemBackdrop.h"
+
+// This needs to be here instead of in CppWinRTIncludes.h because it includes Microsoft.UI.h, which contains
+// definitions of a few types like WindowId that conflict with their definitions in Microsoft.UI.Content.h.
+#include <winrt\Microsoft.UI.Interop.h>
+
+namespace
+{
+    // Reads the material DWM currently draws behind 'windowHandle'. Returns false before Windows 11 22H2, where
+    // the attribute doesn't exist and there is no DWM-drawn backdrop to speak of.
+    bool TryGetWindowBackdropType(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE& backdropType)
+    {
+        backdropType = DWMSBT_AUTO;
+        return SUCCEEDED(DwmGetWindowAttribute(windowHandle, DWMWA_SYSTEMBACKDROP_TYPE, &backdropType, sizeof(backdropType)));
+    }
+
+    bool TrySetWindowBackdropType(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE backdropType)
+    {
+        return SUCCEEDED(DwmSetWindowAttribute(windowHandle, DWMWA_SYSTEMBACKDROP_TYPE, &backdropType, sizeof(backdropType)));
+    }
+
+    // Returns the handle of the Xaml Window whose backdrop 'systemBackdrop' is, given that it was just connected
+    // to 'target' inside 'xamlRoot'. Returns null for every other way a SystemBackdrop can be attached.
+    //
+    // The DWM attribute covers a whole top-level window, so it is only ever the right answer when Xaml owns that
+    // window and the backdrop is meant to fill all of it. Three conditions together say exactly that:
+    //
+    //  - The target has to be a XamlIsland. Window hosts its content in a DesktopWindowXamlSource, whose island
+    //    fills the window's client area. Windowed popups connect the Popup itself, and SystemBackdropElement and
+    //    CommandBarFlyout connect a ContentExternalBackdropLink; none of those cover a window.
+    //  - The Window hosting that island has to be one of the app's Xaml Windows and have this very SystemBackdrop
+    //    set on it. That rules out islands the app hosts in a window of its own, which Xaml doesn't own and may
+    //    not reconfigure.
+    //  - That island has to be the Window's own. XamlRoot.Content unwraps the WindowChrome that Xaml puts at the
+    //    root of a Window's island, so for the Window's island it is the same element as Window.Content, while an
+    //    island the app nested inside the Window has content of its own. Without this, an island nested inside a
+    //    Window would take the whole window over as soon as it shared the Window's backdrop object.
+    HWND TryGetXamlWindowForTarget(
+        const winrt::Microsoft::UI::Xaml::Media::SystemBackdrop& systemBackdrop,
+        const winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop& target,
+        const winrt::Microsoft::UI::Xaml::XamlRoot& xamlRoot)
+    {
+        if (!xamlRoot || !target.try_as<winrt::Microsoft::UI::Xaml::XamlIsland>())
+        {
+            return nullptr;
+        }
+
+        // Absent for an island that is being torn down, or one hosted outside a top-level window.
+        const auto islandEnvironment = xamlRoot.ContentIslandEnvironment();
+        if (!islandEnvironment)
+        {
+            return nullptr;
+        }
+
+        // Null in a host that drives Xaml through WindowsXamlManager instead of an Application.
+        const auto application = winrt::Application::Current();
+        if (!application)
+        {
+            return nullptr;
+        }
+
+        const auto hostWindowId = islandEnvironment.AppWindowId();
+        const auto islandContent = xamlRoot.Content();
+
+        for (const auto& window : application.as<winrt::IFrameworkApplicationPrivate>().Windows())
+        {
+            const auto appWindow = window.AppWindow();
+            if (appWindow &&
+                appWindow.Id().Value == hostWindowId.Value &&
+                window.SystemBackdrop() == systemBackdrop &&
+                window.Content() == islandContent)
+            {
+                return winrt::Microsoft::UI::GetWindowFromWindowId(hostWindowId);
+            }
+        }
+
+        return nullptr;
+    }
+}
+
+/* static */ std::unique_ptr<DwmSystemBackdrop> DwmSystemBackdrop::TryApplyToXamlWindow(
+    const winrt::Microsoft::UI::Xaml::Media::SystemBackdrop& systemBackdrop,
+    const winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop& target,
+    const winrt::Microsoft::UI::Xaml::XamlRoot& xamlRoot,
+    DWM_SYSTEMBACKDROP_TYPE backdropType)
+{
+    const HWND windowHandle = TryGetXamlWindowForTarget(systemBackdrop, target, xamlRoot);
+    if (!windowHandle)
+    {
+        return nullptr;
+    }
+
+    // Remember the window's current material before overwriting it, so that an app that configured the window
+    // itself gets its choice back once this backdrop is detached.
+    DWM_SYSTEMBACKDROP_TYPE previousBackdropType = DWMSBT_AUTO;
+    if (!TryGetWindowBackdropType(windowHandle, previousBackdropType) ||
+        !TrySetWindowBackdropType(windowHandle, backdropType))
+    {
+        return nullptr;
+    }
+
+    return std::unique_ptr<DwmSystemBackdrop>(new DwmSystemBackdrop(windowHandle, previousBackdropType, backdropType));
+}
+
+DwmSystemBackdrop::DwmSystemBackdrop(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE previousBackdropType, DWM_SYSTEMBACKDROP_TYPE backdropType)
+    : m_windowHandle(windowHandle)
+    , m_previousBackdropType(previousBackdropType)
+    , m_appliedBackdropType(backdropType)
+{
+}
+
+DwmSystemBackdrop::~DwmSystemBackdrop()
+{
+    // Undo only our own configuration. If the app has written the attribute behind our back it is the last
+    // writer and gets to keep what it asked for.
+    DWM_SYSTEMBACKDROP_TYPE currentBackdropType = DWMSBT_AUTO;
+    if (TryGetWindowBackdropType(m_windowHandle, currentBackdropType) && currentBackdropType == m_appliedBackdropType)
+    {
+        TrySetWindowBackdropType(m_windowHandle, m_previousBackdropType);
+    }
+}
+
+void DwmSystemBackdrop::BackdropType(DWM_SYSTEMBACKDROP_TYPE backdropType)
+{
+    if (backdropType != m_appliedBackdropType && TrySetWindowBackdropType(m_windowHandle, backdropType))
+    {
+        m_appliedBackdropType = backdropType;
+    }
+}

--- a/controls/dev/Common/DwmSystemBackdrop.h
+++ b/controls/dev/Common/DwmSystemBackdrop.h
@@ -21,13 +21,15 @@ class DwmSystemBackdrop
 {
 public:
     // Asks DWM to draw 'backdropType' behind the Xaml Window that 'systemBackdrop' is set on and that 'target'
-    // covers. Returns null when the backdrop isn't attached to a Xaml Window that way, or when DWM doesn't
-    // support the attribute - callers then fall back to the lifted SystemBackdropController.
+    // covers, in the light or dark variant selected by 'useDarkMode'. Returns null when the backdrop isn't
+    // attached to a Xaml Window that way, or when DWM doesn't support the attribute - callers then fall back to
+    // the lifted SystemBackdropController.
     static std::unique_ptr<DwmSystemBackdrop> TryApplyToXamlWindow(
         const winrt::Microsoft::UI::Xaml::Media::SystemBackdrop& systemBackdrop,
         const winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop& target,
         const winrt::Microsoft::UI::Xaml::XamlRoot& xamlRoot,
-        DWM_SYSTEMBACKDROP_TYPE backdropType);
+        DWM_SYSTEMBACKDROP_TYPE backdropType,
+        bool useDarkMode);
 
     ~DwmSystemBackdrop();
 
@@ -39,11 +41,22 @@ public:
     // window alone once an app has taken the attribute over, just like the destructor does.
     void BackdropType(DWM_SYSTEMBACKDROP_TYPE backdropType);
 
+    // Switches the window between the light and dark variants of the material, for instance when the app's
+    // theme changes. Leaves the window alone once an app has taken the attribute over.
+    void DarkMode(bool useDarkMode);
+
 private:
-    DwmSystemBackdrop(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE previousBackdropType, DWM_SYSTEMBACKDROP_TYPE backdropType);
+    DwmSystemBackdrop(
+        HWND windowHandle,
+        DWM_SYSTEMBACKDROP_TYPE previousBackdropType,
+        DWM_SYSTEMBACKDROP_TYPE backdropType,
+        bool ownsDarkMode,
+        BOOL previousDarkMode,
+        BOOL appliedDarkMode);
 
     // Whether the window is still configured with what we last applied to it.
     bool IsLastWriter() const;
+    bool IsLastDarkModeWriter() const;
 
     HWND m_windowHandle{ nullptr };
 
@@ -53,4 +66,11 @@ private:
 
     // What we last configured the window with, so we can tell whether we are still the last writer.
     DWM_SYSTEMBACKDROP_TYPE m_appliedBackdropType{ DWMSBT_AUTO };
+
+    // DWM picks the light material unless it is told the window is dark, and it knows nothing about the Xaml
+    // theme, so the theme has to be forwarded to it. The attribute predates the backdrop types but is still
+    // guarded, because a window whose light/dark state we couldn't read isn't ours to restore.
+    bool m_ownsDarkMode{ false };
+    BOOL m_previousDarkMode{ FALSE };
+    BOOL m_appliedDarkMode{ FALSE };
 };

--- a/controls/dev/Common/DwmSystemBackdrop.h
+++ b/controls/dev/Common/DwmSystemBackdrop.h
@@ -35,11 +35,15 @@ public:
     DwmSystemBackdrop(const DwmSystemBackdrop& other) = delete;
     DwmSystemBackdrop& operator=(const DwmSystemBackdrop& other) = delete;
 
-    // Switches the window to a different material, for instance when MicaBackdrop.Kind changes.
+    // Switches the window to a different material, for instance when MicaBackdrop.Kind changes. Leaves the
+    // window alone once an app has taken the attribute over, just like the destructor does.
     void BackdropType(DWM_SYSTEMBACKDROP_TYPE backdropType);
 
 private:
     DwmSystemBackdrop(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE previousBackdropType, DWM_SYSTEMBACKDROP_TYPE backdropType);
+
+    // Whether the window is still configured with what we last applied to it.
+    bool IsLastWriter() const;
 
     HWND m_windowHandle{ nullptr };
 

--- a/controls/dev/Common/DwmSystemBackdrop.h
+++ b/controls/dev/Common/DwmSystemBackdrop.h
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include <dwmapi.h>
+#include <memory>
+
+// Asks DWM to draw one of its system backdrop materials behind a Xaml Window, and puts the window back the way
+// it was when this object goes away.
+//
+// Xaml normally draws Mica and desktop Acrylic with a lifted SystemBackdropController, which renders the
+// material into the backdrop's target. Those controllers can only render through the lifted compositor, so in a
+// process that opted into the system composition engine (CompositionEngine.TrySetProcessEngine) they have
+// nothing to render into and the backdrop silently doesn't appear. DWM draws the same materials for a window
+// directly - the recipe the system provides for every other window - which is what Xaml falls back to.
+//
+// Only Xaml's own Windows are configured this way, because the DWM attribute covers a whole top-level window:
+// see TryApplyToXamlWindow.
+class DwmSystemBackdrop
+{
+public:
+    // Asks DWM to draw 'backdropType' behind the Xaml Window that 'systemBackdrop' is set on and that 'target'
+    // covers. Returns null when the backdrop isn't attached to a Xaml Window that way, or when DWM doesn't
+    // support the attribute - callers then fall back to the lifted SystemBackdropController.
+    static std::unique_ptr<DwmSystemBackdrop> TryApplyToXamlWindow(
+        const winrt::Microsoft::UI::Xaml::Media::SystemBackdrop& systemBackdrop,
+        const winrt::Microsoft::UI::Composition::ICompositionSupportsSystemBackdrop& target,
+        const winrt::Microsoft::UI::Xaml::XamlRoot& xamlRoot,
+        DWM_SYSTEMBACKDROP_TYPE backdropType);
+
+    ~DwmSystemBackdrop();
+
+    // Block copy and assignment. This object owns a window's DWM configuration, which only one owner can undo.
+    DwmSystemBackdrop(const DwmSystemBackdrop& other) = delete;
+    DwmSystemBackdrop& operator=(const DwmSystemBackdrop& other) = delete;
+
+    // Switches the window to a different material, for instance when MicaBackdrop.Kind changes.
+    void BackdropType(DWM_SYSTEMBACKDROP_TYPE backdropType);
+
+private:
+    DwmSystemBackdrop(HWND windowHandle, DWM_SYSTEMBACKDROP_TYPE previousBackdropType, DWM_SYSTEMBACKDROP_TYPE backdropType);
+
+    HWND m_windowHandle{ nullptr };
+
+    // What the window was configured with before we touched it, restored on the way out so that an app that set
+    // the attribute itself keeps its choice.
+    DWM_SYSTEMBACKDROP_TYPE m_previousBackdropType{ DWMSBT_AUTO };
+
+    // What we last configured the window with, so we can tell whether we are still the last writer.
+    DWM_SYSTEMBACKDROP_TYPE m_appliedBackdropType{ DWMSBT_AUTO };
+};

--- a/controls/dev/Common/SystemCompositionEngine.cpp
+++ b/controls/dev/Common/SystemCompositionEngine.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "common.h"
+#include "SystemCompositionEngine.h"
+
+bool SystemCompositionEngine::IsEnabledForProcess()
+{
+    // The engine is picked once, before the first composition object exists, so this can't change afterwards.
+    // Every caller on every thread agrees for the lifetime of the process.
+    static const bool isEnabled = []()
+    {
+        auto compositor = winrt::CompositionTarget::GetCompositorForCurrentThread();
+
+        // GetForSystemEngine takes any composition object (IInspectable) and returns null unless that object
+        // belongs to the system engine, so pass the compositor directly rather than allocating a throwaway
+        // visual just to probe the engine. CompositionEngine lives in the Microsoft.UI.Composition namespace
+        // (it was promoted out of the Experimental namespace in the InteractiveExperiences transport).
+        return winrt::Microsoft::UI::Composition::CompositionEngine::GetForSystemEngine(compositor) != nullptr;
+    }();
+
+    return isEnabled;
+}

--- a/controls/dev/Common/SystemCompositionEngine.h
+++ b/controls/dev/Common/SystemCompositionEngine.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+// WinUI renders through the lifted compositor by default, but an app can opt the process into the system
+// composition engine by calling CompositionEngine.TrySetProcessEngine(CompositionEngineType.System). It has to
+// do that before creating any composition object, so the choice is fixed for the lifetime of the process.
+//
+// The engine matters wherever a feature is implemented against one compositor and has to take a different route
+// on the other - see InkCanvas (visual splicing) and MicaBackdrop (window backdrops).
+namespace SystemCompositionEngine
+{
+    // True when this process renders through the system composition engine rather than the lifted one.
+    // Must be called on a thread with a Xaml compositor.
+    bool IsEnabledForProcess();
+}

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -7,6 +7,7 @@
 #include "InkCanvasAutomationPeer.h"
 #include "InkPresenter.h"
 #include "RuntimeProfiler.h"
+#include "SystemCompositionEngine.h"
 #include "Microsoft.UI.Xaml.xamlroot.h"
 #include "Microsoft.UI.Composition.h"
 #include <pplawait.h>
@@ -310,11 +311,10 @@ void InkCanvas::AttachToVisualLink()
     // until the compositor engine has been decided.
     EnsureCompositionDevice();
 
-    // Fork on the compositor engine (IsSystemCompositor detects it via GetForSystemEngine): a
-    // system-backed process splices the ink visual under a lifted MUC visual; a lifted process
-    // bridges it into the XAML tree via ContentExternalOutputLink. Each path binds the ink visual to
-    // the presenter (AttachInkVisualToPresenter) first, then roots it under its own target.
-    if (IsSystemCompositor())
+    // Fork on the compositor engine: a system-backed process splices the ink visual under a lifted MUC
+    // visual; a lifted process bridges it into the XAML tree via ContentExternalOutputLink. Each path binds
+    // the ink visual to the presenter (AttachInkVisualToPresenter) first, then roots it under its own target.
+    if (SystemCompositionEngine::IsEnabledForProcess())
     {
         AttachToSystemCompositor();
     }
@@ -372,7 +372,7 @@ void InkCanvas::AttachInkVisualToPresenter()
 
 // System compositor path: splices the ink visual directly under a lifted MUC visual via
 // IExpCompositorInterop2::CreateDCompVisualUnderMUCVisual, so lifted XAML natively clips/scrolls/
-// z-orders it. Only reached when IsSystemCompositor() is true, so the interop must be present.
+// z-orders it. Only reached on the system composition engine, so the interop must be present.
 void InkCanvas::AttachToSystemCompositor()
 {
     // Create the ink visual and bind it to the presenter before the compositor-specific splice.
@@ -465,24 +465,6 @@ void InkCanvas::DetachFromVisualLink()
     {
         m_threadData->m_compositionDevice->Commit();
     }
-}
-
-// Compositor-engine detection: true when the process runs on the system composition engine.
-// CompositionEngine::GetForSystemEngine returns a non-null system object only on a system-backed
-// compositor, so it selects the system splice (AttachToSystemCompositor) over the lifted
-// ContentExternalOutputLink path (AttachToLiftedCompositor). Evaluated once per process on first
-// use, so every InkCanvas on the thread agrees for the process lifetime.
-bool InkCanvas::IsSystemCompositor()
-{
-    static bool isSystemCompositor = [] {
-        auto compositor = winrt::CompositionTarget::GetCompositorForCurrentThread();
-        // GetForSystemEngine takes any composition object (IInspectable); pass the compositor
-        // directly rather than allocating a throwaway visual just to probe the engine.
-        // CompositionEngine lives in the Microsoft.UI.Composition namespace (it was promoted out of
-        // the Experimental namespace in the InteractiveExperiences transport), so reference it there.
-        return winrt::Microsoft::UI::Composition::CompositionEngine::GetForSystemEngine(compositor) != nullptr;
-    }();
-    return isSystemCompositor;
 }
 
 // Sizes the lifted PlacementVisual to the control's physical-pixel bounds so it has a hit-test area

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -46,12 +46,10 @@ private:
     void AttachToVisualLink();
     void DetachFromVisualLink();
 
-    // Compositor fork: IsSystemCompositor() detects (via CompositionEngine::GetForSystemEngine)
-    // whether the process runs on the system composition engine. A system-backed process splices the
-    // ink visual under a lifted MUC visual (AttachToSystemCompositor); a lifted process bridges it
+    // Compositor fork on SystemCompositionEngine::IsEnabledForProcess(): a system-backed process splices
+    // the ink visual under a lifted MUC visual (AttachToSystemCompositor); a lifted process bridges it
     // into the XAML tree via ContentExternalOutputLink (AttachToLiftedCompositor).
     void EnsureCompositionDevice();
-    bool IsSystemCompositor();
     void AttachToSystemCompositor();
     void AttachToLiftedCompositor();
     // Shared by both compositor paths: creates the ink visual on the shared DComp device and binds

--- a/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdropTests.cs
+++ b/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdropTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Common;
+using Microsoft.UI;
+using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using MUXControlsTestApp.Utilities;
+
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+using WEX.Logging.Interop;
+
+namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
+{
+    [TestClass]
+    public class MicaBackdropTests : ApiTestBase
+    {
+        // DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE and the DWM_SYSTEMBACKDROP_TYPE values, neither of which
+        // is projected into managed code.
+        private const int DWMWA_SYSTEMBACKDROP_TYPE = 38;
+        private const int DWMSBT_AUTO = 0;
+        private const int DWMSBT_TRANSIENTWINDOW = 3;
+
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmGetWindowAttribute(IntPtr hwnd, int attribute, out int value, int size);
+
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+        [TestMethod]
+        public void VerifyMicaBackdropAttachesToAndDetachesFromAWindow()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                UsingWindow(window =>
+                {
+                    var backdrop = new MicaBackdrop();
+
+                    window.SystemBackdrop = backdrop;
+                    Verify.AreSame(backdrop, window.SystemBackdrop, "The Window should report the backdrop that was set on it");
+
+                    window.SystemBackdrop = null;
+                    Verify.IsNull(window.SystemBackdrop, "Clearing the Window's SystemBackdrop should detach the backdrop");
+
+                    // Re-attaching the same instance exercises the connect/disconnect/connect cycle of the
+                    // per-target bookkeeping MicaBackdrop keeps.
+                    window.SystemBackdrop = backdrop;
+                    Verify.AreSame(backdrop, window.SystemBackdrop, "The backdrop should be able to re-attach to the same Window");
+                });
+            });
+        }
+
+        [TestMethod]
+        public void VerifyKindCanBeChangedWhileAttachedToAWindow()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                UsingWindow(window =>
+                {
+                    var backdrop = new MicaBackdrop();
+                    Verify.AreEqual(MicaKind.Base, backdrop.Kind, "MicaKind.Base is the default kind");
+
+                    backdrop.Kind = MicaKind.BaseAlt;
+                    window.SystemBackdrop = backdrop;
+                    Verify.AreEqual(MicaKind.BaseAlt, backdrop.Kind, "A kind set before attaching should be kept");
+
+                    backdrop.Kind = MicaKind.Base;
+                    Verify.AreEqual(MicaKind.Base, backdrop.Kind, "The kind should be changeable while attached");
+                });
+            });
+        }
+
+        [TestMethod]
+        public void VerifyMicaBackdropCanBeSharedBetweenWindows()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var backdrop = new MicaBackdrop();
+
+                UsingWindow(firstWindow =>
+                {
+                    UsingWindow(secondWindow =>
+                    {
+                        firstWindow.SystemBackdrop = backdrop;
+                        secondWindow.SystemBackdrop = backdrop;
+
+                        Verify.AreSame(backdrop, firstWindow.SystemBackdrop);
+                        Verify.AreSame(backdrop, secondWindow.SystemBackdrop);
+
+                        // Each Window keeps its own state for the shared backdrop, so detaching one has to leave
+                        // the other one attached.
+                        firstWindow.SystemBackdrop = null;
+                        Verify.IsNull(firstWindow.SystemBackdrop);
+                        Verify.AreSame(backdrop, secondWindow.SystemBackdrop);
+
+                        backdrop.Kind = MicaKind.BaseAlt;
+                        Verify.AreEqual(MicaKind.BaseAlt, backdrop.Kind, "The kind should still be changeable for the remaining Window");
+                    });
+                });
+            });
+        }
+
+        // On the lifted composition engine MicaController draws the material into the Window's content island,
+        // so Xaml has no reason to ask DWM for a window backdrop. It only does that on the system composition
+        // engine, which this test process doesn't use.
+        [TestMethod]
+        public void VerifyNoDwmSystemBackdropIsConfiguredOnTheLiftedCompositionEngine()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                UsingWindow(window =>
+                {
+                    if (!TryGetDwmSystemBackdropType(window, out int backdropTypeBefore))
+                    {
+                        Log.Comment("DWMWA_SYSTEMBACKDROP_TYPE is not supported on this OS, skipping.");
+                        return;
+                    }
+
+                    Verify.AreEqual(DWMSBT_AUTO, backdropTypeBefore, "A Xaml Window starts out without a DWM system backdrop");
+
+                    window.SystemBackdrop = new MicaBackdrop();
+
+                    Verify.IsTrue(TryGetDwmSystemBackdropType(window, out int backdropTypeAfter));
+                    Verify.AreEqual(DWMSBT_AUTO, backdropTypeAfter, "Attaching a MicaBackdrop shouldn't configure a DWM system backdrop on the lifted composition engine");
+                });
+            });
+        }
+
+        // Apps can configure DWMWA_SYSTEMBACKDROP_TYPE on a Xaml Window themselves. Whatever Xaml does with that
+        // attribute, it has to give the app's choice back.
+        [TestMethod]
+        public void VerifyAppConfiguredDwmSystemBackdropSurvivesAMicaBackdrop()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                UsingWindow(window =>
+                {
+                    if (!TryGetDwmSystemBackdropType(window, out _))
+                    {
+                        Log.Comment("DWMWA_SYSTEMBACKDROP_TYPE is not supported on this OS, skipping.");
+                        return;
+                    }
+
+                    int appBackdropType = DWMSBT_TRANSIENTWINDOW;
+                    IntPtr windowHandle = Win32Interop.GetWindowFromWindowId(window.AppWindow.Id);
+                    Verify.AreEqual(0, DwmSetWindowAttribute(windowHandle, DWMWA_SYSTEMBACKDROP_TYPE, ref appBackdropType, sizeof(int)));
+
+                    var backdrop = new MicaBackdrop();
+                    window.SystemBackdrop = backdrop;
+                    backdrop.Kind = MicaKind.BaseAlt;
+                    window.SystemBackdrop = null;
+
+                    Verify.IsTrue(TryGetDwmSystemBackdropType(window, out int backdropTypeAfter));
+                    Verify.AreEqual(DWMSBT_TRANSIENTWINDOW, backdropTypeAfter, "The app's DWM system backdrop should survive attaching and detaching a MicaBackdrop");
+                });
+            });
+        }
+
+        private static bool TryGetDwmSystemBackdropType(Window window, out int backdropType)
+        {
+            IntPtr windowHandle = Win32Interop.GetWindowFromWindowId(window.AppWindow.Id);
+            return DwmGetWindowAttribute(windowHandle, DWMWA_SYSTEMBACKDROP_TYPE, out backdropType, sizeof(int)) == 0;
+        }
+
+        // Runs 'test' against a Window of its own, so that a backdrop or a DWM attribute a test leaves behind
+        // can't leak into the app's window and the tests that run after it.
+        private static void UsingWindow(Action<Window> test)
+        {
+            var window = new Window { Content = new Grid() };
+
+            try
+            {
+                test(window);
+            }
+            finally
+            {
+                window.SystemBackdrop = null;
+                window.Close();
+            }
+        }
+    }
+}

--- a/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdropTests.cs
+++ b/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdropTests.cs
@@ -21,8 +21,10 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
     public class MicaBackdropTests : ApiTestBase
     {
         // DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE and the DWM_SYSTEMBACKDROP_TYPE values, neither of which
-        // is projected into managed code.
+        // is projected into managed code. DWMWA_USE_IMMERSIVE_DARK_MODE selects the light or dark variant of
+        // the material DWM draws.
         private const int DWMWA_SYSTEMBACKDROP_TYPE = 38;
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
         private const int DWMSBT_AUTO = 0;
         private const int DWMSBT_TRANSIENTWINDOW = 3;
 
@@ -157,6 +159,37 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 
                     Verify.IsTrue(TryGetDwmSystemBackdropType(window, out int backdropTypeAfter));
                     Verify.AreEqual(DWMSBT_TRANSIENTWINDOW, backdropTypeAfter, "The app's DWM system backdrop should survive attaching and detaching a MicaBackdrop");
+                });
+            });
+        }
+
+        // DWM draws the light variant of a material unless it is told the window is dark, so Xaml forwards the
+        // theme to it along with the material. That attribute is the app's to set otherwise, and an app that
+        // set it has to get its choice back - the same rule the material itself follows.
+        [TestMethod]
+        public void VerifyAppConfiguredDarkModeSurvivesAMicaBackdrop()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                UsingWindow(window =>
+                {
+                    IntPtr windowHandle = Win32Interop.GetWindowFromWindowId(window.AppWindow.Id);
+                    if (DwmGetWindowAttribute(windowHandle, DWMWA_USE_IMMERSIVE_DARK_MODE, out _, sizeof(int)) != 0)
+                    {
+                        Log.Comment("DWMWA_USE_IMMERSIVE_DARK_MODE is not supported on this OS, skipping.");
+                        return;
+                    }
+
+                    int appDarkMode = 1;
+                    Verify.AreEqual(0, DwmSetWindowAttribute(windowHandle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref appDarkMode, sizeof(int)));
+
+                    var backdrop = new MicaBackdrop();
+                    window.SystemBackdrop = backdrop;
+                    backdrop.Kind = MicaKind.BaseAlt;
+                    window.SystemBackdrop = null;
+
+                    Verify.AreEqual(0, DwmGetWindowAttribute(windowHandle, DWMWA_USE_IMMERSIVE_DARK_MODE, out int darkModeAfter, sizeof(int)));
+                    Verify.AreEqual(appDarkMode, darkModeAfter, "The app's dark mode choice should survive attaching and detaching a MicaBackdrop");
                 });
             });
         }

--- a/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdrop_APITests.projitems
+++ b/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdrop_APITests.projitems
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>c3ecf03a-9210-42ba-9fc6-094649af0d72</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>MicaBackdrop_APITests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)MicaBackdropTests.cs" />
+  </ItemGroup>
+</Project>

--- a/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdrop_APITests.shproj
+++ b/controls/dev/Materials/MicaBackdrop/APITests/MicaBackdrop_APITests.shproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c3ecf03a-9210-42ba-9fc6-094649af0d72</ProjectGuid>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="MicaBackdrop_APITests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/controls/dev/Materials/MicaBackdrop/MicaBackdrop.cpp
+++ b/controls/dev/Materials/MicaBackdrop/MicaBackdrop.cpp
@@ -30,6 +30,7 @@ void MicaBackdrop::OnTargetConnected(ICompositionSupportsSystemBackdrop target, 
     __super::OnTargetConnected(target, xamlRoot);
 
     auto systemBackdrop = this->try_as<winrt::Microsoft::UI::Xaml::Media::SystemBackdrop>();
+    auto configuration = systemBackdrop.GetDefaultSystemBackdropConfiguration(target, xamlRoot);
 
     // Fork on the composition engine. MicaController renders the material into the target through the lifted
     // compositor, so in a process running on the system composition engine it has nothing to render into and
@@ -40,7 +41,8 @@ void MicaBackdrop::OnTargetConnected(ICompositionSupportsSystemBackdrop target, 
     {
         if (const auto dwmBackdropType = ToDwmBackdropType(Kind()))
         {
-            if (auto dwmBackdrop = DwmSystemBackdrop::TryApplyToXamlWindow(systemBackdrop, target, xamlRoot, *dwmBackdropType))
+            if (auto dwmBackdrop = DwmSystemBackdrop::TryApplyToXamlWindow(
+                    systemBackdrop, target, xamlRoot, *dwmBackdropType, IsDarkTheme(configuration)))
             {
                 m_targets.push_back(std::make_unique<TargetEntry>(target, std::move(dwmBackdrop)));
                 return;
@@ -50,8 +52,35 @@ void MicaBackdrop::OnTargetConnected(ICompositionSupportsSystemBackdrop target, 
 
     auto newController = MicaController();
     newController.Kind(Kind());
-    auto configuration = systemBackdrop.GetDefaultSystemBackdropConfiguration(target, xamlRoot);
     m_targets.push_back(std::make_unique<TargetEntry>(target, newController, configuration));
+}
+
+// The theme is the only part of the configuration a DWM-drawn backdrop can act on: DWM owns the material, so
+// input activation and the high contrast colors are already its own business. Xaml only ever leaves the theme
+// at Default before it has resolved one, which is the same light default DWM would pick on its own.
+bool MicaBackdrop::IsDarkTheme(const SystemBackdropConfiguration& configuration)
+{
+    return configuration && configuration.Theme() == SystemBackdropTheme::Dark;
+}
+
+void MicaBackdrop::OnDefaultSystemBackdropConfigurationChanged(
+    ICompositionSupportsSystemBackdrop target,
+    winrt::Microsoft::UI::Xaml::XamlRoot xamlRoot)
+{
+    __super::OnDefaultSystemBackdropConfigurationChanged(target, xamlRoot);
+
+    auto entryIterator = std::find_if(
+        m_targets.begin(),
+        m_targets.end(),
+        [target](const std::unique_ptr<TargetEntry>& entry){ return entry->Target() == target; });
+
+    if (entryIterator == m_targets.end())
+    {
+        return;
+    }
+
+    auto systemBackdrop = this->try_as<winrt::Microsoft::UI::Xaml::Media::SystemBackdrop>();
+    (*entryIterator)->UpdateDarkMode(IsDarkTheme(systemBackdrop.GetDefaultSystemBackdropConfiguration(target, xamlRoot)));
 }
 
 void MicaBackdrop::OnTargetDisconnected(ICompositionSupportsSystemBackdrop target)
@@ -129,4 +158,14 @@ void MicaBackdrop::TargetEntry::UpdateKind(MicaKind kind, std::optional<DWM_SYST
 
     // A kind with no DWM equivalent leaves the window on the material it already has, for the same reason
     // OnTargetConnected doesn't take the DWM path for one: drawing the wrong material is worse.
+}
+
+void MicaBackdrop::TargetEntry::UpdateDarkMode(bool useDarkMode)
+{
+    // A lifted controller reads the theme out of the SystemBackdropConfiguration it was given, so there is
+    // nothing to forward for one.
+    if (m_dwmBackdrop)
+    {
+        m_dwmBackdrop->DarkMode(useDarkMode);
+    }
 }

--- a/controls/dev/Materials/MicaBackdrop/MicaBackdrop.cpp
+++ b/controls/dev/Materials/MicaBackdrop/MicaBackdrop.cpp
@@ -4,16 +4,54 @@
 #include "pch.h"
 #include "common.h"
 #include "MicaBackdrop.h"
+#include "SystemCompositionEngine.h"
+
+namespace
+{
+    // The DWM material that matches a MicaKind. MicaKind::Base is the material an app's main window uses, and
+    // MicaKind::BaseAlt is the flatter variant behind a tab strip. A kind we don't know about has no equivalent,
+    // and the caller keeps using the lifted controller rather than silently drawing the wrong material.
+    std::optional<DWM_SYSTEMBACKDROP_TYPE> ToDwmBackdropType(MicaKind kind)
+    {
+        switch (kind)
+        {
+        case MicaKind::Base:
+            return DWMSBT_MAINWINDOW;
+        case MicaKind::BaseAlt:
+            return DWMSBT_TABBEDWINDOW;
+        default:
+            return std::nullopt;
+        }
+    }
+}
 
 void MicaBackdrop::OnTargetConnected(ICompositionSupportsSystemBackdrop target, winrt::Microsoft::UI::Xaml::XamlRoot xamlRoot)
 {
     __super::OnTargetConnected(target, xamlRoot);
 
+    auto systemBackdrop = this->try_as<winrt::Microsoft::UI::Xaml::Media::SystemBackdrop>();
+
+    // Fork on the composition engine. MicaController renders the material into the target through the lifted
+    // compositor, so in a process running on the system composition engine it has nothing to render into and
+    // Mica would silently not appear at all. DWM draws the same material for a window directly, which is the
+    // recipe the system provides for every other window, so that is what a Xaml Window falls back to. Targets
+    // that don't cover a Xaml Window can't be expressed as a window attribute and keep the controller.
+    if (SystemCompositionEngine::IsEnabledForProcess())
+    {
+        if (const auto dwmBackdropType = ToDwmBackdropType(Kind()))
+        {
+            if (auto dwmBackdrop = DwmSystemBackdrop::TryApplyToXamlWindow(systemBackdrop, target, xamlRoot, *dwmBackdropType))
+            {
+                m_targets.push_back(std::make_unique<TargetEntry>(target, std::move(dwmBackdrop)));
+                return;
+            }
+        }
+    }
+
     auto newController = MicaController();
     newController.Kind(Kind());
-    auto systemBackdrop = this->try_as<winrt::Microsoft::UI::Xaml::Media::SystemBackdrop>();
     auto configuration = systemBackdrop.GetDefaultSystemBackdropConfiguration(target, xamlRoot);
-    m_controllers.push_back(std::make_unique<ControllerEntry>(target, newController, configuration));
+    m_targets.push_back(std::make_unique<TargetEntry>(target, newController, configuration));
 }
 
 void MicaBackdrop::OnTargetDisconnected(ICompositionSupportsSystemBackdrop target)
@@ -21,11 +59,20 @@ void MicaBackdrop::OnTargetDisconnected(ICompositionSupportsSystemBackdrop targe
     __super::OnTargetDisconnected(target);
 
     auto entryIterator = std::find_if(
-        m_controllers.begin(),
-        m_controllers.end(),
-        [target](const std::unique_ptr<ControllerEntry>& entry){ return entry->m_target == target; });
-    MUX_ASSERT(entryIterator != m_controllers.end());
-    m_controllers.erase(entryIterator);
+        m_targets.begin(),
+        m_targets.end(),
+        [target](const std::unique_ptr<TargetEntry>& entry){ return entry->Target() == target; });
+
+    // Workaround for Bug 44926194: SystemBackdrop's BaseController can fail to ensure system DQ before framework
+    // gets shutdown notification. OnTargetConnected could fail in IXP's BaseController when ensuring a system
+    // DispatcherQueue. If that happens we'll skip adding to the list of targets, which means we won't find
+    // anything when trying to remove it later. When the bug is fixed, take out this if condition and always
+    // assert and erase. We hit the failure when the app has started DQ shutdown, but Xaml hasn't received any
+    // notification yet.
+    if (entryIterator != m_targets.end())
+    {
+        m_targets.erase(entryIterator);
+    }
 }
 
 void MicaBackdrop::OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args)
@@ -34,15 +81,18 @@ void MicaBackdrop::OnPropertyChanged(const winrt::DependencyPropertyChangedEvent
 
     if (property == s_KindProperty)
     {
-        // If no controller exists, Kind will get set as part of OnTargetConnected
-        for (const std::unique_ptr<ControllerEntry>& entry : m_controllers)
+        const auto kind = Kind();
+        const auto dwmBackdropType = ToDwmBackdropType(kind);
+
+        // If no target is connected, Kind will get applied as part of OnTargetConnected
+        for (const std::unique_ptr<TargetEntry>& entry : m_targets)
         {
-            entry->m_controller.Kind(Kind());
+            entry->UpdateKind(kind, dwmBackdropType);
         }
     }
 }
 
-MicaBackdrop::ControllerEntry::ControllerEntry(ICompositionSupportsSystemBackdrop target, MicaController controller, SystemBackdropConfiguration configuration)
+MicaBackdrop::TargetEntry::TargetEntry(ICompositionSupportsSystemBackdrop target, MicaController controller, SystemBackdropConfiguration configuration)
     : m_target(target)
     , m_controller(controller)
 {
@@ -50,9 +100,33 @@ MicaBackdrop::ControllerEntry::ControllerEntry(ICompositionSupportsSystemBackdro
     controller.SetSystemBackdropConfiguration(configuration);
 }
 
-MicaBackdrop::ControllerEntry::~ControllerEntry()
+MicaBackdrop::TargetEntry::TargetEntry(ICompositionSupportsSystemBackdrop target, std::unique_ptr<DwmSystemBackdrop> dwmBackdrop)
+    : m_target(target)
+    , m_dwmBackdrop(std::move(dwmBackdrop))
 {
-    m_controller.RemoveSystemBackdropTarget(m_target);
-    m_controller.Close();
-    m_controller = nullptr;
+}
+
+MicaBackdrop::TargetEntry::~TargetEntry()
+{
+    if (m_controller)
+    {
+        m_controller.RemoveSystemBackdropTarget(m_target);
+        m_controller.Close();
+        m_controller = nullptr;
+    }
+}
+
+void MicaBackdrop::TargetEntry::UpdateKind(MicaKind kind, std::optional<DWM_SYSTEMBACKDROP_TYPE> dwmBackdropType)
+{
+    if (m_controller)
+    {
+        m_controller.Kind(kind);
+    }
+    else if (dwmBackdropType)
+    {
+        m_dwmBackdrop->BackdropType(*dwmBackdropType);
+    }
+
+    // A kind with no DWM equivalent leaves the window on the material it already has, for the same reason
+    // OnTargetConnected doesn't take the DWM path for one: drawing the wrong material is worse.
 }

--- a/controls/dev/Materials/MicaBackdrop/MicaBackdrop.h
+++ b/controls/dev/Materials/MicaBackdrop/MicaBackdrop.h
@@ -4,7 +4,9 @@
 #pragma once
 #include "winrt/Microsoft.UI.Composition.SystemBackdrops.h"
 #include <winrt/windows.system.h>
+#include <optional>
 
+#include "DwmSystemBackdrop.h"
 #include "MicaBackdrop.g.h"
 #include "MicaBackdrop.properties.h"
 
@@ -25,19 +27,31 @@ public:
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
 private:
-    class ControllerEntry
+    // Mica attached to a single target. The material is drawn either by a lifted MicaController, which renders
+    // it into the target, or - on the system composition engine, where that controller has nothing to render
+    // into - by DWM for the Xaml Window the target covers. Exactly one of the two is set.
+    class TargetEntry
     {
     public:
-        ControllerEntry(ICompositionSupportsSystemBackdrop target, MicaController controller, SystemBackdropConfiguration configuration);
-        ~ControllerEntry();
+        TargetEntry(ICompositionSupportsSystemBackdrop target, MicaController controller, SystemBackdropConfiguration configuration);
+        TargetEntry(ICompositionSupportsSystemBackdrop target, std::unique_ptr<DwmSystemBackdrop> dwmBackdrop);
+        ~TargetEntry();
 
         // Block copy and assignment. This class is meant to be constructed in-place in the list.
-        ControllerEntry(const ControllerEntry& other) = delete;
-        ControllerEntry& operator=(const ControllerEntry& other) = delete;
+        TargetEntry(const TargetEntry& other) = delete;
+        TargetEntry& operator=(const TargetEntry& other) = delete;
 
+        const ICompositionSupportsSystemBackdrop& Target() const { return m_target; }
+
+        // Moves this target onto the material for 'kind'. 'dwmBackdropType' is that kind's DWM equivalent, and
+        // is empty for a kind that has none.
+        void UpdateKind(MicaKind kind, std::optional<DWM_SYSTEMBACKDROP_TYPE> dwmBackdropType);
+
+    private:
         ICompositionSupportsSystemBackdrop m_target;
-        MicaController m_controller;
+        MicaController m_controller{ nullptr };
+        std::unique_ptr<DwmSystemBackdrop> m_dwmBackdrop;
     };
 
-    std::vector<std::unique_ptr<ControllerEntry>> m_controllers;
+    std::vector<std::unique_ptr<TargetEntry>> m_targets;
 };

--- a/controls/dev/Materials/MicaBackdrop/MicaBackdrop.h
+++ b/controls/dev/Materials/MicaBackdrop/MicaBackdrop.h
@@ -23,10 +23,15 @@ public:
 
     void OnTargetConnected(ICompositionSupportsSystemBackdrop connectedTarget, winrt::Microsoft::UI::Xaml::XamlRoot xamlRoot);
     void OnTargetDisconnected(ICompositionSupportsSystemBackdrop disconnectedTarget);
+    void OnDefaultSystemBackdropConfigurationChanged(ICompositionSupportsSystemBackdrop target, winrt::Microsoft::UI::Xaml::XamlRoot xamlRoot);
 
     void OnPropertyChanged(const winrt::DependencyPropertyChangedEventArgs& args);
 
 private:
+    // Whether the material should be drawn dark for 'configuration'. A DWM-drawn backdrop needs this told to it
+    // explicitly, where a lifted MicaController reads the configuration itself.
+    static bool IsDarkTheme(const SystemBackdropConfiguration& configuration);
+
     // Mica attached to a single target. The material is drawn either by a lifted MicaController, which renders
     // it into the target, or - on the system composition engine, where that controller has nothing to render
     // into - by DWM for the Xaml Window the target covers. Exactly one of the two is set.
@@ -46,6 +51,10 @@ private:
         // Moves this target onto the material for 'kind'. 'dwmBackdropType' is that kind's DWM equivalent, and
         // is empty for a kind that has none.
         void UpdateKind(MicaKind kind, std::optional<DWM_SYSTEMBACKDROP_TYPE> dwmBackdropType);
+
+        // Moves this target onto the light or dark variant of the material. A no-op for a lifted controller,
+        // which follows the SystemBackdropConfiguration it was given.
+        void UpdateDarkMode(bool useDarkMode);
 
     private:
         ICompositionSupportsSystemBackdrop m_target;

--- a/controls/dev/dll/Microsoft.UI.Xaml.Common.targets
+++ b/controls/dev/dll/Microsoft.UI.Xaml.Common.targets
@@ -34,7 +34,7 @@
       <Enumclass>false</Enumclass>
     </Midl>
     <Link>
-      <AdditionalDependencies>user32.lib;mincore.lib;dxguid.lib;dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;mincore.lib;dxguid.lib;dcomp.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <!-- Microsoft.winmd will contain the definition of both public, preview and private types. -->
       <WindowsMetadataFile>$(OutDir)$(ProjectWinMDName)</WindowsMetadataFile>
       <GenerateMapFile>true</GenerateMapFile>

--- a/controls/test/MUXControlsTestApp/MUXControlsTestApp.csproj
+++ b/controls/test/MUXControlsTestApp/MUXControlsTestApp.csproj
@@ -258,6 +258,7 @@
   <Import Project="$(MUXCProjectRoot)dev\LayoutPanel\APITests\LayoutPanel_APITests.projitems" Label="Shared" Condition="$(FeatureLayoutPanelEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\WrapPanel\APITests\WrapPanel_APITests.projitems" Label="Shared" Condition="$(FeatureWrapPanelEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\Materials\Acrylic\APITests\AcrylicBrush_ApiTests.projitems" Label="Shared" Condition="$(FeatureMaterialsEnabled) == 'true'" />
+  <Import Project="$(MUXCProjectRoot)dev\Materials\MicaBackdrop\APITests\MicaBackdrop_APITests.projitems" Label="Shared" Condition="$(FeatureMaterialsEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\Materials\Reveal\APITests\Reveal_APITests.projitems" Label="Shared" Condition="$(FeatureMaterialsEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\NavigationView\NavigationView_ApiTests\NavigationView_ApiTests.projitems" Label="Shared" Condition="$(FeatureNavigationViewEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\ParallaxView\APITests\ParallaxView_APITests.projitems" Label="Shared" Condition="$(FeatureParallaxViewEnabled) == 'true'" />

--- a/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
+++ b/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
@@ -64,6 +64,9 @@ namespace MUXControlsTestApp.Utilities
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.OptimizeApplyStyles));
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.DefaultStyleOptimizations));
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.DeferContextFlyoutInit));
+            // SkipWindowRedirectionSurface is deliberately not enabled here. It changes how every test window
+            // paints (no GDI redirection surface at all), so it is opted into per test through the
+            // Data:XamlOptionalChanges test property rather than turned on for the whole suite.
         }
 
         public void UpdateXamlOptionalChanges()
@@ -169,6 +172,10 @@ namespace MUXControlsTestApp.Utilities
                         else if (string.Equals(name, "DeferContextFlyoutInit", StringComparison.OrdinalIgnoreCase))
                         {
                             changeId = XamlChangeId.DeferContextFlyoutInit;
+                        }
+                        else if (string.Equals(name, "SkipWindowRedirectionSurface", StringComparison.OrdinalIgnoreCase))
+                        {
+                            changeId = XamlChangeId.SkipWindowRedirectionSurface;
                         }
 
                         Verify.AreNotEqual(changeId, XamlChangeId._Reserved, "Unknown XamlChangeId: " + name);

--- a/docs/design-notes/mica-desktop-acrylic.md
+++ b/docs/design-notes/mica-desktop-acrylic.md
@@ -184,8 +184,9 @@ back to. `MicaKind.Base` maps onto `DWMSBT_MAINWINDOW` and `MicaKind.BaseAlt` on
 Two pieces cooperate:
 * `MicaBackdrop` (controls layer) forks on the engine. On the system engine it configures the attribute through
   `DwmSystemBackdrop` instead of creating a `MicaController`. `DwmSystemBackdrop` snapshots the window's previous
-  attribute value and restores it on detach, but only while Xaml is still the last writer, so an app that
-  configures the attribute itself keeps its own choice.
+  attribute value and restores it on detach. It only updates or restores the attribute while Xaml is still the
+  last writer, so an app that configures the attribute itself keeps its own choice - a later `Kind` change won't
+  take the window back off it either.
 * `DirectUI::DesktopWindowImpl` (framework layer) makes the window itself stop covering the material up. DWM
   composes the material behind the window's redirection surface, which Xaml erases with the theme's window
   background color, so while a DWM system backdrop is configured the window extends its frame across the client

--- a/docs/design-notes/mica-desktop-acrylic.md
+++ b/docs/design-notes/mica-desktop-acrylic.md
@@ -195,20 +195,42 @@ Two pieces cooperate:
   `DWMWA_SYSTEMBACKDROP_TYPE` on a Xaml `Window` itself gets the same treatment, and the frame and the
   background color never disagree.
 
+DWM draws the light variant of a material unless it is told otherwise. It knows nothing about the Xaml theme and
+does not follow the system one either, so a dark themed window would get a near-white material behind its light
+content. `DwmSystemBackdrop` therefore also carries `DWMWA_USE_IMMERSIVE_DARK_MODE`, taking the theme from the
+same `SystemBackdropConfiguration` a lifted `MicaController` reads so that both engines follow one source, and
+`OnDefaultSystemBackdropConfigurationChanged` keeps the window in step when the theme changes later. That
+attribute is owned under the same last-writer rule as the material itself.
+
 Only a Xaml `Window` is configured this way, because the attribute covers a whole top-level window. `MicaBackdrop`
 only takes the DWM path when its target is the island a `Window` hosts its content in, that window is one of the
 app's Xaml `Window`s, and this backdrop object is that window's own `SystemBackdrop`. A backdrop attached to a
 windowed `Popup`, to a `SystemBackdropElement`, to an island the app hosts in a window of its own, or to an
 island the app nested inside a Xaml `Window` keeps using its (inert) `SystemBackdropController`.
 
-Three behaviors differ from the lifted path and are accepted:
-* DWM picks the material's light/dark appearance from the system theme, where a `SystemBackdropController`
-  follows the element tree's `ActualTheme`. An app that overrides `RequestedTheme` against the system theme gets
-  a material for the system theme.
+Two behaviors differ from the lifted path and are accepted:
 * Xaml can't read the window's current frame margins back from DWM, so a Xaml `Window` whose frame the app
   extended itself has its margins replaced rather than restored.
 * If DWM refuses to extend the window's frame, the window keeps erasing an opaque background and the material
   stays hidden, which is the behavior from before this fallback existed.
+
+#### Why the frame is extended
+
+Extending the frame and erasing to black is what makes the window stop covering the material up, but it is not
+the cheapest way to get there. `WS_EX_NOREDIRECTIONBITMAP` skips allocating the GDI redirection surface
+altogether, so DWM neither allocates it nor blends it; with the frame extended it still composes a full-window
+surface that contributes nothing.
+
+That is available as the opt-in `XamlChangeId.SkipWindowRedirectionSurface` (see
+[the Window design note](./xaml-window.md#the-windows-redirection-surface)). When it is enabled none of this
+applies: there is nothing opaque in the way, so the material shows through on its own and neither the frame
+extension nor the black erase runs.
+
+It stays opt-in rather than becoming the way this fallback works, because the decision has to be made when the
+window is created - the style is only honored when passed to `CreateWindowEx`, so the backdrop code can't turn
+it on when `Window.SystemBackdrop` is set - and deciding for the window as a whole means deciding for windows
+that never use a backdrop. A window without a redirection surface can't paint with GDI at all, which is a
+behavior change as much as an optimization.
 
 ### Custom title bar
 

--- a/docs/design-notes/mica-desktop-acrylic.md
+++ b/docs/design-notes/mica-desktop-acrylic.md
@@ -7,6 +7,7 @@
 - [Xaml Public API](#xaml-public-api)
   - [SystemBackdrop](#systembackdrop)
 - [Interaction with other features](#interaction-with-other-features)
+  - [System composition engine](#system-composition-engine)
   - [Custom title bar](#custom-title-bar)
   - [TabView and File Explorer's tabbed shell](#tabview-and-file-explorers-tabbed-shell)
 
@@ -162,6 +163,51 @@ Issues:
 
 
 ## Interaction with other features
+
+### System composition engine
+
+Everything above assumes lifted Xaml renders through the lifted compositor, which is the default. An app can
+instead opt the whole process into the system composition engine by calling
+`Microsoft.UI.Composition.CompositionEngine.TrySetProcessEngine(CompositionEngineType.System)` before it creates
+any composition object.
+
+The `SystemBackdropController`s are lifted objects that render the material into the target through the lifted
+compositor, so on the system composition engine they have nothing to render into. Setting
+`Window.SystemBackdrop` to a `MicaBackdrop` there used to do nothing at all, leaving the window showing the flat
+theme background color it erases itself with.
+
+DWM draws the same materials for a window directly, through the
+[`DWMWA_SYSTEMBACKDROP_TYPE`](https://learn.microsoft.com/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type)
+window attribute - the recipe the system provides for every other window - so that is what `MicaBackdrop` falls
+back to. `MicaKind.Base` maps onto `DWMSBT_MAINWINDOW` and `MicaKind.BaseAlt` onto `DWMSBT_TABBEDWINDOW`.
+
+Two pieces cooperate:
+* `MicaBackdrop` (controls layer) forks on the engine. On the system engine it configures the attribute through
+  `DwmSystemBackdrop` instead of creating a `MicaController`. `DwmSystemBackdrop` snapshots the window's previous
+  attribute value and restores it on detach, but only while Xaml is still the last writer, so an app that
+  configures the attribute itself keeps its own choice.
+* `DirectUI::DesktopWindowImpl` (framework layer) makes the window itself stop covering the material up. DWM
+  composes the material behind the window's redirection surface, which Xaml erases with the theme's window
+  background color, so while a DWM system backdrop is configured the window extends its frame across the client
+  area and erases to black instead. It reconciles the frame against the attribute rather than against its own
+  writes - when the `SystemBackdrop` changes, and whenever it erases its background - so an app that sets
+  `DWMWA_SYSTEMBACKDROP_TYPE` on a Xaml `Window` itself gets the same treatment, and the frame and the
+  background color never disagree.
+
+Only a Xaml `Window` is configured this way, because the attribute covers a whole top-level window. `MicaBackdrop`
+only takes the DWM path when its target is the island a `Window` hosts its content in, that window is one of the
+app's Xaml `Window`s, and this backdrop object is that window's own `SystemBackdrop`. A backdrop attached to a
+windowed `Popup`, to a `SystemBackdropElement`, to an island the app hosts in a window of its own, or to an
+island the app nested inside a Xaml `Window` keeps using its (inert) `SystemBackdropController`.
+
+Three behaviors differ from the lifted path and are accepted:
+* DWM picks the material's light/dark appearance from the system theme, where a `SystemBackdropController`
+  follows the element tree's `ActualTheme`. An app that overrides `RequestedTheme` against the system theme gets
+  a material for the system theme.
+* Xaml can't read the window's current frame margins back from DWM, so a Xaml `Window` whose frame the app
+  extended itself has its margins replaced rather than restored.
+* If DWM refuses to extend the window's frame, the window keeps erasing an opaque background and the material
+  stays hidden, which is the behavior from before this fallback existed.
 
 ### Custom title bar
 

--- a/docs/design-notes/xaml-window.md
+++ b/docs/design-notes/xaml-window.md
@@ -4,6 +4,7 @@
 
 - [Overview](#overview)
 - [How Window works](#how-window-works)
+- [The window's redirection surface](#the-windows-redirection-surface)
 - [What is AppWindow and how does it relate to Xaml Window?](#what-is-appwindow-and-how-does-it-relate-to-xaml-window)
 
 ## Overview
@@ -59,8 +60,36 @@ Microsoft_UI_Xaml!BaseWindow<DirectUI::DesktopWindowImpl>::WndProc
 Microsoft_UI_Xaml!directui::DesktopWindowImpl::OnMessage
 ```
 
-## What is AppWindow and how does it relate to Xaml Window?
+## The window's redirection surface
 
+By default every top-level window gets a GDI redirection surface: a full-window bitmap that GDI painting on the
+HWND lands in, which the compositor then composes as part of the window. A Xaml `Window` barely uses it. The
+content island covers the whole client area and renders through the compositor, so the only thing the surface
+really shows is the themed background painted on `WM_ERASEBKGND`, which exists to stop the window flashing
+unpainted content before the island's first frame.
+
+That surface is not free. It costs one 32-bit bitmap the size of the window, and the compositor blends it on
+every frame even though it contributes nothing once the island is up. The memory is charged to the compositor
+process rather than to the app, so it doesn't show up in the app's own memory counters.
+
+`WS_EX_NOREDIRECTIONBITMAP` tells the system not to create the surface at all. Xaml passes it when
+`XamlChangeId.SkipWindowRedirectionSurface` is enabled:
+
+``` cpp
+// DesktopWindowImpl.cpp
+const DWORD extendedStyle = OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled() ? WS_EX_NOREDIRECTIONBITMAP : 0;
+```
+
+Two things make this opt-in rather than the default:
+
+* **The window can no longer paint with GDI.** The `WM_ERASEBKGND` themed fill stops having any effect, as does
+  any GDI painting an app does on the Xaml HWND. That is a behavior change as much as an optimization, so it is
+  a `XamlChangeId` and is deliberately not folded into the general perf opt-in.
+* **It has to be decided when the window is created.** The style is only honored when passed to
+  `CreateWindowEx`; adding it afterwards through `SetWindowLongPtr` is silently dropped, and the style bit
+  doesn't even read back as set. So it cannot be turned on later in response to anything the app does.
+
+## What is AppWindow and how does it relate to Xaml Window?
 Microsoft.UI.Windowing.AppWindow is an interesting type.  You can create one to create a standalone top-level window
 (similar to Xaml Window).  OR, you can use it to wrap an _existing_ HWND.
 

--- a/dxaml/test/infra/client/lib/WindowHelper.cpp
+++ b/dxaml/test/infra/client/lib/WindowHelper.cpp
@@ -2108,6 +2108,10 @@ std::vector<std::pair<xaml_settings::XamlChangeId, bool>> GetXamlOptionalChanges
             {
                 changeId = xaml_settings::XamlChangeId_DeferContextFlyoutInit;
             }
+            else if (_wcsicmp(name.c_str(), L"SkipWindowRedirectionSurface") == 0)
+            {
+                changeId = xaml_settings::XamlChangeId_SkipWindowRedirectionSurface;
+            }
 
             if (changeId == xaml_settings::XamlChangeId__Reserved)
             {
@@ -2188,6 +2192,9 @@ void WindowHelper::InitializeXamlCore(_In_ xaml_markup::IXamlMetadataProvider* c
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_OptimizeApplyStyles, &mutated);
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_DefaultStyleOptimizations, &mutated);
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_DeferContextFlyoutInit, &mutated);
+        // SkipWindowRedirectionSurface is deliberately not enabled here. It changes how every test window
+        // paints (no GDI redirection surface at all), so it is opted into per test through the
+        // Data:XamlOptionalChanges test property rather than turned on for the whole suite.
 
         // Apply per-test overrides from XamlOptionalChanges test data.
         for (const auto& [changeId, enabled] : changeOverrides)

--- a/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
+++ b/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
@@ -2212,6 +2212,7 @@ namespace DirectUI
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
     };
     DEFINE_ENUM_FLAG_OPERATORS(XamlChangeId);
 

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
@@ -28,6 +28,7 @@ namespace OptionalChangeState
     constexpr int BitIndex_OptimizeApplyStyles = 1;
     constexpr int BitIndex_DefaultStyleOptimizations = 2;
     constexpr int BitIndex_DeferContextFlyoutInit = 3;
+    constexpr int BitIndex_SkipWindowRedirectionSurface = 4;
 
     inline bool IsOptionalChangeEnabled(int bitIndex)
     {
@@ -53,5 +54,13 @@ namespace OptionalChangeState
     inline bool IsDeferContextFlyoutInitEnabled()
     {
         return IsOptionalChangeEnabled(BitIndex_DeferContextFlyoutInit) || IsPerfOptInEnabled();
+    }
+
+    // Note: deliberately not folded into IsPerfOptInEnabled(). Skipping the redirection surface is a
+    // behavior change as much as an optimization - the window stops being able to paint with GDI - so it
+    // stays an explicit opt-in.
+    inline bool IsSkipWindowRedirectionSurfaceEnabled()
+    {
+        return IsOptionalChangeEnabled(BitIndex_SkipWindowRedirectionSurface);
     }
 }

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
@@ -520,6 +520,7 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
     };
 }
 

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -1252,40 +1252,7 @@ LRESULT DesktopWindowImpl::OnMessage(
         case WM_NCRBUTTONUP:
             return LResultFromHResult(OnNonClientRegionButtonUp(wParam, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
         case WM_ERASEBKGND:
-        {
-            // Without a redirection surface there is nothing to erase: GDI painting on this window goes
-            // nowhere, so the themed fill below would have no effect. See CreateDesktopWindow.
-            if (OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled())
-            {
-                return 1;
-            }
-
-            Theming::Theme appTheme = Theming::Theme::None;
-            ctl::ComPtr<xaml::IUIElement> content;
-            if(!m_bIsClosed && SUCCEEDED(get_ContentImpl(&content)) && content)
-            {
-                ctl::ComPtr<DirectUI::FrameworkElement> contentAsFE;
-                VERIFYHR(content.As<DirectUI::FrameworkElement>(&contentAsFE));
-                ASSERT(contentAsFE != nullptr);
-
-                xaml::ElementTheme actualTheme;
-                VERIFYHR(contentAsFE->get_ActualTheme(&actualTheme));
-                if (actualTheme != xaml::ElementTheme_Default)
-                {
-                    appTheme = actualTheme == xaml::ElementTheme_Light ? Theming::Theme::Light : Theming::Theme::Dark;
-                }
-            }
-
-            auto hdc = (HDC)wParam;
-            auto color = ColorUtils::GetWUColor(dxamlCore->GetHandle()->GetFrameworkTheming()->GetHwndBackground(appTheme));
-            RECT rc = WindowHelpers::GetClientWindowCoordinates(m_hwnd.get());
-            auto oldColor  = ::SetBkColor(hdc, RGB(color.R, color.G, color.B));
-            ASSERT(oldColor != CLR_INVALID);
-            ::ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
-            // restore old color back
-            ::SetBkColor(hdc, oldColor);
-            return 1;
-        }
+            return OnEraseBackground(reinterpret_cast<HDC>(wParam));
         default:
         {
             LRESULT nonClientAreaResult = 0;
@@ -1300,6 +1267,140 @@ LRESULT DesktopWindowImpl::OnMessage(
     }
 
     return BaseWindow::OnMessage(uMsg, wParam, lParam);
+}
+
+// Fills the window's redirection surface. That surface is composed underneath the Xaml content island, so it
+// shows through wherever the island is transparent - which is the case whenever a SystemBackdrop is set (see
+// SetXamlIslandRootBackground).
+//
+// Normally we fill it with the theme's window background color, so that the window doesn't flash unpainted
+// content before the island renders its first frame. While DWM draws a system backdrop material for this
+// window we fill it with black instead, which UpdateDwmSystemBackdropState has arranged for DWM to treat as
+// fully transparent, so the material shows through.
+LRESULT DesktopWindowImpl::OnEraseBackground(_In_ HDC hdc)
+{
+    // Without a redirection surface there is nothing to erase - GDI painting on this window goes nowhere -
+    // and nothing opaque for a DWM system backdrop to show through, so none of the work below applies.
+    if (OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled())
+    {
+        return 1;
+    }
+
+    // Reconcile first. Anyone can configure DWMWA_SYSTEMBACKDROP_TYPE on this window at any time, and the frame
+    // and the background color have to agree for the window to look right either way. Nothing to repaint on a
+    // change - we're painting right now - so the return value doesn't matter here.
+    UpdateDwmSystemBackdropState();
+
+    const COLORREF backgroundColor = m_hasDwmSystemBackdrop ? RGB(0, 0, 0) : GetThemedBackgroundColor();
+    const RECT clientRect = WindowHelpers::GetClientWindowCoordinates(m_hwnd.get());
+
+    const COLORREF previousColor = ::SetBkColor(hdc, backgroundColor);
+    ASSERT(previousColor != CLR_INVALID);
+    ::ExtTextOut(hdc, 0, 0, ETO_OPAQUE, &clientRect, nullptr, 0, nullptr);
+    ::SetBkColor(hdc, previousColor);
+
+    // Non-zero tells the caller the background is erased, so DefWindowProc doesn't paint over it.
+    return 1;
+}
+
+// The window background color for the theme the window's content is actually rendering in. The content's
+// ActualTheme takes precedence over the app's base theme so that content overriding RequestedTheme doesn't
+// briefly flash the base theme's color.
+COLORREF DesktopWindowImpl::GetThemedBackgroundColor()
+{
+    Theming::Theme appTheme = Theming::Theme::None;
+
+    ctl::ComPtr<xaml::IUIElement> content;
+    if (!m_bIsClosed && SUCCEEDED(get_ContentImpl(&content)) && content)
+    {
+        ctl::ComPtr<DirectUI::FrameworkElement> contentAsFE;
+        VERIFYHR(content.As<DirectUI::FrameworkElement>(&contentAsFE));
+        ASSERT(contentAsFE != nullptr);
+
+        xaml::ElementTheme actualTheme;
+        VERIFYHR(contentAsFE->get_ActualTheme(&actualTheme));
+        if (actualTheme != xaml::ElementTheme_Default)
+        {
+            appTheme = actualTheme == xaml::ElementTheme_Light ? Theming::Theme::Light : Theming::Theme::Dark;
+        }
+    }
+
+    const auto color = ColorUtils::GetWUColor(DXamlCore::GetCurrent()->GetHandle()->GetFrameworkTheming()->GetHwndBackground(appTheme));
+    return RGB(color.R, color.G, color.B);
+}
+
+// Whether DWM draws one of its backdrop materials behind a window with this attribute value. DWMSBT_AUTO
+// leaves the choice to DWM, which draws no material for an ordinary top-level window.
+static bool IsDwmSystemBackdropMaterial(DWM_SYSTEMBACKDROP_TYPE backdropType)
+{
+    return backdropType == DWMSBT_MAINWINDOW
+        || backdropType == DWMSBT_TRANSIENTWINDOW
+        || backdropType == DWMSBT_TABBEDWINDOW;
+}
+
+// Brings the window's frame in line with the DWM system backdrop configured on it, so that the frame and the
+// background OnEraseBackground paints always agree. Returns whether that changed, so callers that aren't
+// already painting can repaint the window.
+//
+// Mica and desktop Acrylic are normally drawn by a lifted SystemBackdropController into the Xaml content
+// island. Those controllers can only render through the lifted compositor, so when the process runs on the
+// system composition engine the material is drawn by DWM for the window itself instead - the SystemBackdrop
+// object sets DWMWA_SYSTEMBACKDROP_TYPE on our HWND (see MicaBackdrop). DWM composes that material behind the
+// window, so the window has to stop contributing opaque pixels for it to be visible.
+//
+// The window is reconciled against the attribute rather than against our own writes, because an app is free to
+// configure DWMWA_SYSTEMBACKDROP_TYPE on a Xaml Window itself, at any time.
+//
+// None of this is needed when the window has no redirection surface to begin with - see
+// XamlChangeId::SkipWindowRedirectionSurface and CreateDesktopWindow. That is the cheaper arrangement (DWM
+// neither allocates nor blends a full-window surface that contributes nothing), but it is opt-in, because a
+// window without a redirection surface can't paint with GDI at all.
+bool DesktopWindowImpl::UpdateDwmSystemBackdropState()
+{
+    // Nothing to reconcile when the window has no redirection surface: it contributes no opaque pixels in the
+    // first place, so a DWM system backdrop shows through on its own and the frame is left alone.
+    if (OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled())
+    {
+        return false;
+    }
+
+    const bool hadDwmSystemBackdrop = m_hasDwmSystemBackdrop;
+
+    DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_AUTO;
+    // The attribute doesn't exist before Windows 11 22H2, where a failed query just means no DWM backdrop.
+    if (FAILED(DwmGetWindowAttribute(m_hwnd.get(), DWMWA_SYSTEMBACKDROP_TYPE, &backdropType, sizeof(backdropType))))
+    {
+        backdropType = DWMSBT_AUTO;
+    }
+
+    if (IsDwmSystemBackdropMaterial(backdropType))
+    {
+        // Negative margins extend the frame across the whole window, which is what makes DWM honor per-pixel
+        // transparency in the client area and compose the material through the black background
+        // OnEraseBackground leaves behind. Re-applied rather than applied once, because the same frame carries
+        // the window's title bar configuration (see WindowChrome) and we have no way of noticing someone else
+        // replacing the margins.
+        //
+        // Only take on the material once DWM has accepted that - it refuses for windows that run outside the
+        // shell, for instance - so that the window never erases to a black nothing composes away.
+        static constexpr MARGINS wholeWindowMargins{ -1, -1, -1, -1 };
+        m_hasDwmSystemBackdrop = SUCCEEDED(DwmExtendFrameIntoClientArea(m_hwnd.get(), &wholeWindowMargins));
+    }
+    else if (m_hasDwmSystemBackdrop)
+    {
+        // Xaml never extends this window's frame otherwise, so undoing our extension means a frame that isn't
+        // extended at all. DWM has no way to read the current margins back, so an app that extended the frame of
+        // a Xaml Window itself has its margins replaced rather than restored.
+        //
+        // Dropping the material goes through even if DWM refuses, because painting an opaque background over a
+        // frame we no longer control is the safe fallback.
+        static constexpr MARGINS defaultMargins{ 0, 0, 0, 0 };
+        IGNOREHR(DwmExtendFrameIntoClientArea(m_hwnd.get(), &defaultMargins));
+
+        m_hasDwmSystemBackdrop = false;
+    }
+
+    return m_hasDwmSystemBackdrop != hadDwmSystemBackdrop;
 }
 
 // This is a private method that is only called from a Microsoft::UI::XAML::Window
@@ -1678,7 +1779,8 @@ void DesktopWindowImpl::CreateDesktopWindow()
     // WS_EX_NOREDIRECTIONBITMAP tells the system not to give this window a GDI redirection surface at all.
     // Xaml barely uses it: the content island covers the client area, so the surface only really shows before
     // the island's first frame - but DWM still allocates it and blends it every frame, at the cost of one
-    // full-window 32-bit bitmap. Skipping it drops both.
+    // full-window 32-bit bitmap. Skipping it drops both, and it is also what lets a DWM system backdrop show
+    // through without any further help (see UpdateDwmSystemBackdropState).
     //
     // The catch is that the window can no longer paint with GDI, which is a behavior change rather than a pure
     // optimization, so it is opt-in through XamlChangeId::SkipWindowRedirectionSurface. The style is only
@@ -2401,8 +2503,17 @@ _Check_return_ HRESULT DesktopWindowImpl::get_SystemBackdropImpl(_Outptr_result_
 
 _Check_return_ HRESULT DesktopWindowImpl::put_SystemBackdropImpl(_In_opt_ xaml::Media::ISystemBackdrop* systemBackdrop)
 {
+    // Connecting the SystemBackdrop is what gives it the chance to configure a DWM system backdrop on this
+    // window, so bring the window's own painting in line with it afterwards.
     IFC_RETURN(m_desktopWindowXamlSource->put_SystemBackdropImpl(systemBackdrop));
     IFC_RETURN(SetXamlIslandRootBackground(nullptr, systemBackdrop));
+
+    if (UpdateDwmSystemBackdropState())
+    {
+        // The background is erased with a different color now, so anything already painted has to be repainted.
+        IFCW32_RETURN(::InvalidateRect(m_hwnd.get(), nullptr, TRUE));
+    }
+
     return S_OK;
 }
 

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -25,6 +25,7 @@
 #include "Microsoft.UI.Windowing.h"
 #include <FrameworkUdk/Theming.h>
 #include <Microsoft.UI.Interop.h>
+#include <OptionalChangeState.h>
 
 #pragma warning(disable:4267) //'var' : conversion from 'size_t' to 'type', possible loss of data
 
@@ -1252,6 +1253,13 @@ LRESULT DesktopWindowImpl::OnMessage(
             return LResultFromHResult(OnNonClientRegionButtonUp(wParam, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
         case WM_ERASEBKGND:
         {
+            // Without a redirection surface there is nothing to erase: GDI painting on this window goes
+            // nowhere, so the themed fill below would have no effect. See CreateDesktopWindow.
+            if (OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled())
+            {
+                return 1;
+            }
+
             Theming::Theme appTheme = Theming::Theme::None;
             ctl::ComPtr<xaml::IUIElement> content;
             if(!m_bIsClosed && SUCCEEDED(get_ContentImpl(&content)) && content)
@@ -1667,8 +1675,19 @@ void DesktopWindowImpl::RegisterDesktopWindowClass()
 
 void DesktopWindowImpl::CreateDesktopWindow()
 {
+    // WS_EX_NOREDIRECTIONBITMAP tells the system not to give this window a GDI redirection surface at all.
+    // Xaml barely uses it: the content island covers the client area, so the surface only really shows before
+    // the island's first frame - but DWM still allocates it and blends it every frame, at the cost of one
+    // full-window 32-bit bitmap. Skipping it drops both.
+    //
+    // The catch is that the window can no longer paint with GDI, which is a behavior change rather than a pure
+    // optimization, so it is opt-in through XamlChangeId::SkipWindowRedirectionSurface. The style is only
+    // honored here - adding it later with SetWindowLongPtr is silently dropped - so the decision has to be made
+    // for the window as a whole, before the app can set anything on it.
+    const DWORD extendedStyle = OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled() ? WS_EX_NOREDIRECTIONBITMAP : 0;
+
     _CreateWindow(
-        0,                                 // Extended Style
+        extendedStyle,                     // Extended Style
         s_windowClassName,                 // name of window class
         s_defaultWindowTitle,              // title-bar string
         WS_OVERLAPPEDWINDOW | WS_VISIBLE,  // top-level window

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.h
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.h
@@ -140,6 +140,13 @@ namespace DirectUI
         void OpenSystemMenu(const int cursorX, const int cursorY) const noexcept;
         _Check_return_ HRESULT OnNonClientRegionButtonUp(WPARAM wParam, const int cursorX, const int cursorY);
         _Check_return_ HRESULT OnClosed();
+        LRESULT OnEraseBackground(_In_ HDC hdc);
+
+        COLORREF GetThemedBackgroundColor();
+
+        // Brings the window's frame in line with the DWM system backdrop (Mica, desktop Acrylic) configured on
+        // the window, if any. Returns whether that changed the window's painting.
+        bool UpdateDwmSystemBackdropState();
 
         void OnSetFocus();
         void RegisterDesktopWindowClass();
@@ -214,6 +221,11 @@ namespace DirectUI
         DXamlCore* m_dxamlCoreNoRef = nullptr;
         bool m_bMinimizedOrHidden = false;
         bool m_bInitialWindowActivation = true;
+
+        // True while DWM draws a system backdrop material behind this window. The window's frame is extended
+        // across its client area and its background is erased to black, so the material shows through.
+        // See UpdateDwmSystemBackdropState.
+        bool m_hasDwmSystemBackdrop = false;
 
         // --------------------------------------------------
         // Window sizing support

--- a/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
@@ -44,6 +44,8 @@ static int GetBitIndex(xaml_settings::XamlChangeId id)
         return OptionalChangeState::BitIndex_DefaultStyleOptimizations;
     case xaml_settings::XamlChangeId_DeferContextFlyoutInit:
         return OptionalChangeState::BitIndex_DeferContextFlyoutInit;
+    case xaml_settings::XamlChangeId_SkipWindowRedirectionSurface:
+        return OptionalChangeState::BitIndex_SkipWindowRedirectionSurface;
     default:
         return -1;
     }

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
@@ -20,6 +20,7 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
     }
 
     // Provides static methods to opt in to or out of individual breaking or


### PR DESCRIPTION
> [!NOTE]
> Draft PR, as it targets #11563.

## Fixes

Fixes #11515

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Makes `Window.SystemBackdrop = new MicaBackdrop()` produce Mica when the process has opted into the system composition engine, instead of silently doing nothing.

### Current Behavior

`SystemBackdropController`s are lifted objects that render the material into their target through the lifted compositor. In a process that called `CompositionEngine.TrySetProcessEngine(CompositionEngineType.System)` they have nothing to render into, so setting a `MicaBackdrop` does nothing at all.

Nothing fails and nothing is logged. `TrySetProcessEngine` returns `true`, the `SystemBackdrop` property still reports the instance that was assigned, and the app is left with a flat window: black in dark theme, white in light theme.

There are actually two reasons the window ends up flat, and both had to be addressed:

1. The `MicaController` is inert, so no material is drawn.
2. Even with DWM drawing a material behind the window, the window paints an opaque themed background into its redirection surface on `WM_ERASEBKGND`, which sits on top of that material. That opaque fill is what the black or white actually is.

### New Behavior

On the system composition engine, `MicaBackdrop` asks DWM to draw the material for the window instead, through `DWMWA_SYSTEMBACKDROP_TYPE`. This is the same recipe the system provides for every other window. `MicaKind.Base` maps to `DWMSBT_MAINWINDOW` and `MicaKind.BaseAlt` to `DWMSBT_TABBEDWINDOW`.

App code does not change:

```csharp
CompositionEngine.TrySetProcessEngine(CompositionEngineType.System);
// ...
window.SystemBackdrop = new MicaBackdrop();   // now shows Mica
```

Two pieces cooperate:

* **`MicaBackdrop`** (controls layer) forks on the engine, configuring the window attribute through a new `DwmSystemBackdrop` helper rather than creating a `MicaController`.
* **`DesktopWindowImpl`** (framework layer) stops the window covering the material up: while a DWM system backdrop is configured it extends the frame across the client area and erases to black, which DWM treats as transparent inside an extended frame.

Only a Xaml `Window` is configured this way, since the attribute covers a whole top-level window. `MicaBackdrop` takes the DWM path only when its target is the island a `Window` hosts its content in, that window is one of the app's Xaml `Window`s, and this backdrop object is that window's own `SystemBackdrop`. A backdrop on a windowed `Popup`, on a `SystemBackdropElement`, on an island the app hosts in its own window, or on an island nested inside a Xaml `Window` keeps its existing (inert) controller.

`DwmSystemBackdrop` owns the window attributes it writes under a last-writer rule: it snapshots what the window had, only updates or restores while Xaml is still the last writer, and puts the app's value back on detach. An app that configures `DWMWA_SYSTEMBACKDROP_TYPE` on a Xaml `Window` itself keeps its own choice, and a later `Kind` change will not take the window off it.

DWM draws the light variant of a material unless told otherwise, and it knows nothing about the Xaml theme and does not follow the system one either, so the theme is forwarded through `DWMWA_USE_IMMERSIVE_DARK_MODE`. It comes from the same `SystemBackdropConfiguration` a lifted `MicaController` reads, so both engines follow one source, and `OnDefaultSystemBackdropConfigurationChanged` keeps the window in step when the theme changes later.

## Customer Impact

Apps using the system composition engine get the window material they asked for, with no code change.

Today the only alternative is to drop to Win32 interop and drive DWM by hand, which is not a one-liner: it needs the material attribute, the dark mode attribute, an extended frame, and a window subclass to suppress Xaml's opaque fill, all kept in sync with `MicaBackdrop.Kind` and the app's theme. It also has to be conditional on the active composition engine, which couples the app's rendering code to a process-wide startup decision that is otherwise invisible to it.

Two behaviors differ from the lifted path and are accepted, both documented in the design note:

* Xaml cannot read the window's current frame margins back from DWM, so a `Window` whose frame the app extended itself has its margins replaced rather than restored.
* If DWM refuses to extend the frame, the window keeps erasing an opaque background and the material stays hidden, which is the behavior from before this change.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The DWM path is only taken when the process is on the system composition engine, which is where the feature does nothing today, so the behavior it replaces is "no material at all". On the lifted compositor `MicaBackdrop` still creates a `MicaController` exactly as before.

In `DesktopWindowImpl`, the frame extension and the black erase only happen while `DWMWA_SYSTEMBACKDROP_TYPE` actually reports a material on the window. Otherwise the window erases the themed background as it does today. The window reconciles against the attribute rather than against its own writes, so an app that sets the attribute itself gets consistent treatment rather than a window whose frame and background disagree.

No public API is added or changed.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

Validation done:

* **Builds clean.** Both `Microsoft.ui.xaml.vcxproj` and `Microsoft.UI.Xaml.Controls.vcxproj` build with 0 errors and 0 warnings, as does `MUXControlsTestApp` with the new tests present in the built assembly.
* **New API tests** (`MicaBackdropTests`) cover attach/detach/re-attach, changing `Kind` while attached, sharing one backdrop between windows, that no DWM attribute is configured on the lifted engine, and that an app's own `DWMWA_SYSTEMBACKDROP_TYPE` and dark mode values survive a `MicaBackdrop` being attached and detached.
* **Verified end to end in a sample app** on the system composition engine, with a second window applying the DWM recipe by hand for comparison.

Additional notes:

* **The theme forwarding came out of that testing.** Without `DWMWA_USE_IMMERSIVE_DARK_MODE`, a dark themed window sampled `(243,243,243)` instead of `(32,32,32)` on a dark system: DWM was drawing the light material under dark content, which would have been worse than the flat window this fixes.

Not covered: the material's appearance cannot be asserted from the API test harness, since DWM owns the drawing and substitutes a flat fallback color in remote sessions, when transparency effects are off, and in battery saver. The tests assert the window configuration rather than the pixels.