### PR TITLE
NavigationView::BumperNavigation: use footer ItemsSourceView count so shoulder navigation reaches FooterMenuItemsSource items

### DIFF
--- a/controls/dev/NavigationView/NavigationView.cpp
+++ b/controls/dev/NavigationView/NavigationView.cpp
@@ -3188,7 +3188,9 @@ bool NavigationView::BumperNavigation(int offset)
             const auto topPrimaryListSize = m_topDataProvider.GetPrimaryListSize();
 
             auto footerRepeater = m_topNavFooterMenuRepeater.get();
-            auto footerItemsSize = FooterMenuItems().Size();
+            // Use the footer ItemsSourceView count so this works for both FooterMenuItems and
+            // FooterMenuItemsSource (FooterMenuItems() is empty when FooterMenuItemsSource is bound).
+            auto footerItemsSize = m_footerItemsSource ? m_footerItemsSource.Count() : 0;
 
             if (IsSettingsVisible())
             {

--- a/controls/dev/NavigationView/NavigationView_InteractionTests/FocusBehaviorTests.cs
+++ b/controls/dev/NavigationView/NavigationView_InteractionTests/FocusBehaviorTests.cs
@@ -851,5 +851,78 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTes
                 return FindElement.ByName("SelectionChangedResult").GetText();
             }
         }
+
+        [TestMethod]
+        public void VerifyShoulderNavigationReachesFooterMenuItemsSourceItems()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "NavigationViewFooterMenuItemsSourcePage" }))
+            {
+                var navView = FindElement.ByName("NavView");
+
+                Log.Comment("Select the first main menu item to start.");
+                FindElement.ByName("Main 0").Click();
+                Wait.ForIdle();
+                Verify.AreEqual("Main 0", GetSelectedItem());
+
+                // Forward (right shoulder): walk the main list, then cross into the bound footer.
+                // FooterMenuItemsSource is bound, so FooterMenuItems() is empty. Without the fix the
+                // footer count comes back as 0 (or 1 with Settings visible), so selection saturates at
+                // the first footer item instead of walking through the rest.
+                Log.Comment("Walk forward from the main list into the footer items.");
+                string[] forwardTrail = { "Main 1", "Main 2", "Footer 0", "Footer 1", "Footer 2" };
+                foreach (var expected in forwardTrail)
+                {
+                    PressShoulderUntilSelected(navView, GamepadButton.RightShoulder, expected);
+                }
+
+                // Backward (left shoulder): walk back through the footer, then cross into the main list.
+                // Without the fix the in-footer walk reports "nothing here" and the offset < 0 fallback
+                // jumps straight to the main list, so the intermediate footer items are skipped.
+                Log.Comment("Walk backward from the footer items into the main list.");
+                string[] backwardTrail = { "Footer 1", "Footer 0", "Main 2", "Main 1", "Main 0" };
+                foreach (var expected in backwardTrail)
+                {
+                    PressShoulderUntilSelected(navView, GamepadButton.LeftShoulder, expected);
+                }
+            }
+
+            string GetSelectedItem()
+            {
+                return FindElement.ByName("SelectionChangedResult").GetText();
+            }
+
+            // Injected shoulder presses are occasionally dropped, so give each step a retry budget.
+            // A press that leaves the selection unchanged is treated as a dropped keystroke and retried;
+            // a press that moves the selection to the wrong item is a real ordering bug and fails
+            // immediately. This keeps a lost keystroke from looking identical to a skipped item.
+            void PressShoulderUntilSelected(UIObject navView, GamepadButton button, string expected)
+            {
+                const int maxAttempts = 5;
+                string before = GetSelectedItem();
+
+                for (int attempt = 1; attempt <= maxAttempts; attempt++)
+                {
+                    GamepadHelper.PressButton(navView, button);
+                    Wait.ForIdle();
+
+                    string after = GetSelectedItem();
+                    if (after == expected)
+                    {
+                        return;
+                    }
+
+                    if (after != before)
+                    {
+                        // Selection moved but not to the expected item: a real ordering bug, not a dropped press.
+                        Verify.AreEqual(expected, after, "Shoulder navigation reached the wrong item.");
+                        return;
+                    }
+
+                    Log.Comment("Shoulder press appears dropped (selection still '{0}', attempt {1}/{2}), retrying.", before, attempt, maxAttempts);
+                }
+
+                Verify.AreEqual(expected, GetSelectedItem(), "Shoulder navigation never reached the expected item.");
+            }
+        }
     }
 }

