### PR TITLE
Honor explicit Flyout.Placement on SplitButton

### DIFF
--- a/controls/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/controls/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -66,6 +66,61 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void FlyoutPlacementIsRespected()
+        {
+            var setupOptions = new TestSetupHelper.TestSetupHelperOptions
+            {
+                AutomationIdOfSafeItemToClick = null
+            };
+
+            using (var setup = new TestSetupHelper("SplitButton Tests", setupOptions))
+            {
+                const int alignmentTolerance = 12;
+
+                SplitButton defaultPlacementSplitButton = FindElement.ByName<SplitButton>("DefaultPlacementSplitButton");
+                defaultPlacementSplitButton.ExpandAndWait();
+
+                MenuItem defaultPlacementFlyoutItem = new MenuItem(FindElement.ById("DefaultPlacementFlyoutItem"));
+                var defaultButtonBounds = defaultPlacementSplitButton.BoundingRectangle;
+                var defaultFlyoutBounds = defaultPlacementFlyoutItem.BoundingRectangle;
+
+                Log.Comment("Verify that an unset placement preserves the existing bottom-left alignment.");
+                Verify.IsGreaterThan(defaultFlyoutBounds.Y, defaultButtonBounds.Y + defaultButtonBounds.Height);
+                Verify.IsLessThan(Math.Abs(defaultFlyoutBounds.X - defaultButtonBounds.X), alignmentTolerance);
+
+                defaultPlacementSplitButton.CollapseAndWait();
+
+                SplitButton autoPlacementSplitButton = FindElement.ByName<SplitButton>("AutoPlacementSplitButton");
+                autoPlacementSplitButton.ExpandAndWait();
+
+                MenuItem autoPlacementFlyoutItem = new MenuItem(FindElement.ById("AutoPlacementFlyoutItem"));
+                var autoButtonBounds = autoPlacementSplitButton.BoundingRectangle;
+                var autoFlyoutBounds = autoPlacementFlyoutItem.BoundingRectangle;
+
+                Log.Comment("Verify that an explicit Auto placement preserves the existing bottom-left alignment.");
+                Verify.IsGreaterThan(autoFlyoutBounds.Y, autoButtonBounds.Y + autoButtonBounds.Height);
+                Verify.IsLessThan(Math.Abs(autoFlyoutBounds.X - autoButtonBounds.X), alignmentTolerance);
+
+                autoPlacementSplitButton.CollapseAndWait();
+
+                SplitButton topPlacementSplitButton = FindElement.ByName<SplitButton>("TopPlacementSplitButton");
+                topPlacementSplitButton.ExpandAndWait();
+
+                MenuItem topPlacementFlyoutItem = new MenuItem(FindElement.ById("TopPlacementFlyoutItem"));
+                var topButtonBounds = topPlacementSplitButton.BoundingRectangle;
+                var topFlyoutBounds = topPlacementFlyoutItem.BoundingRectangle;
+                var topButtonCenter = topButtonBounds.X + topButtonBounds.Width / 2;
+                var topFlyoutCenter = topFlyoutBounds.X + topFlyoutBounds.Width / 2;
+
+                Log.Comment("Verify that an explicit Top placement centers the flyout above the SplitButton.");
+                Verify.IsLessThan(topFlyoutBounds.Y + topFlyoutBounds.Height, topButtonBounds.Y);
+                Verify.IsLessThan(Math.Abs(topFlyoutCenter - topButtonCenter), alignmentTolerance);
+
+                topPlacementSplitButton.CollapseAndWait();
+            }
+        }
+
+        [TestMethod]
         public void CommandTest()
         {
             using (var setup = new TestSetupHelper("SplitButton Tests"))

--- a/controls/dev/SplitButton/SplitButton.cpp
+++ b/controls/dev/SplitButton/SplitButton.cpp
@@ -223,7 +223,13 @@ void SplitButton::OpenFlyout()
     if (auto flyout = Flyout())
     {
         winrt::FlyoutShowOptions options{};
-        options.Placement(winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft);
+        // Preserve SplitButton's established default when placement is unset or resolves to Auto.
+        if (flyout.ReadLocalValue(winrt::FlyoutBase::PlacementProperty()) == winrt::DependencyProperty::UnsetValue() ||
+            flyout.Placement() == winrt::FlyoutPlacementMode::Auto)
+        {
+            options.Placement(winrt::FlyoutPlacementMode::BottomEdgeAlignedLeft);
+        }
+
         flyout.ShowAt(*this, options);
     }
 }

