### PR TITLE
Legacy IME: restore auxiliary UI via explicit TSF focus park (opt-in)

### DIFF
--- a/dxaml/xcp/components/ContentRoot/InputManager.cpp
+++ b/dxaml/xcp/components/ContentRoot/InputManager.cpp
@@ -5,6 +5,7 @@
 
 #include "InputManager.h"
 #include "ContentRoot.h"
+#include "InputServices.h"
 
 #include "KeyboardEventArgs.h"
 
@@ -221,6 +222,14 @@ _Check_return_ HRESULT CInputManager::RegisterFrameworkInputView()
 _Check_return_ HRESULT CInputManager::NotifyFocusChanged(_In_opt_ CDependencyObject* pFocusedElement, _In_ bool bringIntoView, _In_ bool animateIfBringIntoView)
 {
     IFC_RETURN(m_inputPaneProcessor.NotifyFocusChanged(pFocusedElement, bringIntoView, animateIfBringIntoView));
+
+    // Drive the legacy-IME focus park (installed only under the per-app opt-in) from this central
+    // focus-changed notification, so TSF focus is parked whenever a non-text element is focused.
+    if (CInputServices* inputServices = m_coreServices.GetInputServices())
+    {
+        inputServices->NotifyFocusChangedForImePark(pFocusedElement);
+    }
+
     return S_OK;
 }
 

--- a/dxaml/xcp/components/runtimeEnabledFeatures/RuntimeFeatureData.cpp
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/RuntimeFeatureData.cpp
@@ -66,6 +66,7 @@ namespace RuntimeFeatureBehavior
         { L"DenyRoundedCalendarViewBaseItemChrome", RuntimeEnabledFeature::DenyRoundedCalendarViewBaseItemChrome, false, 0, 0 },
         { L"EnableUWPWindow", RuntimeEnabledFeature::EnableUWPWindow, false, 0, 0 },
         { L"EnableReentrancyChecks", RuntimeEnabledFeature::EnableReentrancyChecks, false, 0, 0 },
+        { L"EnableLegacyImeAuxiliaryUi", RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi, false, 0, 0 },
         #if DBG
         { L"CaptureTrackerPtrCallStack", RuntimeEnabledFeature::CaptureTrackerPtrCallStack, false, 0, 0 },
         #endif

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/RuntimeEnabledFeaturesEnum.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/RuntimeEnabledFeaturesEnum.h
@@ -60,6 +60,7 @@ namespace RuntimeFeatureBehavior
         DenyRoundedCalendarViewBaseItemChrome,
         EnableUWPWindow,                   // if enabled, it will allow creating an UWP window and thus launching UWP apps // task 31614767 : UWP window creation has been disabled
         EnableReentrancyChecks, // If enabled, we will FailFast when reentrancy is detected
+        EnableLegacyImeAuxiliaryUi, // Per-app opt-in (Option A, bug 62702548). If enabled, DXamlCore init skips ImmDisableLegacyIME() and installs the ImeFocusPark so legacy (IMM/CUAS) IMEs show their status bar in text controls without ambiguating text-input focus. Default off keeps the historical ImmDisableLegacyIME() behavior.
         // add entries before here to be safe as C# test code uses fixed numeric values instead of this enum so if added after DBG entry, the enum value can change
         #if DBG
         CaptureTrackerPtrCallStack, // Capture the stack that calls TrackerPtr.Set

--- a/dxaml/xcp/core/dll/focusmgr.cpp
+++ b/dxaml/xcp/core/dll/focusmgr.cpp
@@ -1501,6 +1501,15 @@ CFocusManager::NotifyFocusChanged(_In_ bool bringIntoView, _In_ bool animateIfBr
     {
         IFC_RETURN(m_contentRoot.GetInputManager().NotifyFocusChanged(m_pFocusedElement, bringIntoView, animateIfBringIntoView));
     }
+    else
+    {
+        // Focus was withdrawn to no element (e.g. the focused control was removed, or focus was cleared
+        // programmatically). Still forward a null focused element so the legacy-IME focus park can park
+        // TSF focus on its keyboard-disabled document - otherwise IMM could fall back to the CUAS default
+        // input context while nothing editable is focused (bug 62702548). Other consumers of this
+        // notification (InputPaneProcessor) already no-op on a null focused element.
+        IFC_RETURN(m_contentRoot.GetInputManager().NotifyFocusChanged(nullptr, bringIntoView, animateIfBringIntoView));
+    }
 
     return S_OK;
 }

