### PR TITLE
Update OSS WinUIDetails dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
     <FrameworkUdkPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">3.0.0-experimental-27300.1893.260705-0915.0</FrameworkUdkPackageVersion>
     <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IxpTransportPackageVersion>
     <BasePackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.3-experimental1</BasePackageVersion>
-    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260625.0</WinUIDetailsNugetVersion>
+    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260822.0</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
     <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>

--- a/eng/folderpaths.props
+++ b/eng/folderpaths.props
@@ -205,7 +205,7 @@
     <LiftedIXPInternalPackagePath>$(NugetPackageDirectory)\$(LiftedIXPInternalPackageName)\$(IxpInternalPackageVersion)</LiftedIXPInternalPackagePath>
     <LiftedIXPInternalPGIRuntimePath>$(LiftedIXPInternalPackagePath)\runtimes\win10-$(NugetArch)\native\pgi</LiftedIXPInternalPGIRuntimePath>
 
-    <LiftedIXPIncludePaths>$(LiftedIXPIncludePath);$(WinUIDetailsIncludePath)\LiftedIXP;$(FrameworkUdkPackagePath)\include\;$(LiftedIXPGeneratedIncludePath)</LiftedIXPIncludePaths>
+    <LiftedIXPIncludePaths>$(LiftedIXPIncludePath);$(WinUIDetailsIncludePath)\LiftedIXP;$(WinUIDetailsIncludePath)\Misc;$(FrameworkUdkPackagePath)\include\;$(LiftedIXPGeneratedIncludePath)</LiftedIXPIncludePaths>
   </PropertyGroup>
 
   <!-- Lifted MRT paths -->


### PR DESCRIPTION
## Summary

Updates the OSS WinUIDetails dependency to a package that includes the ContentExternal link helpers required by Popup, and exposes the package's Misc headers to the build.

The package is available from the public WinUI dependencies feed. This change only updates the OSS dependency pin and include path; internal dependency selection remains unchanged.