### PR TITLE
[WinUI OSS] Enable fork-safe pipeline artifact publishing

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-BuildMUXProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildMUXProject-Steps.yml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 parameters:
   buildArtifactsDirectory: $(Build.SourcesDirectory)\BuildOutput
+  outputDirectory: $(ob_outputDirectory)
   additionalMSBuildOptions: ''
   pipelineKind: ''
   buildScenarioApps: false
@@ -47,6 +48,7 @@ steps:
       msbuildInstallDir: '$(_buildToolsDirectory)'
       msbuildInstallLogsDir: '$(_buildToolsInstallLogsDirectory)'
       pipelineKind: ${{ parameters.pipelineKind }}
+      outputDirectory: ${{ parameters.outputDirectory }}
 
   - task: CmdLine@2
     displayName: Set up environment
@@ -128,6 +130,7 @@ steps:
       nugetConfigPath: nuget.config
       msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /m ${{parameters.additionalMSBuildOptions}}'
       msbuildInstallDir: $(_buildToolsDirectory)
+      outputDirectory: ${{ parameters.outputDirectory }}
       projectCaching: ${{ parameters.projectCaching }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
       condition: succeeded()
@@ -140,6 +143,7 @@ steps:
         nugetConfigPath: nuget.config
         msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:WinUIVersion=$(versionFinal) /m ${{parameters.additionalMSBuildOptions}} /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
+        outputDirectory: ${{ parameters.outputDirectory }}
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
       # Build log is published by the WinUI-BuildProject-Steps.yml pipeline
@@ -152,6 +156,7 @@ steps:
         nugetConfigPath: nuget.config
         msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:WinUIVersion=$(versionFinal) /m ${{parameters.additionalMSBuildOptions}} /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
+        outputDirectory: ${{ parameters.outputDirectory }}
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
       # Build log is published by the WinUI-BuildProject-Steps.yml pipeline
@@ -187,7 +192,7 @@ steps:
     condition: succeeded()
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\PackageStore'
-      TargetFolder: '$(ob_outputDirectory)\WinUIComponentPackage'
+      TargetFolder: '${{ parameters.outputDirectory }}\WinUIComponentPackage'
       Contents: |
         Microsoft.WindowsAppSDK.WinUI.*.nupkg
 
@@ -199,6 +204,7 @@ steps:
         nugetConfigPath: nuget.config
         msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:DisableWarnForInvalidRestoreProjects=true ${{parameters.additionalMSBuildOptions}} /p:WinUIVersion=$(versionFinal) /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
+        outputDirectory: ${{ parameters.outputDirectory }}
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
 
@@ -216,6 +222,7 @@ steps:
         nugetConfigPath: nuget.config
         msBuildArgs: '/p:MUXFinalRelease=${{ parameters.MUXFinalRelease }} ${{ parameters.pgoBuildModeMSBuildArg }} /p:DisableWarnForInvalidRestoreProjects=true ${{parameters.additionalMSBuildOptions}} /p:WinUIVersion=$(versionFinal) /p:PublishAot=$(publishAotValue)'
         msbuildInstallDir: $(_buildToolsDirectory)
+        outputDirectory: ${{ parameters.outputDirectory }}
         projectCaching: ${{ parameters.projectCaching }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
         condition: and(succeeded(), ne(variables['Build.Repository.Provider'], 'GitHub'), ne(variables['Build.Repository.Provider'], 'GitHubEnterprise'))
@@ -228,6 +235,7 @@ steps:
     - template: WinUI-BuildSampleApps-Steps.yml
       parameters:
         artifactsRoot: ${{ parameters.buildArtifactsDirectory }}\
+        outputDirectory: ${{ parameters.outputDirectory }}
         pipelineKind: ${{ parameters.pipelineKind }}
         MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -247,7 +255,7 @@ steps:
       contents: |
         **\*
         !**\*.pdb
-      targetFolder: $(ob_outputDirectory)\drop
+      targetFolder: ${{ parameters.outputDirectory }}\drop
 
   # An app that includes the transport package won't run properly if these files aren't present,
   # since then they're part of the NuGet package that are detected to be missing.
@@ -262,7 +270,7 @@ steps:
           !AppTestAutomationHelpers.pdb
           !Microsoft.WinUI.pdb
           !MUXControlsTestApp.pdb
-        targetFolder: $(ob_outputDirectory)\drop\$(buildOutput)$(normalizedConfiguration)\Test\UnpackagedApps\MUXControlsTestApp
+        targetFolder: ${{ parameters.outputDirectory }}\drop\$(buildOutput)$(normalizedConfiguration)\Test\UnpackagedApps\MUXControlsTestApp
 
   - task: PowerShell@2
     displayName: 'Generate fusion manifest'
@@ -290,7 +298,7 @@ steps:
         **\*
         !**\*.pdb
         !**\tools\!($(buildPlatform))\GenXbf.dll
-      targetFolder: $(ob_outputDirectory)\packaging
+      targetFolder: ${{ parameters.outputDirectory }}\packaging
 
   - task: PublishSymbols@2
     displayName: 'Publish full symbols to internal symbol server'
@@ -319,7 +327,7 @@ steps:
     condition: succeeded()
     inputs:
       SourceFolder: '${{ parameters.buildArtifactsDirectory }}\bin\$(buildOutput)$(normalizedConfiguration)\Symbols'
-      TargetFolder: '$(ob_outputDirectory)\Symbols'
+      TargetFolder: '${{ parameters.outputDirectory }}\Symbols'
 
   # Copy Product binaries for APIScan. To save time/resources, not running APIScan on Samples apps for now.
   # We are using this copy as a way to focus on scanning product code only and also a workaround for an APIScan limitation:
@@ -361,7 +369,7 @@ steps:
   - ${{ if eq(parameters.signOutput, true) }}:
     - template: AzurePipelinesTemplates/WindowsAppSDK-EsrpCodeSigning-Steps.yml@WindowsAppSDKConfig
       parameters:
-        FolderPath: '$(ob_outputDirectory)'
+        FolderPath: '${{ parameters.outputDirectory }}'
         Pattern: |
           **/Microsoft.WinUI.dll
           **/Microsoft.UI.Text.winmd

--- a/build/AzurePipelinesTemplates/WinUI-BuildProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildProject-Steps.yml
@@ -8,6 +8,7 @@ parameters:
   doRestore: 'true'
   projectCaching: false
   msbuildInstallDir: $(_buildToolsDirectory)
+  outputDirectory: $(ob_outputDirectory)
   runStaticAnalysis: true
   condition: succeeded()
 
@@ -44,14 +45,14 @@ steps:
       enableDefaultLogger: false
       ${{ if eq(parameters.doRestore, 'true') }}:
         ${{ if eq(parameters.projectCaching, true) }}:
-          msbuildArguments: '${{ parameters.msBuildArgs }} /restore /graph /reportfileaccesses /p:MSBuildCacheEnabled=true /p:MSBuildCacheLogDirectory=$(ob_outputDirectory)/MSBuildCacheLogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration) /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
+          msbuildArguments: '${{ parameters.msBuildArgs }} /restore /graph /reportfileaccesses /p:MSBuildCacheEnabled=true /p:MSBuildCacheLogDirectory=${{ parameters.outputDirectory }}/MSBuildCacheLogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration) /binaryLogger:${{ parameters.outputDirectory }}/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
         ${{ if ne(parameters.projectCaching, true) }}:
-          msbuildArguments: '${{ parameters.msBuildArgs }} /restore /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
+          msbuildArguments: '${{ parameters.msBuildArgs }} /restore /binaryLogger:${{ parameters.outputDirectory }}/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
       ${{ if ne(parameters.doRestore, 'true') }}:
         ${{ if eq(parameters.projectCaching, true) }}:
-          msbuildArguments: '${{ parameters.msBuildArgs }} /graph /reportfileaccesses /p:MSBuildCacheEnabled=true /p:MSBuildCacheLogDirectory=$(ob_outputDirectory)/MSBuildCacheLogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration) /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
+          msbuildArguments: '${{ parameters.msBuildArgs }} /graph /reportfileaccesses /p:MSBuildCacheEnabled=true /p:MSBuildCacheLogDirectory=${{ parameters.outputDirectory }}/MSBuildCacheLogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration) /binaryLogger:${{ parameters.outputDirectory }}/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
         ${{ if ne(parameters.projectCaching, true) }}:
-          msbuildArguments: '${{ parameters.msBuildArgs }} /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
+          msbuildArguments: '${{ parameters.msBuildArgs }} /binaryLogger:${{ parameters.outputDirectory }}/binlogs/${{ parameters.solutionName }}.$(buildPlatform).$(buildConfiguration).binlog /ds:false'
     env:
       ${{ if eq(parameters.projectCaching, true) }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/build/AzurePipelinesTemplates/WinUI-BuildSampleApp-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildSampleApp-Steps.yml
@@ -5,6 +5,7 @@ parameters:
   msBuildArgs: ''
   msbuildInstallDir: $(_buildToolsDirectory)
   artifactsRoot: $(Build.SourcesDirectory)\BuildOutput\
+  outputDirectory: $(ob_outputDirectory)
   displayName: ''
   condition: 'always()'
   useDotNet: false
@@ -49,7 +50,7 @@ steps:
       configuration: '$(buildConfiguration)'
       enableDefaultLogger: false
       restoreNuGetPackages: false
-      msbuildArguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(versionFinal) /p:ArtifactsRoot=${{ parameters.artifactsRoot }} /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).binlog /restore /p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
+      msbuildArguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(versionFinal) /p:ArtifactsRoot=${{ parameters.artifactsRoot }} /binaryLogger:${{ parameters.outputDirectory }}/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).binlog /restore /p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
     env:
       LkgVcToolsName: $(compilerOverridePackageName)
       LkgVcToolsVersion: $(compilerOverrideNupkgVersion)
@@ -93,4 +94,4 @@ steps:
       feedsToUse: config
       restoreArguments: >
         --configfile ${{ parameters.restoreConfigFile }}
-      arguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(versionFinal) -p:ArtifactsRoot=${{ parameters.artifactsRoot }} -binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).dotnet.binlog -p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
+      arguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(versionFinal) -p:ArtifactsRoot=${{ parameters.artifactsRoot }} -binaryLogger:${{ parameters.outputDirectory }}/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).dotnet.binlog -p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}