--- a/dxaml/xcp/core/inc/ImeFocusPark.h
+++ b/dxaml/xcp/core/inc/ImeFocusPark.h
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include <memory>
+
+// Forward-declare HWND so this widely-included header does not have to pull in <windows.h>.
+#ifndef _WINDEF_
+struct HWND__;
+typedef struct HWND__* HWND;
+#endif
+
+// ImeFocusPark makes XAML's TSF text-input focus signal explicit so that legacy (IMM/CUAS) IMEs can be
+// re-enabled (by NOT calling ImmDisableLegacyIME) without the "focus ambiguity" regression: when no
+// text-editable control is focused, the park holds TSF thread-manager focus on a permanent
+// keyboard-disabled document, so TSF never falls back to the CUAS default input context and IMEs cannot
+// consume keystrokes or open composition UI over non-text UI. While a text-editable control is focused,
+// the park stands down and RichEdit owns TSF focus (restoring the legacy IME status bar).
+//
+// This mirrors the well-known Chromium / WPF "park focus on a benign document" pattern. It is installed
+// only when the per-app opt-in (RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi) is set; default builds
+// keep calling ImmDisableLegacyIME() and never create this object.
+//
+// Thread affinity: all methods must run on the owning UI thread (the TSF thread manager is thread-bound).
+// Lifetime is owned by CInputServices (init in SetCoreWindow, teardown in Reset). The TSF details are
+// hidden behind a pimpl so msctf.h does not leak into the widely-included InputServices.h.
+class ImeFocusPark
+{
+public:
+    ImeFocusPark();
+    ~ImeFocusPark();
+
+    ImeFocusPark(const ImeFocusPark&) = delete;
+    ImeFocusPark& operator=(const ImeFocusPark&) = delete;
+
+    // Acquires the per-thread TSF thread manager and creates the permanent keyboard-disabled document.
+    // Idempotent; safe to call once per CInputServices. Returns a failure HRESULT if TSF is unavailable,
+    // in which case the park is simply not installed (IsInitialized() stays false).
+    _Check_return_ HRESULT Initialize();
+
+    // Releases the parked focus and all TSF objects. Safe to call when not initialized.
+    void Shutdown();
+
+    bool IsInitialized() const;
+
+    // Drives the park from the central focus-changed notification. When the newly focused element is NOT
+    // text-editable, parks TSF thread focus on the disabled document AND binds that document to the focus
+    // window (inputHwnd) via ITfThreadMgr::AssociateFocus, so TSF/CUAS reports the window as
+    // keyboard-disabled on every WM_SETFOCUS (a one-time SetFocus is overridden by the HWND association).
+    // When it IS text-editable, removes that association and stands down so RichEdit owns TSF focus.
+    // inputHwnd is the island input HWND that owns TSF text-input for this focus (may be null). No-op when
+    // the park is not initialized.
+    void OnFocusedElementChanged(bool isFocusedElementTextEditable, HWND inputHwnd);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};

--- a/dxaml/xcp/core/inc/InputServices.h
+++ b/dxaml/xcp/core/inc/InputServices.h
@@ -18,6 +18,7 @@
 #include "InteractionManager.h"
 #include "FrameworkInputViewHandler.h"
 #include "TextInputProducerHelper.h"
+#include "ImeFocusPark.h"
 
 // Uncomment for DManip debug outputs.
 //#define DM_DEBUG
@@ -428,6 +429,10 @@ public:
 
     // Called when the focus is changed from the focus manager
     static BOOL IsTextEditableControl(_In_ const CDependencyObject* const pObject);
+
+    // Forwards the central focus-changed notification to the legacy-IME focus park (if installed) so it
+    // can park/stand-down TSF focus based on whether the newly focused element is text-editable.
+    void NotifyFocusChangedForImePark(_In_opt_ CDependencyObject* pFocusedElement);
 
     // Helper method to retrieve the underlying input HWND from an IslandInputSite. Note that these hwnds will always
     // exist, even in a world when islands themselves might no longer be backed by hwnds.
@@ -1669,6 +1674,10 @@ private:
 
     // This is used to disable text insertion when a KeyDown event gets handled
     TextInputProducerHelper m_textInputProducerHelper;
+
+    // Legacy-IME (IMM/CUAS) text-input focus park. Only initialized when the per-app opt-in
+    // (RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi) is set; otherwise unused.
+    ImeFocusPark m_imeFocusPark;
 
     xref_ptr<KeyTipManager> m_keyTipManager;
 

