### PR TITLE
Update ColorPicker More/Less accessibility help text

### DIFF
--- a/controls/dev/ColorPicker/APITests/ColorPickerTests.cs
+++ b/controls/dev/ColorPicker/APITests/ColorPickerTests.cs
@@ -311,6 +311,131 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
             });
         }
 
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/7395:
+        // the More/Less button's accessibility Name and HelpText must both update when toggled,
+        // instead of the HelpText being set once and going stale.
+        [TestMethod]
+        public void VerifyMoreButtonAccessibilityTextUpdatesOnToggle()
+        {
+            ColorPicker colorPicker = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                colorPicker = new ColorPicker { IsMoreButtonVisible = true };
+                Content = colorPicker;
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                var moreButton = VisualTreeUtils.FindVisualChildByName(colorPicker, "MoreButton") as ToggleButton;
+                Verify.IsNotNull(moreButton, "MoreButton template part should be present when IsMoreButtonVisible is true.");
+
+                // Collapsed (initial) state.
+                var collapsedName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(moreButton);
+                var collapsedHelpText = Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(moreButton);
+                Verify.AreEqual("More", collapsedName, "Collapsed AutomationProperties.Name should be 'More'.");
+                Verify.AreEqual("Invoke to show the text entry fields.", collapsedHelpText, "Collapsed AutomationProperties.HelpText should describe showing the fields.");
+
+                // Expand: both Name and HelpText must update (HelpText not updating was the #7395 bug).
+                moreButton.IsChecked = true;
+                Content.UpdateLayout();
+
+                var expandedName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(moreButton);
+                var expandedHelpText = Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(moreButton);
+                Verify.AreEqual("Less", expandedName, "Expanded AutomationProperties.Name should be 'Less'.");
+                Verify.AreEqual("Invoke to hide the text entry fields.", expandedHelpText, "Expanded AutomationProperties.HelpText should describe hiding the fields.");
+                Verify.AreNotEqual(collapsedHelpText, expandedHelpText, "HelpText must change when the More button is expanded (#7395).");
+
+                // Collapse again: both must revert to the collapsed strings (no stale text).
+                moreButton.IsChecked = false;
+                Content.UpdateLayout();
+
+                Verify.AreEqual(collapsedName, Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(moreButton), "Name should revert to the collapsed value.");
+                Verify.AreEqual(collapsedHelpText, Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(moreButton), "HelpText should revert to the collapsed value (#7395).");
+            });
+        }
+
+        // Regression follow-up for https://github.com/microsoft/microsoft-ui-xaml/issues/7395:
+        // if the template is re-applied (e.g. on a theme change) while the text-entry grid is
+        // expanded, OnApplyTemplate must reflect the current expanded state rather than resetting
+        // the More button's accessibility Name/HelpText back to the collapsed values.
+        [TestMethod]
+        public void VerifyMoreButtonAccessibilityTextSurvivesReTemplating()
+        {
+            ColorPicker colorPicker = null;
+            ToggleButton originalMoreButton = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                colorPicker = new ColorPicker { IsMoreButtonVisible = true };
+                Content = colorPicker;
+            });
+
+            IdleSynchronizer.Wait();
+
+            object template = null;
+            string collapsedName = null;
+            string collapsedHelpText = null;
+            string expandedName = null;
+            string expandedHelpText = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                originalMoreButton = VisualTreeUtils.FindVisualChildByName(colorPicker, "MoreButton") as ToggleButton;
+                Verify.IsNotNull(originalMoreButton, "MoreButton template part should be present.");
+
+                collapsedName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(originalMoreButton);
+                collapsedHelpText = Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(originalMoreButton);
+
+                // Expand the text-entry grid, then capture the expanded a11y text.
+                originalMoreButton.IsChecked = true;
+                Content.UpdateLayout();
+                expandedName = Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(originalMoreButton);
+                expandedHelpText = Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(originalMoreButton);
+                Verify.AreEqual("Less", expandedName, "Expanding should set the Name to 'Less'.");
+                Verify.AreNotEqual(collapsedHelpText, expandedHelpText, "Expanded HelpText should differ from collapsed.");
+
+                template = colorPicker.Template;
+            });
+
+            IdleSynchronizer.Wait();
+
+            // Force the template to be re-applied while still expanded, simulating a theme change.
+            RunOnUIThread.Execute(() =>
+            {
+                colorPicker.Template = null;
+                Content.UpdateLayout();
+                colorPicker.Template = (ControlTemplate)template;
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                var reTemplatedMoreButton = VisualTreeUtils.FindVisualChildByName(colorPicker, "MoreButton") as ToggleButton;
+                Verify.IsNotNull(reTemplatedMoreButton, "MoreButton should be present after re-templating.");
+                Verify.IsFalse(object.ReferenceEquals(originalMoreButton, reTemplatedMoreButton), "Template should have been re-applied, producing a new MoreButton instance.");
+
+                // The control is still logically expanded, so the re-applied template must keep the
+                // expanded a11y text instead of reverting to the collapsed strings (the #7395 risk).
+                Verify.AreEqual(expandedName, Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(reTemplatedMoreButton), "Re-applied template should keep the expanded Name while the grid is open.");
+                Verify.AreEqual(expandedHelpText, Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(reTemplatedMoreButton), "Re-applied template should keep the expanded HelpText while the grid is open.");
+
+                // The toggle state must also be restored, otherwise the button is visually unchecked
+                // while the grid is open and the next click would fail to collapse it.
+                Verify.AreEqual(true, reTemplatedMoreButton.IsChecked, "Re-applied template should keep the toggle checked while the grid is open.");
+
+                // Collapsing after re-template must still work and revert the a11y text.
+                reTemplatedMoreButton.IsChecked = false;
+                Content.UpdateLayout();
+                Verify.AreEqual(collapsedName, Microsoft.UI.Xaml.Automation.AutomationProperties.GetName(reTemplatedMoreButton), "Collapsing after re-template should revert the Name.");
+                Verify.AreEqual(collapsedHelpText, Microsoft.UI.Xaml.Automation.AutomationProperties.GetHelpText(reTemplatedMoreButton), "Collapsing after re-template should revert the HelpText.");
+            });
+        }
+
         [TestMethod]
         [TestProperty("Ignore", "True")] // https://github.com/microsoft/microsoft-ui-xaml/issues/3982
         public void VerifyVisualTree()

