### PR TITLE
Promote SelectionModel and IndexPath to public on a new 2.x contract

### DIFF
--- a/controls/dev/Repeater/ItemsRepeater.idl
+++ b/controls/dev/Repeater/ItemsRepeater.idl
@@ -634,7 +634,7 @@ unsealed runtimeclass RecyclingElementFactory : ElementFactory
     overridable String OnSelectTemplateKeyCore(Object dataContext, Microsoft.UI.Xaml.UIElement owner);
 }
 
-[MUX_PREVIEW]
+[MUX_PUBLIC_V12]
 [webhosthidden]
 runtimeclass IndexPath : Windows.Foundation.IStringable
 {
@@ -649,14 +649,14 @@ runtimeclass IndexPath : Windows.Foundation.IStringable
     static IndexPath CreateFromIndices(Windows.Foundation.Collections.IVector<Int32> indices);
 }
 
-[MUX_PREVIEW]
+[MUX_PUBLIC_V12]
 [webhosthidden]
 [default_interface]
 runtimeclass SelectionModelSelectionChangedEventArgs
 {
 }
 
-[MUX_PREVIEW]
+[MUX_PUBLIC_V12]
 [webhosthidden]
 runtimeclass SelectionModelChildrenRequestedEventArgs
 {
@@ -665,7 +665,7 @@ runtimeclass SelectionModelChildrenRequestedEventArgs
     Object Children { get; set; };
 }
 
