### PR TITLE
Add thin acrylic card brushes

### DIFF
--- a/controls/dev/CommonStyles/Common_themeresources_any.xaml
+++ b/controls/dev/CommonStyles/Common_themeresources_any.xaml
@@ -56,6 +56,9 @@
       <Color x:Key="CardBackgroundFillColorDefault">#0DFFFFFF</Color>
       <Color x:Key="CardBackgroundFillColorSecondary">#08FFFFFF</Color>
       <Color x:Key="CardBackgroundFillColorTertiary">#12FFFFFF</Color>
+      <Color x:Key="CardBackgroundFillColorOnThinAcrylicDefault">#A6000000</Color>
+      <Color x:Key="CardBackgroundFillColorOnThinAcrylicSecondary">#86000000</Color>
+      <Color x:Key="LayerOnThinAcrylicFillColorDefault">#09FFFFFF</Color>
       <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
       <Color x:Key="LayerFillColorDefault">#4C3A3A3A</Color>
       <Color x:Key="LayerFillColorAlt">#0DFFFFFF</Color>
@@ -146,6 +149,9 @@
       <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{StaticResource CardBackgroundFillColorDefault}" />
       <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{StaticResource CardBackgroundFillColorSecondary}" />
       <SolidColorBrush x:Key="CardBackgroundFillColorTertiaryBrush" Color="{StaticResource CardBackgroundFillColorTertiary}" />
+      <SolidColorBrush x:Key="CardBackgroundFillColorOnThinAcrylicDefaultBrush" Color="{StaticResource CardBackgroundFillColorOnThinAcrylicDefault}" />
+      <SolidColorBrush x:Key="CardBackgroundFillColorOnThinAcrylicSecondaryBrush" Color="{StaticResource CardBackgroundFillColorOnThinAcrylicSecondary}" />
+      <SolidColorBrush x:Key="LayerOnThinAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnThinAcrylicFillColorDefault}" />
       <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{StaticResource SmokeFillColorDefault}" />
       <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{StaticResource LayerFillColorDefault}" />
       <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource LayerFillColorAlt}" />
@@ -260,6 +266,9 @@
       <Color x:Key="CardBackgroundFillColorDefault">#B3FFFFFF</Color>
       <Color x:Key="CardBackgroundFillColorSecondary">#80F6F6F6</Color>
       <Color x:Key="CardBackgroundFillColorTertiary">#FFFFFF</Color>
+      <Color x:Key="CardBackgroundFillColorOnThinAcrylicDefault">#E6F6F6F6</Color>
+      <Color x:Key="CardBackgroundFillColorOnThinAcrylicSecondary">#F9F9F9</Color>
+      <Color x:Key="LayerOnThinAcrylicFillColorDefault">#40FFFFFF</Color>
       <Color x:Key="SmokeFillColorDefault">#4D000000</Color>
       <Color x:Key="LayerFillColorDefault">#80FFFFFF</Color>
       <Color x:Key="LayerFillColorAlt">#FFFFFF</Color>
@@ -350,6 +359,9 @@
       <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{StaticResource CardBackgroundFillColorDefault}" />
       <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{StaticResource CardBackgroundFillColorSecondary}" />
       <SolidColorBrush x:Key="CardBackgroundFillColorTertiaryBrush" Color="{StaticResource CardBackgroundFillColorTertiary}" />
+      <SolidColorBrush x:Key="CardBackgroundFillColorOnThinAcrylicDefaultBrush" Color="{StaticResource CardBackgroundFillColorOnThinAcrylicDefault}" />
+      <SolidColorBrush x:Key="CardBackgroundFillColorOnThinAcrylicSecondaryBrush" Color="{StaticResource CardBackgroundFillColorOnThinAcrylicSecondary}" />
+      <SolidColorBrush x:Key="LayerOnThinAcrylicFillColorDefaultBrush" Color="{StaticResource LayerOnThinAcrylicFillColorDefault}" />
       <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{StaticResource SmokeFillColorDefault}" />
       <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{StaticResource LayerFillColorDefault}" />
       <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{StaticResource LayerFillColorAlt}" />
@@ -474,6 +486,9 @@
       <SolidColorBrush x:Key="CardBackgroundFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
       <SolidColorBrush x:Key="CardBackgroundFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
       <SolidColorBrush x:Key="CardBackgroundFillColorTertiaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
+      <SolidColorBrush x:Key="CardBackgroundFillColorOnThinAcrylicDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
+      <SolidColorBrush x:Key="CardBackgroundFillColorOnThinAcrylicSecondaryBrush" Color="{ThemeResource SystemColorWindowColor}" />
+      <SolidColorBrush x:Key="LayerOnThinAcrylicFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
       <SolidColorBrush x:Key="SmokeFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
       <SolidColorBrush x:Key="LayerFillColorDefaultBrush" Color="{ThemeResource SystemColorWindowColor}" />
       <SolidColorBrush x:Key="LayerFillColorAltBrush" Color="{ThemeResource SystemColorWindowColor}" />
@@ -558,6 +573,9 @@
       <Color x:Key="CardBackgroundFillColorDefault">#FF0000</Color>
       <Color x:Key="CardBackgroundFillColorSecondary">#FF0000</Color>
       <Color x:Key="CardBackgroundFillColorTertiary">#FF0000</Color>
+      <Color x:Key="CardBackgroundFillColorOnThinAcrylicDefault">#FF0000</Color>
+      <Color x:Key="CardBackgroundFillColorOnThinAcrylicSecondary">#FF0000</Color>
+      <Color x:Key="LayerOnThinAcrylicFillColorDefault">#FF0000</Color>
       <Color x:Key="SmokeFillColorDefault">#FF0000</Color>
       <Color x:Key="LayerFillColorDefault">#FF0000</Color>
       <Color x:Key="LayerFillColorAlt">#FF0000</Color>


### PR DESCRIPTION
## Fixes

Fixes #11105

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

The common resources do not provide card and layer brushes specifically backed for thin acrylic surfaces.

### New Behavior

Adds three thin-acrylic card/layer brush resources and their backing colors for light, dark, and high-contrast themes.

## Customer Impact

Apps can layer cards and surfaces over thin acrylic using shared theme-aware resources.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

These are additive resources.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

The resource definitions cover light, dark, and high-contrast themes. GitHub CI provides persistent validation.

## Screenshots and recordings

![Thin acrylic brushes in light theme](https://github.com/user-attachments/assets/76289129-3290-4266-87d8-ad2cdc73df89)

![Thin acrylic brushes in dark theme](https://github.com/user-attachments/assets/9775c0fc-84ef-45a7-bc1b-a82c3ea1b2f9)

## Prior review sign-offs

@marcelwgn and @godlytalias previously reviewed and signed off, and are tagged to reconfirm the GitHub version.