### PR TITLE
Fix SplitButton visual states when IsEnabled changes

### DIFF
--- a/controls/dev/SplitButton/APITests/SplitButtonTests.cs
+++ b/controls/dev/SplitButton/APITests/SplitButtonTests.cs
@@ -6,8 +6,11 @@ using System.Windows.Input;
 
 using MUXControlsTestApp.Utilities;
 
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Common;
+using System.Linq;
 
 using WEX.TestExecution;
 using WEX.TestExecution.Markup;
@@ -70,6 +73,75 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
                 bool isChecked = (bool)toggleSplitButton.GetValue(ToggleSplitButton.IsCheckedProperty);
                 Verify.IsTrue(isChecked, "ToggleSplitButton is not checked");
             });
+        }
+
+        [TestMethod]
+        [Description("Verifies IsEnabled changes immediately update SplitButton visual states.")]
+        public void VerifyIsEnabledChangeUpdatesVisualState()
+        {
+            VerifyIsEnabledChangeUpdatesVisualStateHelper();
+        }
+
+        [TestMethod]
+        [Description("Verifies IsEnabled changes immediately update SplitButton visual states with legacy styles.")]
+        [TestProperty("Data:XamlOptionalChanges", "{DefaultStyleOptimizations:false}")]
+        public void VerifyIsEnabledChangeUpdatesVisualStateWithLegacyStyles()
+        {
+            VerifyIsEnabledChangeUpdatesVisualStateHelper();
+        }
+
+        private void VerifyIsEnabledChangeUpdatesVisualStateHelper()
+        {
+            ToggleSplitButton checkedToggleSplitButton = null;
+            SplitButton disabledSplitButton = null;
+            VisualStateGroup toggleSplitButtonCommonStates = null;
+            VisualStateGroup splitButtonCommonStates = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                checkedToggleSplitButton = new ToggleSplitButton
+                {
+                    IsChecked = true,
+                };
+                disabledSplitButton = new SplitButton
+                {
+                    IsEnabled = false,
+                };
+
+                var panel = new StackPanel();
+                panel.Children.Add(checkedToggleSplitButton);
+                panel.Children.Add(disabledSplitButton);
+                Content = panel;
+            });
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Content.UpdateLayout();
+                toggleSplitButtonCommonStates = GetCommonStates(checkedToggleSplitButton);
+                splitButtonCommonStates = GetCommonStates(disabledSplitButton);
+
+                Verify.IsTrue(toggleSplitButtonCommonStates.States.Any(state => state.Name == "CheckedDisabled"));
+                Verify.AreEqual("Checked", toggleSplitButtonCommonStates.CurrentState.Name);
+                Verify.AreEqual("Disabled", splitButtonCommonStates.CurrentState.Name);
+
+                checkedToggleSplitButton.IsEnabled = false;
+                Verify.AreEqual("CheckedDisabled", toggleSplitButtonCommonStates.CurrentState.Name);
+                Verify.IsTrue(checkedToggleSplitButton.IsChecked);
+
+                disabledSplitButton.IsEnabled = true;
+                Verify.AreEqual("Normal", splitButtonCommonStates.CurrentState.Name);
+                Verify.IsTrue(disabledSplitButton.IsEnabled);
+
+                checkedToggleSplitButton.IsEnabled = true;
+                Verify.AreEqual("Checked", toggleSplitButtonCommonStates.CurrentState.Name);
+            });
+        }
+
+        private static VisualStateGroup GetCommonStates(Control control)
+        {
+            var layoutRoot = (FrameworkElement)VisualTreeHelper.GetChild(control, 0);
+            return VisualStateManager.GetVisualStateGroups(layoutRoot).Single(group => group.Name == "CommonStates");
         }
     }
 