--- a/dxaml/xcp/core/inc/corep.h
+++ b/dxaml/xcp/core/inc/corep.h
@@ -2255,6 +2255,11 @@ public:
     void ForceDisableTSF3() { m_isTsf3Disabled = true; }
     bool IsTSF3Enabled() const;
 
+    // Set at DXamlCore init when the per-app legacy-IME opt-in is on: CInputServices::SetCoreWindow then
+    // installs the ImeFocusPark (see RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi).
+    void SetShouldInstallImeFocusPark(bool value) { m_shouldInstallImeFocusPark = value; }
+    bool ShouldInstallImeFocusPark() const { return m_shouldInstallImeFocusPark; }
+
     bool IsLayoutCycleTrackingActive() { return m_isLayoutCycleTrackingActive; }
     void SetIsLayoutCycleTrackingActive(bool isActive) { m_isLayoutCycleTrackingActive = isActive; }
 
@@ -2302,6 +2307,10 @@ private:
 
     // Has TSF3 been explicitly disabled?  Set by DesktopWindowXamlSource
     bool                        m_isTsf3Disabled = false;
+
+    // Whether CInputServices should install the legacy-IME focus park (per-app opt-in read at DXamlCore
+    // init; see RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi and ImeFocusPark).
+    bool                        m_shouldInstallImeFocusPark = false;
 
     bool                        m_isDCompLeakDetectionEnabled = true;
     CResourceDictionary        *m_pThemeResources;

--- a/dxaml/xcp/core/input/InputServices.cpp
+++ b/dxaml/xcp/core/input/InputServices.cpp
@@ -47,6 +47,8 @@
 
 #include <ReentrancyGuard.h>
 #include <Windowing.h>
+#include <msctf.h>
+#include <imm.h>
 
 #undef max
 #undef min
@@ -65,6 +67,197 @@ using namespace Focus;
 #define ExitOnSetContactFailure(x) if (x) { goto Cleanup; }
 
 using namespace RuntimeFeatureBehavior;
