### PR TITLE
CImageSource::SetSource: re-qualify DecodeToRenderSize for stream SVGs that enter the tree later

### DIFF
--- a/dxaml/test/native/external/foundation/graphics/image/SVGImageSourceTests.cpp
+++ b/dxaml/test/native/external/foundation/graphics/image/SVGImageSourceTests.cpp
@@ -1484,4 +1484,114 @@ void SvgImageSourceTests::SvgWithoutDevice()
     u->VerifyMockDCompOutput(MockDComp::SurfaceComparison::ReferencedOnly);
 }
 
+// Regression test for AB#47128962: SetSourceAsync on a detached SvgImageSource used to latch
+// DecodeToRenderSize off permanently, leaving the SVG rasterized at the XamlRoot's size instead of
+// the element's render size. Sets the source before parenting, then verifies the render-size decode
+// still happens. Without the fix the DecodeToRenderSize codepath never runs and the waiter times out.
+void SvgImageSourceTests::SetSourceAsyncBeforeEnteringTreeDecodesToRenderSize()
+{
+    TestCleanupWrapper cleanup;
+
+    WUCRenderingScopeGuard guard(DCompRendering::WUCCompleteSynchronousCompTree);
+
+    const int imageElementWidth = 100;
+    const int imageElementHeight = 100;
+
+    // DecodeToRenderSize clamps to the element size; the buggy decode uses the root size and never raises this.
+    Platform::String^ etwValidationString =
+        L"@DecodeWidth=" + imageElementWidth + L" AND " +
+        L"@DecodeHeight=" + imageElementHeight;
+
+    ETWWaiterProxy imageEtwWaiter;
+    imageEtwWaiter.Start(
+        WINDOWS_UI_XAML_ETW_PROVIDER,
+        DecodeToRenderSizeBegin_value,
+        etwValidationString);
+
+    LOG_OUTPUT(L"Getting stream of svg image");
+    wsts::IRandomAccessStream^ svgStream = LoadBinaryFile(GetResourcesPath() + L"msft.svg");
+    wsts::IRandomAccessStream^ svgStreamFirst = LoadBinaryFile(GetResourcesPath() + L"msft.svg");
+
+    auto rootGrid = safe_cast<Grid^>(LoadXamlFileOnUIThread(GetResourcesPath() + L"SimpleImage.xaml"));
+    VERIFY_IS_NOT_NULL(rootGrid);
+
+    SvgImageSource^ svgImageSource = nullptr;
+    xaml_controls::Image^ testImage = nullptr;
+    auto sourceAsyncCompletionEvent = std::make_shared<Event>();
+    SvgImageSourceLoadStatus status;
+
+    RunOnUIThread([&]()
+    {
+        TestServices::WindowHelper->WindowContent = rootGrid;
+
+        testImage = safe_cast<xaml_controls::Image^>(rootGrid->FindName(L"imageElement"));
+        VERIFY_IS_NOT_NULL(testImage);
+        testImage->Width = imageElementWidth;
+        testImage->Height = imageElementHeight;
+        testImage->Stretch = Stretch::Fill;
+    });
+    TestServices::WindowHelper->WaitForIdle();
+
+    // Complete a first detached SetSourceAsync, then set again below to exercise the repeated-set path.
+    auto firstSetCompletionEvent = std::make_shared<Event>();
+    RunOnUIThread([&]()
+    {
+        svgImageSource = ref new SvgImageSource();
+        VERIFY_IS_NOT_NULL(svgImageSource);
+
+        auto firstOp = svgImageSource->SetSourceAsync(svgStreamFirst);
+        firstOp->Completed = ref new wf::AsyncOperationCompletedHandler<SvgImageSourceLoadStatus>(
+            [firstSetCompletionEvent](wf::IAsyncOperation<SvgImageSourceLoadStatus>^, wf::AsyncStatus)
+        {
+            firstSetCompletionEvent->Set();
+        });
+    });
+    firstSetCompletionEvent->WaitForDefault();
+
+    // Second detached set on the same source, then attach and verify the render-size decode.
+    RunOnUIThread([&]()
+    {
+        auto setSourceAsyncOperation = svgImageSource->SetSourceAsync(svgStream);
+        setSourceAsyncOperation->Completed =
+            ref new wf::AsyncOperationCompletedHandler<SvgImageSourceLoadStatus>(
+                [&status, sourceAsyncCompletionEvent](wf::IAsyncOperation<SvgImageSourceLoadStatus>^ operation, wf::AsyncStatus)
+        {
+            LOG_OUTPUT(L"SetSourceAsync operation completed while detached from the tree");
+            status = operation->GetResults();
+            sourceAsyncCompletionEvent->Set();
+        });
+    });
+
+    // Must complete even with no parent, so this also guards against deferring the decode to a render walk.
+    sourceAsyncCompletionEvent->WaitForDefault();
+    VERIFY_IS_TRUE(sourceAsyncCompletionEvent->HasFired());
+    VERIFY_ARE_EQUAL(status, SvgImageSourceLoadStatus::Success);
+
+    auto svgOpenedEvent = std::make_shared<Event>();
+    auto openedRegistration = CreateSafeEventRegistration(SvgImageSource, Opened);
+
+    // Now put the already-populated source into the live tree.
+    RunOnUIThread([&]()
+    {
+        openedRegistration.Attach(
+            svgImageSource,
+            ref new wf::TypedEventHandler<SvgImageSource^, SvgImageSourceOpenedEventArgs^>([svgOpenedEvent](SvgImageSource^, SvgImageSourceOpenedEventArgs^)
+        {
+            LOG_OUTPUT(L"SvgImageSource Opened event fired");
+            svgOpenedEvent->Set();
+        }));
+
+        testImage->Source = svgImageSource;
+    });
+
+    TestServices::WindowHelper->SynchronouslyTickUIThread(2);
+    TestServices::WindowHelper->WaitForIdle();
+
+    svgOpenedEvent->WaitForDefault();
+    VERIFY_IS_TRUE(svgOpenedEvent->HasFired());
+
+    // Without the fix DecodeToRenderSize stays off, so this 100x100 decode event is never raised.
+    imageEtwWaiter.WaitForDefault();
+}
+
 } } } } } } }

