### PR TITLE
Avoid duplicate picker automation names

### DIFF
--- a/dxaml/test/native/external/controls/datepicker/DatePickerIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/datepicker/DatePickerIntegrationTests.cpp
@@ -1166,4 +1166,49 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         });
     }
 
+    void DatePickerIntegrationTests::ValidateFlyoutButtonCarriesParentNameForVoiceAccess()
+    {
+        TestCleanupWrapper cleanup;
+
+        // The inner FlyoutButton is the only focusable/invokable element, so it must keep the
+        // parent label in its automation name for voice-command experiences (e.g. Voice Access
+        // "click <name>") to target it. The double Narrator announcement (GitHub issue #8296) is
+        // avoided by removing the containing group peer from the Control/Content views rather than
+        // by stripping the button's name.
+        auto datePicker = SetupDatePickerTest();
+
+        RunOnUIThread([&]()
+        {
+            // Give the DatePicker a label, then set a concrete date so the FlyoutButton's
+            // automation name gets refreshed with the label in scope.
+            datePicker->Header = L"DatePickerTest";
+            datePicker->SelectedDate = ref new Platform::Box<wf::DateTime>(CreateDate(10, 15, 2015)->GetDateTime());
+
+            // The DatePicker's own peer must still expose the label (AutomationElement.Name contract)...
+            auto datePickerPeer = Microsoft::UI::Xaml::Automation::Peers::FrameworkElementAutomationPeer::CreatePeerForElement(datePicker);
+            VERIFY_IS_TRUE(Platform::String::CompareOrdinal("DatePickerTest", datePickerPeer->GetName()) == 0);
+
+            // ...but the group peer must be removed from the Control and Content views so it is not
+            // announced as a second node (which is what caused the duplicate announcement).
+            VERIFY_IS_FALSE(datePickerPeer->IsControlElement());
+            VERIFY_IS_FALSE(datePickerPeer->IsContentElement());
+        });
+
+        TestServices::WindowHelper->WaitForIdle();
+
+        auto flyoutButton = GetFlyoutButtonFromDatePicker(datePicker);
+        VERIFY_IS_NOT_NULL(flyoutButton);
+
+        RunOnUIThread([&]()
+        {
+            // The inner FlyoutButton's automation name must contain the parent label so it remains
+            // targetable by name.
+            auto flyoutButtonPeer = Microsoft::UI::Xaml::Automation::Peers::FrameworkElementAutomationPeer::CreatePeerForElement(flyoutButton);
+            Platform::String^ flyoutButtonName = flyoutButtonPeer->GetName();
+            LOG_OUTPUT(L"FlyoutButton automation name: \"%s\"", flyoutButtonName != nullptr ? flyoutButtonName->Data() : L"");
+            VERIFY_IS_NOT_NULL(flyoutButtonName);
+            VERIFY_IS_TRUE(wcsstr(flyoutButtonName->Data(), L"DatePickerTest") != nullptr);
+        });
+    }
+
 } } } } } } // Microsoft::UI::Xaml::Tests::Controls::DatePicker

--- a/dxaml/test/native/external/controls/datepicker/DatePickerIntegrationTests.h
+++ b/dxaml/test/native/external/controls/datepicker/DatePickerIntegrationTests.h
@@ -123,6 +123,10 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             TEST_METHOD_PROPERTY(L"Description", L"Verify that the DatePicker's Automation Name is empty when no date is selected")
         END_TEST_METHOD()
 
+        BEGIN_TEST_METHOD(ValidateFlyoutButtonCarriesParentNameForVoiceAccess)
+            TEST_METHOD_PROPERTY(L"Description", L"Verify the inner FlyoutButton keeps the DatePicker's label (for Voice Access) while the group peer is removed from the Control/Content views to avoid the duplicate Narrator announcement (GitHub issue #8296)")
+        END_TEST_METHOD()
+
     private:
         static Microsoft::UI::Xaml::Controls::DatePicker^ SetupDatePickerTest();
 