-[MUX_PREVIEW]
+[MUX_PUBLIC_V12]
 [webhosthidden]
 unsealed runtimeclass SelectionModel : Microsoft.UI.Xaml.Data.INotifyPropertyChanged
 {

--- a/controls/idl/Microsoft.UI.Xaml.Controls.idl
+++ b/controls/idl/Microsoft.UI.Xaml.Controls.idl
@@ -133,12 +133,13 @@ namespace Microsoft.UI.Xaml.CustomAttributes
 #define MUX_PUBLIC_V9 contract(Microsoft.UI.Xaml.XamlContract, 9)   // WinAppSDK 1.8
 #define MUX_PUBLIC_V10 contract(Microsoft.UI.Xaml.XamlContract, 10) // WinAppSDK 2.0
 #define MUX_PUBLIC_V11 contract(Microsoft.UI.Xaml.XamlContract, 11) // WinAppSDK 2.2
-#define MUX_PUBLIC_V12 contract(Microsoft.UI.Xaml.XamlContract, 12) // WinAppSDK 3.0
+#define MUX_PUBLIC_V12 contract(Microsoft.UI.Xaml.XamlContract, 12) // WinAppSDK 2.5
+#define MUX_PUBLIC_V13 contract(Microsoft.UI.Xaml.XamlContract, 13) // WinAppSDK 3.0
 
 // Note: It's expected that these are the same version because we require internal be in a different namespace,
 // and we split out the public vs internal metadata by namespace as well as feature attributes.
-#define MUX_PREVIEW contract(Microsoft.UI.Xaml.XamlContract, 12), feature(Feature_Experimental)
-#define MUX_INTERNAL contract(Microsoft.UI.Xaml.XamlContract, 12), feature(Feature_Experimental)
+#define MUX_PREVIEW contract(Microsoft.UI.Xaml.XamlContract, 13), feature(Feature_Experimental)
+#define MUX_INTERNAL contract(Microsoft.UI.Xaml.XamlContract, 13), feature(Feature_Experimental)
 
 // If this is specified then codegen will not create or register a default activation factory.
 #define MUX_HAS_CUSTOM_FACTORY Microsoft.UI.Xaml.CustomAttributes.MUXHasCustomActivationFactory

--- a/dxaml/xcp/dxaml/idl/winrt/controls/microsoft.ui.xaml.controls.controls2.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/controls/microsoft.ui.xaml.controls.controls2.idl
@@ -129,7 +129,7 @@ namespace Microsoft.UI.Xaml.Controls
         Popup,
         InPlace,
         [feature(Feature_ExperimentalApi)]
-        [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
+        [contract(Microsoft.UI.Xaml.WinUIContract, 13)]
         UnconstrainedPopup,
     };
 

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes.idl
@@ -39,9 +39,9 @@ cpp_quote("#undef GetCurrentTime")
 
 namespace Microsoft.UI.Xaml
 {
-    [contractversion(12)]
+    [contractversion(13)]
     apicontract WinUIContract{};
-    [contractversion(12)]
+    [contractversion(13)]
     apicontract XamlContract{};
 }
 
@@ -884,7 +884,7 @@ namespace Microsoft.UI.Xaml.Automation.Peers
         TextEditTextChanged,
         LayoutInvalidated,
         [feature(Feature_ExperimentalApi)]
-        [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
+        [contract(Microsoft.UI.Xaml.WinUIContract, 13)]
         Notification,
     };
 
@@ -1908,7 +1908,7 @@ namespace Microsoft.UI.Xaml
         Microsoft.UI.Content.ContentIsland ContentIsland{ get; };
         Microsoft.UI.Xaml.Media.SystemBackdrop SystemBackdrop;
     
-        [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
+        [contract(Microsoft.UI.Xaml.WinUIContract, 13)]
         [feature(Feature_ExperimentalApi)]
         [interface_name("Microsoft.UI.Xaml.IXamlIslandFeature_ExperimentalApi")]
         {
@@ -2551,7 +2551,7 @@ namespace Microsoft.UI.Xaml
         overridable void OnApplyTemplate();
         overridable Boolean GoToElementStateCore(String stateName, Boolean useTransitions);
     
-        [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
+        [contract(Microsoft.UI.Xaml.WinUIContract, 13)]
         [feature(Feature_ExperimentalApi)]
         [interface_name("Microsoft.UI.Xaml.IFrameworkElementFeature_ExperimentalApi")]
         {

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
@@ -854,7 +854,7 @@ namespace Microsoft.UI.Xaml
             Microsoft.UI.Windowing.AppWindow AppWindow{ get; };
         }
     
-        [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
+        [contract(Microsoft.UI.Xaml.WinUIContract, 13)]
         [feature(Feature_ExperimentalApi)]
         [interface_name("Microsoft.UI.Xaml.IWindowFeature_ExperimentalApi")]
         {

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Contracts.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Contracts.cs
@@ -33,18 +33,20 @@ namespace Microsoft.UI.Xaml
     [ContractVersion(9)] // WinAppSDK 1.8
     [ContractVersion(10)] // WinAppSDK 2.0
     [ContractVersion(11)] // WinAppSDK 2.2
-    [ContractVersion(12)] // WinAppSDK 3.0
+    [ContractVersion(12)] // WinAppSDK 2.5
+    [ContractVersion(13)] // WinAppSDK 3.0
     public class WinUIContract : Contract
     {
         // Put new APIs in the Experimental contract version. Move into the specific
         // WinAppSDK version after completing API review and determining the stable
         // release version.
-        public const int Experimental  = 12;
+        public const int Experimental  = 13;
 
         public const int WinAppSDK_2_0 = 10;
         public const int WinAppSDK_2_2 = 11;
+        public const int WinAppSDK_2_5 = 12;
 
-        public const int WinAppSDK_3_0 = 12;
+        public const int WinAppSDK_3_0 = 13;
     };
 
     [ContractVersion(1)]
@@ -59,5 +61,6 @@ namespace Microsoft.UI.Xaml
     [ContractVersion(10)]
     [ContractVersion(11)]
     [ContractVersion(12)]
+    [ContractVersion(13)]
     public class XamlContract : Contract { };
 }


### PR DESCRIPTION
Promotes four runtimeclasses in `ItemsRepeater.idl` from `[MUX_PREVIEW]` to `[MUX_PUBLIC_V12]`: `SelectionModel`, `SelectionModelSelectionChangedEventArgs`, `SelectionModelChildrenRequestedEventArgs` and `IndexPath`.

## Why not `MUX_PUBLIC_V11`?

Contract 11 shipped in WinAppSDK 2.2.0, and these four types are still `[MUX_PREVIEW]` on `release/2.0-stable` — they never shipped publicly. Tagging them V11 would add new types to an already-shipped contract, which is exactly the failure described in `docs/publishing/build-pipelines.md` § WinUI-RunStaticTests-Stage. PR 16251944 deleted both `WinMDCompatExceptions_*.txt` files, so `main` must stay compat-clean.

The TitleBar V11 precedent does not transfer — those APIs genuinely shipped in 2.2, so that change was correcting `main` to match reality.

## Why not leave it as contract 12 = 3.0?

Promoting a preview API to public is a **backwards-compatible API addition**, which per the [WinAppSDK versioning policy](https://www.osgwiki.com/wiki/WASDK_New_Major_Version) is a **MINOR**-level payload:

| Level | Contains |
| --- | --- |
| PATCH | backwards-compatible bug fixes |
| **MINOR** | **backwards-compatible API additions (experimental-first)** |
| MAJOR | breaking changes only |

A major rev is reserved for breaking changes, is a product-level decision rather than a per-change call, carries an OS/CBS cost, and runs ~6 months from LT approval to GA. Making a preview API public is not breaking, so gating it behind 3.0 is wrong.

Contract 12 was previously reserved for WinAppSDK 3.0. This PR repurposes contract 12 for the next 2.x minor and moves 3.0 to contract 13.

## Changes

- `Contracts.cs` — add `ContractVersion(13)` to `WinUIContract` and `XamlContract`; add `WinAppSDK_2_5 = 12`; move `WinAppSDK_3_0` and `Experimental` to 13
- `microsoft.ui.xaml.coretypes.idl` — bump both apicontracts to `contractversion(13)`
- `Microsoft.UI.Xaml.Controls.idl` — re-comment `MUX_PUBLIC_V12` as WinAppSDK 2.5, add `MUX_PUBLIC_V13`, repoint `MUX_PREVIEW`/`MUX_INTERNAL` to contract 13
- Regenerated IDL — experimental APIs float from contract 12 to 13
- `ItemsRepeater.idl` — the four `[MUX_PUBLIC_V12]` tags

## On the version label

The `// WinAppSDK x.y` text is advisory and gets trued up at ship time; only the contract **number** is binding. Precedent on `release/2.0-stable`: contract 11 was created labelled `2.0.1` (`ce3ee94c`), relabelled `2.1.0` (PR 15477463), then `2.2.0` (PR 15657572), which is where it actually shipped.

The renumber is cheap **only while contract 12 has no shipped APIs**. Once 3.0 ships as contract 12 this becomes impossible.

## Validation

- `dxaml\xcp\runcodegen.cmd` succeeds and independently reproduces the hand-edited `contractversion(13)`; it floats exactly the 5 `Feature_ExperimentalApi` sites from contract 12 to 13
- Full product build succeeds
- Inspected the resulting `Microsoft.UI.Xaml.winmd`:

  | Type | Contract | Version |
  | --- | --- | --- |
  | `Microsoft.UI.Xaml.WinUIContract` | self | **13**.0 |
  | `Microsoft.UI.Xaml.XamlContract` | self | **13**.0 |
  | `Controls.SelectionModel` | XamlContract | **12**.0 |
  | `Controls.IndexPath` | XamlContract | **12**.0 |
  | `Controls.SelectionModelSelectionChangedEventArgs` | XamlContract | **12**.0 |
  | `Controls.SelectionModelChildrenRequestedEventArgs` | XamlContract | **12**.0 |

  Had the four types still been preview they would now resolve to contract **13**, since `Experimental` moved. Landing on **12** confirms they are genuinely public on the newly opened contract.

> **Note:** `VerifyWinMDCompat.ps1` could not be run locally — `WinMDVersionVerifyLcr` is not on the public WinUI-Dependencies feed and the nuget.org baseline is unreachable from an OSS enlistment. This gate needs to run in CI.

## Follow-ups

- **A companion PR against `release/2.0-stable` opening contract 12 there and retagging the same four runtimeclasses — that is the change that actually ships to the 2.x servicing train.** It needs contract 12 but not 13, mirroring `ce3ee94c`.
- Confirm with Shiproom which 2.x minor carries this, and correct the version comment if it differs from 2.5.
- Flag the 3.0 → contract 13 renumber to the WinUI contract owners, since in-flight work may assume contract 12 means 3.0.

Refs: PR 15930718, PR 16251944, PR 15477463, PR 15657572