--- a/build/AzurePipelinesTemplates/WinUI-BuildSampleApps-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildSampleApps-Steps.yml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 parameters:
   artifactsRoot: $(Build.SourcesDirectory)\BuildOutput\
+  outputDirectory: $(ob_outputDirectory)
   MUXFinalRelease: false
   runStaticAnalysis: true
   pipelineKind: ''
@@ -76,6 +77,7 @@ steps:
       displayName: WinUICsDesktopSampleApp
       solution: Samples\WinUICsDesktopSampleApp\WinUICsDesktopSampleApp.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       msBuildArgs: '/t:Publish'
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -85,6 +87,7 @@ steps:
       displayName: WinUICppDesktopSampleApp
       solution: Samples\WinUICppDesktopSampleApp\WinUICppDesktopSampleApp.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
 
@@ -106,6 +109,7 @@ steps:
       displayName: WinUIGallery
       solution: Samples\WinUIGallery\WinUIGallery.slnx
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       restoreConfigFile: $(Build.SourcesDirectory)\Samples\WinUIGallery\nuget.config
       msBuildArgs: '/p:PublishProfile=win-$(buildPlatform).pubxml /t:Publish /p:PublishAot=$(publishAotValue) $(galleryTrimArg)'
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
@@ -117,6 +121,7 @@ steps:
       displayName: NativeDX12DesktopSample
       solution: Samples\WinUIDesktop\NativeDX12DesktopSample.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
 
