### PR TITLE
Add lightweight styling resources for AppBarButton width

### DIFF
--- a/controls/dev/CommonStyles/APITests/CommonStylesTests.cs
+++ b/controls/dev/CommonStyles/APITests/CommonStylesTests.cs
@@ -415,6 +415,64 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        public void VerifyAppBarButtonWidthLightweightStyling()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var root = (StackPanel)XamlReader.Load(
+                    @"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+                            <AppBarButton x:Name='DefaultAppBarButton' Label='Default'/>
+                            <AppBarToggleButton x:Name='DefaultAppBarToggleButton' Label='Default'/>
+                            <StackPanel>
+                                <StackPanel.Resources>
+                                    <x:Double x:Key='AppBarButtonWidth'>45</x:Double>
+                                    <x:Double x:Key='AppBarToggleButtonWidth'>47</x:Double>
+                                </StackPanel.Resources>
+                                <AppBarButton x:Name='FullSizeAppBarButton' Label='Full size'/>
+                                <AppBarButton x:Name='CompactAppBarButton' Label='Compact' IsCompact='True'/>
+                                <CommandBar DefaultLabelPosition='Right'>
+                                    <AppBarButton x:Name='RightLabelAppBarButton' Label='Right'/>
+                                </CommandBar>
+                                <AppBarButton x:Name='CollapsedLabelAppBarButton' Label='Collapsed' LabelPosition='Collapsed'/>
+                                <AppBarButton x:Name='LocalWidthAppBarButton' Label='Local width' Width='90'/>
+                                <AppBarToggleButton x:Name='AppBarToggleButton' Label='Toggle'/>
+                                <AppBarButton x:Name='OverflowAppBarButton' Label='A long overflow label' Style='{StaticResource AppBarButtonOverflowStyle}'/>
+                                <AppBarToggleButton x:Name='OverflowAppBarToggleButton' Label='A long overflow label' Style='{StaticResource AppBarToggleButtonOverflowStyle}'/>
+                            </StackPanel>
+                      </StackPanel>");
+
+                Content = root;
+                Content.UpdateLayout();
+
+                var defaultAppBarButton = (AppBarButton)root.FindName("DefaultAppBarButton");
+                var defaultAppBarToggleButton = (AppBarToggleButton)root.FindName("DefaultAppBarToggleButton");
+                Verify.AreEqual(68.0, defaultAppBarButton.Width);
+                Verify.AreEqual(68.0, defaultAppBarButton.ActualWidth);
+                Verify.AreEqual(68.0, defaultAppBarToggleButton.Width);
+                Verify.AreEqual(68.0, defaultAppBarToggleButton.ActualWidth);
+
+                foreach (var name in new[] { "FullSizeAppBarButton", "CompactAppBarButton", "RightLabelAppBarButton", "CollapsedLabelAppBarButton" })
+                {
+                    var appBarButton = (AppBarButton)root.FindName(name);
+                    Verify.AreEqual(45.0, appBarButton.Width);
+                    Verify.AreEqual(45.0, appBarButton.ActualWidth);
+                }
+
+                var localWidthAppBarButton = (AppBarButton)root.FindName("LocalWidthAppBarButton");
+                Verify.AreEqual(90.0, localWidthAppBarButton.Width);
+                Verify.AreEqual(90.0, localWidthAppBarButton.ActualWidth);
+
+                var appBarToggleButton = (AppBarToggleButton)root.FindName("AppBarToggleButton");
+                Verify.AreEqual(47.0, appBarToggleButton.Width);
+                Verify.AreEqual(47.0, appBarToggleButton.ActualWidth);
+
+                Verify.IsTrue(Double.IsNaN(((AppBarButton)root.FindName("OverflowAppBarButton")).Width));
+                Verify.IsTrue(Double.IsNaN(((AppBarToggleButton)root.FindName("OverflowAppBarToggleButton")).Width));
+            });
+        }
+
+        [TestMethod]
         public void VerifyAppBarButtonChevronMarginsDoNotCollide()
         {
             StackPanel root = null;

--- a/controls/dev/CommonStyles/AppBarButton_themeresources.xaml
+++ b/controls/dev/CommonStyles/AppBarButton_themeresources.xaml
@@ -117,6 +117,7 @@
   <Thickness x:Key="AppBarButtonInnerBorderMargin">2,6,2,6</Thickness>
   <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">2,6,2,22</Thickness>
   <Thickness x:Key="AppBarButtonInnerBorderOverflowMargin">4,0,4,0</Thickness>
+  <x:Double x:Key="AppBarButtonWidth">68</x:Double>
   <Style TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />
   <Style x:Key="AppBarButtonOverflowStyle" TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}">
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -130,7 +131,7 @@
     <Setter Property="VerticalAlignment" Value="Top" />
     <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
     <Setter Property="FontWeight" Value="Normal" />