--- a/controls/dev/SplitButton/InteractionTests/SplitButtonTests.cs
+++ b/controls/dev/SplitButton/InteractionTests/SplitButtonTests.cs
@@ -220,6 +220,39 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        public void DisablingWhileGamepadButtonIsDownClearsPressedState()
+        {
+            using (var setup = new TestSetupHelper("SplitButton Tests"))
+            {
+                SplitButton splitButton = FindElement.ByName<SplitButton>("ToggleSplitButton");
+                CheckBox enableCheckBox = FindElement.ByName<CheckBox>("ToggleSplitButtonEnableCheckBox");
+                TextBlock toggleStateTextBlock = FindElement.ByName<TextBlock>("ToggleStateTextBlock");
+
+                Verify.AreEqual(ToggleState.On, enableCheckBox.ToggleState);
+                Verify.AreEqual("Unchecked", toggleStateTextBlock.DocumentText);
+
+                splitButton.SetFocus();
+                Wait.ForIdle();
+
+                Log.Comment("Disable the control while GamepadA remains down so the control does not receive KeyUp");
+                GamepadHelper.PressButton(splitButton, GamepadButton.A, () =>
+                {
+                    enableCheckBox.Uncheck();
+                    Wait.ForIdle();
+                    Verify.IsFalse(splitButton.IsEnabled);
+                });
+
+                enableCheckBox.Check();
+                Wait.ForIdle();
+                Verify.IsTrue(splitButton.IsEnabled);
+
+                Log.Comment("Verify the primary region is restored instead of remaining covered by SecondaryButtonSpan");
+                ClickPrimaryButton(splitButton);
+                Verify.AreEqual("Checked", toggleStateTextBlock.DocumentText);
+            }
+        }
+
+        [TestMethod]
         public void ToggleTest()
         {
             using (var setup = new TestSetupHelper("SplitButton Tests"))

--- a/controls/dev/SplitButton/SplitButton.cpp
+++ b/controls/dev/SplitButton/SplitButton.cpp
@@ -24,6 +24,9 @@ void SplitButton::OnApplyTemplate()
 {
     UnregisterEvents();
 
+    m_isEnabledChangedRevoker.revoke();
+    m_isEnabledChangedRevoker = RegisterPropertyChanged(*this, winrt::Control::IsEnabledProperty(), { this, &SplitButton::OnIsEnabledPropertyChanged });
+
     winrt::IControlProtected controlProtected{ *this };
     m_primaryButton.set(GetTemplateChildT<winrt::Button>(L"PrimaryButton", controlProtected));
     m_secondaryButton.set(GetTemplateChildT<winrt::Button>(L"SecondaryButton", controlProtected));
@@ -115,6 +118,16 @@ void SplitButton::OnVisualPropertyChanged(const winrt::DependencyObject& sender,
     UpdateVisualStates();
 }
 
+void SplitButton::OnIsEnabledPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args)
+{
+    if (!IsEnabled())
+    {
+        m_isKeyDown = false;
+    }
+
+    UpdateVisualStates();
+}
+
 void SplitButton::UpdateVisualStates(bool useTransitions)
 {
     // place the secondary button
@@ -130,8 +143,12 @@ void SplitButton::UpdateVisualStates(bool useTransitions)
     // change visual state
     auto primaryButton = m_primaryButton.get();
     auto secondaryButton = m_secondaryButton.get();
-    if (!IsEnabled()) {
-        winrt::VisualStateManager::GoToState(*this, L"Disabled", useTransitions);
+    if (!IsEnabled())
+    {
+        if (!InternalIsChecked() || !winrt::VisualStateManager::GoToState(*this, L"CheckedDisabled", useTransitions))
+        {
+            winrt::VisualStateManager::GoToState(*this, L"Disabled", useTransitions);
+        }
     }
     else if (primaryButton && secondaryButton)
     {

--- a/controls/dev/SplitButton/SplitButton.h
+++ b/controls/dev/SplitButton/SplitButton.h
@@ -45,6 +45,7 @@ private:
     void RegisterFlyoutEvents();
     void UnregisterEvents();
 
+    void OnIsEnabledPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
     void OnVisualPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
 
     // Internal event handlers
@@ -68,6 +69,7 @@ private:
 
     winrt::UIElement::KeyDown_revoker m_keyDownRevoker{};
     winrt::UIElement::KeyUp_revoker m_keyUpRevoker{};
+    PropertyChanged_revoker m_isEnabledChangedRevoker{};
 
     winrt::ButtonBase::Click_revoker m_clickPrimaryRevoker{};
     PropertyChanged_revoker m_pressedPrimaryRevoker{};

--- a/controls/dev/SplitButton/SplitButton.xaml
+++ b/controls/dev/SplitButton/SplitButton.xaml
@@ -77,6 +77,17 @@
                     <Setter Target="RootGrid.Background" Value="Transparent" />
                   </VisualState.Setters>
                 </VisualState>
+                <VisualState x:Name="CheckedDisabled">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedDisabled}" />
+                    <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundCheckedDisabled}" />
+                    <Setter Target="PrimaryButtonBorder.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedDisabled}" />
+                    <Setter Target="SecondaryButtonBorder.BorderBrush" Value="{ThemeResource SplitButtonBorderBrushCheckedDisabled}" />
+                    <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedDisabled}" />
+                    <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource SplitButtonForegroundCheckedDisabled}" />
+                    <Setter Target="DividerBackgroundGrid.Background" Value="{ThemeResource SplitButtonBorderBrushCheckedDivider}" />
+                  </VisualState.Setters>
+                </VisualState>
                 <VisualState x:Name="FlyoutOpen">
                   <VisualState.Setters>
                     <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource SplitButtonBackgroundPressed}" />