@@ -125,6 +130,7 @@ steps:
       displayName: WinUICppNoPCHSampleApp
       solution: Samples\WinUICppNoPCHSampleApp\WinUICppNoPCHSampleApp.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
 
@@ -133,6 +139,7 @@ steps:
       displayName: WinUIGallery
       solution: Samples\WinUIGallery\WinUIGallery\WinUIGallery.csproj
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       restoreConfigFile: $(Build.SourcesDirectory)\Samples\WinUIGallery\nuget.config
       useDotNet: true
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
@@ -144,6 +151,7 @@ steps:
       displayName: WinUICppIsland2SampleApp
       solution: Samples\WinUICppIsland2SampleApp\WinUICppIsland2SampleApp.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       pipelineKind: ${{parameters.pipelineKind}}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: ${{ ne(parameters.MUXFinalRelease, true) }}
@@ -154,6 +162,7 @@ steps:
       displayName: WinUICppIslandsSampleApp
       solution: Samples\WinUICppIslandsSampleApp\WinUICppIslandsSampleApp.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: ${{ ne(parameters.MUXFinalRelease, true) }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -163,6 +172,7 @@ steps:
       displayName: DisableXamlGeneratedMain
       solution: Samples\DisableXamlGeneratedMain\DisableXamlGeneratedMain.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: ${{ ne(parameters.MUXFinalRelease, true) }}
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -172,6 +182,7 @@ steps:
       displayName: DisableXamlGeneratedMainCs
       solution: Samples\DisableXamlGeneratedMain\Cs\DisableXamlGeneratedMainCs.csproj
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       msBuildArgs: '/p:PublishProfile=win-$(buildPlatform).pubxml /t:Publish'
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: ${{ ne(parameters.MUXFinalRelease, true) }}
@@ -182,6 +193,7 @@ steps:
       displayName: DisableXamlGeneratedMainNoCtorCs
       solution: Samples\DisableXamlGeneratedMain\CsNoCtor\DisableXamlGeneratedMainNoCtorCs.csproj
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       msBuildArgs: '/p:PublishProfile=win-$(buildPlatform).pubxml /t:Publish'
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: ${{ ne(parameters.MUXFinalRelease, true) }}
@@ -192,6 +204,7 @@ steps:
       displayName: ChartApp
       solution: Samples\ChartApp\ChartApp.sln
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: and(${{ ne(parameters.MUXFinalRelease, true) }}, ne(variables['Build.Repository.Provider'], 'GitHub'), ne(variables['Build.Repository.Provider'], 'GitHubEnterprise'))
       runStaticAnalysis: ${{ parameters.runStaticAnalysis }}
@@ -201,6 +214,7 @@ steps:
       displayName: ChartAppCsUnpackaged
       solution: Samples\ChartApp\ChartAppCsUnpackaged\ChartAppCsUnpackaged.csproj
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       msBuildArgs: '/p:PublishProfile=win-$(buildPlatform).pubxml /t:Publish'
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: and(${{ ne(parameters.MUXFinalRelease, true) }}, ne(variables['Build.Repository.Provider'], 'GitHub'), ne(variables['Build.Repository.Provider'], 'GitHubEnterprise'))
@@ -211,6 +225,7 @@ steps:
       displayName: ChartAppCsPackaged
       solution: Samples\ChartApp\ChartAppCsPackaged\ChartAppCsPackaged.csproj
       artifactsRoot: ${{ parameters.artifactsRoot }}
+      outputDirectory: ${{ parameters.outputDirectory }}
       msBuildArgs: '/p:PublishProfile=win-$(buildPlatform).pubxml /t:Publish'
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
       condition: and(${{ ne(parameters.MUXFinalRelease, true) }}, ne(variables['Build.Repository.Provider'], 'GitHub'), ne(variables['Build.Repository.Provider'], 'GitHubEnterprise'))
@@ -222,5 +237,6 @@ steps:
         displayName: PGO-set
         solution: perf\scenarios\PGO-set.sln
         artifactsRoot: ${{ parameters.artifactsRoot }}
+        outputDirectory: ${{ parameters.outputDirectory }}
         MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
         runStaticAnalysis: ${{ parameters.runStaticAnalysis }}

--- a/build/AzurePipelinesTemplates/WinUI-BuildWinUI-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildWinUI-Stage.yml
@@ -11,6 +11,7 @@ parameters:
   pgoBuildModeMSBuildArg: '/p:PGOBuildMode=$(pgoBuildMode)'
   buildProductOnly: false
   dependsOn: ''
+  publishArtifactsWithOneBranch: true
 
 stages:
 - stage: ${{ parameters.stageName }}
@@ -116,8 +117,10 @@ stages:
             normalizedConfiguration: 'chk'
             shouldPgo: false
     variables:
-      ob_outputDirectory: '$(Build.SourcesDirectory)\out'
-      ob_artifactBaseName: 'drop_$(buildOutput)$(normalizedConfiguration)'
+      winuiOutputDirectory: '$(Build.SourcesDirectory)\out'
+      ${{ if eq(parameters.publishArtifactsWithOneBranch, true) }}:
+        ob_outputDirectory: '$(winuiOutputDirectory)'
+        ob_artifactBaseName: 'drop_$(buildOutput)$(normalizedConfiguration)'
       ob_sdl_codeSignValidation_excludes: '-|WinUIComponentPackage\**;-|**\Test\**;-|**\Taef\**;-|**\TestDependencies\**;-|**\Microsoft.Internal.FrameworkUdk.dll'
       # The default ob checkout only does a shallow fetch. For PGO to work, it needs to fetch deeper.
       ob_git_fetchDepth: -1
@@ -160,7 +163,15 @@ stages:
         projectCaching: ${{ parameters.projectCaching }}
         pgoBuildModeMSBuildArg: ${{ parameters.pgoBuildModeMSBuildArg }}
         buildProductOnly: ${{ parameters.buildProductOnly }}
+        outputDirectory: $(winuiOutputDirectory)
 
     - ${{ if eq(parameters.pipelineKind, 'Nightly') }}:
       - task: CodeQL3000Finalize@0
         displayName: Finalize CodeQL
+
+    - ${{ if eq(parameters.publishArtifactsWithOneBranch, false) }}:
+      - task: PublishPipelineArtifact@1
+        displayName: Publish build outputs
+        inputs:
+          targetPath: $(winuiOutputDirectory)
+          artifact: 'drop_$(buildOutput)$(normalizedConfiguration)'

--- a/build/AzurePipelinesTemplates/WinUI-CreateTestPayload-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-CreateTestPayload-Job.yml
@@ -7,6 +7,7 @@ parameters:
   pipelineKind: '' # can be: Nightly, CI, PR, BuildAndTest, TestLocalBuild, ValidateWindowsAppSDK
   testPayloadArtifactName: 'TestPayload'
   includeWinUIGallery: true
+  publishArtifactsWithOneBranch: true
 
 jobs:
 - job: ${{ parameters.runTestJobName }}
@@ -82,10 +83,13 @@ jobs:
         value: '-SkipWinUIGallery'
     - name: taefExePath
       value: '$(artifactsDir)\drop\amd64fre\Taef\te.exe' # We need to override this to ensure that we don't try to run arm64 te.exe on this amd64 pipeline machine.
-    - name: ob_outputDirectory
+    - name: winuiOutputDirectory
       value: '$(Build.SourcesDirectory)\out'
-    - name: ob_artifactBaseName
-      value: "${{ parameters.testPayloadArtifactName }}_$(testOS)_$(buildOutput)"
+    - ${{ if eq(parameters.publishArtifactsWithOneBranch, true) }}:
+      - name: ob_outputDirectory
+        value: '$(winuiOutputDirectory)'
+      - name: ob_artifactBaseName
+        value: "${{ parameters.testPayloadArtifactName }}_$(testOS)_$(buildOutput)"
     - ${{ if eq(parameters.pipelineKind, 'ValidateWindowsAppSDK') }}:
       - name: isValidateWindowsAppSDKRun
         value: 1
@@ -173,7 +177,7 @@ jobs:
     displayName: MoveToOutputDirectory
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\TestPayload'
-      TargetFolder: '$(ob_outputDirectory)\TestPayload'
+      TargetFolder: '$(winuiOutputDirectory)\TestPayload'
 
   - ${{ if eq(parameters.testSuite, 'DevTestSuite') }}:
     - template: WinUI-CreateHelixProjFile-Steps.yml
@@ -258,7 +262,7 @@ jobs:
     displayName: 'Copy helix work item proj files'
     inputs:
       SourceFolder: '$(Build.SourcesDirectory)\helixworkitems'
-      TargetFolder: '$(ob_outputDirectory)\helixworkitems\${{ parameters.testSuite }}\$(buildPlatform)$(normalizedConfiguration)\$(testOS)\'
+      TargetFolder: '$(winuiOutputDirectory)\helixworkitems\${{ parameters.testSuite }}\$(buildPlatform)$(normalizedConfiguration)\$(testOS)\'
       Contents: '*.proj'
 
   - ${{ if eq(parameters.testSuite, 'DevTestSuite') }}:
@@ -266,8 +270,15 @@ jobs:
       displayName: 'Copy static helix work item proj files'
       inputs:
         SourceFolder: '$(Build.SourcesDirectory)\Helix\staticTestWorkItems'
-        TargetFolder: '$(ob_outputDirectory)\helixworkitems\${{ parameters.testSuite }}\$(buildPlatform)$(normalizedConfiguration)\$(testOS)\'
+        TargetFolder: '$(winuiOutputDirectory)\helixworkitems\${{ parameters.testSuite }}\$(buildPlatform)$(normalizedConfiguration)\$(testOS)\'
         Contents: '*.proj'
+
+  - ${{ if eq(parameters.publishArtifactsWithOneBranch, false) }}:
+    - task: PublishPipelineArtifact@1
+      displayName: Publish test payload
+      inputs:
+        targetPath: $(winuiOutputDirectory)
+        artifact: "${{ parameters.testPayloadArtifactName }}_$(testOS)_$(buildOutput)"
 
   - script: |
       dir /s $(artifactsDir)

--- a/build/AzurePipelinesTemplates/WinUI-Install-MSBuildTools.yml
+++ b/build/AzurePipelinesTemplates/WinUI-Install-MSBuildTools.yml
@@ -3,6 +3,7 @@
 parameters:
   msbuildInstallDir: 'c:\.buildtools'
   pipelineKind: ''
+  outputDirectory: $(ob_outputDirectory)
 
 steps:
   - script: |
@@ -17,7 +18,7 @@ steps:
       inputs:
         targetType: filePath
         filePath: $(Build.SourcesDirectory)\scripts\init\Initialize-InstallMSBuild.ps1
-        arguments: '-installDir "${{ parameters.msbuildInstallDir }}" -logsDir "$(ob_outputDirectory)\MSBuildToolLogs" -ignoreInstalledVS -VsVersionToInstall $(_VsVersionToInstall)'
+        arguments: '-installDir "${{ parameters.msbuildInstallDir }}" -logsDir "${{ parameters.outputDirectory }}\MSBuildToolLogs" -ignoreInstalledVS -VsVersionToInstall $(_VsVersionToInstall)'
 
   - ${{ if ne(parameters.pipelineKind, 'Preview') }}:
     - task: powershell@2
@@ -26,7 +27,7 @@ steps:
       inputs:
         targetType: filePath
         filePath: $(Build.SourcesDirectory)\scripts\init\Initialize-InstallMSBuild.ps1
-        arguments: '-installDir "${{ parameters.msbuildInstallDir }}" -logsDir "$(ob_outputDirectory)\MSBuildToolLogs" -ignoreInstalledVS'
+        arguments: '-installDir "${{ parameters.msbuildInstallDir }}" -logsDir "${{ parameters.outputDirectory }}\MSBuildToolLogs" -ignoreInstalledVS'
 
   - task: powershell@2
     displayName: 'Update installed VS'
@@ -34,7 +35,7 @@ steps:
     inputs:
       targetType: filePath
       filePath: $(Build.SourcesDirectory)\scripts\init\Initialize-InstallMSBuild.ps1
-      arguments: '-installDir "${{ parameters.msbuildInstallDir }}" -logsDir "$(ob_outputDirectory)\MSBuildToolLogs"'
+      arguments: '-installDir "${{ parameters.msbuildInstallDir }}" -logsDir "${{ parameters.outputDirectory }}\MSBuildToolLogs"'
 
   - task: CmdLine@2
     displayName: Add the VS build tools to the path

--- a/build/AzurePipelinesTemplates/WinUI-RunScenarioTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunScenarioTests-Stage.yml
@@ -4,6 +4,7 @@ parameters:
   pipelineKind: ''
   dependsOn: ''
   runArm64Tests: true
+  publishArtifactsWithOneBranch: true
 
 stages:
 - stage: RunScenarioTests
@@ -17,6 +18,7 @@ stages:
       pipelineKind: ${{ parameters.pipelineKind }}
       testSuite: 'ScenarioTestSuite'
       testPayloadArtifactName: 'ScenarioTestPayload'
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
       # Include WinUIGallery on GitHub PR validation.
       ${{ if eq(parameters.pipelineKind, 'GitHubPR') }}:
         includeWinUIGallery: true
@@ -30,6 +32,7 @@ stages:
       buildConfiguration: chk
       testOS: Win10-RS5
       testPayloadArtifactName: 'ScenarioTestPayload'
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
   - template: WinUI-RunTestPassOnPipeline-Job.yml
     parameters:
@@ -40,6 +43,7 @@ stages:
       buildConfiguration: fre
       testOS: Win11-25H2
       testPayloadArtifactName: 'ScenarioTestPayload'
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
   - template: WinUI-RunTestPassOnPipeline-Job.yml
     parameters:
@@ -50,6 +54,7 @@ stages:
       buildConfiguration: fre
       testOS: Win11-23H2
       testPayloadArtifactName: 'ScenarioTestPayload'
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
   - ${{ if in(parameters.pipelineKind, 'Nightly', 'Official' ) }}:
     - ${{ if eq(parameters.runArm64Tests, true ) }}:
@@ -62,6 +67,7 @@ stages:
           buildConfiguration: fre
           testOS: Win11-23H2
           testPayloadArtifactName: 'ScenarioTestPayload'
+          publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
       - template: WinUI-RunTestPassOnPipeline-Job.yml
         parameters:
@@ -72,6 +78,7 @@ stages:
           buildConfiguration: fre
           testOS: Win11-23H2
           testPayloadArtifactName: 'ScenarioTestPayload'
+          publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
   - template: WinUI-RunScenarioUnitTests-Job.yml
     parameters:

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
@@ -4,6 +4,7 @@ parameters:
   runTestJobName: 'RunStaticTests'
   dependsOn: ''
   MUXFinalRelease: false
+  publishArtifactsWithOneBranch: true
 
 jobs:
 - job: ${{ parameters.runTestJobName }}
@@ -15,7 +16,8 @@ jobs:
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
     packagesDir: $(Agent.TempDirectory)\WinUI-RunStaticTests-Job\packages
-    ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+    ${{ if eq(parameters.publishArtifactsWithOneBranch, true) }}:
+      ob_outputDirectory: '$(Build.SourcesDirectory)\out'
     ob_sdl_codeSignValidation_excludes: '-|packaging\**;-|**\Test\**;-|**\Taef\**;-|**\TestDependencies\**;-|**\Microsoft.Internal.FrameworkUdk.dll'
     ob_sdl_prefast_enabled: false   # this job does no native build
 

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 parameters:
   MUXFinalRelease: false
+  publishArtifactsWithOneBranch: true
 
 stages:
 - stage: RunStaticTests
@@ -13,3 +14,4 @@ stages:
     parameters:
       runTestJobName: RunStaticTests
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}