-    <Setter Property="Width" Value="68" />
+    <Setter Property="Width" Value="{ThemeResource AppBarButtonWidth}" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="FocusVisualMargin" Value="-3" />
     <Setter Property="AllowFocusOnInteraction" Value="False" />

--- a/controls/dev/CommonStyles/AppBarButton_themeresources_perf2026.xaml
+++ b/controls/dev/CommonStyles/AppBarButton_themeresources_perf2026.xaml
@@ -117,6 +117,7 @@
   <Thickness x:Key="AppBarButtonInnerBorderMargin">2,6,2,6</Thickness>
   <Thickness x:Key="AppBarButtonInnerBorderCompactMargin">2,6,2,22</Thickness>
   <Thickness x:Key="AppBarButtonInnerBorderOverflowMargin">4,0,4,0</Thickness>
+  <x:Double x:Key="AppBarButtonWidth">68</x:Double>
   <Style TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />
   <Style x:Key="AppBarButtonOverflowStyle" TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}">
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -130,7 +131,7 @@
     <Setter Property="VerticalAlignment" Value="Top" />
     <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
     <Setter Property="FontWeight" Value="Normal" />
-    <Setter Property="Width" Value="68" />
+    <Setter Property="Width" Value="{ThemeResource AppBarButtonWidth}" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="FocusVisualMargin" Value="-3" />
     <Setter Property="AllowFocusOnInteraction" Value="False" />

--- a/controls/dev/CommonStyles/AppBarToggleButton_themeresources.xaml
+++ b/controls/dev/CommonStyles/AppBarToggleButton_themeresources.xaml
@@ -204,6 +204,7 @@
   <Thickness x:Key="AppBarToggleButtonTextLabelMargin">2,0,2,8</Thickness>
   <Thickness x:Key="AppBarToggleButtonTextLabelOnRightMargin">8,16,12,10</Thickness>
   <Thickness x:Key="AppBarToggleButtonOverflowTextLabelPadding">0,5,0,8</Thickness>
+  <x:Double x:Key="AppBarToggleButtonWidth">68</x:Double>
   <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}" />
   <Style x:Key="AppBarToggleButtonOverflowStyle" TargetType="AppBarToggleButton" BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}">
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -218,7 +219,7 @@
     <Setter Property="VerticalAlignment" Value="Top" />
     <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
     <Setter Property="FontWeight" Value="Normal" />
-    <Setter Property="Width" Value="68" />
+    <Setter Property="Width" Value="{ThemeResource AppBarToggleButtonWidth}" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="FocusVisualMargin" Value="-3" />
     <Setter Property="AllowFocusOnInteraction" Value="False" />

--- a/controls/dev/CommonStyles/AppBarToggleButton_themeresources_perf2026.xaml
+++ b/controls/dev/CommonStyles/AppBarToggleButton_themeresources_perf2026.xaml
@@ -204,6 +204,7 @@
   <Thickness x:Key="AppBarToggleButtonTextLabelMargin">2,0,2,8</Thickness>
   <Thickness x:Key="AppBarToggleButtonTextLabelOnRightMargin">8,16,12,10</Thickness>
   <Thickness x:Key="AppBarToggleButtonOverflowTextLabelPadding">0,5,0,8</Thickness>