--- a/controls/dev/ColorPicker/ColorPicker.cpp
+++ b/controls/dev/ColorPicker/ColorPicker.cpp
@@ -101,6 +101,10 @@ void ColorPicker::OnApplyTemplate()
     {
         if (const auto moreButtonAsToggleButton = moreButton.try_as<winrt::ToggleButton>())
         {
+            // Restore the toggle state from the current state before wiring up the handlers, so a
+            // re-applied template (e.g. on a theme change) while the text-entry grid is open keeps
+            // the button checked without firing the handlers or triggering a state transition.
+            moreButtonAsToggleButton.IsChecked(m_textEntryGridOpened);
             moreButtonAsToggleButton.Checked({ this, &ColorPicker::OnMoreButtonChecked });
             moreButtonAsToggleButton.Unchecked({ this, &ColorPicker::OnMoreButtonUnchecked });
         }
@@ -109,13 +113,16 @@ void ColorPicker::OnApplyTemplate()
             moreButton.Click({ this, &ColorPicker::OnMoreButtonClicked });
         }
 
-        winrt::AutomationProperties::SetName(moreButton, ResourceAccessor::GetLocalizedStringResource(SR_AutomationNameMoreButtonCollapsed));
-        winrt::AutomationProperties::SetHelpText(moreButton, ResourceAccessor::GetLocalizedStringResource(SR_HelpTextMoreButton));
+        // Reflect the current expanded/collapsed state rather than hardcoding the collapsed
+        // strings: OnApplyTemplate can run again (e.g. on a theme change) while the text-entry
+        // grid is open, in which case the More button must keep its expanded a11y text (#7395).
+        winrt::AutomationProperties::SetName(moreButton, ResourceAccessor::GetLocalizedStringResource(m_textEntryGridOpened ? SR_AutomationNameMoreButtonExpanded : SR_AutomationNameMoreButtonCollapsed));
+        winrt::AutomationProperties::SetHelpText(moreButton, ResourceAccessor::GetLocalizedStringResource(m_textEntryGridOpened ? SR_HelpTextMoreButtonExpanded : SR_HelpTextMoreButtonCollapsed));
 
         if (const auto moreButtonLabel = GetTemplateChildT<winrt::TextBlock>(L"MoreButtonLabel", thisAsControlProtected))
         {
             m_moreButtonLabel.set(moreButtonLabel);
-            moreButtonLabel.Text(ResourceAccessor::GetLocalizedStringResource(SR_TextMoreButtonLabelCollapsed));
+            moreButtonLabel.Text(ResourceAccessor::GetLocalizedStringResource(m_textEntryGridOpened ? SR_TextMoreButtonLabelExpanded : SR_TextMoreButtonLabelCollapsed));
         }
     }
 