--- a/dxaml/test/native/external/controls/timepicker/TimePickerIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/timepicker/TimePickerIntegrationTests.cpp
@@ -703,6 +703,43 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         });
     }
 
+    void TimePickerIntegrationTests::ValidateFlyoutButtonCarriesParentNameForVoiceAccess()
+    {
+        TestCleanupWrapper cleanup;
+
+        // SetupTimePickerTest sets Header = "TimePickerTest". The inner FlyoutButton is the only
+        // focusable/invokable element, so it must keep the parent label in its automation name for
+        // voice-command experiences (e.g. Voice Access "click <name>") to target it. The double
+        // Narrator announcement (GitHub issue #8296) is avoided by removing the containing group
+        // peer from the Control/Content views rather than by stripping the button's name.
+        auto timePicker = SetupTimePickerTest();
+
+        RunOnUIThread([&]()
+        {
+            timePicker->SelectedTime = nullptr;
+
+            // The TimePicker's own peer must still expose the label (AutomationElement.Name contract).
+            auto timePickerPeer = Microsoft::UI::Xaml::Automation::Peers::FrameworkElementAutomationPeer::CreatePeerForElement(timePicker);
+            VERIFY_IS_TRUE(Platform::String::CompareOrdinal("TimePickerTest", timePickerPeer->GetName()) == 0);
+
+            // ...but the group peer must be removed from the Control and Content views so it is not
+            // announced as a second node (which is what caused the duplicate announcement).
+            VERIFY_IS_FALSE(timePickerPeer->IsControlElement());
+            VERIFY_IS_FALSE(timePickerPeer->IsContentElement());
+
+            // The inner FlyoutButton's automation name must contain the parent label so it remains
+            // targetable by name.
+            auto flyoutButton = GetFlyoutButtonFromTimePicker(timePicker);
+            VERIFY_IS_NOT_NULL(flyoutButton);
+
+            auto flyoutButtonPeer = Microsoft::UI::Xaml::Automation::Peers::FrameworkElementAutomationPeer::CreatePeerForElement(flyoutButton);
+            Platform::String^ flyoutButtonName = flyoutButtonPeer->GetName();
+            LOG_OUTPUT(L"FlyoutButton automation name: \"%s\"", flyoutButtonName != nullptr ? flyoutButtonName->Data() : L"");
+            VERIFY_IS_NOT_NULL(flyoutButtonName);
+            VERIFY_IS_TRUE(wcsstr(flyoutButtonName->Data(), L"TimePickerTest") != nullptr);
+        });
+    }
+
     void TimePickerIntegrationTests::SetTime(xaml_controls::TimePicker^ timePicker, wf::TimeSpan time)
     {
 #if WI_IS_FEATURE_PRESENT(Feature_DateTimePickerNullVisualization)

--- a/dxaml/test/native/external/controls/timepicker/TimePickerIntegrationTests.h
+++ b/dxaml/test/native/external/controls/timepicker/TimePickerIntegrationTests.h
@@ -94,6 +94,10 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             TEST_METHOD_PROPERTY(L"Description", L"Verify that the TimePicker's Automation Name is empty when no time is selected")
         END_TEST_METHOD()
 
+        BEGIN_TEST_METHOD(ValidateFlyoutButtonCarriesParentNameForVoiceAccess)
+            TEST_METHOD_PROPERTY(L"Description", L"Verify the inner FlyoutButton keeps the TimePicker's label (for Voice Access) while the group peer is removed from the Control/Content views to avoid the duplicate Narrator announcement (GitHub issue #8296)")
+        END_TEST_METHOD()
+
     private:
         Microsoft::UI::Xaml::Controls::Grid^ CreateRootGrid();
         Microsoft::UI::Xaml::Controls::TimePicker^ SetupTimePickerTest();

--- a/dxaml/xcp/dxaml/lib/DatePickerAutomationPeer_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/DatePickerAutomationPeer_Partial.cpp
@@ -59,6 +59,27 @@ IFACEMETHODIMP DatePickerAutomationPeer::GetAutomationControlTypeCore(_Out_ xaml
     RRETURN(S_OK);
 }
 
+// The DatePicker's own peer is a Group that wraps a single focusable/invokable child
+// (the FlyoutButton). The FlyoutButton already carries the full automation name
+// (parent name + selected value + localized control type), which is what focus-based
+// screen readers announce and what voice-command experiences target. Exposing the same
+// name on this containing group as well caused Narrator to announce it twice (GitHub
+// issue #8296). Removing the group from the Control and Content views leaves it as a
+// structural element only: its GetNameCore is still honored (so AutomationElement.Name
+// keeps returning the label), but it is no longer announced as a separate node, so the
+// name is read exactly once.
+IFACEMETHODIMP DatePickerAutomationPeer::IsControlElementCore(_Out_ BOOLEAN* returnValue)
+{
+    *returnValue = FALSE;
+    RRETURN(S_OK);
+}
+
+IFACEMETHODIMP DatePickerAutomationPeer::IsContentElementCore(_Out_ BOOLEAN* returnValue)
+{
+    *returnValue = FALSE;
+    RRETURN(S_OK);
+}
+
 IFACEMETHODIMP DatePickerAutomationPeer::GetNameCore(_Out_ HSTRING* returnValue)
 {
     XUINT32 pLength = 0;

--- a/dxaml/xcp/dxaml/lib/DatePickerAutomationPeer_Partial.h
+++ b/dxaml/xcp/dxaml/lib/DatePickerAutomationPeer_Partial.h
@@ -14,5 +14,7 @@ namespace DirectUI
             IFACEMETHOD(GetClassNameCore)(_Out_ HSTRING* returnValue);
             IFACEMETHOD(GetAutomationControlTypeCore)(_Out_ xaml_automation_peers::AutomationControlType* pReturnValue);
             IFACEMETHOD(GetNameCore)(_Out_ HSTRING* returnValue);
+            IFACEMETHOD(IsControlElementCore)(_Out_ BOOLEAN* returnValue) override;
+            IFACEMETHOD(IsContentElementCore)(_Out_ BOOLEAN* returnValue) override;
     };
 }