+
+// ---------------------------------------------------------------------------
+// ImeFocusPark
+//
+// Owns the per-thread TSF thread manager and a permanent keyboard-disabled document. When no
+// text-editable control is focused, TSF thread-manager focus is parked on that document so IMM never
+// falls back to the CUAS default input context (which would let legacy IMEs consume keys / open
+// composition UI over non-text UI). This is the Chromium/WPF "park focus on a benign document" pattern;
+// it lets XAML re-enable legacy IMEs (by not calling ImmDisableLegacyIME) without ambiguating text-input
+// focus. See ImeFocusPark.h and RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi.
+// ---------------------------------------------------------------------------
+struct ImeFocusPark::Impl
+{
+    Microsoft::WRL::ComPtr<ITfThreadMgr2> threadMgr;
+    // Same underlying TF_ThreadMgr object, QI'd to the v1 interface which exposes AssociateFocus (used to
+    // bind the disabled document to the focus HWND). ITfThreadMgr2 does not derive from ITfThreadMgr.
+    Microsoft::WRL::ComPtr<ITfThreadMgr> threadMgrForAssoc;
+    Microsoft::WRL::ComPtr<ITfDocumentMgr> disabledDocMgr;
+    TfClientId clientId = TF_CLIENTID_NULL;
+    bool activated = false;
+    bool parked = false;
+    // HWND currently associated with disabledDocMgr via AssociateFocus (nullptr when none). Tracked so we
+    // move/remove the association as focus changes.
+    HWND associatedHwnd = nullptr;
+};
+
+ImeFocusPark::ImeFocusPark() = default;
+
+ImeFocusPark::~ImeFocusPark()
+{
+    Shutdown();
+}
+
+bool ImeFocusPark::IsInitialized() const
+{
+    return m_impl != nullptr;
+}
+
+_Check_return_ HRESULT ImeFocusPark::Initialize()
+{
+    // Idempotent: only one park per CInputServices / UI thread.
+    if (m_impl != nullptr)
+    {
+        return S_OK;
+    }
+
+    auto impl = std::make_unique<Impl>();
+
+    // Acquire the per-thread TSF thread manager. A distinct COM wrapper still routes through the same
+    // per-thread focus state that RichEdit / CUAS use, so parking focus here is observed by IMM.
+    IFC_RETURN(CoCreateInstance(
+        CLSID_TF_ThreadMgr,
+        nullptr,
+        CLSCTX_INPROC_SERVER,
+        IID_PPV_ARGS(impl->threadMgr.GetAddressOf())));
+
+    IFC_RETURN(impl->threadMgr->Activate(&impl->clientId));
+    impl->activated = true;
+
+    // Create the permanent "no editing here" document: a document manager with a single context that has
+    // no text store and is explicitly keyboard-disabled, so IMEs treat this focus as non-editable.
+    IFC_RETURN(impl->threadMgr->CreateDocumentMgr(impl->disabledDocMgr.GetAddressOf()));
+
+    Microsoft::WRL::ComPtr<ITfContext> context;
+    TfEditCookie editCookie = 0;
+    IFC_RETURN(impl->disabledDocMgr->CreateContext(
+        impl->clientId,
+        0,
+        nullptr,
+        context.GetAddressOf(),
+        &editCookie));
+
+    Microsoft::WRL::ComPtr<ITfCompartmentMgr> compartmentMgr;
+    IFC_RETURN(context.As(&compartmentMgr));
+
+    Microsoft::WRL::ComPtr<ITfCompartment> keyboardDisabled;
+    IFC_RETURN(compartmentMgr->GetCompartment(GUID_COMPARTMENT_KEYBOARD_DISABLED, keyboardDisabled.GetAddressOf()));
+
+    VARIANT disabledValue = {};
+    disabledValue.vt = VT_I4;
+    disabledValue.lVal = 1;
+    IFC_RETURN(keyboardDisabled->SetValue(impl->clientId, &disabledValue));
+
+    IFC_RETURN(impl->disabledDocMgr->Push(context.Get()));
+
+    // QI the same thread-manager object for the v1 interface, which exposes AssociateFocus. Optional: if
+    // it is unavailable we still park via SetFocus (TSF-aware IMEs), we just lose the per-HWND CUAS gate.
+    IGNOREHR(impl->threadMgr.As(&impl->threadMgrForAssoc));
+
+    m_impl = std::move(impl);
+    return S_OK;
+}
+
+void ImeFocusPark::Shutdown()
+{
+    if (m_impl == nullptr)
+    {
+        return;
+    }
+
+    if (m_impl->threadMgr != nullptr)
+    {
+        // Remove any per-HWND association we installed so we never leave the disabled document bound to a
+        // window (which would block keyboard input there).
+        if (m_impl->associatedHwnd != nullptr && m_impl->threadMgrForAssoc != nullptr)
+        {
+            Microsoft::WRL::ComPtr<ITfDocumentMgr> prev;
+            IGNOREHR(m_impl->threadMgrForAssoc->AssociateFocus(m_impl->associatedHwnd, nullptr, prev.GetAddressOf()));
+            m_impl->associatedHwnd = nullptr;
+        }
+
+        if (m_impl->parked)
+        {
+            // Relinquish the parked focus before tearing down.
+            IGNOREHR(m_impl->threadMgr->SetFocus(nullptr));
+            m_impl->parked = false;
+        }
+
+        if (m_impl->disabledDocMgr != nullptr)
+        {
+            IGNOREHR(m_impl->disabledDocMgr->Pop(TF_POPF_ALL));
+        }
+
+        if (m_impl->activated)
+        {
+            IGNOREHR(m_impl->threadMgr->Deactivate());
+        }
+    }
+
+    m_impl.reset();
+}
+
+void ImeFocusPark::OnFocusedElementChanged(bool isFocusedElementTextEditable, HWND inputHwnd)
+{
+    if (m_impl == nullptr || m_impl->threadMgr == nullptr)
+    {
+        return;
+    }
+
+    if (!isFocusedElementTextEditable)
+    {
+        // Focus is on a non-text element (or nothing editable). Two complementary actions:
+        //
+        // 1) Park TSF thread focus on the disabled document (covers TSF-aware IMEs and the moment before
+        //    the next WM_SETFOCUS).
+        if (!m_impl->parked)
+        {
+            if (SUCCEEDED(m_impl->threadMgr->SetFocus(m_impl->disabledDocMgr.Get())))
+            {
+                m_impl->parked = true;
+            }
+        }
+
+        // 2) Bind the keyboard-disabled document to the focus window. TSF re-activates the document
+        //    *associated with the focused HWND* on every WM_SETFOCUS, so - unlike a one-time SetFocus,
+        //    which CUAS overrides when it hands the window its default input context - this keeps the
+        //    legacy (IMM/CUAS) IME disabled for as long as a non-text control holds focus. This is the
+        //    action that actually stops composition / candidate / mode UI over non-text controls.
+        if (m_impl->threadMgrForAssoc != nullptr && inputHwnd != nullptr && m_impl->associatedHwnd != inputHwnd)
+        {
+            // Focus HWND changed: drop the stale association first so we never bind two windows.
+            if (m_impl->associatedHwnd != nullptr)
+            {
+                Microsoft::WRL::ComPtr<ITfDocumentMgr> prev;
+                IGNOREHR(m_impl->threadMgrForAssoc->AssociateFocus(m_impl->associatedHwnd, nullptr, prev.GetAddressOf()));
+                m_impl->associatedHwnd = nullptr;
+            }
+
+            Microsoft::WRL::ComPtr<ITfDocumentMgr> prev;
+            if (SUCCEEDED(m_impl->threadMgrForAssoc->AssociateFocus(inputHwnd, m_impl->disabledDocMgr.Get(), prev.GetAddressOf())))
+            {
+                m_impl->associatedHwnd = inputHwnd;
+            }
+        }
+    }
+    else
+    {
+        // A text-editable control is focused: RichEdit owns TSF focus (and shows the legacy IME UI) while
+        // editing. Stand down and, critically, REMOVE our disabled-document association from the window so
+        // TSF returns to the default (RichEdit-driven) context - otherwise the disabled document would keep
+        // suppressing input while the user is trying to type.
+        m_impl->parked = false;
+
+        if (m_impl->threadMgrForAssoc != nullptr && m_impl->associatedHwnd != nullptr)
+        {
+            Microsoft::WRL::ComPtr<ITfDocumentMgr> prev;
+            IGNOREHR(m_impl->threadMgrForAssoc->AssociateFocus(m_impl->associatedHwnd, nullptr, prev.GetAddressOf()));
+            m_impl->associatedHwnd = nullptr;
+        }
+    }
+}
 
 CInputServices::CInputServices(_In_ CCoreServices *pCoreService)
     : m_pVisualTree(pCoreService->GetMainVisualTree())