--- a/controls/dev/NavigationView/TestUI/Common/NavigationViewFooterMenuItemsSourcePage.xaml
+++ b/controls/dev/NavigationView/TestUI/Common/NavigationViewFooterMenuItemsSourcePage.xaml
@@ -1,0 +1,32 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<local:TestPage
+    x:Class="MUXControlsTestApp.NavigationViewFooterMenuItemsSourcePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <StackPanel>
+            <muxcontrols:NavigationView
+                Width="1000"
+                x:Name="NavView"
+                AutomationProperties.Name="NavView"
+                AutomationProperties.AutomationId="NavView"
+                PaneDisplayMode="Top"
+                IsSettingsVisible="True"
+                ShoulderNavigationEnabled="Always"
+                FooterMenuItemsSource="{x:Bind FooterItems}">
+                <muxcontrols:NavigationView.MenuItems>
+                    <muxcontrols:NavigationViewItem x:Name="MainItem0" Content="Main 0" AutomationProperties.Name="Main 0" />
+                    <muxcontrols:NavigationViewItem x:Name="MainItem1" Content="Main 1" AutomationProperties.Name="Main 1" />
+                    <muxcontrols:NavigationViewItem x:Name="MainItem2" Content="Main 2" AutomationProperties.Name="Main 2" />
+                </muxcontrols:NavigationView.MenuItems>
+            </muxcontrols:NavigationView>
+            <TextBox x:Name="SelectionChangedResult" AutomationProperties.Name="SelectionChangedResult" />
+        </StackPanel>
+    </Grid>
+</local:TestPage>

--- a/controls/dev/NavigationView/TestUI/Common/NavigationViewFooterMenuItemsSourcePage.xaml.cs
+++ b/controls/dev/NavigationView/TestUI/Common/NavigationViewFooterMenuItemsSourcePage.xaml.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.ObjectModel;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+
+using NavigationView = Microsoft.UI.Xaml.Controls.NavigationView;
+using NavigationViewItem = Microsoft.UI.Xaml.Controls.NavigationViewItem;
+using NavigationViewSelectionChangedEventArgs = Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs;
+
+namespace MUXControlsTestApp
+{
+    public sealed partial class NavigationViewFooterMenuItemsSourcePage : TestPage
+    {
+        public ObservableCollection<NavigationViewItem> FooterItems { get; } = new ObservableCollection<NavigationViewItem>();
+
+        public NavigationViewFooterMenuItemsSourcePage()
+        {
+            this.InitializeComponent();
+
+            FooterItems.Add(CreateFooterItem("Footer 0"));
+            FooterItems.Add(CreateFooterItem("Footer 1"));
+            FooterItems.Add(CreateFooterItem("Footer 2"));
+
+            NavView.SelectionChanged += NavView_SelectionChanged;
+        }
+
+        private static NavigationViewItem CreateFooterItem(string name)
+        {
+            var item = new NavigationViewItem { Content = name };
+            AutomationProperties.SetName(item, name);
+            return item;
+        }
+
+        private void NavView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs e)
+        {
+            if (e.SelectedItemContainer is NavigationViewItem container)
+            {
+                SelectionChangedResult.Text = container.Content?.ToString() ?? "Null";
+            }
+            else
+            {
+                SelectionChangedResult.Text = "Null";
+            }
+        }
+    }
+}

--- a/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml
+++ b/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml
@@ -49,6 +49,7 @@
                 <Button x:Name="NavigationViewBlankPage1" AutomationProperties.Name="NavigationView Blank Test1" Margin="2" HorizontalAlignment="Stretch">NavigationView Blank Test1</Button>
                 <Button x:Name="NavigationViewMenuItemStretchPageButton" AutomationProperties.Name="NavigationView Menuitem Stretch Test" Margin="2" HorizontalAlignment="Stretch">NavigationView Menuitem Stretch Test</Button>
                 <Button x:Name="NavigationViewMenuItemsSourcePage" AutomationProperties.Name="NavigationViewMenuItemsSourcePage" Margin="2" HorizontalAlignment="Stretch">NavigationView MenuItemsSource</Button>
