### PR TITLE
Add Copilot skill: scaffold monthly WinAppSDK experimental samples

### DIFF
--- a/.github/skills/creating-winappsdk-experimental-sample/New-WinAppSdkSample.ps1
+++ b/.github/skills/creating-winappsdk-experimental-sample/New-WinAppSdkSample.ps1
@@ -1,0 +1,325 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Scaffolds, builds, and (optionally) launches a minimal self-contained WinUI 3
+    desktop app that references a specific experimental Windows App SDK release.
+
+.DESCRIPTION
+    Windows App SDK ships an "experimental" channel roughly once a month
+    (for example 2.3.2-experimentalA). This script produces a tiny, known-good
+    WinUI 3 sample wired to that exact package version so the release can be
+    smoke-tested end to end (restore -> build -> launch).
+
+    It is resilient to two common environment problems:
+      1. A broken / private-only NuGet setup - it writes an isolated nuget.config
+         that uses only nuget.org and neutralizes NUGET_PLUGIN_PATHS.
+      2. A machine with no Windows SDK targeting pack installed - the .NET SDK
+         refuses to pull Microsoft.Windows.SDK.NET.Ref from nuget.org and only
+         looks in the offline "library-packs" folder. When the pack is missing,
+         the script downloads the nupkg and materializes a valid v3 *fallback
+         package folder*, then registers it in nuget.config.
+
+.PARAMETER Version
+    Windows App SDK package version, e.g. '2.3.2-experimentalA'.
+    Default: the newest '*experimental*' version published on nuget.org.
+
+.PARAMETER OutputDir
+    Folder to generate the app into. Default: $HOME\WinAppSdkSamples\WinUISample-<Version>.
+    Keep this OUTSIDE any repo that uses Central Package Management / Directory.Build.props.
+
+.PARAMETER Platform
+    x64 (default), x86, or arm64.
+
+.PARAMETER TargetFramework
+    Default 'net9.0-windows10.0.22621.0'.
+
+.PARAMETER WindowsSdkPackageVersion
+    Windows SDK projection pack version. Default: newest stable pack matching the
+    TFM's platform band (e.g. 10.0.22621.*) on nuget.org.
+
+.PARAMETER Launch
+    Launch the built app.
+
+.PARAMETER NoBuild
+    Only generate files; skip restore/build.
+
+.EXAMPLE
+    # Recommended: auto-detect and build/launch the latest monthly experimental release.
+    .\New-WinAppSdkSample.ps1 -Launch
+
+.EXAMPLE
+    # Pin an explicit release id (any experimental version published on nuget.org):
+    .\New-WinAppSdkSample.ps1 -Version <MAJOR.MINOR.PATCH-experimentalX> -Launch
+#>
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$OutputDir,
+    [ValidateSet('x64', 'x86', 'arm64')]
+    [string]$Platform = 'x64',
+    [string]$TargetFramework = 'net9.0-windows10.0.22621.0',
+    [string]$TargetPlatformMinVersion = '10.0.17763.0',
+    [string]$WindowsSdkPackageVersion,
+    [switch]$Launch,
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$AppName = 'WinAppSdkSample'
+$feed = 'https://api.nuget.org/v3/index.json'
+$flat = 'https://api.nuget.org/v3-flatcontainer'
+
+function Get-Versions([string]$id) {
+    (Invoke-RestMethod "$flat/$id/index.json" -UseBasicParsing).versions
+}
+
+function Select-LatestVersion([string[]]$versions) {
+    # Order-independent, SemVer-aware "highest version" selection. Does NOT rely on
+    # the order the feed returns. Sorts by the numeric base version first, then by
+    # the prerelease label; a release with no prerelease outranks the same base with
+    # one (SemVer rule), achieved by mapping "no prerelease" to a label that sorts last.
+    ($versions | ForEach-Object {
+            $dash = $_.IndexOf('-')
+            if ($dash -ge 0) { $base = $_.Substring(0, $dash); $pre = $_.Substring($dash + 1) }
+            else { $base = $_; $pre = [char]0xFFEF }  # sorts after any real prerelease label
+            [pscustomobject]@{ Raw = $_; Base = [version]$base; Pre = $pre }
+        } | Sort-Object -Property Base, Pre)[-1].Raw
+}
+
+# --- Resolve the Windows App SDK version --------------------------------------
+if (-not $Version) {
+    Write-Host 'Detecting latest experimental Windows App SDK version...'
+    $exp = Get-Versions 'microsoft.windowsappsdk' | Where-Object { $_ -match '-experimental' }
+    if (-not $exp) { throw 'No experimental Microsoft.WindowsAppSDK versions found on nuget.org.' }
+    $Version = Select-LatestVersion $exp
+}
+Write-Host "Windows App SDK version: $Version"
+
+# --- Derive the platform band and resolve the ref-pack version ----------------
+if ($TargetFramework -match 'windows(\d+\.\d+\.\d+)\.\d+') { $band = $Matches[1] } else { $band = '10.0.22621' }
+if (-not $WindowsSdkPackageVersion) {
+    $stable = Get-Versions 'microsoft.windows.sdk.net.ref' | Where-Object { $_ -like "$band.*" -and $_ -notmatch 'preview' }
+    if (-not $stable) { throw "No stable Microsoft.Windows.SDK.NET.Ref $band.* versions found on nuget.org." }
+    $WindowsSdkPackageVersion = Select-LatestVersion $stable
+}
+Write-Host "Windows SDK projection pack: $WindowsSdkPackageVersion"
+
+# --- Resolve paths ------------------------------------------------------------
+if (-not $OutputDir) { $OutputDir = Join-Path $HOME "WinAppSdkSamples\WinUISample-$Version" }
+$rid = @{ x64 = 'win-x64'; x86 = 'win-x86'; arm64 = 'win-arm64' }[$Platform]
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+Write-Host "Output directory: $OutputDir"
+
+# --- Ensure the Windows SDK ref pack is resolvable ----------------------------
+# The .NET SDK treats Microsoft.Windows.SDK.NET.Ref as a targeting pack and only
+# looks in the offline library-packs fallback folder. If it is not installed,
+# materialize a local v3 fallback folder from the nuget.org nupkg.
+$fallbackRoot = Join-Path $OutputDir '.fallback'
+$id = 'microsoft.windows.sdk.net.ref'
+$installedPack = Test-Path (Join-Path $env:ProgramFiles "dotnet\packs\Microsoft.Windows.SDK.NET.Ref\$WindowsSdkPackageVersion")
+$inLibPacks = Test-Path (Join-Path $env:ProgramFiles "dotnet\library-packs\$id.$WindowsSdkPackageVersion.nupkg")
+$useFallback = -not ($installedPack -or $inLibPacks)
+
+if ($useFallback) {
+    $dir = Join-Path $fallbackRoot "$id\$WindowsSdkPackageVersion"
+    $sha512File = Join-Path $dir "$id.$WindowsSdkPackageVersion.nupkg.sha512"
+    if (-not (Test-Path $sha512File)) {
+        Write-Host 'No Windows SDK targeting pack installed - building local fallback folder...'
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        $nupkg = Join-Path $dir "$id.$WindowsSdkPackageVersion.nupkg"
+        Invoke-WebRequest "$flat/$id/$WindowsSdkPackageVersion/$id.$WindowsSdkPackageVersion.nupkg" -OutFile $nupkg -UseBasicParsing
+        $zip = "$nupkg.zip"; Copy-Item $nupkg $zip -Force
+        Expand-Archive -Path $zip -DestinationPath $dir -Force; Remove-Item $zip -Force
+        $sha = [System.Security.Cryptography.SHA512]::Create()
+        $hashB64 = [Convert]::ToBase64String($sha.ComputeHash([System.IO.File]::ReadAllBytes($nupkg)))
+        Set-Content -Path $sha512File -Value $hashB64 -NoNewline -Encoding ascii
+        Set-Content -Path (Join-Path $dir '.nupkg.metadata') -Value ('{"version":2,"contentHash":"' + $hashB64 + '","source":"' + $feed + '"}') -NoNewline -Encoding ascii
+    }
+}
+
+# --- File templates (placeholders are replaced below) -------------------------
+$csproj = @'
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>__TFM__</TargetFramework>
+    <TargetPlatformMinVersion>__MINVER__</TargetPlatformMinVersion>
+    <WindowsSdkPackageVersion>__WINSDKPKG__</WindowsSdkPackageVersion>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <RootNamespace>WinAppSdkSample</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>__PLATFORM__</Platforms>
+    <RuntimeIdentifiers>__RID__</RuntimeIdentifiers>
+    <UseWinUI>true</UseWinUI>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <WindowsPackageType>None</WindowsPackageType>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="__VERSION__" />
+  </ItemGroup>
+
+</Project>
+'@
+
+$nugetFallback = @'
+  <fallbackPackageFolders>
+    <add key="local-winsdk-ref" value="__FALLBACK__" />
+  </fallbackPackageFolders>
+'@
+
+$nugetConfig = @'
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+__FALLBACKBLOCK__</configuration>
+'@
+
+$manifest = @'
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="WinAppSdkSample.app" />
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>
+'@
+
+$appXaml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="WinAppSdkSample.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>
+'@
+
+$appCs = @'
+using Microsoft.UI.Xaml;
+
+namespace WinAppSdkSample;
+
+public partial class App : Application
+{
+    private Window? _window;
+
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window = new MainWindow();
+        _window.Activate();
+    }
+}
+'@
+
+$mainXaml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="WinAppSdkSample.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="WinAppSDK Experimental Sample">
+    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="12">
+        <TextBlock
+            Text="Hello from Windows App SDK __VERSION__!"
+            FontSize="24"
+            HorizontalAlignment="Center" />
+        <Button
+            x:Name="myButton"
+            Click="myButton_Click"
+            Content="Click Me"
+            HorizontalAlignment="Center" />
+    </StackPanel>
+</Window>
+'@
+
+$mainCs = @'
+using Microsoft.UI.Xaml;
+
+namespace WinAppSdkSample;
+
+public sealed partial class MainWindow : Window
+{
+    private int _count;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void myButton_Click(object sender, RoutedEventArgs e)
+    {
+        _count++;
+        myButton.Content = $"Clicked {_count} time(s)";
+    }
+}
+'@
+
+# --- Substitute placeholders and write files ----------------------------------
+$csproj = $csproj.Replace('__TFM__', $TargetFramework).Replace('__MINVER__', $TargetPlatformMinVersion).Replace('__WINSDKPKG__', $WindowsSdkPackageVersion).Replace('__PLATFORM__', $Platform).Replace('__RID__', $rid).Replace('__VERSION__', $Version)
+$fallbackBlock = if ($useFallback) { $nugetFallback.Replace('__FALLBACK__', $fallbackRoot) } else { '' }
+$nugetConfig = $nugetConfig.Replace('__FALLBACKBLOCK__', $fallbackBlock)
+$mainXaml = $mainXaml.Replace('__VERSION__', $Version)
+
+Set-Content -Path (Join-Path $OutputDir "$AppName.csproj") -Value $csproj -Encoding utf8
+Set-Content -Path (Join-Path $OutputDir 'nuget.config')     -Value $nugetConfig -Encoding utf8
+Set-Content -Path (Join-Path $OutputDir 'app.manifest')     -Value $manifest -Encoding utf8
+Set-Content -Path (Join-Path $OutputDir 'App.xaml')         -Value $appXaml -Encoding utf8
+Set-Content -Path (Join-Path $OutputDir 'App.xaml.cs')      -Value $appCs -Encoding utf8
+Set-Content -Path (Join-Path $OutputDir 'MainWindow.xaml')  -Value $mainXaml -Encoding utf8
+Set-Content -Path (Join-Path $OutputDir 'MainWindow.xaml.cs') -Value $mainCs -Encoding utf8
+Write-Host 'Generated project files.'
+
+if ($NoBuild) { Write-Host 'Skipping build (-NoBuild).'; return }
+
+# --- Restore + build ----------------------------------------------------------
+$env:NUGET_PLUGIN_PATHS = ''   # neutralize a broken/absent NuGet credential provider
+Push-Location $OutputDir
+try {
+    Write-Host 'Building...'
+    & dotnet build -c Debug -p:Platform=$Platform -p:EnableWindowsTargeting=true
+    if ($LASTEXITCODE -ne 0) { throw "dotnet build failed with exit code $LASTEXITCODE." }
+}
+finally {
+    Pop-Location
+}
+
+$exe = Join-Path $OutputDir "bin\$Platform\Debug\$TargetFramework\$AppName.exe"
+if (-not (Test-Path $exe)) { throw "Build reported success but the exe was not found at: $exe" }
+Write-Host "Build succeeded: $exe"
+
+if ($Launch) {
+    $p = Start-Process -FilePath $exe -PassThru
+    Start-Sleep -Seconds 5
+    if (Get-Process -Id $p.Id -ErrorAction SilentlyContinue) {
+        Write-Host "Launched (PID $($p.Id)) - app is running."
+    }
+    else {
+        throw "App exited immediately (exit code $($p.ExitCode))."
+    }
+}