--- a/dxaml/test/native/external/foundation/graphics/image/SVGImageSourceTests.h
+++ b/dxaml/test/native/external/foundation/graphics/image/SVGImageSourceTests.h
@@ -32,6 +32,12 @@ public:
         TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
     END_TEST_METHOD()
 
+    // Regression test for AB#47128962. Asserts decode size via ETW, so no master file.
+    BEGIN_TEST_METHOD(SetSourceAsyncBeforeEnteringTreeDecodesToRenderSize)
+        TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
+        TEST_METHOD_PROPERTY(L"Hosting:Mode", L"UAP")   // Illegal to wait on a task in a Windows Runtime STA
+    END_TEST_METHOD()
+
     BEGIN_TEST_METHOD(UriSource)
         TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
         TEST_METHOD_PROPERTY(L"Hosting:Mode", L"UAP")   // MockDComp surface mismatch

--- a/dxaml/xcp/core/core/elements/imagesource.cpp
+++ b/dxaml/xcp/core/core/elements/imagesource.cpp
@@ -169,6 +169,7 @@ CImageSource::CImageSource(_In_ CCoreServices *pCore)
     m_pAsyncAction          = nullptr;
     m_fDecodeToRenderSize   = FALSE;
     m_fDecodeToRenderSizeForcedOff = FALSE;
+    m_decodeToRenderSizeDisqualifiedByLiveness = false;
     m_pendingDecodeForLostSoftwareSurface = FALSE;
     m_downloadProgress = 0;
     m_nCreateOptions = DirectUI::BitmapCreateOptions::None;