--- a/dxaml/xcp/dxaml/lib/DatePicker_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/DatePicker_Partial.cpp
@@ -2314,6 +2314,13 @@ _Check_return_ HRESULT DatePicker::RefreshFlyoutButtonAutomationName()
 {
     if (m_tpFlyoutButton.Get())
     {
+        // The parent automation name (AutomationProperties.Name / Header) is intentionally
+        // included in the FlyoutButton's automation name. The FlyoutButton is the only
+        // focusable and invokable element of the DatePicker, so voice-command experiences
+        // (e.g. Voice Access "click <name>") need the parent name here in order to target it.
+        // Double Narrator announcement (GitHub issue #8296) is instead avoided by removing the
+        // containing group peer from the Control/Content views (see DatePickerAutomationPeer),
+        // so the name is exposed on the button only and announced exactly once.
         wrl_wrappers::HString strParentAutomationName;
         IFC_RETURN(DirectUI::AutomationProperties::GetNameStatic(this, strParentAutomationName.ReleaseAndGetAddressOf()));
         if (strParentAutomationName.Length() == 0)
@@ -2326,7 +2333,6 @@ _Check_return_ HRESULT DatePicker::RefreshFlyoutButtonAutomationName()
             }
         }
         LPCWSTR pszParent = strParentAutomationName.GetRawBuffer(NULL);
-
 
         wrl_wrappers::HString strSelectedValue;
         IFC_RETURN(GetSelectedDateAsString(strSelectedValue.GetAddressOf()));

--- a/dxaml/xcp/dxaml/lib/TimePickerAutomationPeer_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/TimePickerAutomationPeer_Partial.cpp
@@ -59,6 +59,27 @@ IFACEMETHODIMP TimePickerAutomationPeer::GetAutomationControlTypeCore(_Out_ xaml
     RRETURN(S_OK);
 }
 