+  <x:Double x:Key="AppBarToggleButtonWidth">68</x:Double>
   <Style TargetType="AppBarToggleButton" BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}" />
   <Style x:Key="AppBarToggleButtonOverflowStyle" TargetType="AppBarToggleButton" BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}">
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -218,7 +219,7 @@
     <Setter Property="VerticalAlignment" Value="Top" />
     <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
     <Setter Property="FontWeight" Value="Normal" />
-    <Setter Property="Width" Value="68" />
+    <Setter Property="Width" Value="{ThemeResource AppBarToggleButtonWidth}" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="FocusVisualMargin" Value="-3" />
     <Setter Property="AllowFocusOnInteraction" Value="False" />

--- a/controls/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
+++ b/controls/dev/CommonStyles/InteractionTests/CommonStylesTests.cs
@@ -108,6 +108,12 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
             RunDensityTests("AppBarButtonDensityTest");
         }
 
+        [TestMethod]
+        public void AppBarButtonWidthResourceTest()
+        {
+            RunDensityTests("AppBarButtonWidthResourceTest");
+        }
+
         private void RunDensityTests(string buttonName)
         {
             using (var setup = new TestSetupHelper("CommonStyles Tests"))

--- a/controls/dev/CommonStyles/TestUI/CommonStylesPage.xaml
+++ b/controls/dev/CommonStyles/TestUI/CommonStylesPage.xaml
@@ -396,6 +396,24 @@
                 <TextBlock Text="Validating" Style="{ThemeResource StandardGroupHeader}"/>
                 <TextBox x:Name="DensityTestResult" AutomationProperties.Name="DensityTestResult" Text="Result" Header="Test result"/>
                 <TextBlock Text="Control tests"/>
+                <StackPanel>
+                    <StackPanel.Resources>
+                        <x:Double x:Key="AppBarButtonWidth">45</x:Double>
+                        <x:Double x:Key="AppBarToggleButtonWidth">47</x:Double>
+                    </StackPanel.Resources>
+                    <TextBlock Text="AppBarButton width resource"/>
+                    <StackPanel Orientation="Horizontal">
+                        <AppBarButton x:Name="AppBarButtonWidthFullSize" Label="Full size" Icon="Accept"/>
+                        <AppBarButton x:Name="AppBarButtonWidthCompact" Label="Compact" Icon="Accept" IsCompact="True"/>
+                        <CommandBar DefaultLabelPosition="Right">
+                            <AppBarButton x:Name="AppBarButtonWidthRight" Label="Right" Icon="Accept"/>
+                        </CommandBar>
+                        <AppBarButton x:Name="AppBarButtonWidthCollapsed" Label="Collapsed" Icon="Accept" LabelPosition="Collapsed"/>
+                        <AppBarButton x:Name="AppBarButtonLocalWidth" Label="Local" Icon="Accept" Width="90"/>
+                        <AppBarToggleButton x:Name="AppBarToggleButtonWidthFullSize" Label="Toggle" Icon="Accept"/>
+                        <AppBarToggleButton x:Name="AppBarToggleButtonWidthCompact" Label="Compact toggle" Icon="Accept" IsCompact="True"/>
+                    </StackPanel>
+                </StackPanel>
                 <StackPanel Grid.Row="1" Orientation="Horizontal" BorderBrush="{ThemeResource SystemChromeGrayColor}" BorderThickness="2">
                     <Button x:Name="SliderDensityTest" AutomationProperties.Name="SliderDensityTest" Content="Slider" Click="SliderDensityTest_Click" />
                     <Button x:Name="ToggleSwitchDensityTest" AutomationProperties.Name="ToggleSwitchDensityTest" Content="ToggleSwitch" Click="ToggleSwitchDensityTest_Click" />
@@ -408,6 +426,7 @@
                     <Button x:Name="ComboBoxDensityTest" AutomationProperties.Name="ComboBoxDensityTest" Content="ComboBoxDensity" Click="ComboBoxDensityTest_Click" />
                     <Button x:Name="AppBarButtonDensityTest" AutomationProperties.Name="AppBarButtonDensityTest" Content="AppBarButtonDensity" Click="AppBarButtonDensityTest_Click" />
                     <Button x:Name="AppBarToggleButtonDensityTest" AutomationProperties.Name="AppBarToggleButtonDensityTest" Content="AppBarToggleButtonDensity" Click="AppBarToggleButtonDensityTest_Click" />
+                    <Button x:Name="AppBarButtonWidthResourceTest" AutomationProperties.Name="AppBarButtonWidthResourceTest" Content="AppBarButtonWidthResource" Click="AppBarButtonWidthResourceTest_Click" />
                     <Button x:Name="RichEditBoxDensityTest" AutomationProperties.Name="RichEditBoxDensityTest" Content="RichEditBoxDensity" Click="RichEditBoxDensityTest_Click" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">

--- a/controls/dev/CommonStyles/TestUI/CommonStylesPage.xaml.cs
+++ b/controls/dev/CommonStyles/TestUI/CommonStylesPage.xaml.cs
@@ -277,6 +277,15 @@ namespace MUXControlsTestApp
             }
         }
 