--- a/controls/dev/SplitButton/SplitButton_themeresources.xaml
+++ b/controls/dev/SplitButton/SplitButton_themeresources.xaml
@@ -17,7 +17,7 @@
       <StaticResource x:Key="SplitButtonForegroundChecked" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
       <StaticResource x:Key="SplitButtonForegroundCheckedPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
       <StaticResource x:Key="SplitButtonForegroundCheckedPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush" />
-      <StaticResource x:Key="SplitButtonForegroundCheckedDisabled" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="SplitButtonForegroundCheckedDisabled" ResourceKey="TextOnAccentFillColorDisabled" />
       <StaticResource x:Key="SplitButtonForegroundSecondary" ResourceKey="TextFillColorSecondaryBrush" />
       <StaticResource x:Key="SplitButtonForegroundSecondaryPressed" ResourceKey="TextFillColorTertiaryBrush" />
       <StaticResource x:Key="SplitButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
@@ -49,7 +49,7 @@
       <StaticResource x:Key="SplitButtonForegroundChecked" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
       <StaticResource x:Key="SplitButtonForegroundCheckedPointerOver" ResourceKey="TextOnAccentFillColorPrimaryBrush" />
       <StaticResource x:Key="SplitButtonForegroundCheckedPressed" ResourceKey="TextOnAccentFillColorSecondaryBrush" />
-      <StaticResource x:Key="SplitButtonForegroundCheckedDisabled" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="SplitButtonForegroundCheckedDisabled" ResourceKey="TextOnAccentFillColorDisabled" />
       <StaticResource x:Key="SplitButtonForegroundSecondary" ResourceKey="TextFillColorSecondaryBrush" />
       <StaticResource x:Key="SplitButtonForegroundSecondaryPressed" ResourceKey="TextFillColorTertiaryBrush" />
       <StaticResource x:Key="SplitButtonBorderBrush" ResourceKey="ControlElevationBorderBrush" />
@@ -162,6 +162,15 @@
                 <VisualState x:Name="Disabled">
                   <VisualState.Setters>
                     <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarButtonBorderBrushDisabled}" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="CheckedDisabled">
+                  <VisualState.Setters>
+                    <Setter Target="PrimaryBackgroundGrid.Background" Value="{ThemeResource AppBarToggleButtonBackgroundCheckedDisabled}" />
+                    <Setter Target="SecondaryBackgroundGrid.Background" Value="{ThemeResource AppBarToggleButtonBackgroundCheckedDisabled}" />
+                    <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarToggleButtonBorderBrushCheckedDisabled}" />
+                    <Setter Target="PrimaryButton.Foreground" Value="{ThemeResource AppBarToggleButtonForegroundCheckedDisabled}" />
+                    <Setter Target="SecondaryButton.Foreground" Value="{ThemeResource AppBarToggleButtonForegroundCheckedDisabled}" />
                   </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FlyoutOpen">

--- a/controls/dev/SplitButton/TestUI/SplitButtonPage.xaml
+++ b/controls/dev/SplitButton/TestUI/SplitButtonPage.xaml
@@ -127,6 +127,13 @@
                 </controls:ToggleSplitButton>
 
                 <ToggleButton Content="For Comparison" Margin="6,0,0,0"/>
+                <CheckBox x:Name="ToggleSplitButtonEnableCheckBox"
+                          AutomationProperties.Name="ToggleSplitButtonEnableCheckBox"
+                          Content="Enable"
+                          IsChecked="True"
+                          Checked="ToggleSplitButtonEnableCheckBox_Checked"
+                          Unchecked="ToggleSplitButtonEnableCheckBox_Unchecked"
+                          Margin="12,0,0,0"/>
             </StackPanel>
             <StackPanel Orientation="Horizontal">
                 <TextBlock Text="Toggle State:"/>

