### PR TITLE
Fix TitleBarAutomationPeer namespace

### DIFF
--- a/controls/dev/Generated/TitleBarAutomationPeer.properties.cpp
+++ b/controls/dev/Generated/TitleBarAutomationPeer.properties.cpp
@@ -6,7 +6,7 @@
 #include "common.h"
 #include "TitleBarAutomationPeer.h"
 
-namespace winrt::Microsoft::UI::Xaml::Controls
+namespace winrt::Microsoft::UI::Xaml::Automation::Peers
 {
     CppWinRTActivatableClassWithBasicFactory(TitleBarAutomationPeer)
 }

--- a/controls/dev/TitleBar/TitleBar.idl
+++ b/controls/dev/TitleBar/TitleBar.idl
@@ -75,6 +75,11 @@ unsealed runtimeclass TitleBarTemplateSettings : Microsoft.UI.Xaml.DependencyObj
     static Microsoft.UI.Xaml.DependencyProperty IconElementProperty{ get; };
 }
 
+}
+
+namespace MU_XAP_NAMESPACE
+{
+
 [MUX_PUBLIC_V8]
 [webhosthidden]
 unsealed runtimeclass TitleBarAutomationPeer : Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer


### PR DESCRIPTION
## Fixes

Fixes #10871

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

`TitleBarAutomationPeer` is declared outside the namespace pattern used by other automation peers, while its generated activation registration uses the controls namespace.

### New Behavior

The runtime class is declared in the `Automation.Peers` namespace pattern, and the generated activation registration is updated to match.

## Customer Impact

The TitleBar automation peer has the expected namespace and activation registration.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

The `Microsoft.UI.Xaml.Controls` project was previously built with 0 warnings and 0 errors.

## Screenshots (if appropriate)

Not applicable.