@@ -129,6 +322,8 @@ void CInputServices::Reset()
     // Cleanup all create pointer objects
     DestroyPointerObjects();
 
+    m_imeFocusPark.Shutdown();
+
     m_pCoreService = nullptr;
 }
 
@@ -162,6 +357,28 @@ void CInputServices::RegisterIslandInputSite(_In_ InputSiteHelper::IIslandInputS
             // Transfer the pending callback to the registration entry we just added.
             m_islandInputSiteRegistrations.at(0).ShouldRegisterDMViewportCallback(true);
             m_shouldRegisterPrimaryDMViewportCallback = false;
+        }
+
+        // Install the legacy-IME focus park for WinUI 3 desktop / island apps. These apps have NO CoreWindow
+        // (see DXamlCore::ConfigureJupiterWindow: "CoreWindow does not exist in Win32/ Islands"), so
+        // CInputServices::SetCoreWindow - the CoreWindow-only path that installs the park for UWP - is never
+        // called, and without this the park would never initialize and NotifyFocusChangedForImePark would be
+        // a no-op on desktop. Island input arrives here instead, so this is the desktop-equivalent install
+        // point. Best-effort and idempotent (Initialize() no-ops if already installed); gated on the same
+        // per-app opt-in and TSF3 requirement as the CoreWindow path. Runs on the UI thread (island
+        // registration is UI-thread affine), which the TSF thread manager requires.
+        if (m_pCoreService->ShouldInstallImeFocusPark() && m_pCoreService->IsTSF3Enabled() && !m_imeFocusPark.IsInitialized())
+        {
+            IGNOREHR(m_imeFocusPark.Initialize());
+
+            // Engage immediately so we don't leave a startup window (before the first focus change) where
+            // nothing is parked. At island-registration time nothing text-editable is focused yet, so park
+            // on the disabled document by default; subsequent real focus changes (driven by
+            // CInputManager::NotifyFocusChanged) re-evaluate with the actual focused element.
+            if (m_imeFocusPark.IsInitialized())
+            {
+                NotifyFocusChangedForImePark(nullptr);
+            }
         }
     }
 }
@@ -3075,6 +3292,105 @@ CInputServices::IsTextEditableControl(_In_ const CDependencyObject* const pObjec
     }
 
     return isEditableControl;
