### PR TITLE
Add TitleBar compact content alignment resource

### DIFF
--- a/controls/dev/TitleBar/TitleBar.xaml
+++ b/controls/dev/TitleBar/TitleBar.xaml
@@ -150,7 +150,7 @@
                                     <VisualState.Setters>
                                         <Setter Target="PART_TitleText.Visibility" Value="Collapsed" />
                                         <Setter Target="PART_SubtitleText.Visibility" Value="Collapsed" />
-                                        <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="Left" />
+                                        <Setter Target="PART_ContentPresenter.HorizontalAlignment" Value="{ThemeResource TitleBarCompactContentHorizontalAlignment}" />
                                         <Setter Target="PART_ContentPresenter.Margin" Value="{ThemeResource TitleBarCompactContentMargin}" />
                                     </VisualState.Setters>
                                 </VisualState>

--- a/controls/dev/TitleBar/TitleBar_themeresources.xaml
+++ b/controls/dev/TitleBar/TitleBar_themeresources.xaml
@@ -95,6 +95,7 @@
     <HorizontalAlignment x:Key="TitleBarLeftHeaderHorizontalAlignment">Left</HorizontalAlignment>
     <VerticalAlignment x:Key="TitleBarLeftHeaderVerticalAlignment">Center</VerticalAlignment>
     <HorizontalAlignment x:Key="TitleBarContentHorizontalAlignment">Center</HorizontalAlignment>
+    <HorizontalAlignment x:Key="TitleBarCompactContentHorizontalAlignment">Left</HorizontalAlignment>
     <VerticalAlignment x:Key="TitleBarContentVerticalAlignment">Center</VerticalAlignment>
     <HorizontalAlignment x:Key="TitleBarRightHeaderHorizontalAlignment">Right</HorizontalAlignment>
     <VerticalAlignment x:Key="TitleBarRightHeaderVerticalAlignment">Center</VerticalAlignment>

--- a/controls/dev/TitleBar/TitleBar_themeresources_perf2026.xaml
+++ b/controls/dev/TitleBar/TitleBar_themeresources_perf2026.xaml
@@ -95,6 +95,7 @@
     <HorizontalAlignment x:Key="TitleBarLeftHeaderHorizontalAlignment">Left</HorizontalAlignment>
     <VerticalAlignment x:Key="TitleBarLeftHeaderVerticalAlignment">Center</VerticalAlignment>
     <HorizontalAlignment x:Key="TitleBarContentHorizontalAlignment">Center</HorizontalAlignment>
+    <HorizontalAlignment x:Key="TitleBarCompactContentHorizontalAlignment">Left</HorizontalAlignment>
     <VerticalAlignment x:Key="TitleBarContentVerticalAlignment">Center</VerticalAlignment>
     <HorizontalAlignment x:Key="TitleBarRightHeaderHorizontalAlignment">Right</HorizontalAlignment>
     <VerticalAlignment x:Key="TitleBarRightHeaderVerticalAlignment">Center</VerticalAlignment>


### PR DESCRIPTION
## Fixes

Fixes #11181

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

Compact TitleBar content is always left-aligned and cannot be adjusted through lightweight styling.

### New Behavior

Adds `TitleBarCompactContentHorizontalAlignment`, defaulting to `Left`, and uses it in the compact visual state. Existing behavior is preserved while apps can override the alignment resource.

## Customer Impact

Apps can customize compact TitleBar content alignment without replacing the template.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

The default resource value preserves the existing left-aligned behavior. GitHub CI provides persistent validation.

## Screenshots (if appropriate)

Not included.