+                <Button x:Name="NavigationViewFooterMenuItemsSourcePage" AutomationProperties.Name="NavigationViewFooterMenuItemsSourcePage" Margin="2" HorizontalAlignment="Stretch">NavigationView FooterMenuItemsSource</Button>
                 <TextBlock Text="Hierarchy Tests" />
                 <Button x:Name="NavigateToHierarchicalNavigationViewMarkupPage" AutomationProperties.Name="HierarchicalNavigationView Markup Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView Markup Test</Button>
                 <Button x:Name="NavigateToHierarchicalNavigationViewDataBindingPage" AutomationProperties.Name="HierarchicalNavigationView DataBinding Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView DataBinding Test</Button>

--- a/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml.cs
+++ b/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml.cs
@@ -31,6 +31,7 @@ namespace MUXControlsTestApp
             NavigateToInitPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewInitPage), 0); };
             NavigateToStretchPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewStretchPage), 0); };
             NavigationViewMenuItemsSourcePage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewMenuItemsSourcePage), 0); };
+            NavigationViewFooterMenuItemsSourcePage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewFooterMenuItemsSourcePage), 0); };
             NavigateToItemTemplatePage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewItemTemplatePage), 0); };
             NavigationViewCustomMenuItemPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewCustomMenuItemPage), 0); };
             NavigateToRS3Page.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewRS3Page), 0); };

--- a/controls/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
+++ b/controls/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
@@ -66,6 +66,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Common\NavigationViewFooterMenuItemsSourcePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Regression\NavigationViewRS3Page.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -172,6 +176,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Common\NavigationViewMenuItemsSourcePage.xaml.cs">
       <DependentUpon>NavigationViewMenuItemsSourcePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Common\NavigationViewFooterMenuItemsSourcePage.xaml.cs">
+      <DependentUpon>NavigationViewFooterMenuItemsSourcePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Regression\NavigationViewRS3Page.xaml.cs">
       <DependentUpon>NavigationViewRS3Page.xaml</DependentUpon>


### PR DESCRIPTION
Fixes the case where gamepad shoulder navigation cannot reach footer items when `FooterMenuItemsSource` is bound.

Description:
With `FooterMenuItemsSource` bound, shoulder navigation could not move the selection into the footer. Forward navigation stalled at the last main menu item (or at the first footer item when Settings was visible), and backward navigation from a footer item jumped straight to the main list, skipping the remaining footer items. Inline `FooterMenuItems` was unaffected.

Root cause:
`BumperNavigation` sized the footer walk from `FooterMenuItems().Size()`. That inline collection is empty when `FooterMenuItemsSource` is bound, so the cap was 0 (1 with Settings visible) and `SelectSelectableItemWithOffset` never entered its loop.

Fix:
```cpp
auto footerItemsSize = m_footerItemsSource ? m_footerItemsSource.Count() : 0;
```
`m_footerItemsSource` is the `ItemsSourceView` NavigationView already maintains for that collection. It wraps `FooterMenuItems()` when no source is bound, so inline behavior is unchanged. The existing `IsSettingsVisible()` increment still applies, matching the settings item appended to the footer repeater's item list.

Behavior:
Forward walks main -> every footer item; backward walks the footer in order before crossing into the main list.

Testing:
Adds `VerifyShoulderNavigationReachesFooterMenuItemsSourceItems` plus a `NavigationViewFooterMenuItemsSourcePage` test page that binds `FooterMenuItemsSource` and asserts the full selection trail in both directions.

Verified with an A/B harness over three builds of `Microsoft.UI.Xaml.Controls.dll` from the same tree (22 scenarios x 2 repetitions, deterministic):

| leg | result |
| --- | --- |
| baseline | 5 failures, all bound-`FooterMenuItemsSource` shoulder cases; inline footer cases pass |
| with this fix | 0 failures |
| shared-`ItemsSourceView` guard reverted (control) | reproduces the earlier collection-mutation AV, confirming that separate fix is already in main and is unrelated to this change |

Note on the test page: it uses `NavigationViewItem`s directly rather than data items with a `MenuItemTemplate`, because `NavigationViewItemsFactory::GetElementCore` applies the template to every data item, which would re-template the inline `MenuItems` and make `AutomationProperties.Name="{Binding Name}"` resolve to `FrameworkElement.Name` instead of the content. The page width and short item names keep every main menu item in the top nav primary list, since `BumperNavigation` intentionally skips items in the overflow menu.
