### PR TITLE
Announce NavigationView pane open and close states

### DIFF
--- a/controls/dev/NavigationView/NavigationView.cpp
+++ b/controls/dev/NavigationView/NavigationView.cpp
@@ -1663,6 +1663,11 @@ void NavigationView::OnPaneToggleButtonClick(const winrt::IInspectable& /*sender
         m_wasForceClosed = false;
         OpenPane();
     }
+
+    // The pane toggle button only swaps its AutomationProperties.Name between its open and closed
+    // states, which a screen reader announces on focus but not when the user activates the button.
+    // Raise a UIA notification so the new pane state is announced when the user toggles it.
+    AnnouncePaneOpenStateChange();
 }
 
 void NavigationView::OnPaneSearchButtonClick(const winrt::IInspectable& /*sender*/, const winrt::RoutedEventArgs& /*args*/)
@@ -1716,6 +1721,12 @@ bool NavigationView::AttemptClosePaneLightly()
     {
         m_blockNextClosingEvent = true;
         ClosePane();
+
+        // This path handles closing the pane via the light-dismiss keyboard gestures
+        // (Alt+Left, GoBack, XButton1). Like the pane toggle button, these are explicit
+        // user actions, so announce the new state for screen readers. Resize/adaptive
+        // layout never routes through here, so no resize noise is introduced.
+        AnnouncePaneOpenStateChange();
         return true;
     }
 
@@ -1915,6 +1926,25 @@ void NavigationView::SetPaneToggleButtonAutomationName()
         auto toolTip = winrt::ToolTip();
         toolTip.Content(box_value(navigationName));
         winrt::ToolTipService::SetToolTip(paneToggleButton, toolTip);
+    }
+}
+
+void NavigationView::AnnouncePaneOpenStateChange()
+{
+    auto peer = winrt::FrameworkElementAutomationPeer::FromElement(*this);
+    if (!peer)
+    {
+        peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(*this);
+    }
+
+    if (peer)
+    {
+        const auto isPaneOpen = IsPaneOpen();
+        peer.RaiseNotificationEvent(
+            winrt::AutomationNotificationKind::ActionCompleted,
+            winrt::AutomationNotificationProcessing::ImportantMostRecent,
+            ResourceAccessor::GetLocalizedStringResource(isPaneOpen ? SR_NavigationViewPaneOpenedNotification : SR_NavigationViewPaneClosedNotification),
+            L"NavigationViewPaneOpenStateChangedActivityId");
     }
 }
 
@@ -4364,6 +4394,18 @@ void NavigationView::OnIsPaneOpenChanged()
             // If, however, splitView.IsPaneOpen=false, then nav.IsPaneOpen is just following the SplitView here and the pane
             // was closed, for example, due to app window resizing. We don't set the force flag in this situation.
             m_wasForceClosed = splitView.IsPaneOpen();
+
+            // A close that originates from the SplitView itself (splitView.IsPaneOpen() is already false when
+            // NavigationView's IsPaneOpen follows) is a light-dismiss gesture - the user pressed Esc or clicked
+            // outside the open pane. Announce it for screen readers so it matches the pane toggle button path.
+            // Resize/adaptive-layout closes go through ClosePane(), which sets m_isOpenPaneForInteraction and so
+            // never reach this branch, and requiring the pane to have been open on the previous state change guards
+            // against announcing a non-open initial state, so this does not reintroduce resize noise or spurious
+            // startup announcements.
+            if (!m_wasForceClosed && m_previousIsPaneOpen)
+            {
+                AnnouncePaneOpenStateChange();
+            }
         }
         else
         {
@@ -4391,6 +4433,10 @@ void NavigationView::OnIsPaneOpenChanged()
             UnsetDropShadow();
         }
     }