+}
+
+void
+CInputServices::NotifyFocusChangedForImePark(_In_opt_ CDependencyObject* pFocusedElement)
+{
+    // Gate on the per-app opt-in (EnableLegacyImeAuxiliaryUi), NOT on the TSF park being initialized.
+    //
+    // Root cause of the original defect: this feature targets the LEGACY IME path, and in that
+    // configuration TSF3 is disabled (IsTSF3Enabled()==false). The TSF focus park is only installed when
+    // TSF3 is enabled, so it never initializes here - which meant the old `if (!IsInitialized()) return;`
+    // guard turned this entire method (including the IMM disable below, the layer that actually stops a
+    // legacy IMM/CUAS IME like 2345 Pinyin) into dead code. The IMM disable does not depend on the TSF
+    // park at all, so it must run whenever the feature is on.
+    const bool featureEnabled = (m_pCoreService != nullptr) && m_pCoreService->ShouldInstallImeFocusPark();
+
+    if (!featureEnabled)
+    {
+        return;
+    }
+
+    const bool isTextEditable = (pFocusedElement != nullptr) && (IsTextEditableControl(pFocusedElement) != FALSE);
+
+    // Resolve the HWND that owns TSF text-input for this focus. This is the island input HWND - the same
+    // window RichEdit's TextServicesHost uses (TxGetWindow / ImmGetContext), so it is also the window whose
+    // *default IMM context* the legacy IME composes into. GetElementIslandInputSite never returns null for a
+    // live element (it falls back to the XamlIslandRoot's site or the primary registered site), so this is
+    // valid for non-text controls (Button/Slider) too.
+    wrl::ComPtr<InputSiteHelper::IIslandInputSite> islandInputSite =
+        (pFocusedElement != nullptr)
+            ? pFocusedElement->GetElementIslandInputSite()
+            : GetPrimaryRegisteredIslandInputSite();
+    HWND inputHwnd = GetUnderlyingInputHwndFromIslandInputSite(islandInputSite.Get());
+
+    // Layer 1 (TSF-aware IMEs): park TSF focus on / associate the keyboard-disabled document with the input
+    // window. This is the "correct" layer for well-behaved TSF IMEs, but only applies when the TSF park was
+    // actually installed (TSF3 enabled). In the legacy-IME configuration this is skipped and Layer 2 does
+    // the work.
+    if (m_imeFocusPark.IsInitialized())
+    {
+        m_imeFocusPark.OnFocusedElementChanged(isTextEditable, inputHwnd);
+    }
+
+    // Layer 2 (legacy IMM / CUAS IMEs like 2345 Pinyin): with EnableLegacyImeAuxiliaryUi ON we skip the
+    // process-wide ImmDisableLegacyIME(), so the legacy IME composes into the *default IMM context* of the
+    // focused window (RichEdit reads exactly this via ImmGetContext(inputHwnd)). The TSF park alone does not
+    // stop a legacy IMM IME - it hangs its context off the Win32 focus window - so we must act on the IMM
+    // context directly. On non-text focus, cancel any composition and REMOVE the context association so the
+    // IME has nothing to compose into; on text focus, restore the default context so editing works again.
+    //
+    // Apply across every window the IME could be hanging its context off, because the composition/candidate
+    // UI has been observed appearing "outside" the island (i.e. tied to the top-level / foreground window):
+    //   - ::GetFocus()            : the Win32 focus window on this (UI) thread
+    //   - inputHwnd               : the XAML island input window (RichEdit's own IME window)
+    //   - GA_ROOT of inputHwnd    : the top-level host window
+    //   - ::GetForegroundWindow() : whatever the shell considers foreground
+    // The IMM calls are idempotent, so covering all of them is safe.
+    HWND candidateHwnds[4] = {};
+    int candidateCount = 0;
+    auto addCandidate = [&](HWND hwnd)
+    {
+        if (hwnd == nullptr) { return; }
+        for (int k = 0; k < candidateCount; ++k)
+        {
+            if (candidateHwnds[k] == hwnd) { return; }
+        }
+        if (candidateCount < ARRAYSIZE(candidateHwnds))
+        {
+            candidateHwnds[candidateCount++] = hwnd;
+        }
+    };
+    addCandidate(::GetFocus());
+    addCandidate(inputHwnd);
+    if (inputHwnd != nullptr) { addCandidate(::GetAncestor(inputHwnd, GA_ROOT)); }
+    addCandidate(::GetForegroundWindow());
+
+    for (int i = 0; i < candidateCount; ++i)
+    {
+        HWND hwnd = candidateHwnds[i];
+
+        if (isTextEditable)
+        {
+            ImmAssociateContextEx(hwnd, nullptr, IACE_DEFAULT);
+            if (HIMC himc = ImmGetContext(hwnd))
+            {
+                ImmSetOpenStatus(himc, TRUE);
+                ImmReleaseContext(hwnd, himc);
+            }
+        }
+        else
+        {
+            if (HIMC himc = ImmGetContext(hwnd))
+            {
+                ImmNotifyIME(himc, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+                ImmSetOpenStatus(himc, FALSE);
+                ImmReleaseContext(hwnd, himc);
+            }
+            ImmAssociateContextEx(hwnd, nullptr, 0);
+        }
+    }
 }
 
 // static
@@ -14850,12 +15166,29 @@ void CInputServices::SetCoreWindow(_In_ wuc::ICoreWindow* pCoreWindow)
     if (m_pCoreService->IsTSF3Enabled())
     {
         m_textInputProducerHelper.Init(pCoreWindow);
+
+        // Install the legacy-IME focus park when the per-app opt-in was set at DXamlCore init. Best-effort:
+        // if TSF is unavailable the park stays uninitialized and simply doesn't run.
+        if (m_pCoreService->ShouldInstallImeFocusPark())
+        {
+            IGNOREHR(m_imeFocusPark.Initialize());
+        }
     }
 
     CContentRoot* contentRoot = m_pCoreService->GetContentRootCoordinator()->Unsafe_IslandsIncompatible_CoreWindowContentRoot();
     FocusObserver* focusObserver = contentRoot->GetFocusManagerNoRef()->GetFocusObserverNoRef();
 
     IFCFAILFAST(focusObserver->Init(pCoreWindow));
+
+    // If the legacy-IME focus park was installed, engage it immediately based on the current focus so we
+    // don't leave a window at startup (before the first focus change) where nothing is parked and IMM
+    // could reach the CUAS default input context. If a text-editable control is already focused, this
+    // stands down and RichEdit keeps TSF focus.
+    if (m_imeFocusPark.IsInitialized())
+    {
+        CDependencyObject* focusedElement = contentRoot->GetFocusManagerNoRef()->GetFocusedElementNoRef();
+        NotifyFocusChangedForImePark(focusedElement);
+    }
 }
 
 wuc::ICoreWindow* CInputServices::GetCoreWindow() const