--- a/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
@@ -11,6 +11,7 @@ parameters:
   rerunPassesRequiredToAvoidFailure: 5
   testPayloadArtifactName: 'TestPayload'
   failOnTestFailure: true
+  publishArtifactsWithOneBranch: true
 # We run the bulk of our tests in Helix. But this Job runs tests directly on the Pipeline agents.
 # These Pipeline agents are running on a ni_release build of Windows which is not available in Helix.
 # This approach allows us to run tests on prerelease builds of Windows.
@@ -59,8 +60,9 @@ jobs:
     # This should reduce concurrent memory allocations and allow us to make better use of our buffer pool which will help with the failures on arm64 machines to download artifacts
     AZURE_PIPELINES_DEDUP_PARALLELISM: 16
 
-    ob_outputDirectory: '$(uploadRoot)'
-    ob_artifactBaseName: '${{ parameters.runTestStageName }}_${{ parameters.runTestJobName }}_$(System.JobPositionInPhase)_$(artifactStatus)'
+    ${{ if eq(parameters.publishArtifactsWithOneBranch, true) }}:
+      ob_outputDirectory: '$(uploadRoot)'
+      ob_artifactBaseName: '${{ parameters.runTestStageName }}_${{ parameters.runTestJobName }}_$(System.JobPositionInPhase)_$(artifactStatus)'
 
     ${{ if eq( parameters.buildPlatform, 'arm64') }}:
       skipComponentGovernanceDetection: true # dotnet install currently fails on arm64 with "Unsupported OS/platform configuration detected, not downloading .NET..."