@@ -761,6 +768,7 @@ void ColorPicker::UpdateMoreButton()
     if (auto&& moreButton = m_moreButton.get())
     {
         winrt::AutomationProperties::SetName(moreButton, ResourceAccessor::GetLocalizedStringResource(m_textEntryGridOpened ? SR_AutomationNameMoreButtonExpanded : SR_AutomationNameMoreButtonCollapsed));
+        winrt::AutomationProperties::SetHelpText(moreButton, ResourceAccessor::GetLocalizedStringResource(m_textEntryGridOpened ? SR_HelpTextMoreButtonExpanded : SR_HelpTextMoreButtonCollapsed));
     }
 
     if (auto&& moreButtonLabel = m_moreButtonLabel.get())

--- a/controls/dev/ColorPicker/Strings/en-us/Resources.resw
+++ b/controls/dev/ColorPicker/Strings/en-us/Resources.resw
@@ -287,7 +287,15 @@
   </data>
   <data name="HelpTextMoreButton" xml:space="preserve">
     <value>Invoke to show or hide the text entry fields.</value>
-    <comment>The help text associated with the "more" button.</comment>
+    <comment>[Deprecated, use HelpTextMoreButtonCollapsed/HelpTextMoreButtonExpanded.] The help text associated with the "more" button.</comment>
+  </data>
+  <data name="HelpTextMoreButtonCollapsed" xml:space="preserve">
+    <value>Invoke to show the text entry fields.</value>
+    <comment>The help text associated with the "more" button when it's collapsed (showing "More").</comment>
+  </data>
+  <data name="HelpTextMoreButtonExpanded" xml:space="preserve">
+    <value>Invoke to hide the text entry fields.</value>
+    <comment>The help text associated with the "more" button when it's expanded (showing "Less").</comment>
   </data>
   <data name="TextMoreButtonLabelCollapsed" xml:space="preserve">
     <value>More</value>

--- a/controls/dev/ResourceHelper/ResourceAccessor.h
+++ b/controls/dev/ResourceHelper/ResourceAccessor.h
@@ -110,6 +110,8 @@ public:
 #define SR_AutomationNameMoreButtonCollapsed L"AutomationNameMoreButtonCollapsed"
 #define SR_AutomationNameMoreButtonExpanded L"AutomationNameMoreButtonExpanded"
 #define SR_HelpTextMoreButton L"HelpTextMoreButton"
+#define SR_HelpTextMoreButtonCollapsed L"HelpTextMoreButtonCollapsed"
+#define SR_HelpTextMoreButtonExpanded L"HelpTextMoreButtonExpanded"
 #define SR_TextMoreButtonLabelCollapsed L"TextMoreButtonLabelCollapsed"
 #define SR_TextMoreButtonLabelExpanded L"TextMoreButtonLabelExpanded"
 #define SR_BadgeItemPlural1 L"BadgeItemPlural1"


### PR DESCRIPTION
## Fixes

Fixes #7395

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

The ColorPicker More/Less button exposes stale accessibility HelpText that does not reflect whether the additional controls are collapsed or expanded.

### New Behavior

Adds localized collapsed and expanded HelpText resources and updates the button dynamically as state changes, including after re-templating. The legacy string remains for compatibility, and API coverage is included.

## Customer Impact

Assistive technology receives accurate guidance for the current More/Less action.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

The controls DLL was previously built. A live harness was blocked by a startup failure also reproduced on the unchanged baseline.

## Screenshots and recordings

**ColorPicker More and Less help text demonstration**

https://github.com/user-attachments/assets/1aa969f6-769b-4b75-94d0-ffd9cfdc3a05