--- a/.github/skills/creating-winappsdk-experimental-sample/New-WinAppSdkSample.ps1
+++ b/.github/skills/creating-winappsdk-experimental-sample/New-WinAppSdkSample.ps1
@@ -298,7 +298,10 @@ Write-Host 'Generated project files.'
 if ($NoBuild) { Write-Host 'Skipping build (-NoBuild).'; return }
 
 # --- Restore + build ----------------------------------------------------------
-$env:NUGET_PLUGIN_PATHS = ''   # neutralize a broken/absent NuGet credential provider
+# Neutralize a broken/absent NuGet credential provider for this restore only. Save the caller's
+# value first and restore it in finally so later restores in the same session keep their provider.
+$prevNugetPluginPaths = $env:NUGET_PLUGIN_PATHS
+$env:NUGET_PLUGIN_PATHS = ''
 Push-Location $OutputDir
 try {
     Write-Host 'Building...'
@@ -306,6 +309,8 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "dotnet build failed with exit code $LASTEXITCODE." }
 }
 finally {
+    # Assigning $null (when it was unset) removes the variable, faithfully restoring the prior state.
+    $env:NUGET_PLUGIN_PATHS = $prevNugetPluginPaths
     Pop-Location
 }
 

--- a/.github/skills/creating-winappsdk-experimental-sample/SKILL.md
+++ b/.github/skills/creating-winappsdk-experimental-sample/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: creating-winappsdk-experimental-sample
+description: Use when a new monthly experimental Windows App SDK (WinAppSDK) release ships and you need to scaffold, build, and launch a minimal self-contained WinUI 3 sample pinned to that exact package version to smoke-test the release. Also use when a WinUI 3 build fails with "Unable to find package Microsoft.Windows.SDK.NET.Ref" (only searches library-packs), or a NuGet credential-provider / private-feed error blocks restore of Microsoft.WindowsAppSDK experimental packages.
+---
+
+# Creating a WinAppSDK Experimental Sample
+
+## Overview
+
+Windows App SDK publishes an **experimental** channel roughly once a month
+(e.g. `2.3.2-experimentalA`). This skill produces a tiny, known-good WinUI 3
+desktop app pinned to a specific `Microsoft.WindowsAppSDK` version so the
+release can be validated end-to-end: **restore → build → launch**.
+
+The work is done by [`New-WinAppSdkSample.ps1`](New-WinAppSdkSample.ps1) in this
+folder. It generates a minimal unpackaged, **self-contained** app (the WinAppSDK
+runtime is bundled next to the exe, so no separate runtime install is needed).
+
+## When to Use
+
+- A new monthly WinAppSDK experimental package is out and you want a quick sanity app.
+- You need a repro app against one exact experimental version.
+- Symptoms this skill also fixes:
+  - `error NU1101: Unable to find package Microsoft.Windows.SDK.NET.Ref ... source(s): ...\dotnet\library-packs`
+  - `A plugin was not found at path '...CredentialProvider.Microsoft...'` during restore
+  - Private-only NuGet feeds prompting auth when the package is on nuget.org
+
+**Not for:** shipping/production apps, packaged MSIX store submissions, or adding a
+control page to WinUI Gallery itself (edit `ControlInfoData.json` for that).
+
+## Quick Reference
+
+```powershell
+$skill = ".github\skills\creating-winappsdk-experimental-sample\New-WinAppSdkSample.ps1"
+
+# Auto-detect the latest experimental release, build, and launch:
+& $skill -Launch
+
+# Pin an exact version:
+& $skill -Version 2.3.2-experimentalA -Launch
+
+# Generate only (no build), into a chosen folder:
+& $skill -Version 2.3.2-experimentalA -OutputDir C:\temp\wasdk-smoke -NoBuild
+
+# ARM64:
+& $skill -Version 2.3.2-experimentalA -Platform arm64 -Launch
+```
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `-Version` | latest `*experimental*` on nuget.org | `Microsoft.WindowsAppSDK` version to pin |
+| `-OutputDir` | `$HOME\WinAppSdkSamples\WinUISample-<Version>` | where the app is generated |
+| `-Platform` | `x64` | `x64` \| `x86` \| `arm64` |
+| `-TargetFramework` | `net9.0-windows10.0.22621.0` | app TFM |
+| `-WindowsSdkPackageVersion` | latest stable pack for the TFM band | `Microsoft.Windows.SDK.NET.Ref` version |
+| `-Launch` | off | launch and verify the process stays alive |
+| `-NoBuild` | off | generate files only |
+
+## How It Works (and why)
+
+1. **Resolves versions from nuget.org** — newest experimental WinAppSDK and a
+   matching stable Windows SDK projection pack (`Microsoft.Windows.SDK.NET.Ref`).
+2. **Generates the project** — `.csproj` (pins `Microsoft.WindowsAppSDK`),
+   `App.xaml(.cs)`, `MainWindow.xaml(.cs)`, `app.manifest`, and an isolated
+   `nuget.config` (`<clear/>` + nuget.org only).
+3. **Neutralizes NuGet blockers** — sets `NUGET_PLUGIN_PATHS=""` so a broken/absent
+   credential provider can't fail the restore.
+4. **Handles the missing Windows SDK targeting pack** — the .NET SDK treats
+   `Microsoft.Windows.SDK.NET.Ref` as a targeting pack and only searches the offline
+   `library-packs` folder (it will **not** pull it from nuget.org, even as a plain
+   `PackageReference`). When no pack is installed, the script downloads the `.nupkg`
+   and builds a valid **v3 fallback package folder** (`<id>/<ver>/` + expanded
+   contents + `.nupkg`, `.nupkg.sha512`, `.nupkg.metadata`), registered via
+   `<fallbackPackageFolders>`. If a pack is already installed, this step is skipped.
+5. **Builds and (optionally) launches**, verifying the exe exists and the process
+   survives startup.
+
+## Common Mistakes
+
+- **Generating inside a repo that uses Central Package Management / `Directory.Build.props`.**
+  The sample uses an explicit `PackageReference Version`, which CPM forbids. Keep
+  `-OutputDir` **outside** such a repo (the default location already is).
+- **Expecting a runtime install.** The app is self-contained/unpackaged — run the exe
+  directly from `bin\<Platform>\Debug\<TFM>\`. No MSIX registration or runtime installer.
+- **Pinning a `-WindowsSdkPackageVersion` that isn't on nuget.org.** Use one listed for
+  the TFM's platform band (e.g. `10.0.22621.*`); the script auto-picks a valid one.
+- **Ignoring `NU1603`.** A dependency patch-bump warning (e.g. build tools) is expected
+  and harmless.
+
+## Monthly Cadence
+
+When the next experimental release drops, just re-run with the new version
+(`& $skill -Version <new-version> -Launch`) or let auto-detect pick it. Each run is
+self-contained in its own `-OutputDir`, so past samples are preserved for comparison.

--- a/.github/skills/creating-winappsdk-experimental-sample/copilot-skill.json
+++ b/.github/skills/creating-winappsdk-experimental-sample/copilot-skill.json
@@ -1,0 +1,53 @@
+{
+    "name": "creating-winappsdk-experimental-sample",
+    "displayName": "Create WinAppSDK Experimental Sample App",
+    "version": "1.0.0",
+    "description": "Use when a new monthly experimental Windows App SDK (WinAppSDK) release ships and you need to scaffold, build, and launch a minimal self-contained WinUI 3 sample pinned to that exact package version to smoke-test the release. Also use when a WinUI 3 build fails with 'Unable to find package Microsoft.Windows.SDK.NET.Ref' (only searches library-packs), or a NuGet credential-provider / private-feed error blocks restore of Microsoft.WindowsAppSDK experimental packages.",
+    "author": "protikbiswas100",
+    "category": "winui-tooling",
+    "keywords": [
+        "winui",
+        "winui3",
+        "windows-app-sdk",
+        "winappsdk",
+        "experimental",
+        "nuget",
+        "scaffold",
+        "sample-app",
+        "self-contained",
+        "unpackaged",
+        "Microsoft.WindowsAppSDK",
+        "Microsoft.Windows.SDK.NET.Ref",
+        "library-packs",
+        "fallback-package-folder",
+        "NUGET_PLUGIN_PATHS",
+        "credential-provider",
+        "smoke-test",
+        "monthly-release"
+    ],
+    "skill_file": "SKILL.md",
+    "supporting_files": [
+        "New-WinAppSdkSample.ps1"
+    ],
+    "usage": {
+        "install_methods": [
+            {
+                "method": "copy",
+                "description": "Copy this skill directory into your personal Copilot skills directory so Copilot CLI auto-discovers it. Replace <skill-source> with the absolute path to this folder.",
+                "command": "xcopy /E /I <skill-source> \"%USERPROFILE%\\.copilot\\skills\\creating-winappsdk-experimental-sample\""
+            },
+            {
+                "method": "copilot-instructions",
+                "description": "Reference this skill from the repo's .github/copilot-instructions.md so it is active for anyone working in the repo.",
+                "example": "To scaffold/build/launch a WinUI 3 sample for an experimental Windows App SDK release, follow the skill at .github/skills/creating-winappsdk-experimental-sample/SKILL.md"
+            }
+        ],
+        "invoke": {
+            "description": "Skills are not invoked with @name (that mentions files). After the skill is discovered, trigger it by describing the task; the description's triggers match. Use /skills to view/manage.",
+            "example_prompts": [
+                "Create a new WinUI app for the latest experimental Windows App SDK release and launch it.",
+                "Scaffold and build a WinUI 3 sample pinned to Microsoft.WindowsAppSDK 2.3.2-experimentalA."
+            ]
+        }
+    }
+}

--- a/docs/.unbroken_exclusions
+++ b/docs/.unbroken_exclusions
@@ -5,3 +5,6 @@ URL not found https://dev.azure.com/ms/microsoft-ui-xaml/_build?definitionId=20 
 
 # Microsoft Store returns HTTP 403 to non-browser user agents
 URL not found https://www.microsoft.com/store/p/windbg/9pgjgd53tn86 while parsing debugging_crashes.md (HTTP 403)
+
+# cla.microsoft.com returns HTTP 403 to non-browser user agents
+URL not found https://cla.microsoft.com while parsing contribution_workflow.md (HTTP 403)


### PR DESCRIPTION
ADO PR: https://microsoft.visualstudio.com/WinUI/_git/microsoft-ui-xaml-lift/pullrequest/16340349

Adds a Copilot skill under `.github/skills/creating-winappsdk-experimental-sample` that scaffolds, builds, and launches a minimal self-contained WinUI 3 app pinned to a specific experimental Windows App SDK release, so each monthly experimental drop can be smoke-tested end to end (restore -> build -> launch).

**Files:**
- `SKILL.md` — when to use, quick reference, how it works, common mistakes.
- `New-WinAppSdkSample.ps1` — generator (auto-detects the latest experimental `Microsoft.WindowsAppSDK` version, or accepts `-Version`).
- `copilot-skill.json` — Copilot CLI skill manifest (name, description triggers, keywords).

**Behavior / environment fixes:**
- Generates a minimal app (App.xaml/.cs, MainWindow.xaml/.cs, app.manifest, isolated nuget.config).
- Works around a broken/absent NuGet credential provider and a missing Windows SDK targeting pack (builds a local v3 fallback package folder for `Microsoft.Windows.SDK.NET.Ref`).
- Restores, builds, and optionally launches (`-Launch`), verifying the process stays alive.

**Verified:** `New-WinAppSdkSample.ps1 -Version 2.3.2-experimentalA -Launch` -> resolved ref pack 10.0.22621.87, build succeeded, app launched.
