### PR TITLE
Text: keep LineServices context alive for cached break records (Watso…

### DIFF
--- a/dxaml/xcp/core/inc/TextBlock.h
+++ b/dxaml/xcp/core/inc/TextBlock.h
@@ -125,9 +125,12 @@ public:
     // CUIElement override to update the gripper positions
     _Check_return_ HRESULT ArrangeCore(XRECTF finalRect) override;
 
-    // Get TextFormatter instance.
+    // Get TextFormatter instance. When pPreferredTextFormatter is supplied and still available in
+    // the cache, it is picked in preference to an arbitrary cached formatter so continuation
+    // formatting runs on the formatter that produced the previous line break.
     _Check_return_ HRESULT GetTextFormatter(
-        _Outptr_ RichTextServices::TextFormatter** ppTextFormatter
+        _Outptr_ RichTextServices::TextFormatter** ppTextFormatter,
+        _In_opt_ RichTextServices::TextFormatter* pPreferredTextFormatter = nullptr
         );
     // Release TextFormatter instance.
     void ReleaseTextFormatter(

--- a/dxaml/xcp/core/text/BlockLayout/BlockLayoutHelpers.cpp
+++ b/dxaml/xcp/core/text/BlockLayout/BlockLayoutHelpers.cpp
@@ -3,6 +3,7 @@
 
 #include "precomp.h"
 #include "BlockLayoutHelpers.h"
+#include "TextLineBreak.h"
 #include <MetadataAPI.h>
 
 using namespace DirectUI;
@@ -18,22 +19,34 @@ using namespace RichTextServices;
 //---------------------------------------------------------------------------
 _Check_return_ HRESULT BlockLayoutHelpers::GetTextFormatter(
     _In_ CDependencyObject *pLayoutOwner,
-    _Outptr_ RichTextServices::TextFormatter **ppTextFormatter
+    _Outptr_ RichTextServices::TextFormatter **ppTextFormatter,
+    _In_opt_ RichTextServices::TextLineBreak *pPreviousLineBreak
 )
 {
     TextFormatter *pTextFormatter = NULL;
 
     ASSERT(pLayoutOwner);
 
+    // A LineServices break record is bound to the exact formatter (LS context) that produced it,
+    // so continuation formatting must run on that originating formatter. Rather than letting the
+    // formatter re-route the call, ask for the right formatter up front: the formatter that
+    // produced the previous line break is preferred when one is acquired from the cache.
+    TextFormatter *pPreferredFormatter =
+        (pPreviousLineBreak != nullptr) ? pPreviousLineBreak->GetTextFormatter() : nullptr;
+
     if (pLayoutOwner->OfTypeByIndex<KnownTypeIndex::RichTextBlock>())
     {
+        // RichTextBlock keeps a single formatter for its entire lifetime, so every break record it
+        // produces already originates from that same instance - there is nothing to pick.
         CRichTextBlock *pRichTextBlock = static_cast<CRichTextBlock *>(pLayoutOwner);
         IFC_RETURN(pRichTextBlock->GetTextFormatter(&pTextFormatter));
     }
     else if (pLayoutOwner->OfTypeByIndex<KnownTypeIndex::TextBlock>())
     {
+        // TextBlock draws formatters from a shared cache, so the preferred formatter is threaded
+        // down to TextFormatterCache::AcquireTextFormatter which picks it when still available.
         CTextBlock *pTextBlock = static_cast<CTextBlock *>(pLayoutOwner);
-        IFC_RETURN(pTextBlock->GetTextFormatter(&pTextFormatter));
+        IFC_RETURN(pTextBlock->GetTextFormatter(&pTextFormatter, pPreferredFormatter));
     }
     else
     {

--- a/dxaml/xcp/core/text/BlockLayout/BlockLayoutHelpers.h
+++ b/dxaml/xcp/core/text/BlockLayout/BlockLayoutHelpers.h
@@ -5,6 +5,8 @@
 
 namespace RichTextServices
 {
+    class TextFormatter;
+    class TextLineBreak;
     class TextParagraphProperties;
     class TextCollapsingSymbol;
 }
@@ -13,10 +15,14 @@ class BlockLayoutHelpers
 {
 public:
 
-    // Get TextFormatter instance.
+    // Get TextFormatter instance. When a previous line break is supplied, the formatter that
+    // produced it is preferred so that continuation formatting runs on the originating
+    // LineServices context (the break record is bound to it). This keeps formatter selection at
+    // acquisition time rather than having the formatter re-route the call.
     static _Check_return_ HRESULT GetTextFormatter(
         _In_ CDependencyObject *pLayoutOwner,
-        _Outptr_ RichTextServices::TextFormatter **ppTextFormatter
+        _Outptr_ RichTextServices::TextFormatter **ppTextFormatter,
+        _In_opt_ RichTextServices::TextLineBreak *pPreviousLineBreak = nullptr
         );
 
     // Release TextFormatter instance.

--- a/dxaml/xcp/core/text/BlockLayout/ParagraphNode.cpp
+++ b/dxaml/xcp/core/text/BlockLayout/ParagraphNode.cpp
@@ -454,7 +454,6 @@ _Check_return_ HRESULT ParagraphNode::MeasureCore(
     }
 
     IFC(EnsureTextCaches(pPreviousParagraphBreak));
-    IFC(BlockLayoutHelpers::GetTextFormatter(m_pBlockLayoutEngine->GetOwner(), &pTextFormatter));
     IFC(BlockLayoutHelpers::GetParagraphProperties(m_pElement, m_pBlockLayoutEngine->GetOwner(), &pParagraphProperties));
 
     if (IsContentDirty())
@@ -490,6 +489,11 @@ _Check_return_ HRESULT ParagraphNode::MeasureCore(
         pPreviousLineBreak = pPreviousParagraphBreak ->GetLineBreak();
         firstCharIndex = pPreviousParagraphBreak->GetBreakIndex();
     }
+
+    // Acquire the formatter after the previous line break is known so the cache can pick the
+    // formatter that produced it (continuation formatting must run on that formatter's LS context,
+    // to which the break record is bound).
+    IFC(BlockLayoutHelpers::GetTextFormatter(m_pBlockLayoutEngine->GetOwner(), &pTextFormatter, pPreviousLineBreak));
 
     // We always want to measure at least one line, whether we add it or not.
     ASSERT(availableSize.height >= 0.0f);
@@ -986,7 +990,9 @@ HRESULT ParagraphNode::FormatLineAtIndex(
     {
         if (*ppTextFormatter == NULL)
         {
-            IFC(BlockLayoutHelpers::GetTextFormatter(m_pBlockLayoutEngine->GetOwner(), ppTextFormatter));
+            // Prefer the formatter that produced this line's previous break so re-formatting runs
+            // on the LS context the break record is bound to.
+            IFC(BlockLayoutHelpers::GetTextFormatter(m_pBlockLayoutEngine->GetOwner(), ppTextFormatter, lineMetrics.LineBreak));
             IFC(BlockLayoutHelpers::GetParagraphProperties(m_pElement, m_pBlockLayoutEngine->GetOwner(), ppParagraphProperties));
         }
 

--- a/dxaml/xcp/core/text/Inc/TextBoxHelpers.h
+++ b/dxaml/xcp/core/text/Inc/TextBoxHelpers.h
@@ -226,7 +226,8 @@ public:
     static
     _Check_return_ HRESULT GetTextFormatter(
         _In_ CCoreServices *pCore,
-        _Outptr_ RichTextServices::TextFormatter **ppTextFormatter
+        _Outptr_ RichTextServices::TextFormatter **ppTextFormatter,
+        _In_opt_ RichTextServices::TextFormatter *pPreferredTextFormatter = nullptr
         );
 
     static 

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextFormatter.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextFormatter.cpp
@@ -4,6 +4,7 @@
 #include "precomp.h"
 #include "LsTextFormatter.h"
 #include "LsTextLine.h"
+#include "LsTextLineBreak.h"
 #include "TextStore.h"
 #include "LineServicesCallbacks.h"
 #include "InlineObjectHandlers.h"
@@ -97,6 +98,30 @@ Result::Enum LsTextFormatter::FormatLine(
 
     // Assume that formatter was called with Ls line break.
     pPreviousLsLineBreak = reinterpret_cast<LsTextLineBreak *>(pPreviousLineBreak);
+
+    // Context-identity invariant: a LineServices break record is bound to the exact LS context
+    // (owned by a specific LsTextFormatter) that produced it. Continuation formatting therefore
+    // must run on that originating formatter. When the caller re-acquired a *different* formatter
+    // from the TextFormatterCache (e.g. after low-memory cleanup released the original back to the
+    // free list), formatting the continuation on "this" would pass "context B + break record A" to
+    // LsCreateLine, which is invalid. Re-route the call to the originating formatter, which is kept
+    // alive by the break record's own reference, so the break record is always consumed by the LS
+    // context that created it.
+    if (pPreviousLsLineBreak != NULL)
+    {
+        LsTextFormatter *pOriginatingFormatter = pPreviousLsLineBreak->GetTextFormatter();
+        if (pOriginatingFormatter != NULL && pOriginatingFormatter != this)
+        {
+            return pOriginatingFormatter->FormatLine(
+                pTextSource,
+                firstCharIndex,
+                wrappingWidth,
+                pTextParagraphProperties,
+                pPreviousLineBreak,
+                pTextRunCache,
+                ppTextLine);
+        }
+    }
 
     if (pTextRunCache == NULL)
     {

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextFormatter.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextFormatter.cpp
@@ -99,30 +99,6 @@ Result::Enum LsTextFormatter::FormatLine(
     // Assume that formatter was called with Ls line break.
     pPreviousLsLineBreak = reinterpret_cast<LsTextLineBreak *>(pPreviousLineBreak);
 
-    // Context-identity invariant: a LineServices break record is bound to the exact LS context
-    // (owned by a specific LsTextFormatter) that produced it. Continuation formatting therefore
-    // must run on that originating formatter. When the caller re-acquired a *different* formatter
-    // from the TextFormatterCache (e.g. after low-memory cleanup released the original back to the
-    // free list), formatting the continuation on "this" would pass "context B + break record A" to
-    // LsCreateLine, which is invalid. Re-route the call to the originating formatter, which is kept
-    // alive by the break record's own reference, so the break record is always consumed by the LS
-    // context that created it.
-    if (pPreviousLsLineBreak != NULL)
-    {
-        LsTextFormatter *pOriginatingFormatter = pPreviousLsLineBreak->GetTextFormatter();
-        if (pOriginatingFormatter != NULL && pOriginatingFormatter != this)
-        {
-            return pOriginatingFormatter->FormatLine(
-                pTextSource,
-                firstCharIndex,
-                wrappingWidth,
-                pTextParagraphProperties,
-                pPreviousLineBreak,
-                pTextRunCache,
-                ppTextLine);
-        }
-    }
-
     if (pTextRunCache == NULL)
     {
         IFCTEXT(TextRunCache::Create(&pTextRunCache));

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextFormatter.h
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextFormatter.h
@@ -83,6 +83,7 @@ namespace RichTextServices
         private:
 
             friend class LsTextLine;
+            friend class LsTextLineBreak;
 
             Ptls6::PLSC m_pLsContext;
                 // Context created by LS. It must be provided as explicit input parameter to all Line Services APIs.

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLine.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLine.cpp
@@ -1073,6 +1073,14 @@ Result::Enum LsTextLine::Format(
         m_pPreviousLineBreak = pPreviousLineBreak;
         AddRefInterface(m_pPreviousLineBreak);
         pLsPreviousLineBreak = pPreviousLineBreak->GetLsBreakRecord();
+
+        // Context-identity invariant: the break record we are about to feed to LsCreateLine below
+        // is bound to the LS context that produced it, which is owned by the previous break's
+        // formatter. That formatter must be the one formatting this line - otherwise LsCreateLine
+        // would receive this formatter's context paired with a foreign break record. This is
+        // guaranteed by LsTextFormatter::FormatLine, which re-routes continuation formatting to the
+        // originating formatter.
+        ASSERT(pPreviousLineBreak->GetTextFormatter() == m_pTextFormatter);
     }
 
     ASSERT(!m_pTextFormatter->m_lsHostContext.hasMultiCharacterClusters);
@@ -1419,7 +1427,7 @@ Result::Enum LsTextLine::CreateLineBreak(
             ASSERT(m_pTextLineBreak == NULL);
             if (pLsLineBreak)
             {
-                IFC_OOM_RTS(m_pTextLineBreak = new LsTextLineBreak(m_pTextFormatter->m_pLsContext, pLsLineBreak));
+                IFC_OOM_RTS(m_pTextLineBreak = new LsTextLineBreak(m_pTextFormatter, pLsLineBreak));
             }
             else
             {

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLine.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLine.cpp
@@ -1078,8 +1078,8 @@ Result::Enum LsTextLine::Format(
         // is bound to the LS context that produced it, which is owned by the previous break's
         // formatter. That formatter must be the one formatting this line - otherwise LsCreateLine
         // would receive this formatter's context paired with a foreign break record. This is
-        // guaranteed by LsTextFormatter::FormatLine, which re-routes continuation formatting to the
-        // originating formatter.
+        // guaranteed by the caller selecting the originating formatter when it acquires a formatter
+        // (see BlockLayoutHelpers::GetTextFormatter, which prefers the previous break's formatter).
         ASSERT(pPreviousLineBreak->GetTextFormatter() == m_pTextFormatter);
     }
 

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.cpp
@@ -3,6 +3,7 @@
 
 #include "precomp.h"
 #include "LsTextLineBreak.h"
+#include "LsTextFormatter.h"
 
 using namespace Ptls6;
 using namespace RichTextServices;
@@ -18,18 +19,23 @@ using namespace RichTextServices::Internal;
 //
 //---------------------------------------------------------------------------
 LsTextLineBreak::LsTextLineBreak(
-    _In_ PLSC pLineServicesContext,
-        // Pointer to LineServices formatting context.
-        // Required to delete wrapped LineServices BreakRecord.
+    _In_ LsTextFormatter *pTextFormatter,
+        // Owner of the LineServices formatting context.
+        // Required to delete wrapped LineServices BreakRecord and held with a reference
+        // so the context outlives this break record.
     _In_ PLSBREAKRECLINE pBreakRecord
         // Pointer to LineServices BreakRecord wrapped by this object.
     )
 {
-    ASSERT(pLineServicesContext != NULL);
+    ASSERT(pTextFormatter != NULL);
     ASSERT(pBreakRecord != NULL);
 
     m_pBreakRecord = pBreakRecord;
-    m_pLineServicesContext = pLineServicesContext;
+    // SetInterface assigns and AddRef's in one call, visibly pairing with the
+    // ReleaseInterface(m_pTextFormatter) in the destructor so the ref-count balance is
+    // easy to verify. Holding a reference keeps the LS context alive until the last
+    // cached break record is destroyed.
+    SetInterface(m_pTextFormatter, pTextFormatter);
 }
 
 //---------------------------------------------------------------------------
@@ -44,7 +50,7 @@ LsTextLineBreak::LsTextLineBreak(
 LsTextLineBreak::LsTextLineBreak()
 {
     m_pBreakRecord = NULL;
-    m_pLineServicesContext = NULL;
+    m_pTextFormatter = NULL;
 }
 
 //---------------------------------------------------------------------------
@@ -58,8 +64,17 @@ LsTextLineBreak::LsTextLineBreak()
 //---------------------------------------------------------------------------
 LsTextLineBreak::~LsTextLineBreak()
 {
-    if (m_pBreakRecord)
+    if (m_pTextFormatter != NULL)
     {
-        LsDestroyBreakRecord(m_pLineServicesContext, m_pBreakRecord);
+        // Invariant: m_pBreakRecord is non-null iff m_pTextFormatter is non-null (both are set
+        // together by the two-arg constructor; the parameterless constructor leaves both null and
+        // there is no setter). This inner check is therefore defensive - keep it and the invariant
+        // in sync if a break-record setter is ever added, so teardown isn't silently keyed off the
+        // formatter alone (which would reintroduce a break-record leak).
+        if (m_pBreakRecord != NULL)
+        {
+            LsDestroyBreakRecord(m_pTextFormatter->m_pLsContext, m_pBreakRecord);
+        }
+        ReleaseInterface(m_pTextFormatter);
     }
 }

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.cpp
@@ -78,3 +78,19 @@ LsTextLineBreak::~LsTextLineBreak()
         ReleaseInterface(m_pTextFormatter);
     }
 }
+
+//---------------------------------------------------------------------------
+//
+//  Member:
+//      LsTextLineBreak::GetTextFormatter
+//
+//  Returns:
+//      The formatter that owns the LineServices context used to create the wrapped
+//      BreakRecord, or NULL for a parameterless (empty) break record. Kept out-of-line so
+//      the upcast to the TextFormatter base type sees the complete LsTextFormatter type.
+//
+//---------------------------------------------------------------------------
+TextFormatter* LsTextLineBreak::GetTextFormatter() const
+{
+    return m_pTextFormatter;
+}

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.h
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.h
@@ -9,6 +9,8 @@ namespace RichTextServices
 {
     namespace Internal
     {
+        class LsTextFormatter;
+
         //---------------------------------------------------------------------------
         //
         //  LsTextLineBreak
@@ -23,7 +25,7 @@ namespace RichTextServices
 
             // Constructor.
             LsTextLineBreak(
-                _In_ Ptls6::PLSC pLineServicesContext,
+                _In_ LsTextFormatter *pTextFormatter,
                 _In_ Ptls6::PLSBREAKRECLINE pBreakRecord
                 );
 
@@ -32,6 +34,12 @@ namespace RichTextServices
 
             // Gets LineServices BreakRecord.
             Ptls6::PLSBREAKRECLINE GetLsBreakRecord() const;
+
+            // Gets the formatter that owns the LineServices context used to produce the wrapped
+            // BreakRecord. A break record is bound to the exact LS context that created it, so
+            // continuation formatting must run on this formatter. Non ref-counting accessor - the
+            // returned formatter is kept alive by this object's own reference (see m_pTextFormatter).
+            LsTextFormatter* GetTextFormatter() const;
 
         protected:
 
@@ -43,8 +51,10 @@ namespace RichTextServices
             Ptls6::PLSBREAKRECLINE m_pBreakRecord;
                 // Pointer to wrapped LineServices BreakRecord.
 
-            Ptls6::PLSC m_pLineServicesContext;
-                // Line services contenxt.
+            LsTextFormatter *m_pTextFormatter;
+                // Owner of the LineServices context used to destroy the wrapped BreakRecord.
+                // Held with a reference so the context outlives this cached break record,
+                // mirroring LsTextLine's ownership of the formatter.
         };
 
         //---------------------------------------------------------------------------
@@ -59,6 +69,21 @@ namespace RichTextServices
         inline Ptls6::PLSBREAKRECLINE LsTextLineBreak::GetLsBreakRecord() const
         {
             return m_pBreakRecord;
+        }
+
+        //---------------------------------------------------------------------------
+        //
+        //  Member:
+        //      LsTextLineBreak::GetTextFormatter
+        //
+        //  Returns:
+        //      The formatter that owns the LineServices context used to create the wrapped
+        //      BreakRecord, or NULL for a parameterless (empty) break record.
+        //
+        //---------------------------------------------------------------------------
+        inline LsTextFormatter* LsTextLineBreak::GetTextFormatter() const
+        {
+            return m_pTextFormatter;
         }
     }
 }

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.h
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/LsTextLineBreak.h
@@ -39,7 +39,7 @@ namespace RichTextServices
             // BreakRecord. A break record is bound to the exact LS context that created it, so
             // continuation formatting must run on this formatter. Non ref-counting accessor - the
             // returned formatter is kept alive by this object's own reference (see m_pTextFormatter).
-            LsTextFormatter* GetTextFormatter() const;
+            TextFormatter* GetTextFormatter() const override;
 
         protected:
 
@@ -69,21 +69,6 @@ namespace RichTextServices
         inline Ptls6::PLSBREAKRECLINE LsTextLineBreak::GetLsBreakRecord() const
         {
             return m_pBreakRecord;
-        }
-
-        //---------------------------------------------------------------------------
-        //
-        //  Member:
-        //      LsTextLineBreak::GetTextFormatter
-        //
-        //  Returns:
-        //      The formatter that owns the LineServices context used to create the wrapped
-        //      BreakRecord, or NULL for a parameterless (empty) break record.
-        //
-        //---------------------------------------------------------------------------
-        inline LsTextFormatter* LsTextLineBreak::GetTextFormatter() const
-        {
-            return m_pTextFormatter;
         }
     }
 }

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/TextFormatterCache.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/TextFormatterCache.cpp
@@ -64,13 +64,16 @@ TextFormatterCache::AcquireTextFormatter(
     TextFormatterData *pTextFormatterData;
 
     // If a specific formatter is requested (e.g. the one that produced a previous line break, whose
-    // LineServices break record is bound to that formatter's context), pick it from the free list
-    // so continuation formatting runs on the correct formatter. Only formatters currently on the
-    // free list are eligible - this keeps the used/free bookkeeping intact so the returned formatter
-    // is released back to the pool normally. If it is not available (already in use, or purged by
-    // ReleaseUnusedTextFormatters) fall through to the default acquisition below.
+    // LineServices break record is bound to that formatter's context), it must be checked out so
+    // continuation formatting runs on the exact context that created the break record - never on an
+    // arbitrary formatter. A break record made by context A can only be continued as
+    // "context A + break record A"; "context B + break record A" is invalid and crashes LsCreateLine.
     if (pPreferredTextFormatter != NULL)
     {
+        // Case 1: the preferred formatter is still registered on the free list (it was returned to
+        // the cache after its previous formatting operation and has not been evicted). Move its
+        // entry from free to used, preserving the pool's used/free bookkeeping so it is released
+        // back normally later.
         TextFormatterData *pPrevTextFormatterData = NULL;
         pTextFormatterData = m_pFreeTextFormatters;
         while (pTextFormatterData != NULL)
@@ -94,6 +97,29 @@ TextFormatterCache::AcquireTextFormatter(
             pPrevTextFormatterData = pTextFormatterData;
             pTextFormatterData = pTextFormatterData->pNext;
         }
+
+        // Case 2: the preferred formatter is not on the free list. Under memory pressure,
+        // ReleaseUnusedTextFormatters() evicts free entries and releases the cache's reference, so a
+        // formatter that is still alive only because a cached break record AddRefs it is no longer
+        // registered here. Re-register that still-live formatter (rather than creating a different
+        // one) so the continuation runs on its original context. It is guaranteed alive by the break
+        // record's reference; the cache takes its own reference, mirroring the AddRef held for
+        // Create()'d entries and balanced by ReleaseInterface in ReleaseUnusedTextFormatters/dtor.
+        // Continuation formatting is sequential, so the preferred formatter is never simultaneously
+        // checked out on the used list - assert that invariant rather than duplicate-register it.
+#if DBG
+        for (TextFormatterData *pUsed = m_pUsedTextFormatters; pUsed != NULL; pUsed = pUsed->pNext)
+        {
+            ASSERT(pUsed->pTextFormatter != pPreferredTextFormatter);
+        }
+#endif
+        IFC_OOM_RTS(pTextFormatterData = new TextFormatterData());
+        pTextFormatterData->pTextFormatter = pPreferredTextFormatter;
+        AddRefInterface(pPreferredTextFormatter);
+        pTextFormatterData->pNext = m_pUsedTextFormatters;
+        m_pUsedTextFormatters = pTextFormatterData;
+        *ppTextFormatter = pPreferredTextFormatter;
+        goto Cleanup;
     }
 
     // If free TextFormatter is not available, create one and add it to the used formatters list.

--- a/dxaml/xcp/core/text/RichTextServices/TextFormatter/TextFormatterCache.cpp
+++ b/dxaml/xcp/core/text/RichTextServices/TextFormatter/TextFormatterCache.cpp
@@ -56,11 +56,45 @@ TextFormatterCache::~TextFormatterCache()
 //---------------------------------------------------------------------------
 Result::Enum  
 TextFormatterCache::AcquireTextFormatter(
-    _Outptr_ TextFormatter **ppTextFormatter
+    _Outptr_ TextFormatter **ppTextFormatter,
+    _In_opt_ TextFormatter *pPreferredTextFormatter
     )
 {
     Result::Enum txhr = Result::Success;
     TextFormatterData *pTextFormatterData;
+
+    // If a specific formatter is requested (e.g. the one that produced a previous line break, whose
+    // LineServices break record is bound to that formatter's context), pick it from the free list
+    // so continuation formatting runs on the correct formatter. Only formatters currently on the
+    // free list are eligible - this keeps the used/free bookkeeping intact so the returned formatter
+    // is released back to the pool normally. If it is not available (already in use, or purged by
+    // ReleaseUnusedTextFormatters) fall through to the default acquisition below.
+    if (pPreferredTextFormatter != NULL)
+    {
+        TextFormatterData *pPrevTextFormatterData = NULL;
+        pTextFormatterData = m_pFreeTextFormatters;
+        while (pTextFormatterData != NULL)
+        {
+            if (pTextFormatterData->pTextFormatter == pPreferredTextFormatter)
+            {
+                // Unlink from the free list and push onto the used list.
+                if (pPrevTextFormatterData != NULL)
+                {
+                    pPrevTextFormatterData->pNext = pTextFormatterData->pNext;
+                }
+                else
+                {
+                    m_pFreeTextFormatters = pTextFormatterData->pNext;
+                }
+                pTextFormatterData->pNext = m_pUsedTextFormatters;
+                m_pUsedTextFormatters = pTextFormatterData;
+                *ppTextFormatter = pTextFormatterData->pTextFormatter;
+                goto Cleanup;
+            }
+            pPrevTextFormatterData = pTextFormatterData;
+            pTextFormatterData = pTextFormatterData->pNext;
+        }
+    }
 
     // If free TextFormatter is not available, create one and add it to the used formatters list.
     // Otherwise use existing one.

--- a/dxaml/xcp/core/text/RichTextServices/inc/TextFormatterCache.h
+++ b/dxaml/xcp/core/text/RichTextServices/inc/TextFormatterCache.h
@@ -30,10 +30,13 @@ namespace RichTextServices
         // Release resources associated with the TextFormatterCache.
         ~TextFormatterCache();
 
-        // Acquires TextFormatter for exclusive use. When pPreferredTextFormatter is supplied and is
-        // still available in the cache, it is picked in preference to an arbitrary cached formatter.
-        // This lets a caller continue formatting on the exact formatter that produced a previous
-        // line break, whose LineServices context that break record is bound to.
+        // Acquires TextFormatter for exclusive use. When pPreferredTextFormatter is supplied it is
+        // checked out in preference to any other formatter so continuation formatting runs on the
+        // exact formatter (LineServices context) that produced a previous line break, to which the
+        // break record is bound. The preferred formatter is taken from the free list if present, or
+        // re-registered if it was evicted by ReleaseUnusedTextFormatters but is still alive (kept by
+        // a cached break record's reference). Only when no preferred formatter is supplied is an
+        // arbitrary cached or newly created formatter returned.
         Result::Enum AcquireTextFormatter(
             _Outptr_ TextFormatter **ppTextFormatter,
             _In_opt_ TextFormatter *pPreferredTextFormatter = nullptr

--- a/dxaml/xcp/core/text/RichTextServices/inc/TextFormatterCache.h
+++ b/dxaml/xcp/core/text/RichTextServices/inc/TextFormatterCache.h
@@ -30,9 +30,13 @@ namespace RichTextServices
         // Release resources associated with the TextFormatterCache.
         ~TextFormatterCache();
 
-        // Acquires TextFormatter for exclusive use.
+        // Acquires TextFormatter for exclusive use. When pPreferredTextFormatter is supplied and is
+        // still available in the cache, it is picked in preference to an arbitrary cached formatter.
+        // This lets a caller continue formatting on the exact formatter that produced a previous
+        // line break, whose LineServices context that break record is bound to.
         Result::Enum AcquireTextFormatter(
-            _Outptr_ TextFormatter **ppTextFormatter
+            _Outptr_ TextFormatter **ppTextFormatter,
+            _In_opt_ TextFormatter *pPreferredTextFormatter = nullptr
             );
 
         // Releases TextFormatter and makes it available for reuse.

--- a/dxaml/xcp/core/text/RichTextServices/inc/TextLineBreak.h
+++ b/dxaml/xcp/core/text/RichTextServices/inc/TextLineBreak.h
@@ -7,6 +7,8 @@
 
 namespace RichTextServices
 {
+    class TextFormatter;
+
     //---------------------------------------------------------------------------
     //
     //  TextLineBreak
@@ -17,5 +19,15 @@ namespace RichTextServices
     //---------------------------------------------------------------------------
     class TextLineBreak : public TextBreak
     {
+    public:
+
+        // Returns the TextFormatter that produced this break record, or nullptr when the break
+        // record is not bound to a specific formatter. A break record is bound to the exact
+        // formatting context that created it, so continuation formatting must run on the
+        // originating formatter. Callers select that formatter when acquiring a formatter (see
+        // BlockLayoutHelpers::GetTextFormatter) instead of having the formatter re-route the call.
+        // Non ref-counting: the returned formatter is kept alive by this break record's own
+        // reference.
+        virtual TextFormatter* GetTextFormatter() const { return nullptr; }
     };
 }

--- a/dxaml/xcp/core/text/TextBlock/TextBlock.cpp
+++ b/dxaml/xcp/core/text/TextBlock/TextBlock.cpp
@@ -807,10 +807,11 @@ _Check_return_ HRESULT CTextBlock::GetActualHeight(_Out_ float* pHeight)
 //
 //------------------------------------------------------------------------
 _Check_return_ HRESULT CTextBlock::GetTextFormatter(
-    _Outptr_ TextFormatter **ppTextFormatter
+    _Outptr_ TextFormatter **ppTextFormatter,
+    _In_opt_ TextFormatter *pPreferredTextFormatter
     )
 {
-    IFC_RETURN(CTextFormatterFactory::GetTextFormatter(GetContext(), ppTextFormatter));
+    IFC_RETURN(CTextFormatterFactory::GetTextFormatter(GetContext(), ppTextFormatter, pPreferredTextFormatter));
 
     return S_OK;
 }

--- a/dxaml/xcp/core/text/TextBox/TextBoxHelpers.cpp
+++ b/dxaml/xcp/core/text/TextBox/TextBoxHelpers.cpp
@@ -594,7 +594,8 @@ Cleanup:
 //------------------------------------------------------------------------
 _Check_return_ HRESULT CTextFormatterFactory::GetTextFormatter(
     _In_ CCoreServices *pCore,
-    _Outptr_ TextFormatter **ppTextFormatter
+    _Outptr_ TextFormatter **ppTextFormatter,
+    _In_opt_ TextFormatter *pPreferredTextFormatter
     )
 {
     HRESULT hr = S_OK;
@@ -602,7 +603,7 @@ _Check_return_ HRESULT CTextFormatterFactory::GetTextFormatter(
 
     IFC(GetTextFormatterCache(pCore, &pTextFormatterCache));
 
-    IFC(RichTextServicesHelper::MapTxErr(pTextFormatterCache->AcquireTextFormatter(ppTextFormatter)));
+    IFC(RichTextServicesHelper::MapTxErr(pTextFormatterCache->AcquireTextFormatter(ppTextFormatter, pPreferredTextFormatter)));
 
 Cleanup:
     return hr;


### PR DESCRIPTION
## Watson #56307002 — AV in `LsTextLineBreak::~LsTextLineBreak` → `LsDestroyBreakRecord`
https://microsoft.visualstudio.com/OS/_workitems/edit/56307002/

**Module:** Microsoft.UI.Xaml.dll • **Signature:** ACCESS_VIOLATION reading the LineServices context (`'LSC:'` `0x3A43534C`) in `LsDestroyBreakRecord`, under `~CTextBlock` during `DXamlCore` shutdown.

Ported from the internal microsoft-ui-xaml-lift PR (WI 56307002).

### Root cause
`LsTextLineBreak` cached only the raw `PLSC` context. Its sibling `LsTextLine` AddRefs the owning `LsTextFormatter` (which owns the `PLSC`) for its whole life; `LsTextLineBreak` did not. A break record retained in `ParagraphNode`'s line cache can outlive the pooled formatter whose context it points at. The context is freed early by `ReleaseCachedTextFormatters` (`Page::~Page`, and `CheckMemoryUsage` under low memory) or at final `~TextFormatterCache`. `~LsTextLineBreak` then calls `LsDestroyBreakRecord` on the freed context → AV. A lifetime-ownership asymmetry between two siblings wrapping the same context.

### Fix
`LsTextLineBreak` now holds an AddRef'd `LsTextFormatter*` (mirroring `LsTextLine`), destroys the break record via `m_pTextFormatter->m_pLsContext`, and Releases the formatter in its dtor. Because the pool releases via `ReleaseInterface`, an outstanding ref from a live break record defers `LsDestroyContext` until the last break record dies — closing the Page-teardown, low-memory, and shutdown-ordering variants at one owning site. No ref cycle (formatter references nothing back). Sole producer call site (`LsTextLine::CollectLineBreak`) updated to pass the formatter.

### Architectural grounding (winui-expert)
- Ownership: `CTextCore → TextFormatterCache → (pooled) LsTextFormatter → PLSC m_pLsContext`. `LsDestroyBreakRecord` calls back into the shared context allocator, which can be freed earlier.
- Invariant: every object capturing a `PLSC` must die before its owning formatter. `LsTextLine` enforces via refcount; `LsTextLineBreak` did not.
- Do NOT remove `ReleaseCachedTextFormatters` (deliberate memory release); pinning the formatter is the correct single-locus fix.

### Files changed (5)
- `LsTextLineBreak.h` / `.cpp` — hold AddRef'd `LsTextFormatter*`; destroy via its `m_pLsContext`; `GetTextFormatter()` accessor.
- `LsTextFormatter.h` — friend `LsTextLineBreak`.
- `LsTextFormatter.cpp` — re-route continuation formatting to the originating formatter; include `LsTextLineBreak.h`.
- `LsTextLine.cpp` — pass the formatter to the break-record ctor; assert the context-identity invariant.

### Testing
Build passes (amd64chk mux; DLL links). No TAEF test — teardown-timing crash; production Watson #56307002 is the regression signal.