--- a/controls/dev/SplitButton/TestUI/SplitButtonPage.xaml.cs
+++ b/controls/dev/SplitButton/TestUI/SplitButtonPage.xaml.cs
@@ -100,6 +100,22 @@ namespace MUXControlsTestApp
             DisabledSplitButton.IsEnabled = false;
         }
 
+        private void ToggleSplitButtonEnableCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            if (ToggleSplitButton != null)
+            {
+                ToggleSplitButton.IsEnabled = true;
+            }
+        }
+
+        private void ToggleSplitButtonEnableCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (ToggleSplitButton != null)
+            {
+                ToggleSplitButton.IsEnabled = false;
+            }
+        }
+
         private void CanExecuteCheckBox_Checked(object sender, RoutedEventArgs e)
         {
             if (TestExecuteCommand != null)

--- a/controls/test/testinfra/MUXTestInfra/Common/GamepadHelper.cs
+++ b/controls/test/testinfra/MUXTestInfra/Common/GamepadHelper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests.Common
 
     public class GamepadHelper
     {
-        public static void PressButton(UIObject obj, GamepadButton button)
+        public static void PressButton(UIObject obj, GamepadButton button, Action whilePressed = null)
         {
             var keyInputReceivedUIObject = FindElement.ById("__KeyInputReceived");
 
@@ -67,22 +67,28 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests.Common
             array[0].virtualKeyCode = (ushort)button;
             NativeMethods.InjectKeyboardInput(array, 1);
 
-
-            // Wait until app reports it received the input
-            if(keyInputReceivedUIObject == null)
+            try
             {
-                // Fallback if we don't find out helper
-                Wait.ForMilliseconds(50);
-            }
-            else
-            {
-                var keyInputReceivedCheckbox = new CheckBox(keyInputReceivedUIObject);
-                keyInputReceivedCheckbox.GetToggledWaiter().TryWait(TimeSpan.FromMilliseconds(50));
-            }
+                // Wait until app reports it received the input
+                if(keyInputReceivedUIObject == null)
+                {
+                    // Fallback if we don't find out helper
+                    Wait.ForMilliseconds(50);
+                }
+                else
+                {
+                    var keyInputReceivedCheckbox = new CheckBox(keyInputReceivedUIObject);
+                    keyInputReceivedCheckbox.GetToggledWaiter().TryWait(TimeSpan.FromMilliseconds(50));
+                }
 
-            Wait.ForIdle();
-            array[0].flags = KEY_EVENT_FLAGS.KEYUP;
-            NativeMethods.InjectKeyboardInput(array, 1);
+                Wait.ForIdle();
+                whilePressed?.Invoke();
+            }
+            finally
+            {
+                array[0].flags = KEY_EVENT_FLAGS.KEYUP;
+                NativeMethods.InjectKeyboardInput(array, 1);
+            }
         }
 
         #region Keyboard Structures


### PR DESCRIPTION
## Fixes

Fixes #9098

Related to #9656.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

A `SplitButton` can remain in a stale visual state when `IsEnabled` changes after template application. A checked `ToggleSplitButton` also does not consistently use its checked-disabled resources.

### New Behavior

`SplitButton` observes `IsEnabled` after template application and updates its visual state immediately. A checked `ToggleSplitButton` uses `CheckedDisabled` when available and falls back to `Disabled` otherwise. The default and command-bar templates use the existing checked-disabled resources. Optimized and legacy API coverage is included.

## Customer Impact

Disabled split buttons now render the correct state, including checked toggle split buttons.

## Regression Potential

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The change affects common-state transitions and SplitButton template resources.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

The product and test app were previously built. `VerifyIsEnabledChangeUpdatesVisualState` and `VerifyIsEnabledChangeUpdatesVisualStateWithLegacyStyles` each passed 1/1.

## Screenshots and recordings

![Checked and disabled SplitButton before and after](https://github.com/user-attachments/assets/191873a1-507a-4de8-9e58-5071a2a8ce05)

![Standard ToggleButton checked-disabled reference](https://github.com/user-attachments/assets/63a3bbb0-1b4c-4fa6-be4f-2208159a6e54)

## Prior review sign-offs

@godlytalias previously reviewed and signed off, and is tagged to reconfirm the GitHub version.