--- a/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
@@ -3,6 +3,7 @@
 parameters:
   pipelineKind: ''
   failOnTestFailure: true
+  publishArtifactsWithOneBranch: true
 
 stages:
 - stage: RunTests
@@ -16,6 +17,7 @@ stages:
       pipelineKind: ${{ parameters.pipelineKind }}
       testSuite: 'DevTestSuite'
       testPayloadArtifactName: 'TestPayload'
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
   - template: WinUI-RunTestPassOnPipeline-Job.yml
     parameters:
@@ -24,6 +26,7 @@ stages:
       testOS: 'Win11-25H2'
       testPayloadArtifactName: 'TestPayload'
       failOnTestFailure: ${{ parameters.failOnTestFailure }}
+      publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
   - ${{ if ne(parameters.pipelineKind, 'QuickPR') }}:
     - template: WinUI-RunTestPassOnPipeline-Job.yml
@@ -33,6 +36,7 @@ stages:
         testOS: 'Win11-23H2'
         testPayloadArtifactName: 'TestPayload'
         failOnTestFailure: ${{ parameters.failOnTestFailure }}
+        publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}
 
     - template: WinUI-RunTestPassOnPipeline-Job.yml
       parameters:
@@ -41,3 +45,4 @@ stages:
         testOS: 'Win10-RS5'
         testPayloadArtifactName: 'TestPayload'
         failOnTestFailure: ${{ parameters.failOnTestFailure }}
+        publishArtifactsWithOneBranch: ${{ parameters.publishArtifactsWithOneBranch }}


### PR DESCRIPTION
## Summary

Fork PR validation runs with restricted credentials, but the shared templates currently opt affected jobs into OneBranch artifact publishing that cannot initialize in that environment.

This change adds a built-in Pipeline Artifact publishing mode for build outputs and test payloads while preserving OneBranch publishing as the default. It also passes a neutral output directory through the affected build helpers so artifact names and layouts remain unchanged.

This PR only introduces the backward-compatible template capability. A follow-up PR will enable it for GitHub PR validation and remove the redundant context-validation stage.

## Validation

- Parsed all changed YAML with duplicate-key detection.
- Verified parameter propagation through build, test, static-test, and scenario-test templates.
- Verified existing artifact producer and consumer names remain aligned.