### PR TITLE
Lower ToggleSwitch default minimum width

### DIFF
--- a/controls/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+++ b/controls/dev/CommonStyles/ToggleSwitch_themeresources.xaml
@@ -185,7 +185,7 @@
   <Thickness x:Key="ToggleSwitchTopHeaderMargin">0,0,0,4</Thickness>
   <x:Double x:Key="ToggleSwitchPreContentMargin">10</x:Double>
   <x:Double x:Key="ToggleSwitchPostContentMargin">10</x:Double>
-  <x:Double x:Key="ToggleSwitchThemeMinWidth">154</x:Double>
+  <x:Double x:Key="ToggleSwitchThemeMinWidth">48</x:Double>
   <Style TargetType="ToggleSwitch" BasedOn="{StaticResource DefaultToggleSwitchStyle}" />
   <Style x:Key="DefaultToggleSwitchStyle" TargetType="ToggleSwitch">
     <Setter Property="Foreground" Value="{ThemeResource ToggleSwitchContentForeground}" />

--- a/controls/dev/CommonStyles/ToggleSwitch_themeresources_perf2026.xaml
+++ b/controls/dev/CommonStyles/ToggleSwitch_themeresources_perf2026.xaml
@@ -185,7 +185,7 @@
   <Thickness x:Key="ToggleSwitchTopHeaderMargin">0,0,0,4</Thickness>
   <x:Double x:Key="ToggleSwitchPreContentMargin">10</x:Double>
   <x:Double x:Key="ToggleSwitchPostContentMargin">10</x:Double>
-  <x:Double x:Key="ToggleSwitchThemeMinWidth">154</x:Double>
+  <x:Double x:Key="ToggleSwitchThemeMinWidth">48</x:Double>
   <Style TargetType="ToggleSwitch" BasedOn="{StaticResource DefaultToggleSwitchStyle}" />
   <Style x:Key="DefaultToggleSwitchStyle" TargetType="ToggleSwitch">
     <Setter Property="Foreground" Value="{ThemeResource ToggleSwitchContentForeground}" />


### PR DESCRIPTION
## Fixes

Fixes #3652

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

`ToggleSwitchThemeMinWidth` defaults to 154px, forcing extra width even when the visible switch and content need less space.

### New Behavior

Lowers `ToggleSwitchThemeMinWidth` to 48px in the regular and perf2026 resources. The resource remains overridable, and the visible switch itself does not shrink.

## Customer Impact

ToggleSwitch can fit narrower layouts by default.

## Regression Potential

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

**Behavior-change risk:** layouts that implicitly depended on the previous 154px minimum may become narrower. Apps can override `ToggleSwitchThemeMinWidth` to retain a larger minimum.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

The resource-only change preserves the visible switch dimensions. GitHub CI provides persistent validation.

## Screenshots and recordings

![ToggleSwitch layout before the minimum width change](https://github.com/user-attachments/assets/e9e2a17c-5434-4fe6-b319-1df089bb8463)

![ToggleSwitch layout after the minimum width change](https://github.com/user-attachments/assets/070dfa38-b6e8-4e29-881b-3dfbe7c987d9)

## Prior review sign-offs

@godlytalias previously reviewed and signed off, and is tagged to reconfirm the GitHub version.