+        private void VerifyWidth(FrameworkElement[] frameworkElements, SimpleVerify simpleVerify, int width)
+        {
+            var expectedWidth = width.ToString();
+            foreach (var element in frameworkElements)
+            {
+                simpleVerify.IsEqual(element.ActualWidth.ToString(), expectedWidth, element.Name.ToString() + ".ActualWidth");
+            }
+        }
+
         private void AppBarButtonDensityTest_Click(object sender, RoutedEventArgs e)
         {
             SimpleVerify simpleVerify = new SimpleVerify();
@@ -291,6 +300,21 @@ namespace MUXControlsTestApp
             SimpleVerify simpleVerify = new SimpleVerify();
             FrameworkElement[] iconCollapsedElements = { AppBarToggleButton1, AppBarToggleButton3 };
             VerifyHeight(iconCollapsedElements, simpleVerify, 48);
+
+            DensityTestResult.Text = simpleVerify.ToString();
+        }
+
+        private void AppBarButtonWidthResourceTest_Click(object sender, RoutedEventArgs e)
+        {
+            SimpleVerify simpleVerify = new SimpleVerify();
+            FrameworkElement[] defaultWidthElements = { AppBarButton1, AppBarButton2, AppBarToggleButton1, AppBarToggleButton2 };
+            FrameworkElement[] appBarButtonWidthElements = { AppBarButtonWidthFullSize, AppBarButtonWidthCompact, AppBarButtonWidthRight, AppBarButtonWidthCollapsed };
+            FrameworkElement[] appBarToggleButtonWidthElements = { AppBarToggleButtonWidthFullSize, AppBarToggleButtonWidthCompact };
+
+            VerifyWidth(defaultWidthElements, simpleVerify, 68);
+            VerifyWidth(appBarButtonWidthElements, simpleVerify, 45);
+            VerifyWidth(appBarToggleButtonWidthElements, simpleVerify, 47);
+            VerifyWidth(new FrameworkElement[] { AppBarButtonLocalWidth }, simpleVerify, 90);
 
             DensityTestResult.Text = simpleVerify.ToString();
         }


### PR DESCRIPTION
## Fixes

Fixes #9403

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

The default 68px width of `AppBarButton` and `AppBarToggleButton` is fixed in their styles and cannot be changed through lightweight styling resources.

### New Behavior

Adds `AppBarButtonWidth` and `AppBarToggleButtonWidth` resources, both defaulting to 68px in the regular and perf2026 styles. Overflow buttons remain auto-sized, and a locally set `Width` continues to take precedence. API and rendered-width coverage verify default, resource-overridden, overflow, and local-width behavior.

## Customer Impact

Apps can adjust command button widths through lightweight styling without replacing the control templates.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The new resources preserve the current defaults and precedence rules.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

The product controls, core XAML, theme XBF, resource satellites, test app, and test project were previously built. The focused tests built and were discovered; execution was blocked by an activation failure also reproduced on the unchanged baseline.

## Screenshots (if appropriate)

Not applicable.