+
+    // Track the pane state so the light-dismiss (Esc/outside-click) announcement above only fires on a
+    // genuine open -> closed transition, never on a non-open initial state.
+    m_previousIsPaneOpen = isPaneOpen;
 }
 
 void NavigationView::UpdatePaneToggleButtonVisibility()

--- a/controls/dev/NavigationView/NavigationView.h
+++ b/controls/dev/NavigationView/NavigationView.h
@@ -310,6 +310,7 @@ private:
     void ClosePane();
     bool AttemptClosePaneLightly();
     void SetPaneToggleButtonAutomationName();
+    void AnnouncePaneOpenStateChange();
     void SwapPaneHeaderContent(tracker_ref<winrt::ContentControl> newParent, tracker_ref<winrt::ContentControl> oldParent, winrt::hstring const& propertyPathName);
     void UpdateSettingsItemToolTip();
     void UpdatePaneTitleFrameworkElementParents();
@@ -465,6 +466,7 @@ private:
     winrt::NavigationViewItem::LayoutUpdated_revoker m_selectedItemLayoutUpdatedRevoker{};
 
     bool m_wasForceClosed{ false };
+    bool m_previousIsPaneOpen{ false };
     bool m_isClosedCompact{ false };
     bool m_blockNextClosingEvent{ false };
     bool m_initialListSizeStateSet{ false };

--- a/controls/dev/NavigationView/Strings/en-us/Resources.resw
+++ b/controls/dev/NavigationView/Strings/en-us/Resources.resw
@@ -125,6 +125,14 @@
     <value>Close Navigation</value>
     <comment>Automation name and tooltip caption for the hamburger button when it is in an open state, and tooltip caption for the close button</comment>
   </data>
+  <data name="NavigationViewPaneOpenedNotification" xml:space="preserve">
+    <value>Navigation pane opened</value>
+    <comment>Screen reader announcement made when the user opens the NavigationView pane</comment>
+  </data>
+  <data name="NavigationViewPaneClosedNotification" xml:space="preserve">
+    <value>Navigation pane closed</value>
+    <comment>Screen reader announcement made when the user closes the NavigationView pane</comment>
+  </data>
   <data name="NavigationViewItemDefaultControlName" xml:space="preserve">
     <value>NavigationViewItem</value>
     <comment>Default automation id if no name or id is provided</comment>

--- a/controls/dev/ResourceHelper/ResourceAccessor.h
+++ b/controls/dev/ResourceHelper/ResourceAccessor.h
@@ -57,6 +57,8 @@ public:
 #define SR_NavigationButtonToggleName L"NavigationButtonToggleName"
 #define SR_NavigationButtonClosedName L"NavigationButtonClosedName"
 #define SR_NavigationButtonOpenName L"NavigationButtonOpenName"
+#define SR_NavigationViewPaneOpenedNotification L"NavigationViewPaneOpenedNotification"
+#define SR_NavigationViewPaneClosedNotification L"NavigationViewPaneClosedNotification"
 #define SR_NavigationViewItemDefaultControlName L"NavigationViewItemDefaultControlName"
 #define SR_NavigationBackButtonName L"NavigationBackButtonName"
 #define SR_NavigationBackButtonToolTip L"NavigationBackButtonToolTip"


### PR DESCRIPTION
## Fixes

Fixes #11250

Also addresses microsoft/terminal#19687.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

Assistive technology does not receive a concise state announcement when the NavigationView pane toggle opens or closes the pane.

### New Behavior

The pane toggle click raises a localized UI Automation notification with opened or closed text. Notifications are tied to explicit toggle interaction to avoid noise from adaptive layout changes.

## Customer Impact

Screen reader users receive immediate pane state feedback after using the NavigationView toggle.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally

A standalone UI Automation client previously observed four alternating notifications across four toggles. The behavior was also manually validated with Narrator.

## Screenshots and recordings

**NavigationView pane announcement demonstration**

https://github.com/user-attachments/assets/de39c91d-96de-4bd4-8fb8-44ee5e6c69c6