@@ -729,6 +730,10 @@ CImageSource::SetSource(
     if (!IsActive())
     {
         TraceDecodeToRenderSizeDisqualified(ImageDecodeBoundsFinder::NotInLiveTree);
+
+        // Remember liveness disabled DecodeToRenderSize so EnterImpl can re-enable it once the SVG is live.
+        m_decodeToRenderSizeDisqualifiedByLiveness = OfTypeByIndex<KnownTypeIndex::SvgImageSource>();
+
         m_fDecodeToRenderSizeForcedOff = TRUE;
     }
 
@@ -1981,6 +1986,14 @@ CImageSource::EnterImpl(_In_ CDependencyObject *pNamescopeOwner, _In_ EnterParam
     if (params.fIsLive)
     {
         UnregisterForCleanupOnEnter();
+
+        // Now live: re-enable DecodeToRenderSize so the render walk decodes to the element size.
+        if (m_decodeToRenderSizeDisqualifiedByLiveness)
+        {
+            m_decodeToRenderSizeDisqualifiedByLiveness = false;
+            m_fDecodeToRenderSizeForcedOff = FALSE;
+            m_fDecodeToRenderSize = ShouldDecodeToRenderSize();
+        }
     }
 
     return S_OK;

--- a/dxaml/xcp/core/inc/imagesource.h
+++ b/dxaml/xcp/core/inc/imagesource.h
@@ -177,6 +177,9 @@ public:
 protected:
     bool m_fDecodeToRenderSize;
     bool m_fDecodeToRenderSizeForcedOff;
+
+    // Set when only liveness disabled DecodeToRenderSize, cleared when the SVG enters the live tree.
+    bool m_decodeToRenderSizeDisqualifiedByLiveness;
     uint32_t m_frameIndex = 0;
 
     _Check_return_ HRESULT OnImageAvailableCommon(


### PR DESCRIPTION
Description:  
SvgImageSource populated by SetSourceAsync rasterizes to the size of the XamlRoot rather than the element's render size, and keeps that surface for the life of the source. 

A 32x32 icon in a 1200x800 window holds a 1850x1850 surface, the same SVG set through UriSource decodes at 48x48.

Root cause:  
CImageSource::SetSource runs on the stream-read completion and sets m_fDecodeToRenderSizeForcedOff = TRUE when !IsActive() (imagesource.cpp:730). 

Nothing clears that flag outside the constructor.

Fix:  
Record that liveness was the only disqualifier

the liveness latch with OfTypeByIndex m_decodeToRenderSizeDisqualifiedByLiveness=OfTypeByIndexKnownTypeIndex::SvgImageSource(

whenever a detached source is an SVG, dropping the earlier && !m_fDecodeToRenderSizeForcedOff so a repeated SetSourceAsync still re-qualifies in EnterImpl

```
FRAME N - source is assigned into the tree

  img.Source = svg
  +- CImageSource::EnterImpl                      imagesource.cpp:1971
       if (m_decodeToRenderSizeDisqualifiedByLiveness)
           m_fDecodeToRenderSizeForcedOff = FALSE
           m_fDecodeToRenderSize = ShouldDecodeToRenderSize()   -> true

     No decode here. EnterImpl only re-opens the gate and dirties the element.

FRAME N+1 - the render walk pulls the decode at the element size

  CCoreServices::NWDrawTree                       xcpcore.cpp:6865
  +- CImageBrush::QueueRequestDecode              hwwalk.cpp:3202
  |    +- CCoreServices::EnqueueImageDecodeRequest    xcpcore.cpp:9842
  +- CCoreServices::FlushImageDecodeRequests      xcpcore.cpp:9917
       +- CImageSource::RequestDecode             imagesource.cpp:2502
            if (IsMetadataAvailable() && m_fDecodeToRenderSize)
                 before: false -> render size discarded, every frame
                 after:  true  -> proceeds
            +- CImageSource::DecodeToRenderSize   imagesource.cpp:2628
                 clamp to element size -> 48x48; SVG sizeChange is !=, so re-decodes
                 +- CImageSource::DecodeStreamWithSize(48, 48, decodeToRenderSize=true)

  +- CSvgImageSource::OnDownloadImageAvailableImpl
                              core/elements/SvgImageSource.cpp:57
       ResetSurfaces() releases the 1850x1850 surface

```

Behavior:  
UriSource, attach-then-SetSourceAsync, RasterizePixelWidth/Height and BitmapImage are unchanged. 

A stream SVG that enters the tree re-decodes at the element size and drops the oversized surface. 

A source that is never parented, or enters collapsed, is unchanged.

Testing:  
Repro'd locally in a WinUI 3 app across 8 cases of 24 SVGs each, main against the fix. 

Steady-state cost for the detached-stream case drops 187 MB -> 1.1 MB   
Attach during decode 317 MB -> 15 MB  
 uri, attach-first, explicit rasterize size, never-parented, collapsed and BitmapImage are flat to within noise

Added SvgImageSourceTests::SetSourceAsyncBeforeEnteringTreeDecodesToRenderSize, asserting DecodeWidth/DecodeHeight on the DecodeToRenderSizeBegin ETW event with the existing ETWWaiterProxy pattern from ImageTests::StreamCleanupAndRestore and It times out and fails on unfixed main.