--- a/dxaml/xcp/dxaml/lib/DXamlCore.cpp
+++ b/dxaml/xcp/dxaml/lib/DXamlCore.cpp
@@ -534,10 +534,27 @@ _Check_return_ HRESULT DXamlCore::InitializeInstance(_In_ InitializationType ini
     IFC(m_spDispatcherImpl->Connect(this));
     initDxamlCoreTest.set_flag(TIP_reason(DXamlInitializeCoreTest::reason::initialized_dispatcher));
 
-    // Disable the legacy IME since the legacy IMEs aren't designed for the immersive environment.
+    // Historically we unconditionally disabled legacy (IMM/CUAS) IMEs here because they weren't designed
+    // for the Windows 8 "immersive" environment. That call also suppresses IMM's fallback to the CUAS
+    // default input context, which regressed the status-bar / language-switch UI of several legacy CJK/JP/KR
+    // IMEs (Baidu, Sogou, Palm, ...) in XAML apps such as Start, the WinUI Gallery, and File Explorer
+    // (bug 62702548). Simply removing the call re-enables that fallback and lets IMEs consume keys / open
+    // composition UI over non-text UI ("ambiguated text-input focus").
     //
-    // We only want to do this when not in design mode, since the design-mode process should use the legacy IMEs.
-    ImmDisableLegacyIME();
+    // Option A: a per-app opt-in (default off) instead keeps the legacy IMM path enabled AND installs the
+    // ImeFocusPark, which parks TSF focus on a keyboard-disabled document whenever no text-editable control
+    // is focused - so the status bar returns while editing without the focus-ambiguity regression. When the
+    // opt-in is off we preserve the historical behavior and disable the legacy IME immersive fallback.
+    if (RuntimeFeatureBehavior::GetRuntimeEnabledFeatureDetector()->IsFeatureEnabled(
+            RuntimeFeatureBehavior::RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi))
+    {
+        m_hCore->SetShouldInstallImeFocusPark(true);
+    }
+    else
+    {
+        // We only want to do this when not in design mode, since the design-mode process should use the legacy IMEs.
+        ImmDisableLegacyIME();
+    }
 
     m_hCore->SetInitializationType(initializationType);
 

--- a/dxaml/xcp/tools/GenXbfDLL/InputManagerStub.cpp
+++ b/dxaml/xcp/tools/GenXbfDLL/InputManagerStub.cpp
@@ -4,6 +4,17 @@
 #include "precomp.h"
 #include "InputServices.h"
 
+// GenXbf links this stub in place of the real InputServices.cpp (see GenXbf.vcxproj), so it must also
+// supply trivial definitions for ImeFocusPark's out-of-line ctor/dtor: CInputServices owns one by value
+// (m_imeFocusPark), so the CInputServices ctor/dtor below construct and destroy it. A local empty Impl
+// satisfies the std::unique_ptr<Impl> complete-type requirement in the destructor. The real behavior
+// lives in InputServices.cpp and is never needed by the XBF generation tool.
+struct ImeFocusPark::Impl {};
+
+ImeFocusPark::ImeFocusPark() = default;
+
+ImeFocusPark::~ImeFocusPark() = default;
+
 CInputServices::CInputServices(_In_ CCoreServices*)
 {
 }


### PR DESCRIPTION
ADO PR : https://microsoft.visualstudio.com/WinUI/_git/microsoft-ui-xaml-lift/pullrequest/16230316
ADO issue: https://microsoft.visualstudio.com/OS/_workitems/edit/63251456/

## Problem
`DXamlCore::InitializeInstance` calls `ImmDisableLegacyIME()`, which suppresses IMM's fallback to the CUAS default input context. Side effect: several legacy CJK/JP/KR IMEs lost their status-bar / language-switch UI in XAML text controls. Simply removing the call (PR 15911731) re-enables the fallback and lets IMEs consume keys / open composition UI over **non-text** UI — the "ambiguated text-input focus" regression the OS TSF owner flagged.

## Approach (Option A)
Make XAML's TSF focus signal explicit instead of relying on the global IMM disable. A per-app opt-in (default off) keeps the legacy IMM path enabled **and** installs an `ImeFocusPark` that parks TSF thread-manager focus on a permanent keyboard-disabled document whenever the focused element is **not** text-editable. While a text-editable control is focused RichEdit owns TSF focus (status bar shows); otherwise the disabled document stops IMM reaching the CUAS default context.

## Changes
- **`ImeFocusPark`** (`core/inc/ImeFocusPark.h` + impl in `InputServices.cpp`): owns the per-thread `ITfThreadMgr2` + a keyboard-disabled `ITfDocumentMgr`; parks/stands-down on focus change; thread-affine.
- **Focus hook**: `CInputManager::NotifyFocusChanged` forwards to `CInputServices::NotifyFocusChangedForImePark`, keyed off `IsTextEditableControl`.
- **Gating**: new `RuntimeEnabledFeature::EnableLegacyImeAuxiliaryUi` (default off). When set, `DXamlCore::InitializeInstance` skips `ImmDisableLegacyIME()` and flags `CCoreServices::ShouldInstallImeFocusPark`. Registry kill-switch: `HKLM\Software\Microsoft\WinUI\XAML`.

## Update 2026-08-24 — desktop fix: why the park-only fix failed
On a **WinUI 3 desktop** app the park never suppressed the legacy IME. Two wrong assumptions:
1. **The park was assumed installed** — but it installs only in `CInputServices::SetCoreWindow` (a UWP/CoreWindow path). Desktop apps have **no CoreWindow** (`DXamlCore::ConfigureJupiterWindow`: "CoreWindow does not exist in Win32/ Islands"), so it never initialized and `NotifyFocusChangedForImePark` early-returned on `!IsInitialized()` — dead code on desktop.
2. **TSF park was assumed able to stop the IME** — but here `IsTSF3Enabled()==false` (proven by file-tracing on the VM) and a legacy **IMM/CUAS** IME (2345 Pinyin) composes into the focused window's **default IMM context**, not TSF, so parking TSF focus can't stop it.

Fix: drive `NotifyFocusChangedForImePark` off the **feature opt-in** instead of `IsInitialized()`, so the IMM layer runs regardless of the TSF park; disable/restore the **IMM context** across the focus / island / root / foreground windows; and also install the park from `RegisterIslandInputSite` (the island/desktop entry point). Verified on the VM with 2345 Pinyin: no IME UI over Button/Slider; TextBox input still works.

## Draft caveats / open items
1. **Load-bearing assumption**: `CoCreateInstance(CLSID_TF_ThreadMgr)` shares the same per-thread focus (`CThreadInputMgr`) that RichEdit/CUAS use.
2. Uses a keyboard-disabled context (`GUID_COMPARTMENT_KEYBOARD_DISABLED`); confirm this is a true non-fallback focus.
3. **Per-process, not per-island**: `ImmDisableLegacyIME` is a per-process flag read at init; per-app manifest opt-in surface and per-island scoping are follow-ups.
4. Full CI build + manual IME passes (~17-IME matrix) pending.

_Ported from internal PR 16230316._

https://github.com/user-attachments/assets/057c3f88-20c2-4ad3-91b1-c599a102a5df