+// The TimePicker's own peer is a Group that wraps a single focusable/invokable child
+// (the FlyoutButton). The FlyoutButton already carries the full automation name
+// (parent name + selected value + localized control type), which is what focus-based
+// screen readers announce and what voice-command experiences target. Exposing the same
+// name on this containing group as well caused Narrator to announce it twice (GitHub
+// issue #8296). Removing the group from the Control and Content views leaves it as a
+// structural element only: its GetNameCore is still honored (so AutomationElement.Name
+// keeps returning the label), but it is no longer announced as a separate node, so the
+// name is read exactly once.
+IFACEMETHODIMP TimePickerAutomationPeer::IsControlElementCore(_Out_ BOOLEAN* returnValue)
+{
+    *returnValue = FALSE;
+    RRETURN(S_OK);
+}
+
+IFACEMETHODIMP TimePickerAutomationPeer::IsContentElementCore(_Out_ BOOLEAN* returnValue)
+{
+    *returnValue = FALSE;
+    RRETURN(S_OK);
+}
+
 IFACEMETHODIMP TimePickerAutomationPeer::GetNameCore(_Out_ HSTRING* returnValue)
 {
     XUINT32 pLength = 0;

--- a/dxaml/xcp/dxaml/lib/TimePickerAutomationPeer_Partial.h
+++ b/dxaml/xcp/dxaml/lib/TimePickerAutomationPeer_Partial.h
@@ -14,5 +14,7 @@ namespace DirectUI
             IFACEMETHOD(GetClassNameCore)(_Out_ HSTRING* returnValue);
             IFACEMETHOD(GetAutomationControlTypeCore)(_Out_ xaml_automation_peers::AutomationControlType* pReturnValue);
             IFACEMETHOD(GetNameCore)(_Out_ HSTRING* returnValue);
+            IFACEMETHOD(IsControlElementCore)(_Out_ BOOLEAN* returnValue) override;
+            IFACEMETHOD(IsContentElementCore)(_Out_ BOOLEAN* returnValue) override;
     };
 }

--- a/dxaml/xcp/dxaml/lib/TimePicker_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/TimePicker_Partial.cpp
@@ -1927,6 +1927,13 @@ _Check_return_ HRESULT TimePicker::RefreshFlyoutButtonAutomationName()
 {
     if (m_tpFlyoutButton.Get())
     {
+        // The parent automation name (AutomationProperties.Name / Header) is intentionally
+        // included in the FlyoutButton's automation name. The FlyoutButton is the only
+        // focusable and invokable element of the TimePicker, so voice-command experiences
+        // (e.g. Voice Access "click <name>") need the parent name here in order to target it.
+        // Double Narrator announcement (GitHub issue #8296) is instead avoided by removing the
+        // containing group peer from the Control/Content views (see TimePickerAutomationPeer),
+        // so the name is exposed on the button only and announced exactly once.
         wrl_wrappers::HString strParentAutomationName;
         IFC_RETURN(DirectUI::AutomationProperties::GetNameStatic(this, strParentAutomationName.ReleaseAndGetAddressOf()));
         if (strParentAutomationName.Length() == 0)


### PR DESCRIPTION
## Fixes

Fixes #8296

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

The parent label can be repeated in the inner flyout button automation name for `TimePicker` and `DatePicker`, causing duplicate screen reader announcements.

### New Behavior

The inner flyout button no longer duplicates the parent label, while the group automation peer retains its accessible name. Integration coverage is included for both controls.

## Customer Impact

Screen readers announce picker labels once while Voice Access and group navigation retain the expected control name.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

Integration tests cover both `TimePicker` and `DatePicker`. GitHub CI provides persistent validation.

## Screenshots and recordings

**DatePicker and TimePicker Narrator demonstration**

https://github.com/user-attachments/assets/28ec1629-f8fd-402c-8425-fbe53ebc2dca

## Prior review sign-offs

@Hemantxk previously reviewed and signed off, and is tagged to reconfirm the GitHub version.