--- a/controls/dev/SplitButton/TestUI/SplitButtonPage.xaml
+++ b/controls/dev/SplitButton/TestUI/SplitButtonPage.xaml
@@ -117,6 +117,41 @@
         <StackPanel Grid.Column="1"  Orientation="Vertical" VerticalAlignment="Top" HorizontalAlignment="Left"
                     Margin="8,0,0,0" Style="{ThemeResource StandardGroupingStackPanel}">
             <TextBlock Text="Demo interaction controls" Style="{ThemeResource StandardGroupHeader}"/>
+            <controls:SplitButton x:Name="DefaultPlacementSplitButton"
+                                  AutomationProperties.Name="DefaultPlacementSplitButton"
+                                  Content="Default placement"
+                                  HorizontalAlignment="Left"
+                                  Width="300">
+                <controls:SplitButton.Flyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem AutomationProperties.AutomationId="DefaultPlacementFlyoutItem" Text="Item" Width="120"/>
+                    </MenuFlyout>
+                </controls:SplitButton.Flyout>
+            </controls:SplitButton>
+            <controls:SplitButton x:Name="AutoPlacementSplitButton"
+                                  AutomationProperties.Name="AutoPlacementSplitButton"
+                                  Content="Explicit Auto placement"
+                                  HorizontalAlignment="Left"
+                                  Margin="0,8,0,0"
+                                  Width="300">
+                <controls:SplitButton.Flyout>
+                    <MenuFlyout Placement="Auto">
+                        <MenuFlyoutItem AutomationProperties.AutomationId="AutoPlacementFlyoutItem" Text="Item" Width="120"/>
+                    </MenuFlyout>
+                </controls:SplitButton.Flyout>
+            </controls:SplitButton>
+            <controls:SplitButton x:Name="TopPlacementSplitButton"
+                                  AutomationProperties.Name="TopPlacementSplitButton"
+                                  Content="Explicit Top placement"
+                                  HorizontalAlignment="Left"
+                                  Margin="0,8,0,12"
+                                  Width="300">
+                <controls:SplitButton.Flyout>
+                    <MenuFlyout Placement="Top">
+                        <MenuFlyoutItem AutomationProperties.AutomationId="TopPlacementFlyoutItem" Text="Item" Width="120"/>
+                    </MenuFlyout>
+                </controls:SplitButton.Flyout>
+            </controls:SplitButton>
             <StackPanel Orientation="Horizontal">
                 <controls:ToggleSplitButton x:Name="ToggleSplitButton" AutomationProperties.Name="ToggleSplitButton" Content="Toggle" IsCheckedChanged="ToggleSplitButton_IsCheckedChanged" Click="ToggleSplitButton_Click">
                     <controls:SplitButton.Flyout>


### PR DESCRIPTION
## Fixes

Fixes #11006

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

`SplitButton` always forces `BottomEdgeAlignedLeft` when it opens its flyout, so an explicitly configured or bound `Flyout.Placement` is ignored.

### New Behavior

An unset or `Auto` placement keeps the established `BottomEdgeAlignedLeft` behavior. Explicit placement values, including bound values, are honored. UI regression coverage exercises the default, explicit `Auto`, and explicit `Top` cases.

## Customer Impact

Apps can control a `SplitButton` flyout's placement without losing the existing default behavior.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The change is limited to the placement options used when `SplitButton` opens its flyout.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

Previously validated with a full x64 Debug product and test build. `FlyoutPlacementIsRespected` passed 1/1.

## Screenshots and recordings

![Unset placement preserves the default](https://github.com/user-attachments/assets/ceba8a8b-7697-4c04-a0af-a297e85f80b4)

![Explicit Top placement is honored](https://github.com/user-attachments/assets/c604e3ff-ec79-4348-b441-ee7360c77e7b)

## Prior review sign-offs

@godlytalias previously reviewed and signed off, and is tagged to reconfirm the GitHub version.