### PR TITLE
Round CommandBarFlyout checked toggle button fill

### DIFF
--- a/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -321,6 +321,7 @@
     <Setter Property="Width" Value="NaN" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="AllowFocusOnInteraction" Value="False" />
+    <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     <Setter Property="primitives:CommandBarFlyoutCommandBarAutomationProperties.ControlType" Value="MenuItem" />
     <Setter Property="Template">
       <Setter.Value>

--- a/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources_perf2026.xaml
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources_perf2026.xaml
@@ -321,6 +321,7 @@
     <Setter Property="Width" Value="NaN" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="AllowFocusOnInteraction" Value="False" />
+    <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
     <Setter Property="primitives:CommandBarFlyoutCommandBarAutomationProperties.ControlType" Value="MenuItem" />
     <Setter Property="Template">
       <Setter.Value>


### PR DESCRIPTION
## Description

Adds the standard `ControlCornerRadius` to the base toggle-button style used by `CommandBarFlyout`. Checked formatting buttons in surfaces such as the `RichEditBox` text flyout now have the same rounded fill as their non-toggle counterparts.

## Motivation and Context

The toggle-button base style did not set `CornerRadius`, so its checked accent fill used square corners. The sibling button style already applies the standard control corner radius.

Fixes #8539.

## How Has This Been Tested?

- Built `Microsoft.UI.Xaml.Controls.dll` for `amd64chk`.
- Verified the checked toggle-button appearance in the `MUXControlsTestApp` `TextCommandBarFlyout` page.

## Screenshots and recordings

![Before: square checked fill](https://github.com/user-attachments/assets/6bd9d0fe-c9dc-4f9a-80fc-11c28577c2aa)

![After: rounded checked fill](https://github.com/user-attachments/assets/1c2ef33e-0a84-4627-a7ca-a79e8bf71aae)

## Prior review sign-offs

The following reviewer previously reviewed and signed off on this change and is tagged to reconfirm the GitHub version:

- @godlytalias
