### PR TITLE
Move remaining sample, perf, and test apps off the .NET 6 projection moniker

### DIFF
--- a/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/ItemsViewIntegrationApp.csproj
+++ b/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/ItemsViewIntegrationApp.csproj
@@ -2,13 +2,14 @@
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(WindowsAppSdkTargetFrameworkMoniker)</TargetFramework>
+    <TargetFramework>$(SamplesTargetFrameworkMoniker)</TargetFramework>
     <TargetPlatformMinVersion>$(WindowsAppSdkTargetPlatformVersion)</TargetPlatformMinVersion>
     <RootNamespace>ItemsViewIntegrationApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/Properties/PublishProfiles/win-arm64.pubxml
+++ b/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/Properties/PublishProfiles/win-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/Properties/PublishProfiles/win-x86.pubxml
+++ b/Samples/ItemsViewIntegrationApp/ItemsViewIntegrationApp/Properties/PublishProfiles/win-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/controls/test/testinfra/MUXTestInfra/MUXTestInfra.csproj
+++ b/controls/test/testinfra/MUXTestInfra/MUXTestInfra.csproj
@@ -2,10 +2,11 @@
   <PropertyGroup>
     <TargetName>MUXTestInfra</TargetName>
     <Platforms>x86;x64;ARM64</Platforms>
-    <TargetFramework>$(WindowsAppSdkTargetFrameworkMoniker)</TargetFramework>
+    <TargetFramework>$(DotNetCoreTargetFrameworkMoniker)</TargetFramework>
     <TargetPlatformMinVersion>$(WindowsAppSdkTargetPlatformVersion)</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <DefineConstants Condition="$(SolutionName) == 'MUXControlsInnerLoop'">$(DefineConstants);INNERLOOP_BUILD</DefineConstants>
   </PropertyGroup>
 

--- a/eng/adhocapp.props
+++ b/eng/adhocapp.props
@@ -25,7 +25,9 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.wapproj'">
-    <AssetTargetFallback>net6.0-windows$(WindowsTargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <!-- Packaging projects wrap both net6.0 projection-floor projects and net8.0 sample/test apps,
+         so both fallbacks are needed. -->
+    <AssetTargetFallback>net6.0-windows$(WindowsTargetPlatformVersion);net8.0-windows$(WindowsTargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
   </PropertyGroup>
 
   <!-- These ProjectReferences have metadata on them with the purpose of affect the actual build as little as possible -->

--- a/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/Properties/PublishProfiles/win-arm64.pubxml
+++ b/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/Properties/PublishProfiles/win-x64.pubxml
+++ b/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/Properties/PublishProfiles/win-x64.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/Properties/PublishProfiles/win-x86.pubxml
+++ b/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/Properties/PublishProfiles/win-x86.pubxml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
@@ -6,7 +6,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/XAMLPerf.UnpackagedApp.Cs.MUX.csproj
+++ b/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/XAMLPerf.UnpackagedApp.Cs.MUX.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(SamplesTargetFrameworkMoniker)</TargetFramework>
+    <TargetFramework>$(DotNetCoreTargetFrameworkMoniker)</TargetFramework>
     <TargetPlatformMinVersion>$(WindowsAppSdkTargetPlatformVersion)</TargetPlatformMinVersion>
     <RootNamespace>XAMLPerf.UnpackagedApp.Cs.MUX</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/XAMLPerf.UnpackagedApp.Cs.MUX.csproj
+++ b/perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX/XAMLPerf.UnpackagedApp.Cs.MUX.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(WindowsAppSdkTargetFrameworkMoniker)</TargetFramework>
+    <TargetFramework>$(SamplesTargetFrameworkMoniker)</TargetFramework>
     <TargetPlatformMinVersion>$(WindowsAppSdkTargetPlatformVersion)</TargetPlatformMinVersion>
     <RootNamespace>XAMLPerf.UnpackagedApp.Cs.MUX</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &lt; 8">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
     <WindowsPackageType>None</WindowsPackageType>


### PR DESCRIPTION
## Summary

Follow-up to the `SamplesTargetFrameworkMoniker` split. Three projects were
missed and were still resolving `$(WindowsAppSdkTargetFrameworkMoniker)`
(.NET 6) with unconditional `win10-*` RIDs.

`$(WindowsAppSdkTargetFrameworkMoniker)` is unchanged at net6.0 — it governs
the shipped projection, so moving it would be a consumer breaking change.

## Changes

| Project | Before | After |
|---|---|---|
| `Samples/ItemsViewIntegrationApp` | WindowsAppSdk moniker | `$(SamplesTargetFrameworkMoniker)` |
| `perf/scenarios/XAMLPerf.UnpackagedApp.Cs.MUX` | WindowsAppSdk moniker | `$(SamplesTargetFrameworkMoniker)` |
| `controls/test/testinfra/MUXTestInfra` | WindowsAppSdk moniker | `$(DotNetCoreTargetFrameworkMoniker)` |

- **RIDs** — adopted the TFM-conditional pattern already used elsewhere in
  `Samples\`, rather than a flat rename, so `init.cmd net6` keeps working.
- **Publish profiles** — renamed 6 `win10-*.pubxml` → `win-*.pubxml` (via
  `git mv`, rename detection intact) and updated `<PublishProfile>` to match.
  `RuntimeIdentifier` inside each is conditional; the filename is only a
  lookup key, so net6 still resolves `win10-*`.
- **`eng/adhocapp.props`** — `AssetTargetFallback` now lists net6.0 and net8.0,
  as packaging projects wrap both projection-floor and sample/test apps.

## Note on MUXTestInfra

It uses `$(DotNetCoreTargetFrameworkMoniker)`, not the samples moniker.
`SamplesTargetFrameworkMoniker` is hardcoded net8.0, but `init.cmd net6` is
still supported and its consumer `MUXControls.Test` uses the DotNetCore
moniker — pinning it to net8 would leave a net6 project referencing a net8
library. Same moniker as its consumer keeps them in lockstep.

## Not included

`MUXControlsTestApp` / `MUXControls.Test` still carry unconditional `win10-*`
RIDs and `win10-$(Platform).pubxml`. They resolve to net8 today via
`$(DotNetCoreTargetFrameworkMoniker)`, so they carry the same latent
NETSDK1083 exposure, but they're outside this change's scope.

## Validation

- [ ] `init.cmd x64chk` + build samples
- [ ] `init.cmd x64chk net6` + restore, to confirm the `< 8` RID branch
- [ ] MUXControls test pass