### PR TITLE
Fix DatePicker and TimePicker styling

### DIFF
--- a/controls/dev/CommonStyles/DatePicker_themeresources.xaml
+++ b/controls/dev/CommonStyles/DatePicker_themeresources.xaml
@@ -6,7 +6,7 @@
       <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
-      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
       <StaticResource x:Key="DatePickerSpacerFill" ResourceKey="ControlStrokeColorDefaultBrush" />
       <StaticResource x:Key="DatePickerSpacerFillDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
@@ -67,7 +67,7 @@
       <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
-      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
       <SolidColorBrush x:Key="DatePickerHeaderForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <SolidColorBrush x:Key="DatePickerForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
@@ -78,7 +78,7 @@
       <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
-      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
       <StaticResource x:Key="DatePickerSpacerFill" ResourceKey="ControlStrokeColorDefaultBrush" />
       <StaticResource x:Key="DatePickerSpacerFillDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
@@ -110,16 +110,16 @@
       <StaticResource x:Key="DatePickerFlyoutPresenterHighlightForegroundColor" ResourceKey="TextOnAccentAAFillColorPrimary" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
-  <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,4</Thickness>
+  <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,8</Thickness>
   <x:Double x:Key="DatePickerFlyoutPresenterHighlightHeight">40</x:Double>
   <x:Double x:Key="DatePickerFlyoutPresenterItemHeight">40</x:Double>
   <x:Double x:Key="DatePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
   <x:Double x:Key="DatePickerThemeMinWidth">296</x:Double>
   <x:Double x:Key="DatePickerThemeMaxWidth">456</x:Double>
-  <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
-  <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,3,0,6</Thickness>
-  <Thickness x:Key="DatePickerHostPadding">0,3,0,6</Thickness>
-  <Thickness x:Key="DatePickerHostMonthPadding">9,3,0,6</Thickness>
+  <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,4,0,6</Thickness>
+  <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,4,0,6</Thickness>
+  <Thickness x:Key="DatePickerHostPadding">0,4,0,6</Thickness>
+  <Thickness x:Key="DatePickerHostMonthPadding">9,4,0,6</Thickness>
   <Thickness x:Key="DatePickerFlyoutPresenterAcceptMargin">4,4,2,4</Thickness>
   <Thickness x:Key="DatePickerFlyoutPresenterDismissMargin">2,4,4,4</Thickness>
   <Style TargetType="DatePicker" BasedOn="{StaticResource DefaultDatePickerStyle}" />

--- a/controls/dev/CommonStyles/DatePicker_themeresources_perf2026.xaml
+++ b/controls/dev/CommonStyles/DatePicker_themeresources_perf2026.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Default">
@@ -6,7 +6,7 @@
       <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
-      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
       <StaticResource x:Key="DatePickerSpacerFill" ResourceKey="ControlStrokeColorDefaultBrush" />
       <StaticResource x:Key="DatePickerSpacerFillDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
@@ -67,7 +67,7 @@
       <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
-      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
       <SolidColorBrush x:Key="DatePickerHeaderForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <SolidColorBrush x:Key="DatePickerForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
@@ -78,7 +78,7 @@
       <x:Double x:Key="DatePickerSpacerThemeWidth">1</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeWidth">20</x:Double>
       <x:Double x:Key="DatePickerSpacingThemeHeight">20</x:Double>
-      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="DatePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <FontWeight x:Key="DatePickerHeaderThemeFontWeight">Normal</FontWeight>
       <StaticResource x:Key="DatePickerSpacerFill" ResourceKey="ControlStrokeColorDefaultBrush" />
       <StaticResource x:Key="DatePickerSpacerFillDisabled" ResourceKey="ControlStrokeColorDefaultBrush" />
@@ -110,16 +110,16 @@
       <StaticResource x:Key="DatePickerFlyoutPresenterHighlightForegroundColor" ResourceKey="TextOnAccentAAFillColorPrimary" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
-  <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,4</Thickness>
+  <Thickness x:Key="DatePickerTopHeaderMargin">0,0,0,8</Thickness>
   <x:Double x:Key="DatePickerFlyoutPresenterHighlightHeight">40</x:Double>
   <x:Double x:Key="DatePickerFlyoutPresenterItemHeight">40</x:Double>
   <x:Double x:Key="DatePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
   <x:Double x:Key="DatePickerThemeMinWidth">296</x:Double>
   <x:Double x:Key="DatePickerThemeMaxWidth">456</x:Double>
-  <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
-  <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,3,0,6</Thickness>
-  <Thickness x:Key="DatePickerHostPadding">0,3,0,6</Thickness>
-  <Thickness x:Key="DatePickerHostMonthPadding">9,3,0,6</Thickness>
+  <Thickness x:Key="DatePickerFlyoutPresenterItemPadding">0,4,0,6</Thickness>
+  <Thickness x:Key="DatePickerFlyoutPresenterMonthPadding">9,4,0,6</Thickness>
+  <Thickness x:Key="DatePickerHostPadding">0,4,0,6</Thickness>
+  <Thickness x:Key="DatePickerHostMonthPadding">9,4,0,6</Thickness>
   <Thickness x:Key="DatePickerFlyoutPresenterAcceptMargin">4,4,2,4</Thickness>
   <Thickness x:Key="DatePickerFlyoutPresenterDismissMargin">2,4,4,4</Thickness>
   <Style TargetType="DatePicker" BasedOn="{StaticResource DefaultDatePickerStyle}" />

--- a/controls/dev/CommonStyles/TestUI/CommonStylesPage.xaml.cs
+++ b/controls/dev/CommonStyles/TestUI/CommonStylesPage.xaml.cs
@@ -176,9 +176,9 @@ namespace MUXControlsTestApp
             var contentPresenter = (ContentPresenter)root.FindName("HeaderContentPresenter");
             simpleVerify.IsTrue(contentPresenter != null, "HeaderContentPresenter can't be found");
 
-            string expectedHeaderMargin = "0,0,0,4";
-            string expectDatePickerFlyoutPresenterItemPadding = "0,3,0,6";
-            string expectDatePickerFlyoutPresenterMonthPadding = "9,3,0,6";
+            string expectedHeaderMargin = "0,0,0,8";
+            string expectDatePickerFlyoutPresenterItemPadding = "0,4,0,6";
+            string expectDatePickerFlyoutPresenterMonthPadding = "9,4,0,6";
 
             if (contentPresenter != null)
             {
@@ -207,8 +207,8 @@ namespace MUXControlsTestApp
             var contentPresenter = (ContentPresenter)root.FindName("HeaderContentPresenter");
             simpleVerify.IsTrue(contentPresenter != null, "HeaderContentPresenter can't be found");
 
-            string expectedHeaderMargin = "0,0,0,4";
-            string expectTimePickerFlyoutPresenterItemPadding = "0,3,0,6";
+            string expectedHeaderMargin = "0,0,0,8";
+            string expectTimePickerFlyoutPresenterItemPadding = "0,4,0,6";
 
             if (contentPresenter != null)
             {

--- a/controls/dev/CommonStyles/TimePicker_themeresources.xaml
+++ b/controls/dev/CommonStyles/TimePicker_themeresources.xaml
@@ -32,7 +32,7 @@
       <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
       <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
       <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
-      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
       <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
       <FontWeight x:Key="TimePickerHeaderThemeFontWeight">Normal</FontWeight>
@@ -66,7 +66,7 @@
       <SolidColorBrush x:Key="TimePickerForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <SolidColorBrush x:Key="TimePickerHeaderForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
-      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
       <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
       <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
@@ -104,20 +104,20 @@
       <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
       <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
       <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
-      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
       <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
       <FontWeight x:Key="TimePickerHeaderThemeFontWeight">Normal</FontWeight>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
-  <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,4</Thickness>
+  <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,8</Thickness>
   <x:Double x:Key="TimePickerFlyoutPresenterHighlightHeight">40</x:Double>
   <x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
   <x:Double x:Key="TimePickerThemeMinWidth">242</x:Double>
   <x:Double x:Key="TimePickerThemeMaxWidth">456</x:Double>
   <x:Double x:Key="TimePickerFlyoutPresenterItemHeight">40</x:Double>
   <Thickness x:Key="TimePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
-  <Thickness x:Key="TimePickerHostPadding">0,3,0,6</Thickness>
+  <Thickness x:Key="TimePickerHostPadding">0,4,0,6</Thickness>
   <Style TargetType="TimePicker">
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="FocusVisualMargin" Value="0" />

--- a/controls/dev/CommonStyles/TimePicker_themeresources_perf2026.xaml
+++ b/controls/dev/CommonStyles/TimePicker_themeresources_perf2026.xaml
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Default">
@@ -32,7 +32,7 @@
       <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
       <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
       <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
-      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
       <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
       <FontWeight x:Key="TimePickerHeaderThemeFontWeight">Normal</FontWeight>
@@ -66,7 +66,7 @@
       <SolidColorBrush x:Key="TimePickerForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <SolidColorBrush x:Key="TimePickerHeaderForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
-      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
       <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
       <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
@@ -104,20 +104,20 @@
       <x:Double x:Key="TimePickerSelectorThemeMinWidth">80</x:Double>
       <x:Double x:Key="TimePickerSpacerThemeWidth">1</x:Double>
       <Thickness x:Key="TimePickerBorderThemeThickness">1</Thickness>
-      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,4</Thickness>
+      <Thickness x:Key="TimePickerHeaderThemeMargin">0,0,0,8</Thickness>
       <Thickness x:Key="TimePickerFirstHostThemeMargin">0,0,20,0</Thickness>
       <Thickness x:Key="TimePickerThirdHostThemeMargin">20,0,0,0</Thickness>
       <FontWeight x:Key="TimePickerHeaderThemeFontWeight">Normal</FontWeight>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
-  <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,4</Thickness>
+  <Thickness x:Key="TimePickerTopHeaderMargin">0,0,0,8</Thickness>
   <x:Double x:Key="TimePickerFlyoutPresenterHighlightHeight">40</x:Double>
   <x:Double x:Key="TimePickerFlyoutPresenterAcceptDismissHostGridHeight">41</x:Double>
   <x:Double x:Key="TimePickerThemeMinWidth">242</x:Double>
   <x:Double x:Key="TimePickerThemeMaxWidth">456</x:Double>
   <x:Double x:Key="TimePickerFlyoutPresenterItemHeight">40</x:Double>
   <Thickness x:Key="TimePickerFlyoutPresenterItemPadding">0,3,0,6</Thickness>
-  <Thickness x:Key="TimePickerHostPadding">0,3,0,6</Thickness>
+  <Thickness x:Key="TimePickerHostPadding">0,4,0,6</Thickness>
   <Style TargetType="TimePicker">
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="FocusVisualMargin" Value="0" />

--- a/controls/test/MUXControlsTestApp/verification/DatePicker.xml
+++ b/controls/test/MUXControlsTestApp/verification/DatePicker.xml
@@ -25,7 +25,7 @@
       Foreground=#E4000000
       Margin=0,0,0,0
       Padding=0,0,0,0
-      RenderSize=296,28
+      RenderSize=296,29
       Visibility=Visible
     [Microsoft.UI.Xaml.Controls.Grid]
         Background=[NULL]
@@ -39,7 +39,7 @@
         Margin=0,0,0,0
         Name=LayoutRoot
         Padding=0,0,0,0
-        RenderSize=296,28
+        RenderSize=296,29
         Visibility=Visible
       [Microsoft.UI.Xaml.Controls.ContentPresenter]
           Background=[NULL]
@@ -51,7 +51,7 @@
           FocusVisualSecondaryBrush=#B3FFFFFF
           FocusVisualSecondaryThickness=1,1,1,1
           Foreground=#E4000000
-          Margin=0,0,0,4
+          Margin=0,0,0,8
           MaxWidth=456
           Name=HeaderContentPresenter
           Padding=0,0,0,0
@@ -72,7 +72,7 @@
           MinWidth=296
           Name=FlyoutButton
           Padding=11,5,11,6
-          RenderSize=296,28
+          RenderSize=296,29
           Visibility=Visible
         [Microsoft.UI.Xaml.Controls.Grid]
             Background=[NULL]
@@ -85,7 +85,7 @@
             FocusVisualSecondaryThickness=1,1,1,1
             Margin=0,0,0,0
             Padding=0,0,0,0
-            RenderSize=296,28
+            RenderSize=296,29
             Visibility=Visible
           [Microsoft.UI.Xaml.Controls.ContentPresenter]
               Background=#B3FFFFFF
@@ -100,7 +100,7 @@
               Margin=0,0,0,0
               Name=ContentPresenter
               Padding=0,0,0,0
-              RenderSize=296,28
+              RenderSize=296,29
               Visibility=Visible
             [Microsoft.UI.Xaml.Controls.Grid]
                 Background=[NULL]
@@ -114,7 +114,7 @@
                 Margin=0,0,0,0
                 Name=FlyoutButtonContentGrid
                 Padding=0,0,0,0
-                RenderSize=294,26
+                RenderSize=294,27
                 Visibility=Visible
               [Microsoft.UI.Xaml.Controls.TextBlock]
                   FocusVisualPrimaryBrush=#E4000000
@@ -124,8 +124,8 @@
                   Foreground=#9E000000
                   Margin=0,0,0,0
                   Name=DayTextBlock
-                  Padding=0,3,0,6
-                  RenderSize=79,26
+                  Padding=0,4,0,6
+                  RenderSize=79,27
                   Visibility=Visible
               [Microsoft.UI.Xaml.Controls.TextBlock]
                   FocusVisualPrimaryBrush=#E4000000
@@ -135,8 +135,8 @@
                   Foreground=#9E000000
                   Margin=1,0,0,0
                   Name=MonthTextBlock
-                  Padding=9,3,0,6
-                  RenderSize=133,26
+                  Padding=9,4,0,6
+                  RenderSize=133,27
                   Visibility=Visible
               [Microsoft.UI.Xaml.Controls.TextBlock]
                   FocusVisualPrimaryBrush=#E4000000
@@ -146,8 +146,8 @@
                   Foreground=#9E000000
                   Margin=0,0,0,0
                   Name=YearTextBlock
-                  Padding=0,3,0,6
-                  RenderSize=79,26
+                  Padding=0,4,0,6
+                  RenderSize=79,27
                   Visibility=Visible
               [Microsoft.UI.Xaml.Shapes.Rectangle]
                   FocusVisualPrimaryBrush=#E4000000
@@ -156,7 +156,7 @@
                   FocusVisualSecondaryThickness=1,1,1,1
                   Margin=0,0,0,0
                   Name=FirstPickerSpacing
-                  RenderSize=1,26
+                  RenderSize=1,27
                   StrokeThickness=1
                   Visibility=Visible
                   Width=1
@@ -167,7 +167,7 @@
                   FocusVisualSecondaryThickness=1,1,1,1
                   Margin=0,0,0,0
                   Name=SecondPickerSpacing
-                  RenderSize=1,26
+                  RenderSize=1,27
                   StrokeThickness=1
                   Visibility=Visible
                   Width=1

--- a/controls/test/MUXControlsTestApp/verification/TimePicker.xml
+++ b/controls/test/MUXControlsTestApp/verification/TimePicker.xml
@@ -25,7 +25,7 @@
       Foreground=#E4000000
       Margin=0,0,0,0
       Padding=0,0,0,0
-      RenderSize=242,28
+      RenderSize=242,29
       Visibility=Visible
     [Microsoft.UI.Xaml.Controls.Grid]
         Background=[NULL]
@@ -39,7 +39,7 @@
         Margin=0,0,0,0
         Name=LayoutRoot
         Padding=0,0,0,0
-        RenderSize=242,28
+        RenderSize=242,29
         Visibility=Visible
       [Microsoft.UI.Xaml.Controls.ContentPresenter]
           Background=[NULL]
@@ -51,7 +51,7 @@
           FocusVisualSecondaryBrush=#B3FFFFFF
           FocusVisualSecondaryThickness=1,1,1,1
           Foreground=#E4000000
-          Margin=0,0,0,4
+          Margin=0,0,0,8
           MaxWidth=456
           Name=HeaderContentPresenter
           Padding=0,0,0,0
@@ -72,7 +72,7 @@
           MinWidth=242
           Name=FlyoutButton
           Padding=11,5,11,6
-          RenderSize=242,28
+          RenderSize=242,29
           Visibility=Visible
         [Microsoft.UI.Xaml.Controls.Grid]
             Background=[NULL]
@@ -85,7 +85,7 @@
             FocusVisualSecondaryThickness=1,1,1,1
             Margin=0,0,0,0
             Padding=0,0,0,0
-            RenderSize=242,28
+            RenderSize=242,29
             Visibility=Visible
           [Microsoft.UI.Xaml.Controls.ContentPresenter]
               Background=#B3FFFFFF
@@ -100,7 +100,7 @@
               Margin=0,0,0,0
               Name=ContentPresenter
               Padding=0,0,0,0
-              RenderSize=242,28
+              RenderSize=242,29
               Visibility=Visible
             [Microsoft.UI.Xaml.Controls.Grid]
                 Background=[NULL]
@@ -114,7 +114,7 @@
                 Margin=0,0,0,0
                 Name=FlyoutButtonContentGrid
                 Padding=0,0,0,0
-                RenderSize=240,26
+                RenderSize=240,27
                 Visibility=Visible
               [Microsoft.UI.Xaml.Controls.Border]
                   Background=[NULL]
@@ -128,7 +128,7 @@
                   Margin=0,0,0,0
                   Name=FirstPickerHost
                   Padding=0,0,0,0
-                  RenderSize=79,26
+                  RenderSize=79,27
                   Visibility=Visible
                 [Microsoft.UI.Xaml.Controls.TextBlock]
                     FocusVisualPrimaryBrush=#E4000000
@@ -138,8 +138,8 @@
                     Foreground=#9E000000
                     Margin=0,0,0,0
                     Name=HourTextBlock
-                    Padding=0,3,0,6
-                    RenderSize=79,26
+                    Padding=0,4,0,6
+                    RenderSize=79,27
                     Visibility=Visible
               [Microsoft.UI.Xaml.Shapes.Rectangle]
                   FocusVisualPrimaryBrush=#E4000000
@@ -148,7 +148,7 @@
                   FocusVisualSecondaryThickness=1,1,1,1
                   Margin=0,0,0,0
                   Name=FirstColumnDivider
-                  RenderSize=1,26
+                  RenderSize=1,27
                   StrokeThickness=1
                   Visibility=Visible
                   Width=1
@@ -164,7 +164,7 @@
                   Margin=0,0,0,0
                   Name=SecondPickerHost
                   Padding=0,0,0,0
-                  RenderSize=80,26
+                  RenderSize=80,27
                   Visibility=Visible
                 [Microsoft.UI.Xaml.Controls.TextBlock]
                     FocusVisualPrimaryBrush=#E4000000
@@ -174,8 +174,8 @@
                     Foreground=#9E000000
                     Margin=0,0,0,0
                     Name=MinuteTextBlock
-                    Padding=0,3,0,6
-                    RenderSize=80,26
+                    Padding=0,4,0,6
+                    RenderSize=80,27
                     Visibility=Visible
               [Microsoft.UI.Xaml.Shapes.Rectangle]
                   FocusVisualPrimaryBrush=#E4000000
@@ -184,7 +184,7 @@
                   FocusVisualSecondaryThickness=1,1,1,1
                   Margin=0,0,0,0
                   Name=SecondColumnDivider
-                  RenderSize=1,26
+                  RenderSize=1,27
                   StrokeThickness=1
                   Visibility=Visible
                   Width=1
@@ -200,7 +200,7 @@
                   Margin=0,0,0,0
                   Name=ThirdPickerHost
                   Padding=0,0,0,0
-                  RenderSize=79,26
+                  RenderSize=79,27
                   Visibility=Visible
                 [Microsoft.UI.Xaml.Controls.TextBlock]
                     FocusVisualPrimaryBrush=#E4000000
@@ -210,6 +210,6 @@
                     Foreground=#9E000000
                     Margin=0,0,0,0
                     Name=PeriodTextBlock
-                    Padding=0,3,0,6
-                    RenderSize=79,26
+                    Padding=0,4,0,6
+                    RenderSize=79,27
                     Visibility=Visible

--- a/dxaml/test/native/external/controls/datepicker/DatePickerIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/datepicker/DatePickerIntegrationTests.cpp
@@ -867,8 +867,8 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         double const expectedDatePickerWidth = 296;
         double const expectedDatePickerWidth_WithWideHeader = 350;
 
-        double const expectedDatePickerHeight = 30;
-        double const expectedDatePickerHeight_WithHeader = 19 + 4 + expectedDatePickerHeight;
+        double const expectedDatePickerHeight = 31;
+        double const expectedDatePickerHeight_WithHeader = 19 + 8 + expectedDatePickerHeight;
 
         xaml_controls::DatePicker^ datePicker;
         xaml_controls::DatePicker^ datePickerWithHeader;

--- a/dxaml/test/native/external/controls/inc/DateTimePickerHelper.h
+++ b/dxaml/test/native/external/controls/inc/DateTimePickerHelper.h
@@ -110,7 +110,10 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
                 auto buttonCenter = ControlHelper::GetCenterOfElement(button);
 
                 VERIFY_ARE_EQUAL(highlightRectCenter.X, buttonCenter.X);
-                VERIFY_ARE_EQUAL(highlightRectCenter.Y, buttonCenter.Y);
+                // The button height is now odd (27px due to host padding 0,4,0,6), which puts buttonCenter.Y
+                // on a half-pixel boundary while the HighlightRect lands on a whole pixel. Allow a
+                // half-pixel tolerance instead of requiring exact equality.
+                VERIFY_IS_TRUE(ControlHelper::AreClose(highlightRectCenter.Y, buttonCenter.Y, 0.5f));
             });
 
             ControlHelper::ClickFlyoutCloseButton(dateTimePicker, true /* isAccept */);

--- a/dxaml/test/native/external/controls/timepicker/TimePickerIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/timepicker/TimePickerIntegrationTests.cpp
@@ -334,8 +334,8 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         double const expectedTimePickerWidth = 242;
         double const expectedTimePickerWidth_WithWideHeader = 350;
 
-        double const expectedTimePickerHeight = 30;
-        double const expectedTimePickerHeight_WithHeader = 19 + 4 + expectedTimePickerHeight;
+        double const expectedTimePickerHeight = 31;
+        double const expectedTimePickerHeight_WithHeader = 19 + 8 + expectedTimePickerHeight;
 
         xaml_controls::TimePicker^ timePicker;
         xaml_controls::TimePicker^ timePickerWithHeader;

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Dark.Dark.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Dark.Dark.Unwindowed.master.xml
@@ -169,7 +169,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="133x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -243,7 +243,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -266,7 +266,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -303,7 +303,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -326,7 +326,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -363,7 +363,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -386,7 +386,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -423,7 +423,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -446,7 +446,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -483,7 +483,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -506,7 +506,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -543,7 +543,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -566,7 +566,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -603,7 +603,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -626,7 +626,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -663,7 +663,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -686,7 +686,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -723,7 +723,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -746,7 +746,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -783,7 +783,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -806,7 +806,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -843,7 +843,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -866,7 +866,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -903,7 +903,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -926,7 +926,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -963,7 +963,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -986,7 +986,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1023,7 +1023,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1046,7 +1046,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1083,7 +1083,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1106,7 +1106,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1143,7 +1143,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1166,7 +1166,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1203,7 +1203,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1226,7 +1226,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1263,7 +1263,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1286,7 +1286,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1323,7 +1323,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1346,7 +1346,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1439,7 +1439,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="79x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1513,7 +1513,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1536,7 +1536,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1573,7 +1573,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1596,7 +1596,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1633,7 +1633,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1656,7 +1656,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1693,7 +1693,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1716,7 +1716,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1753,7 +1753,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1776,7 +1776,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1813,7 +1813,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1836,7 +1836,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1873,7 +1873,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1896,7 +1896,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1933,7 +1933,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1956,7 +1956,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1993,7 +1993,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2016,7 +2016,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2053,7 +2053,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2076,7 +2076,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2113,7 +2113,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2136,7 +2136,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2173,7 +2173,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2196,7 +2196,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2233,7 +2233,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2256,7 +2256,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2293,7 +2293,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2316,7 +2316,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2353,7 +2353,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2376,7 +2376,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2413,7 +2413,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2436,7 +2436,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2473,7 +2473,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2496,7 +2496,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2533,7 +2533,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2556,7 +2556,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2593,7 +2593,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2616,7 +2616,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2709,7 +2709,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="78x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2783,7 +2783,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2806,7 +2806,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2843,7 +2843,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2866,7 +2866,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2903,7 +2903,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2926,7 +2926,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2963,7 +2963,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2986,7 +2986,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3023,7 +3023,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3046,7 +3046,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3083,7 +3083,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3106,7 +3106,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3143,7 +3143,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3166,7 +3166,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3203,7 +3203,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3226,7 +3226,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3263,7 +3263,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3286,7 +3286,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3323,7 +3323,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3346,7 +3346,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3383,7 +3383,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3406,7 +3406,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3443,7 +3443,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3466,7 +3466,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3503,7 +3503,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3526,7 +3526,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3563,7 +3563,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3586,7 +3586,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3623,7 +3623,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3646,7 +3646,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3683,7 +3683,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3706,7 +3706,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3743,7 +3743,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3766,7 +3766,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3803,7 +3803,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3826,7 +3826,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3863,7 +3863,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3886,7 +3886,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Dark.Dark.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Dark.Dark.Windowed.master.xml
@@ -169,7 +169,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="133x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -243,7 +243,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -266,7 +266,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -303,7 +303,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -326,7 +326,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -363,7 +363,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -386,7 +386,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -423,7 +423,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -446,7 +446,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -483,7 +483,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -506,7 +506,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -543,7 +543,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -566,7 +566,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -603,7 +603,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -626,7 +626,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -663,7 +663,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -686,7 +686,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -723,7 +723,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -746,7 +746,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -783,7 +783,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -806,7 +806,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -843,7 +843,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -866,7 +866,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -903,7 +903,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -926,7 +926,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -963,7 +963,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -986,7 +986,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1023,7 +1023,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1046,7 +1046,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1083,7 +1083,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1106,7 +1106,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1143,7 +1143,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1166,7 +1166,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1203,7 +1203,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1226,7 +1226,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1263,7 +1263,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1286,7 +1286,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1323,7 +1323,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1346,7 +1346,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1439,7 +1439,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="79x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1513,7 +1513,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1536,7 +1536,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1573,7 +1573,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1596,7 +1596,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1633,7 +1633,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1656,7 +1656,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1693,7 +1693,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1716,7 +1716,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1753,7 +1753,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1776,7 +1776,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1813,7 +1813,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1836,7 +1836,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1873,7 +1873,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1896,7 +1896,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1933,7 +1933,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1956,7 +1956,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1993,7 +1993,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2016,7 +2016,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2053,7 +2053,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2076,7 +2076,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2113,7 +2113,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2136,7 +2136,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2173,7 +2173,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2196,7 +2196,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2233,7 +2233,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2256,7 +2256,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2293,7 +2293,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2316,7 +2316,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2353,7 +2353,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2376,7 +2376,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2413,7 +2413,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2436,7 +2436,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2473,7 +2473,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2496,7 +2496,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2533,7 +2533,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2556,7 +2556,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2593,7 +2593,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2616,7 +2616,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2709,7 +2709,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="78x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2783,7 +2783,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2806,7 +2806,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2843,7 +2843,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2866,7 +2866,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2903,7 +2903,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2926,7 +2926,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2963,7 +2963,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2986,7 +2986,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3023,7 +3023,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3046,7 +3046,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3083,7 +3083,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3106,7 +3106,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3143,7 +3143,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3166,7 +3166,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3203,7 +3203,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3226,7 +3226,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3263,7 +3263,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3286,7 +3286,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3323,7 +3323,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3346,7 +3346,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3383,7 +3383,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3406,7 +3406,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3443,7 +3443,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3466,7 +3466,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3503,7 +3503,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3526,7 +3526,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3563,7 +3563,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3586,7 +3586,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3623,7 +3623,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3646,7 +3646,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3683,7 +3683,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3706,7 +3706,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3743,7 +3743,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3766,7 +3766,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3803,7 +3803,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3826,7 +3826,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3863,7 +3863,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3886,7 +3886,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Full.Full.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Full.Full.Windowed.master.xml
@@ -169,7 +169,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="181x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -243,7 +243,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -266,7 +266,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -303,7 +303,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -326,7 +326,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -363,7 +363,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -386,7 +386,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -423,7 +423,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -446,7 +446,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -483,7 +483,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -506,7 +506,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -543,7 +543,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -566,7 +566,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -603,7 +603,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -626,7 +626,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -663,7 +663,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -686,7 +686,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -723,7 +723,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -746,7 +746,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -783,7 +783,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -806,7 +806,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -843,7 +843,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -866,7 +866,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -903,7 +903,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -926,7 +926,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -963,7 +963,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -986,7 +986,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1023,7 +1023,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1046,7 +1046,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1083,7 +1083,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1106,7 +1106,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1143,7 +1143,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1166,7 +1166,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1203,7 +1203,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1226,7 +1226,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1263,7 +1263,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1286,7 +1286,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1323,7 +1323,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="181x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1346,7 +1346,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="177x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1439,7 +1439,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="107x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1513,7 +1513,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1536,7 +1536,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1573,7 +1573,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1596,7 +1596,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1633,7 +1633,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1656,7 +1656,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1693,7 +1693,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1716,7 +1716,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1753,7 +1753,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1776,7 +1776,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1813,7 +1813,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1836,7 +1836,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1873,7 +1873,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1896,7 +1896,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1933,7 +1933,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1956,7 +1956,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1993,7 +1993,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2016,7 +2016,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2053,7 +2053,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2076,7 +2076,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2113,7 +2113,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2136,7 +2136,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2173,7 +2173,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2196,7 +2196,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2233,7 +2233,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2256,7 +2256,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2293,7 +2293,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2316,7 +2316,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2353,7 +2353,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2376,7 +2376,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2413,7 +2413,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2436,7 +2436,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2473,7 +2473,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2496,7 +2496,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2533,7 +2533,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2556,7 +2556,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2593,7 +2593,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="107x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2616,7 +2616,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="103x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2709,7 +2709,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="106x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2783,7 +2783,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2806,7 +2806,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2843,7 +2843,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2866,7 +2866,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2903,7 +2903,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2926,7 +2926,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2963,7 +2963,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2986,7 +2986,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3023,7 +3023,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3046,7 +3046,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3083,7 +3083,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3106,7 +3106,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3143,7 +3143,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3166,7 +3166,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3203,7 +3203,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3226,7 +3226,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3263,7 +3263,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3286,7 +3286,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3323,7 +3323,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3346,7 +3346,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3383,7 +3383,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3406,7 +3406,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3443,7 +3443,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3466,7 +3466,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3503,7 +3503,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3526,7 +3526,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3563,7 +3563,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3586,7 +3586,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3623,7 +3623,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3646,7 +3646,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3683,7 +3683,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3706,7 +3706,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3743,7 +3743,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3766,7 +3766,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3803,7 +3803,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3826,7 +3826,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3863,7 +3863,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="106x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3886,7 +3886,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="102x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_HC.HC.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_HC.HC.Unwindowed.master.xml
@@ -172,7 +172,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="133x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -246,7 +246,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -269,7 +269,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -308,7 +308,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -331,7 +331,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -370,7 +370,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -393,7 +393,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -432,7 +432,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -455,7 +455,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -494,7 +494,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -517,7 +517,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -556,7 +556,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -579,7 +579,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -618,7 +618,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -641,7 +641,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -680,7 +680,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -703,7 +703,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -742,7 +742,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -765,7 +765,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -804,7 +804,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -827,7 +827,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -866,7 +866,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -889,7 +889,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -928,7 +928,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -951,7 +951,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -990,7 +990,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1013,7 +1013,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1052,7 +1052,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1075,7 +1075,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1114,7 +1114,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1137,7 +1137,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1176,7 +1176,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1199,7 +1199,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1238,7 +1238,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1261,7 +1261,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1300,7 +1300,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1323,7 +1323,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1362,7 +1362,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1385,7 +1385,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1480,7 +1480,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="79x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1554,7 +1554,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1577,7 +1577,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1616,7 +1616,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1639,7 +1639,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1678,7 +1678,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1701,7 +1701,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1740,7 +1740,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1763,7 +1763,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1802,7 +1802,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1825,7 +1825,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1864,7 +1864,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1887,7 +1887,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1926,7 +1926,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1949,7 +1949,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1988,7 +1988,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2011,7 +2011,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2050,7 +2050,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2073,7 +2073,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2112,7 +2112,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2135,7 +2135,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2174,7 +2174,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2197,7 +2197,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2236,7 +2236,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2259,7 +2259,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2298,7 +2298,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2321,7 +2321,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2360,7 +2360,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2383,7 +2383,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2422,7 +2422,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2445,7 +2445,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2484,7 +2484,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2507,7 +2507,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2546,7 +2546,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2569,7 +2569,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2608,7 +2608,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2631,7 +2631,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2670,7 +2670,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2693,7 +2693,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2788,7 +2788,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="78x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2862,7 +2862,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2885,7 +2885,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2924,7 +2924,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2947,7 +2947,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2986,7 +2986,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3009,7 +3009,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3048,7 +3048,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3071,7 +3071,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3110,7 +3110,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3133,7 +3133,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3172,7 +3172,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3195,7 +3195,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3234,7 +3234,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3257,7 +3257,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3296,7 +3296,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3319,7 +3319,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3358,7 +3358,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3381,7 +3381,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3420,7 +3420,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3443,7 +3443,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3482,7 +3482,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3505,7 +3505,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3544,7 +3544,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3567,7 +3567,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3606,7 +3606,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3629,7 +3629,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3668,7 +3668,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3691,7 +3691,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3730,7 +3730,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3753,7 +3753,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3792,7 +3792,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3815,7 +3815,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3854,7 +3854,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3877,7 +3877,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3916,7 +3916,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3939,7 +3939,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3978,7 +3978,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -4001,7 +4001,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_HC.HC.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_HC.HC.Windowed.master.xml
@@ -172,7 +172,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="133x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -246,7 +246,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -269,7 +269,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -308,7 +308,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -331,7 +331,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -370,7 +370,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -393,7 +393,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -432,7 +432,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -455,7 +455,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -494,7 +494,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -517,7 +517,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -556,7 +556,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -579,7 +579,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -618,7 +618,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -641,7 +641,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -680,7 +680,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -703,7 +703,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -742,7 +742,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -765,7 +765,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -804,7 +804,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -827,7 +827,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -866,7 +866,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -889,7 +889,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -928,7 +928,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -951,7 +951,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -990,7 +990,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1013,7 +1013,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1052,7 +1052,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1075,7 +1075,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1114,7 +1114,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1137,7 +1137,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1176,7 +1176,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1199,7 +1199,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1238,7 +1238,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1261,7 +1261,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1300,7 +1300,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1323,7 +1323,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1362,7 +1362,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1385,7 +1385,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1480,7 +1480,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="79x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1554,7 +1554,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1577,7 +1577,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1616,7 +1616,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1639,7 +1639,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1678,7 +1678,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1701,7 +1701,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1740,7 +1740,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1763,7 +1763,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1802,7 +1802,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1825,7 +1825,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1864,7 +1864,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1887,7 +1887,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1926,7 +1926,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1949,7 +1949,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1988,7 +1988,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2011,7 +2011,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2050,7 +2050,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2073,7 +2073,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2112,7 +2112,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2135,7 +2135,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2174,7 +2174,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2197,7 +2197,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2236,7 +2236,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2259,7 +2259,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2298,7 +2298,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2321,7 +2321,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2360,7 +2360,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2383,7 +2383,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2422,7 +2422,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2445,7 +2445,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2484,7 +2484,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2507,7 +2507,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2546,7 +2546,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2569,7 +2569,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2608,7 +2608,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2631,7 +2631,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2670,7 +2670,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2693,7 +2693,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2788,7 +2788,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="78x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2862,7 +2862,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2885,7 +2885,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2924,7 +2924,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2947,7 +2947,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2986,7 +2986,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3009,7 +3009,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3048,7 +3048,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3071,7 +3071,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3110,7 +3110,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3133,7 +3133,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3172,7 +3172,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3195,7 +3195,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3234,7 +3234,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3257,7 +3257,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3296,7 +3296,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3319,7 +3319,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3358,7 +3358,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3381,7 +3381,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3420,7 +3420,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3443,7 +3443,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3482,7 +3482,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3505,7 +3505,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3544,7 +3544,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3567,7 +3567,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3606,7 +3606,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3629,7 +3629,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3668,7 +3668,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3691,7 +3691,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3730,7 +3730,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3753,7 +3753,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3792,7 +3792,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3815,7 +3815,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3854,7 +3854,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3877,7 +3877,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3916,7 +3916,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3939,7 +3939,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3978,7 +3978,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -4001,7 +4001,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Light.Light.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Light.Light.Unwindowed.master.xml
@@ -173,7 +173,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="133x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -247,7 +247,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -270,7 +270,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -307,7 +307,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -330,7 +330,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -367,7 +367,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -390,7 +390,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -427,7 +427,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -450,7 +450,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -487,7 +487,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -510,7 +510,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -547,7 +547,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -570,7 +570,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -607,7 +607,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -630,7 +630,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -667,7 +667,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -690,7 +690,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -727,7 +727,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -750,7 +750,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -787,7 +787,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -810,7 +810,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -847,7 +847,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -870,7 +870,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -907,7 +907,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -930,7 +930,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -967,7 +967,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -990,7 +990,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1027,7 +1027,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1050,7 +1050,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1087,7 +1087,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1110,7 +1110,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1147,7 +1147,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1170,7 +1170,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1207,7 +1207,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1230,7 +1230,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1267,7 +1267,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1290,7 +1290,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1327,7 +1327,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1350,7 +1350,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1443,7 +1443,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="79x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1517,7 +1517,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1540,7 +1540,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1577,7 +1577,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1600,7 +1600,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1637,7 +1637,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1660,7 +1660,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1697,7 +1697,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1720,7 +1720,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1757,7 +1757,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1780,7 +1780,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1817,7 +1817,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1840,7 +1840,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1877,7 +1877,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1900,7 +1900,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1937,7 +1937,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1960,7 +1960,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1997,7 +1997,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2020,7 +2020,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2057,7 +2057,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2080,7 +2080,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2117,7 +2117,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2140,7 +2140,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2177,7 +2177,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2200,7 +2200,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2237,7 +2237,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2260,7 +2260,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2297,7 +2297,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2320,7 +2320,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2357,7 +2357,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2380,7 +2380,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2417,7 +2417,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2440,7 +2440,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2477,7 +2477,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2500,7 +2500,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2537,7 +2537,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2560,7 +2560,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2597,7 +2597,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2620,7 +2620,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2713,7 +2713,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="78x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2787,7 +2787,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2810,7 +2810,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2847,7 +2847,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2870,7 +2870,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2907,7 +2907,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2930,7 +2930,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2967,7 +2967,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2990,7 +2990,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3027,7 +3027,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3050,7 +3050,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3087,7 +3087,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3110,7 +3110,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3147,7 +3147,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3170,7 +3170,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3207,7 +3207,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3230,7 +3230,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3267,7 +3267,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3290,7 +3290,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3327,7 +3327,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3350,7 +3350,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3387,7 +3387,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3410,7 +3410,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3447,7 +3447,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3470,7 +3470,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3507,7 +3507,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3530,7 +3530,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3567,7 +3567,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3590,7 +3590,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3627,7 +3627,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3650,7 +3650,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3687,7 +3687,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3710,7 +3710,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3747,7 +3747,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3770,7 +3770,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3807,7 +3807,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3830,7 +3830,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3867,7 +3867,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3890,7 +3890,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Light.Light.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePickerFlyout_DatePickerFlyoutIntegrationTests_ValidateUIElementTree_Light.Light.Windowed.master.xml
@@ -173,7 +173,7 @@
                 <Property Name="Grid.Column" Value="0" />
                 <Property Name="HorizontalContentAlignment" Value="0" />
                 <Property Name="Name" Value="MonthLoopingSelector" />
-                <Property Name="Padding" Value="9,3,0,6" />
+                <Property Name="Padding" Value="9,4,0,6" />
                 <Property Name="RenderSize" Value="133x355" />
                 <Property Name="TabIndex" Value="0" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -247,7 +247,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -270,7 +270,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -307,7 +307,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -330,7 +330,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -367,7 +367,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -390,7 +390,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -427,7 +427,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -450,7 +450,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -487,7 +487,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -510,7 +510,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -547,7 +547,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -570,7 +570,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -607,7 +607,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -630,7 +630,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -667,7 +667,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -690,7 +690,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -727,7 +727,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -750,7 +750,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -787,7 +787,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -810,7 +810,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -847,7 +847,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -870,7 +870,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -907,7 +907,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -930,7 +930,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -967,7 +967,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -990,7 +990,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1027,7 +1027,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1050,7 +1050,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1087,7 +1087,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1110,7 +1110,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1147,7 +1147,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1170,7 +1170,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1207,7 +1207,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1230,7 +1230,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1267,7 +1267,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1290,7 +1290,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1327,7 +1327,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="0" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="9,3,0,6" />
+                            <Property Name="Padding" Value="9,4,0,6" />
                             <Property Name="RenderSize" Value="133x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1350,7 +1350,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="0" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="9,3,0,6" />
+                                <Property Name="Padding" Value="9,4,0,6" />
                                 <Property Name="RenderSize" Value="129x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1443,7 +1443,7 @@
                 <Property Name="Grid.Column" Value="2" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="DayLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="79x355" />
                 <Property Name="TabIndex" Value="1" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1517,7 +1517,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1540,7 +1540,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1577,7 +1577,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1600,7 +1600,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1637,7 +1637,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1660,7 +1660,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1697,7 +1697,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1720,7 +1720,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1757,7 +1757,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1780,7 +1780,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1817,7 +1817,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1840,7 +1840,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1877,7 +1877,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1900,7 +1900,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1937,7 +1937,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -1960,7 +1960,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1997,7 +1997,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2020,7 +2020,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2057,7 +2057,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2080,7 +2080,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2117,7 +2117,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2140,7 +2140,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2177,7 +2177,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2200,7 +2200,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2237,7 +2237,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2260,7 +2260,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2297,7 +2297,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2320,7 +2320,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2357,7 +2357,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2380,7 +2380,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2417,7 +2417,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2440,7 +2440,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2477,7 +2477,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2500,7 +2500,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2537,7 +2537,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2560,7 +2560,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2597,7 +2597,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="79x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2620,7 +2620,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="75x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2713,7 +2713,7 @@
                 <Property Name="Grid.Column" Value="4" />
                 <Property Name="HorizontalContentAlignment" Value="1" />
                 <Property Name="Name" Value="YearLoopingSelector" />
-                <Property Name="Padding" Value="0,3,0,6" />
+                <Property Name="Padding" Value="0,4,0,6" />
                 <Property Name="RenderSize" Value="78x355" />
                 <Property Name="TabIndex" Value="2" />
                 <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2787,7 +2787,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2810,7 +2810,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2847,7 +2847,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2870,7 +2870,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2907,7 +2907,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2930,7 +2930,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2967,7 +2967,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -2990,7 +2990,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3027,7 +3027,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3050,7 +3050,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3087,7 +3087,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3110,7 +3110,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3147,7 +3147,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3170,7 +3170,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3207,7 +3207,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3230,7 +3230,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3267,7 +3267,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3290,7 +3290,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3327,7 +3327,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3350,7 +3350,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3387,7 +3387,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3410,7 +3410,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3447,7 +3447,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3470,7 +3470,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3507,7 +3507,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3530,7 +3530,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3567,7 +3567,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3590,7 +3590,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3627,7 +3627,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3650,7 +3650,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3687,7 +3687,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3710,7 +3710,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3747,7 +3747,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3770,7 +3770,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3807,7 +3807,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3830,7 +3830,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -3867,7 +3867,7 @@
                             <Property Name="HorizontalAlignment" Value="3" />
                             <Property Name="HorizontalContentAlignment" Value="1" />
                             <Property Name="IsTabStop" Value="False" />
-                            <Property Name="Padding" Value="0,3,0,6" />
+                            <Property Name="Padding" Value="0,4,0,6" />
                             <Property Name="RenderSize" Value="78x40" />
                             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                             <Property Name="VerticalAlignment" Value="3" />
@@ -3890,7 +3890,7 @@
                                 <Property Name="HorizontalContentAlignment" Value="1" />
                                 <Property Name="Margin" Value="2,0,2,0" />
                                 <Property Name="Name" Value="ContentPresenter" />
-                                <Property Name="Padding" Value="0,3,0,6" />
+                                <Property Name="Padding" Value="0,4,0,6" />
                                 <Property Name="RenderSize" Value="74x40" />
                                 <Property Name="VerticalContentAlignment" Value="1" />
                                 <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_DatePicker_DatePickerIntegrationTests_ValidateUIElementTree.Dark.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePicker_DatePickerIntegrationTests_ValidateUIElementTree.Dark.master.xml
@@ -7,7 +7,7 @@
       <Property Name="IsHitTestVisible" Value="False" />
       <Property Name="RenderSize" Value="500x600" />
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -23,18 +23,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -45,7 +45,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -67,7 +67,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Rest ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -77,7 +77,6 @@
             <Property Name="Content" Value="[Microsoft.UI.Xaml.Controls.Grid]" />
             <Property Name="CornerRadius" Value="4,4,4,4" />
             <Property Name="ElementSoundMode" Value="1" />
-            <Property Name="FocusState" Value="1" />
             <Property Name="FocusVisualMargin" Value="-3,-3,-3,-3" />
             <Property Name="FontFamily" Value="Segoe UI" />
             <Property Name="FontSize" Value="14" />
@@ -91,17 +90,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#0FFFFFFF" />
@@ -112,16 +111,16 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -129,8 +128,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -139,7 +138,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -148,8 +147,8 @@
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
                     <Property Name="Visibility" Value="0" />
@@ -158,7 +157,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -166,8 +165,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -176,24 +175,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -204,7 +203,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -220,18 +219,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -242,7 +241,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -264,7 +263,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Hover ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -287,17 +286,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#15FFFFFF" />
@@ -308,16 +307,16 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -325,8 +324,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -335,7 +334,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -344,8 +343,8 @@
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
                     <Property Name="Visibility" Value="0" />
@@ -354,7 +353,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -362,8 +361,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -372,24 +371,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -400,7 +399,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -416,18 +415,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -438,7 +437,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -460,7 +459,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Pressed ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -483,17 +482,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#08FFFFFF" />
@@ -504,16 +503,16 @@
                 <Property Name="Foreground" Value="#C5FFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -521,8 +520,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -531,7 +530,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -540,8 +539,8 @@
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
                     <Property Name="Visibility" Value="0" />
@@ -550,7 +549,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -558,8 +557,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -568,24 +567,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -596,7 +595,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -613,18 +612,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -635,7 +634,7 @@
             <Property Name="Foreground" Value="#5DFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -657,7 +656,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Disabled ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -682,17 +681,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#0BFFFFFF" />
@@ -703,16 +702,16 @@
                 <Property Name="Foreground" Value="#5DFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -720,8 +719,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -730,7 +729,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -739,8 +738,8 @@
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
                     <Property Name="Visibility" Value="0" />
@@ -749,7 +748,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -757,8 +756,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -767,24 +766,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -795,7 +794,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -811,18 +810,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -833,7 +832,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -855,7 +854,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Focused ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -878,17 +877,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#0FFFFFFF" />
@@ -899,16 +898,16 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -916,8 +915,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -926,7 +925,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -935,8 +934,8 @@
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
                     <Property Name="Visibility" Value="0" />
@@ -945,7 +944,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -953,8 +952,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -963,24 +962,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -991,7 +990,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -1007,18 +1006,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -1029,7 +1028,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -1051,7 +1050,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Focused Hover ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -1074,17 +1073,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#15FFFFFF" />
@@ -1095,16 +1094,16 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1112,8 +1111,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -1122,7 +1121,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1131,8 +1130,8 @@
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
                     <Property Name="Visibility" Value="0" />
@@ -1141,7 +1140,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1149,8 +1148,8 @@
                     <Property Name="FontWeight" Value="400" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
                     <Property Name="Visibility" Value="0" />
@@ -1159,24 +1158,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>

--- a/dxaml/test/resources/masters/Controls_DatePicker_DatePickerIntegrationTests_ValidateUIElementTree.HC.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePicker_DatePickerIntegrationTests_ValidateUIElementTree.HC.master.xml
@@ -9,7 +9,7 @@
       <Property Name="RenderSize" Value="500x600" />
       <Property Name="RequestedTheme" Value="1" />
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -25,18 +25,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -47,7 +47,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -72,7 +72,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Rest ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -82,7 +82,6 @@
             <Property Name="Content" Value="[Microsoft.UI.Xaml.Controls.Grid]" />
             <Property Name="CornerRadius" Value="4,4,4,4" />
             <Property Name="ElementSoundMode" Value="1" />
-            <Property Name="FocusState" Value="1" />
             <Property Name="FocusVisualMargin" Value="-3,-3,-3,-3" />
             <Property Name="FontFamily" Value="Segoe UI" />
             <Property Name="FontSize" Value="14" />
@@ -96,17 +95,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF952AAB" />
@@ -117,16 +116,16 @@
                 <Property Name="Foreground" Value="#FF00FF00" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -135,8 +134,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -147,7 +146,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -157,8 +156,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -169,7 +168,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -178,8 +177,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -190,24 +189,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -218,7 +217,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -234,18 +233,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -256,7 +255,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -281,7 +280,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Hover ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -304,17 +303,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FFC0C0C0" />
@@ -325,16 +324,16 @@
                 <Property Name="Foreground" Value="#FFFF0066" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -343,8 +342,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -355,7 +354,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -365,8 +364,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -377,7 +376,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -386,8 +385,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -398,24 +397,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -426,7 +425,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -442,18 +441,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -464,7 +463,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -489,7 +488,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Pressed ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -512,17 +511,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF00007F" />
@@ -533,16 +532,16 @@
                 <Property Name="Foreground" Value="#FFFF0066" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -551,8 +550,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -563,7 +562,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -573,8 +572,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -585,7 +584,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -594,8 +593,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -606,24 +605,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -634,7 +633,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -651,18 +650,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -673,7 +672,7 @@
             <Property Name="Foreground" Value="#FF8080FF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -698,7 +697,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Disabled ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -723,17 +722,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF00007F" />
@@ -744,16 +743,16 @@
                 <Property Name="Foreground" Value="#FF8080FF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -762,8 +761,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -774,7 +773,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -784,8 +783,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -796,7 +795,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -805,8 +804,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -817,24 +816,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF8080FF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF8080FF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -845,7 +844,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -861,18 +860,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -883,7 +882,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -908,7 +907,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Focused ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -931,17 +930,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF952AAB" />
@@ -952,16 +951,16 @@
                 <Property Name="Foreground" Value="#FF00FF00" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -970,8 +969,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -982,7 +981,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -992,8 +991,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -1004,7 +1003,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1013,8 +1012,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -1025,24 +1024,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -1053,7 +1052,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -1069,18 +1068,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -1091,7 +1090,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -1116,7 +1115,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Focused Hover ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -1139,17 +1138,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FFC0C0C0" />
@@ -1160,16 +1159,16 @@
                 <Property Name="Foreground" Value="#FFFF0066" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1178,8 +1177,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -1190,7 +1189,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1200,8 +1199,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -1212,7 +1211,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1221,8 +1220,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -1233,24 +1232,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>

--- a/dxaml/test/resources/masters/Controls_DatePicker_DatePickerIntegrationTests_ValidateUIElementTree.Light.master.xml
+++ b/dxaml/test/resources/masters/Controls_DatePicker_DatePickerIntegrationTests_ValidateUIElementTree.Light.master.xml
@@ -9,7 +9,7 @@
       <Property Name="RenderSize" Value="500x600" />
       <Property Name="RequestedTheme" Value="1" />
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -25,18 +25,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -47,7 +47,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -72,7 +72,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Rest ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -82,7 +82,6 @@
             <Property Name="Content" Value="[Microsoft.UI.Xaml.Controls.Grid]" />
             <Property Name="CornerRadius" Value="4,4,4,4" />
             <Property Name="ElementSoundMode" Value="1" />
-            <Property Name="FocusState" Value="1" />
             <Property Name="FocusVisualMargin" Value="-3,-3,-3,-3" />
             <Property Name="FontFamily" Value="Segoe UI" />
             <Property Name="FontSize" Value="14" />
@@ -96,17 +95,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#B3FFFFFF" />
@@ -117,16 +116,16 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -135,8 +134,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -147,7 +146,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -157,8 +156,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -169,7 +168,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -178,8 +177,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -190,24 +189,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -218,7 +217,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -234,18 +233,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -256,7 +255,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -281,7 +280,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Hover ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -304,17 +303,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#80F9F9F9" />
@@ -325,16 +324,16 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -343,8 +342,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -355,7 +354,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -365,8 +364,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -377,7 +376,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -386,8 +385,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -398,24 +397,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -426,7 +425,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -442,18 +441,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -464,7 +463,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -489,7 +488,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Pressed ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -512,17 +511,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#4DF9F9F9" />
@@ -533,16 +532,16 @@
                 <Property Name="Foreground" Value="#9E000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -551,8 +550,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -563,7 +562,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -573,8 +572,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -585,7 +584,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -594,8 +593,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -606,24 +605,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -634,7 +633,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -651,18 +650,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -673,7 +672,7 @@
             <Property Name="Foreground" Value="#5C000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -698,7 +697,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Disabled ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -723,17 +722,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#4DF9F9F9" />
@@ -744,16 +743,16 @@
                 <Property Name="Foreground" Value="#5C000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -762,8 +761,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -774,7 +773,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -784,8 +783,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -796,7 +795,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -805,8 +804,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -817,24 +816,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -845,7 +844,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -861,18 +860,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -883,7 +882,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -908,7 +907,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Focused ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -931,17 +930,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#B3FFFFFF" />
@@ -952,16 +951,16 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -970,8 +969,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -982,7 +981,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -992,8 +991,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -1004,7 +1003,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1013,8 +1012,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -1025,24 +1024,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
@@ -1053,7 +1052,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.DatePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="296" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -1069,18 +1068,18 @@
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
         <Property Name="Orientation" Value="1" />
-        <Property Name="RenderSize" Value="296x53" />
+        <Property Name="RenderSize" Value="296x58" />
         <Property Name="SelectedDate" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="296" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="296x53" />
+          <Property Name="RenderSize" Value="296x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="296" />
@@ -1091,7 +1090,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="296x19" />
@@ -1116,7 +1115,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="296" />
             <Property Name="AutomationProperties.Name" Value="Focused Hover ‎December‎ ‎31‎, ‎1990 date picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -1139,17 +1138,17 @@
             <Property Name="MinWidth" Value="296" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="296x30" />
+            <Property Name="RenderSize" Value="296x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="296" />
-              <Property Name="RenderSize" Value="296x30" />
+              <Property Name="RenderSize" Value="296x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="296" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#80F9F9F9" />
@@ -1160,16 +1159,16 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="296x30" />
+                <Property Name="RenderSize" Value="296x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="294" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="294x28" />
+                  <Property Name="RenderSize" Value="294x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="15.0938" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1178,8 +1177,8 @@
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="DayTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎31" />
                     <Property Name="TextAlignment" Value="0" />
@@ -1190,7 +1189,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="72.4033" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1200,8 +1199,8 @@
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Margin" Value="1,0,0,0" />
                     <Property Name="Name" Value="MonthTextBlock" />
-                    <Property Name="Padding" Value="9,3,0,6" />
-                    <Property Name="RenderSize" Value="133x28" />
+                    <Property Name="Padding" Value="9,4,0,6" />
+                    <Property Name="RenderSize" Value="133x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="December" />
                     <Property Name="TextAlignment" Value="1" />
@@ -1212,7 +1211,7 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                    <Property Name="ActualHeight" Value="27.6211" />
+                    <Property Name="ActualHeight" Value="28.6211" />
                     <Property Name="ActualWidth" Value="30.1875" />
                     <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                     <Property Name="FontFamily" Value="Segoe UI" />
@@ -1221,8 +1220,8 @@
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                     <Property Name="Name" Value="YearTextBlock" />
-                    <Property Name="Padding" Value="0,3,0,6" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="Padding" Value="0,4,0,6" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                     <Property Name="Text" Value="‎1990" />
                     <Property Name="TextAlignment" Value="0" />
@@ -1233,24 +1232,24 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondPickerSpacing" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Dark.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Dark.Unwindowed.master.xml
@@ -151,7 +151,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="2" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -224,7 +224,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -247,7 +247,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -284,7 +284,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -307,7 +307,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -344,7 +344,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -367,7 +367,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -404,7 +404,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -427,7 +427,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -464,7 +464,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -487,7 +487,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -524,7 +524,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -547,7 +547,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -584,7 +584,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -607,7 +607,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -644,7 +644,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -667,7 +667,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -704,7 +704,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -727,7 +727,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -764,7 +764,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -787,7 +787,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -824,7 +824,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -847,7 +847,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -884,7 +884,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -907,7 +907,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -944,7 +944,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -967,7 +967,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1004,7 +1004,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1027,7 +1027,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1064,7 +1064,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1087,7 +1087,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1124,7 +1124,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1147,7 +1147,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1184,7 +1184,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1207,7 +1207,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1244,7 +1244,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1267,7 +1267,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1304,7 +1304,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1327,7 +1327,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1438,7 +1438,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1511,7 +1511,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1534,7 +1534,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1571,7 +1571,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1594,7 +1594,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1631,7 +1631,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1654,7 +1654,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1691,7 +1691,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1714,7 +1714,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1751,7 +1751,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1774,7 +1774,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1811,7 +1811,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1834,7 +1834,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1871,7 +1871,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1894,7 +1894,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1931,7 +1931,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1954,7 +1954,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1991,7 +1991,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2014,7 +2014,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2051,7 +2051,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2074,7 +2074,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2111,7 +2111,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2134,7 +2134,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2171,7 +2171,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2194,7 +2194,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2231,7 +2231,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2254,7 +2254,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2291,7 +2291,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2314,7 +2314,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2351,7 +2351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2374,7 +2374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2411,7 +2411,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2434,7 +2434,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2471,7 +2471,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2494,7 +2494,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2531,7 +2531,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2554,7 +2554,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2591,7 +2591,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2614,7 +2614,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2725,7 +2725,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2798,7 +2798,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2821,7 +2821,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2858,7 +2858,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2881,7 +2881,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Dark.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Dark.Windowed.master.xml
@@ -151,7 +151,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -224,7 +224,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -247,7 +247,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -284,7 +284,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -307,7 +307,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -344,7 +344,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -367,7 +367,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -404,7 +404,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -427,7 +427,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -464,7 +464,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -487,7 +487,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -524,7 +524,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -547,7 +547,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -584,7 +584,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -607,7 +607,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -644,7 +644,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -667,7 +667,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -704,7 +704,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -727,7 +727,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -764,7 +764,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -787,7 +787,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -824,7 +824,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -847,7 +847,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -884,7 +884,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -907,7 +907,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -944,7 +944,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -967,7 +967,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1004,7 +1004,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1027,7 +1027,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1064,7 +1064,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1087,7 +1087,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1124,7 +1124,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1147,7 +1147,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1184,7 +1184,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1207,7 +1207,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1244,7 +1244,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1267,7 +1267,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1304,7 +1304,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1327,7 +1327,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1438,7 +1438,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1511,7 +1511,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1534,7 +1534,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1571,7 +1571,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1594,7 +1594,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1631,7 +1631,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1654,7 +1654,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1691,7 +1691,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1714,7 +1714,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1751,7 +1751,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1774,7 +1774,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1811,7 +1811,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1834,7 +1834,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1871,7 +1871,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1894,7 +1894,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1931,7 +1931,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1954,7 +1954,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1991,7 +1991,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2014,7 +2014,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2051,7 +2051,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2074,7 +2074,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2111,7 +2111,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2134,7 +2134,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2171,7 +2171,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2194,7 +2194,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2231,7 +2231,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2254,7 +2254,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2291,7 +2291,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2314,7 +2314,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2351,7 +2351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2374,7 +2374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2411,7 +2411,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2434,7 +2434,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2471,7 +2471,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2494,7 +2494,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2531,7 +2531,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2554,7 +2554,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2591,7 +2591,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2614,7 +2614,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2725,7 +2725,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2798,7 +2798,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2821,7 +2821,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2858,7 +2858,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2881,7 +2881,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Dark.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Dark.master.xml
@@ -151,7 +151,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -224,7 +224,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -247,7 +247,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -284,7 +284,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -307,7 +307,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -344,7 +344,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -367,7 +367,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -404,7 +404,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -427,7 +427,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -464,7 +464,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -487,7 +487,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -524,7 +524,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -547,7 +547,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -584,7 +584,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -607,7 +607,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -644,7 +644,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -667,7 +667,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -704,7 +704,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -727,7 +727,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -764,7 +764,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -787,7 +787,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -824,7 +824,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -847,7 +847,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -884,7 +884,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -907,7 +907,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -944,7 +944,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -967,7 +967,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1004,7 +1004,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1027,7 +1027,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1064,7 +1064,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1087,7 +1087,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1124,7 +1124,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1147,7 +1147,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1184,7 +1184,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1207,7 +1207,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1244,7 +1244,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1267,7 +1267,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1304,7 +1304,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1327,7 +1327,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1438,7 +1438,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1511,7 +1511,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1534,7 +1534,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1571,7 +1571,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1594,7 +1594,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1631,7 +1631,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1654,7 +1654,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1691,7 +1691,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1714,7 +1714,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1751,7 +1751,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1774,7 +1774,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1811,7 +1811,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1834,7 +1834,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1871,7 +1871,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1894,7 +1894,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1931,7 +1931,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1954,7 +1954,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1991,7 +1991,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2014,7 +2014,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2051,7 +2051,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2074,7 +2074,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2111,7 +2111,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2134,7 +2134,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2171,7 +2171,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2194,7 +2194,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2231,7 +2231,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2254,7 +2254,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2291,7 +2291,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2314,7 +2314,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2351,7 +2351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2374,7 +2374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2411,7 +2411,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2434,7 +2434,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2471,7 +2471,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2494,7 +2494,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2531,7 +2531,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2554,7 +2554,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2591,7 +2591,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2614,7 +2614,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2725,7 +2725,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2798,7 +2798,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2821,7 +2821,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2858,7 +2858,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2881,7 +2881,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Full.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Full.Unwindowed.master.xml
@@ -151,7 +151,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="2" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="131x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -224,7 +224,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -247,7 +247,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -284,7 +284,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -307,7 +307,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -344,7 +344,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -367,7 +367,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -404,7 +404,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -427,7 +427,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -464,7 +464,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -487,7 +487,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -524,7 +524,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -547,7 +547,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -584,7 +584,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -607,7 +607,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -644,7 +644,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -667,7 +667,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -704,7 +704,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -727,7 +727,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -764,7 +764,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -787,7 +787,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -824,7 +824,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -847,7 +847,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -884,7 +884,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -907,7 +907,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -944,7 +944,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -967,7 +967,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1004,7 +1004,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1027,7 +1027,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1064,7 +1064,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1087,7 +1087,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1124,7 +1124,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1147,7 +1147,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1184,7 +1184,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1207,7 +1207,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1244,7 +1244,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1267,7 +1267,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1304,7 +1304,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1327,7 +1327,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1438,7 +1438,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="132x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1511,7 +1511,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1534,7 +1534,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1571,7 +1571,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1594,7 +1594,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1631,7 +1631,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1654,7 +1654,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1691,7 +1691,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1714,7 +1714,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1751,7 +1751,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1774,7 +1774,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1811,7 +1811,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1834,7 +1834,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1871,7 +1871,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1894,7 +1894,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1931,7 +1931,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1954,7 +1954,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1991,7 +1991,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2014,7 +2014,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2051,7 +2051,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2074,7 +2074,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2111,7 +2111,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2134,7 +2134,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2171,7 +2171,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2194,7 +2194,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2231,7 +2231,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2254,7 +2254,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2291,7 +2291,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2314,7 +2314,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2351,7 +2351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2374,7 +2374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2411,7 +2411,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2434,7 +2434,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2471,7 +2471,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2494,7 +2494,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2531,7 +2531,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2554,7 +2554,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2591,7 +2591,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2614,7 +2614,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2725,7 +2725,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="131x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2798,7 +2798,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2821,7 +2821,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2858,7 +2858,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2881,7 +2881,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Full.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Full.Windowed.master.xml
@@ -151,7 +151,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="131x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -224,7 +224,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -247,7 +247,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -284,7 +284,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -307,7 +307,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -344,7 +344,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -367,7 +367,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -404,7 +404,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -427,7 +427,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -464,7 +464,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -487,7 +487,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -524,7 +524,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -547,7 +547,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -584,7 +584,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -607,7 +607,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -644,7 +644,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -667,7 +667,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -704,7 +704,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -727,7 +727,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -764,7 +764,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -787,7 +787,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -824,7 +824,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -847,7 +847,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -884,7 +884,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -907,7 +907,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -944,7 +944,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -967,7 +967,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1004,7 +1004,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1027,7 +1027,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1064,7 +1064,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1087,7 +1087,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1124,7 +1124,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1147,7 +1147,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1184,7 +1184,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1207,7 +1207,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1244,7 +1244,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1267,7 +1267,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1304,7 +1304,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1327,7 +1327,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1438,7 +1438,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="132x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1511,7 +1511,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1534,7 +1534,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1571,7 +1571,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1594,7 +1594,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1631,7 +1631,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1654,7 +1654,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1691,7 +1691,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1714,7 +1714,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1751,7 +1751,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1774,7 +1774,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1811,7 +1811,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1834,7 +1834,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1871,7 +1871,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1894,7 +1894,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1931,7 +1931,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1954,7 +1954,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1991,7 +1991,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2014,7 +2014,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2051,7 +2051,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2074,7 +2074,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2111,7 +2111,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2134,7 +2134,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2171,7 +2171,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2194,7 +2194,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2231,7 +2231,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2254,7 +2254,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2291,7 +2291,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2314,7 +2314,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2351,7 +2351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2374,7 +2374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2411,7 +2411,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2434,7 +2434,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2471,7 +2471,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2494,7 +2494,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2531,7 +2531,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2554,7 +2554,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2591,7 +2591,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2614,7 +2614,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2725,7 +2725,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="131x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2798,7 +2798,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2821,7 +2821,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2858,7 +2858,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2881,7 +2881,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Full.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Full.master.xml
@@ -151,7 +151,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="131x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -224,7 +224,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -247,7 +247,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -284,7 +284,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -307,7 +307,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -344,7 +344,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -367,7 +367,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -404,7 +404,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -427,7 +427,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -464,7 +464,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -487,7 +487,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -524,7 +524,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -547,7 +547,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -584,7 +584,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -607,7 +607,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -644,7 +644,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -667,7 +667,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -704,7 +704,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -727,7 +727,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -764,7 +764,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -787,7 +787,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -824,7 +824,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -847,7 +847,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -884,7 +884,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -907,7 +907,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -944,7 +944,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -967,7 +967,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1004,7 +1004,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1027,7 +1027,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1064,7 +1064,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1087,7 +1087,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1124,7 +1124,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1147,7 +1147,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1184,7 +1184,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1207,7 +1207,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1244,7 +1244,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1267,7 +1267,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1304,7 +1304,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1327,7 +1327,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1438,7 +1438,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="132x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1511,7 +1511,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1534,7 +1534,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1571,7 +1571,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1594,7 +1594,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1631,7 +1631,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1654,7 +1654,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1691,7 +1691,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1714,7 +1714,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1751,7 +1751,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1774,7 +1774,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1811,7 +1811,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1834,7 +1834,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1871,7 +1871,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1894,7 +1894,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1931,7 +1931,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1954,7 +1954,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1991,7 +1991,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2014,7 +2014,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2051,7 +2051,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2074,7 +2074,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2111,7 +2111,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2134,7 +2134,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2171,7 +2171,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2194,7 +2194,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2231,7 +2231,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2254,7 +2254,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2291,7 +2291,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2314,7 +2314,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2351,7 +2351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2374,7 +2374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2411,7 +2411,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2434,7 +2434,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2471,7 +2471,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2494,7 +2494,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2531,7 +2531,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2554,7 +2554,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2591,7 +2591,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="132x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2614,7 +2614,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="128x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2725,7 +2725,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="131x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2798,7 +2798,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2821,7 +2821,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2858,7 +2858,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="131x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2881,7 +2881,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="127x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.HC.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.HC.Unwindowed.master.xml
@@ -154,7 +154,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="2" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -227,7 +227,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -250,7 +250,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -289,7 +289,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -312,7 +312,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -351,7 +351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -374,7 +374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -413,7 +413,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -436,7 +436,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -475,7 +475,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -498,7 +498,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -537,7 +537,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -560,7 +560,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -599,7 +599,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -622,7 +622,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -661,7 +661,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -684,7 +684,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -723,7 +723,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -746,7 +746,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -785,7 +785,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -808,7 +808,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -847,7 +847,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -870,7 +870,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -909,7 +909,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -932,7 +932,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -971,7 +971,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -994,7 +994,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1033,7 +1033,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1056,7 +1056,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1095,7 +1095,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1118,7 +1118,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1157,7 +1157,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1180,7 +1180,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1219,7 +1219,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1242,7 +1242,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1281,7 +1281,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1304,7 +1304,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1343,7 +1343,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1366,7 +1366,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1479,7 +1479,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1552,7 +1552,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1575,7 +1575,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1614,7 +1614,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1637,7 +1637,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1676,7 +1676,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1699,7 +1699,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1738,7 +1738,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1761,7 +1761,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1800,7 +1800,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1823,7 +1823,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1862,7 +1862,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1885,7 +1885,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1924,7 +1924,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1947,7 +1947,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1986,7 +1986,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2009,7 +2009,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2048,7 +2048,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2071,7 +2071,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2110,7 +2110,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2133,7 +2133,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2172,7 +2172,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2195,7 +2195,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2234,7 +2234,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2257,7 +2257,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2296,7 +2296,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2319,7 +2319,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2358,7 +2358,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2381,7 +2381,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2420,7 +2420,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2443,7 +2443,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2482,7 +2482,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2505,7 +2505,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2544,7 +2544,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2567,7 +2567,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2606,7 +2606,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2629,7 +2629,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2668,7 +2668,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2691,7 +2691,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2804,7 +2804,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2877,7 +2877,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2900,7 +2900,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2939,7 +2939,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2962,7 +2962,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.HC.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.HC.Windowed.master.xml
@@ -154,7 +154,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -227,7 +227,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -250,7 +250,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -289,7 +289,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -312,7 +312,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -351,7 +351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -374,7 +374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -413,7 +413,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -436,7 +436,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -475,7 +475,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -498,7 +498,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -537,7 +537,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -560,7 +560,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -599,7 +599,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -622,7 +622,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -661,7 +661,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -684,7 +684,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -723,7 +723,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -746,7 +746,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -785,7 +785,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -808,7 +808,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -847,7 +847,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -870,7 +870,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -909,7 +909,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -932,7 +932,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -971,7 +971,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -994,7 +994,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1033,7 +1033,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1056,7 +1056,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1095,7 +1095,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1118,7 +1118,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1157,7 +1157,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1180,7 +1180,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1219,7 +1219,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1242,7 +1242,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1281,7 +1281,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1304,7 +1304,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1343,7 +1343,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1366,7 +1366,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1479,7 +1479,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1552,7 +1552,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1575,7 +1575,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1614,7 +1614,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1637,7 +1637,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1676,7 +1676,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1699,7 +1699,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1738,7 +1738,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1761,7 +1761,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1800,7 +1800,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1823,7 +1823,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1862,7 +1862,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1885,7 +1885,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1924,7 +1924,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1947,7 +1947,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1986,7 +1986,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2009,7 +2009,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2048,7 +2048,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2071,7 +2071,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2110,7 +2110,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2133,7 +2133,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2172,7 +2172,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2195,7 +2195,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2234,7 +2234,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2257,7 +2257,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2296,7 +2296,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2319,7 +2319,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2358,7 +2358,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2381,7 +2381,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2420,7 +2420,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2443,7 +2443,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2482,7 +2482,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2505,7 +2505,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2544,7 +2544,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2567,7 +2567,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2606,7 +2606,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2629,7 +2629,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2668,7 +2668,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2691,7 +2691,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2804,7 +2804,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2877,7 +2877,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2900,7 +2900,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2939,7 +2939,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2962,7 +2962,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.HC.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.HC.master.xml
@@ -154,7 +154,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -227,7 +227,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -250,7 +250,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -289,7 +289,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -312,7 +312,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -351,7 +351,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -374,7 +374,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -413,7 +413,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -436,7 +436,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -475,7 +475,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -498,7 +498,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -537,7 +537,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -560,7 +560,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -599,7 +599,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -622,7 +622,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -661,7 +661,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -684,7 +684,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -723,7 +723,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -746,7 +746,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -785,7 +785,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -808,7 +808,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -847,7 +847,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -870,7 +870,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -909,7 +909,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -932,7 +932,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -971,7 +971,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -994,7 +994,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1033,7 +1033,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1056,7 +1056,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1095,7 +1095,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1118,7 +1118,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1157,7 +1157,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1180,7 +1180,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1219,7 +1219,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1242,7 +1242,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1281,7 +1281,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1304,7 +1304,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1343,7 +1343,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1366,7 +1366,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1479,7 +1479,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1552,7 +1552,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1575,7 +1575,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1614,7 +1614,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1637,7 +1637,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1676,7 +1676,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1699,7 +1699,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1738,7 +1738,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1761,7 +1761,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1800,7 +1800,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1823,7 +1823,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1862,7 +1862,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1885,7 +1885,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1924,7 +1924,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1947,7 +1947,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1986,7 +1986,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2009,7 +2009,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2048,7 +2048,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2071,7 +2071,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2110,7 +2110,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2133,7 +2133,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2172,7 +2172,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2195,7 +2195,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2234,7 +2234,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2257,7 +2257,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2296,7 +2296,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2319,7 +2319,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2358,7 +2358,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2381,7 +2381,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2420,7 +2420,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2443,7 +2443,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2482,7 +2482,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2505,7 +2505,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2544,7 +2544,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2567,7 +2567,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2606,7 +2606,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2629,7 +2629,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2668,7 +2668,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2691,7 +2691,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2804,7 +2804,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2877,7 +2877,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2900,7 +2900,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2939,7 +2939,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2962,7 +2962,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Light.Unwindowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Light.Unwindowed.master.xml
@@ -154,7 +154,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="2" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -227,7 +227,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -250,7 +250,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -287,7 +287,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -310,7 +310,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -347,7 +347,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -370,7 +370,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -407,7 +407,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -430,7 +430,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -467,7 +467,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -490,7 +490,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -527,7 +527,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -550,7 +550,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -587,7 +587,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -610,7 +610,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -647,7 +647,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -670,7 +670,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -707,7 +707,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -730,7 +730,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -767,7 +767,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -790,7 +790,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -827,7 +827,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -850,7 +850,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -887,7 +887,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -910,7 +910,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -947,7 +947,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -970,7 +970,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1007,7 +1007,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1030,7 +1030,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1067,7 +1067,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1090,7 +1090,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1127,7 +1127,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1150,7 +1150,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1187,7 +1187,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1210,7 +1210,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1247,7 +1247,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1270,7 +1270,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1307,7 +1307,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1330,7 +1330,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1441,7 +1441,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1514,7 +1514,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1537,7 +1537,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1574,7 +1574,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1597,7 +1597,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1634,7 +1634,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1657,7 +1657,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1694,7 +1694,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1717,7 +1717,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1754,7 +1754,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1777,7 +1777,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1814,7 +1814,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1837,7 +1837,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1874,7 +1874,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1897,7 +1897,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1934,7 +1934,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1957,7 +1957,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1994,7 +1994,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2017,7 +2017,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2054,7 +2054,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2077,7 +2077,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2114,7 +2114,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2137,7 +2137,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2174,7 +2174,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2197,7 +2197,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2234,7 +2234,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2257,7 +2257,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2294,7 +2294,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2317,7 +2317,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2354,7 +2354,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2377,7 +2377,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2414,7 +2414,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2437,7 +2437,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2474,7 +2474,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2497,7 +2497,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2534,7 +2534,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2557,7 +2557,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2594,7 +2594,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2617,7 +2617,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2728,7 +2728,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2801,7 +2801,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2824,7 +2824,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2861,7 +2861,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2884,7 +2884,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Light.Windowed.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Light.Windowed.master.xml
@@ -154,7 +154,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -227,7 +227,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -250,7 +250,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -287,7 +287,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -310,7 +310,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -347,7 +347,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -370,7 +370,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -407,7 +407,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -430,7 +430,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -467,7 +467,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -490,7 +490,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -527,7 +527,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -550,7 +550,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -587,7 +587,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -610,7 +610,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -647,7 +647,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -670,7 +670,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -707,7 +707,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -730,7 +730,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -767,7 +767,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -790,7 +790,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -827,7 +827,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -850,7 +850,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -887,7 +887,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -910,7 +910,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -947,7 +947,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -970,7 +970,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1007,7 +1007,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1030,7 +1030,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1067,7 +1067,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1090,7 +1090,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1127,7 +1127,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1150,7 +1150,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1187,7 +1187,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1210,7 +1210,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1247,7 +1247,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1270,7 +1270,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1307,7 +1307,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1330,7 +1330,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1441,7 +1441,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1514,7 +1514,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1537,7 +1537,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1574,7 +1574,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1597,7 +1597,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1634,7 +1634,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1657,7 +1657,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1694,7 +1694,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1717,7 +1717,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1754,7 +1754,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1777,7 +1777,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1814,7 +1814,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1837,7 +1837,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1874,7 +1874,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1897,7 +1897,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1934,7 +1934,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1957,7 +1957,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1994,7 +1994,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2017,7 +2017,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2054,7 +2054,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2077,7 +2077,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2114,7 +2114,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2137,7 +2137,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2174,7 +2174,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2197,7 +2197,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2234,7 +2234,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2257,7 +2257,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2294,7 +2294,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2317,7 +2317,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2354,7 +2354,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2377,7 +2377,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2414,7 +2414,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2437,7 +2437,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2474,7 +2474,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2497,7 +2497,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2534,7 +2534,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2557,7 +2557,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2594,7 +2594,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2617,7 +2617,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2728,7 +2728,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2801,7 +2801,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2824,7 +2824,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2861,7 +2861,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2884,7 +2884,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Light.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePickerFlyout_TimePickerFlyoutIntegrationTests_ValidateUIElementTree.Light.master.xml
@@ -154,7 +154,7 @@
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="FocusState" Value="1" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="0" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -227,7 +227,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -250,7 +250,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -287,7 +287,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -310,7 +310,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -347,7 +347,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -370,7 +370,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -407,7 +407,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -430,7 +430,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -467,7 +467,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -490,7 +490,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -527,7 +527,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -550,7 +550,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -587,7 +587,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -610,7 +610,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -647,7 +647,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -670,7 +670,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -707,7 +707,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -730,7 +730,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -767,7 +767,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -790,7 +790,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -827,7 +827,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -850,7 +850,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -887,7 +887,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -910,7 +910,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -947,7 +947,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -970,7 +970,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1007,7 +1007,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1030,7 +1030,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1067,7 +1067,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1090,7 +1090,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1127,7 +1127,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1150,7 +1150,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1187,7 +1187,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1210,7 +1210,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1247,7 +1247,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1270,7 +1270,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1307,7 +1307,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1330,7 +1330,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1441,7 +1441,7 @@
                   <Property Name="AutomationProperties.Name" Value="minute" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="79x355" />
                   <Property Name="TabIndex" Value="1" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -1514,7 +1514,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1537,7 +1537,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1574,7 +1574,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1597,7 +1597,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1634,7 +1634,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1657,7 +1657,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1694,7 +1694,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1717,7 +1717,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1754,7 +1754,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1777,7 +1777,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1814,7 +1814,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1837,7 +1837,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1874,7 +1874,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1897,7 +1897,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1934,7 +1934,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -1957,7 +1957,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -1994,7 +1994,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2017,7 +2017,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2054,7 +2054,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2077,7 +2077,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2114,7 +2114,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2137,7 +2137,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2174,7 +2174,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2197,7 +2197,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2234,7 +2234,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2257,7 +2257,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2294,7 +2294,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2317,7 +2317,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2354,7 +2354,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2377,7 +2377,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2414,7 +2414,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2437,7 +2437,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2474,7 +2474,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2497,7 +2497,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2534,7 +2534,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2557,7 +2557,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2594,7 +2594,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="79x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2617,7 +2617,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="75x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2728,7 +2728,7 @@
                   <Property Name="AutomationProperties.Name" Value="period" />
                   <Property Name="DefaultStyleKey" Value="Microsoft.UI.Xaml.Controls.Primitives.LoopingSelector" />
                   <Property Name="HorizontalContentAlignment" Value="1" />
-                  <Property Name="Padding" Value="0,3,0,6" />
+                  <Property Name="Padding" Value="0,4,0,6" />
                   <Property Name="RenderSize" Value="78x355" />
                   <Property Name="TabIndex" Value="2" />
                   <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
@@ -2801,7 +2801,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2824,7 +2824,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">
@@ -2861,7 +2861,7 @@
                               <Property Name="HorizontalAlignment" Value="3" />
                               <Property Name="HorizontalContentAlignment" Value="1" />
                               <Property Name="IsTabStop" Value="False" />
-                              <Property Name="Padding" Value="0,3,0,6" />
+                              <Property Name="Padding" Value="0,4,0,6" />
                               <Property Name="RenderSize" Value="78x40" />
                               <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
                               <Property Name="VerticalAlignment" Value="3" />
@@ -2884,7 +2884,7 @@
                                   <Property Name="HorizontalContentAlignment" Value="1" />
                                   <Property Name="Margin" Value="2,0,2,0" />
                                   <Property Name="Name" Value="ContentPresenter" />
-                                  <Property Name="Padding" Value="0,3,0,6" />
+                                  <Property Name="Padding" Value="0,4,0,6" />
                                   <Property Name="RenderSize" Value="74x40" />
                                   <Property Name="VerticalContentAlignment" Value="1" />
                                   <Element Type="Microsoft.UI.Xaml.Controls.StackPanel">

--- a/dxaml/test/resources/masters/Controls_TimePicker_TimePickerIntegrationTests_ValidateUIElementTree.Dark.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePicker_TimePickerIntegrationTests_ValidateUIElementTree.Dark.master.xml
@@ -7,7 +7,7 @@
       <Property Name="IsHitTestVisible" Value="False" />
       <Property Name="RenderSize" Value="400x600" />
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -21,19 +21,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -44,7 +44,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -66,7 +66,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Rest ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -76,7 +76,6 @@
             <Property Name="Content" Value="[Microsoft.UI.Xaml.Controls.Grid]" />
             <Property Name="CornerRadius" Value="4,4,4,4" />
             <Property Name="ElementSoundMode" Value="1" />
-            <Property Name="FocusState" Value="1" />
             <Property Name="FocusVisualMargin" Value="-3,-3,-3,-3" />
             <Property Name="FontFamily" Value="Segoe UI" />
             <Property Name="FontSize" Value="14" />
@@ -90,17 +89,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#0FFFFFFF" />
@@ -111,32 +110,32 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -145,34 +144,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -181,34 +180,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -223,7 +222,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -237,19 +236,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -260,7 +259,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -282,7 +281,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Hover ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -305,17 +304,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#15FFFFFF" />
@@ -326,32 +325,32 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -360,34 +359,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -396,34 +395,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -438,7 +437,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -452,19 +451,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -475,7 +474,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -497,7 +496,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Pressed ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -520,17 +519,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#08FFFFFF" />
@@ -541,32 +540,32 @@
                 <Property Name="Foreground" Value="#C5FFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -575,34 +574,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -611,34 +610,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -653,7 +652,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -668,19 +667,19 @@
         <Property Name="IsEnabled" Value="False" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -691,7 +690,7 @@
             <Property Name="Foreground" Value="#5DFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -713,7 +712,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Disabled ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -738,17 +737,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#0BFFFFFF" />
@@ -759,32 +758,32 @@
                 <Property Name="Foreground" Value="#5DFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -793,34 +792,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -829,34 +828,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -871,7 +870,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -885,19 +884,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -908,7 +907,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -930,7 +929,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Focused ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -953,17 +952,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#0FFFFFFF" />
@@ -974,32 +973,32 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -1008,34 +1007,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -1044,34 +1043,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -1086,7 +1085,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#0FFFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -1100,19 +1099,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -1123,7 +1122,7 @@
             <Property Name="Foreground" Value="#FFFFFFFF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -1145,7 +1144,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Focused Hover ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#0FFFFFFF" />
@@ -1168,17 +1167,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#15FFFFFF" />
@@ -1189,32 +1188,32 @@
                 <Property Name="Foreground" Value="#FFFFFFFF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -1223,34 +1222,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">
@@ -1259,34 +1258,34 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#12FFFFFF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
                       <Property Name="FontSize" Value="14" />
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
                       <Element Type="Microsoft.UI.Xaml.Documents.Run">

--- a/dxaml/test/resources/masters/Controls_TimePicker_TimePickerIntegrationTests_ValidateUIElementTree.HC.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePicker_TimePickerIntegrationTests_ValidateUIElementTree.HC.master.xml
@@ -9,7 +9,7 @@
       <Property Name="RenderSize" Value="400x600" />
       <Property Name="RequestedTheme" Value="1" />
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -23,19 +23,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -46,7 +46,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -71,7 +71,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Rest ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -81,7 +81,6 @@
             <Property Name="Content" Value="[Microsoft.UI.Xaml.Controls.Grid]" />
             <Property Name="CornerRadius" Value="4,4,4,4" />
             <Property Name="ElementSoundMode" Value="1" />
-            <Property Name="FocusState" Value="1" />
             <Property Name="FocusVisualMargin" Value="-3,-3,-3,-3" />
             <Property Name="FontFamily" Value="Segoe UI" />
             <Property Name="FontSize" Value="14" />
@@ -95,17 +94,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF952AAB" />
@@ -116,24 +115,24 @@
                 <Property Name="Foreground" Value="#FF00FF00" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -141,8 +140,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -153,26 +152,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -180,8 +179,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -192,26 +191,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -219,8 +218,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -237,7 +236,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -251,19 +250,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -274,7 +273,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -299,7 +298,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Hover ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -322,17 +321,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FFC0C0C0" />
@@ -343,24 +342,24 @@
                 <Property Name="Foreground" Value="#FFFF0066" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -368,8 +367,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -380,26 +379,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -407,8 +406,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -419,26 +418,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -446,8 +445,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -464,7 +463,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -478,19 +477,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -501,7 +500,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -526,7 +525,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Pressed ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -549,17 +548,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF00007F" />
@@ -570,24 +569,24 @@
                 <Property Name="Foreground" Value="#FFFF0066" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -595,8 +594,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -607,26 +606,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -634,8 +633,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -646,26 +645,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -673,8 +672,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -691,7 +690,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -706,19 +705,19 @@
         <Property Name="IsEnabled" Value="False" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -729,7 +728,7 @@
             <Property Name="Foreground" Value="#FF8080FF" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -754,7 +753,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Disabled ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -779,17 +778,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF00007F" />
@@ -800,24 +799,24 @@
                 <Property Name="Foreground" Value="#FF8080FF" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -825,8 +824,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -837,26 +836,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF8080FF" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -864,8 +863,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -876,26 +875,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF8080FF" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -903,8 +902,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -921,7 +920,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -935,19 +934,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -958,7 +957,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -983,7 +982,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Focused ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -1006,17 +1005,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FF952AAB" />
@@ -1027,24 +1026,24 @@
                 <Property Name="Foreground" Value="#FF00FF00" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1052,8 +1051,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1064,26 +1063,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1091,8 +1090,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1103,26 +1102,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1130,8 +1129,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1148,7 +1147,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#FF952AAB" />
         <Property Name="BorderBrush" Value="#FF00FF00" />
@@ -1162,19 +1161,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -1185,7 +1184,7 @@
             <Property Name="Foreground" Value="#FF00FF00" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -1210,7 +1209,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Focused Hover ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#FF952AAB" />
@@ -1233,17 +1232,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#FFC0C0C0" />
@@ -1254,24 +1253,24 @@
                 <Property Name="Foreground" Value="#FFFF0066" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1279,8 +1278,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1291,26 +1290,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1318,8 +1317,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1330,26 +1329,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#FF00FF00" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1357,8 +1356,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />

--- a/dxaml/test/resources/masters/Controls_TimePicker_TimePickerIntegrationTests_ValidateUIElementTree.Light.master.xml
+++ b/dxaml/test/resources/masters/Controls_TimePicker_TimePickerIntegrationTests_ValidateUIElementTree.Light.master.xml
@@ -9,7 +9,7 @@
       <Property Name="RenderSize" Value="400x600" />
       <Property Name="RequestedTheme" Value="1" />
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -23,19 +23,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -46,7 +46,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -71,7 +71,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Rest ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -81,7 +81,6 @@
             <Property Name="Content" Value="[Microsoft.UI.Xaml.Controls.Grid]" />
             <Property Name="CornerRadius" Value="4,4,4,4" />
             <Property Name="ElementSoundMode" Value="1" />
-            <Property Name="FocusState" Value="1" />
             <Property Name="FocusVisualMargin" Value="-3,-3,-3,-3" />
             <Property Name="FontFamily" Value="Segoe UI" />
             <Property Name="FontSize" Value="14" />
@@ -95,17 +94,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#B3FFFFFF" />
@@ -116,24 +115,24 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -141,8 +140,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -153,26 +152,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -180,8 +179,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -192,26 +191,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -219,8 +218,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -237,7 +236,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -251,19 +250,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -274,7 +273,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -299,7 +298,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Hover ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -322,17 +321,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#80F9F9F9" />
@@ -343,24 +342,24 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -368,8 +367,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -380,26 +379,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -407,8 +406,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -419,26 +418,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -446,8 +445,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -464,7 +463,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -478,19 +477,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -501,7 +500,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -526,7 +525,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Pressed ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -549,17 +548,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#4DF9F9F9" />
@@ -570,24 +569,24 @@
                 <Property Name="Foreground" Value="#9E000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -595,8 +594,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -607,26 +606,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -634,8 +633,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -646,26 +645,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -673,8 +672,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -691,7 +690,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -706,19 +705,19 @@
         <Property Name="IsEnabled" Value="False" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -729,7 +728,7 @@
             <Property Name="Foreground" Value="#5C000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -754,7 +753,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Disabled ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -779,17 +778,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#4DF9F9F9" />
@@ -800,24 +799,24 @@
                 <Property Name="Foreground" Value="#5C000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -825,8 +824,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -837,26 +836,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -864,8 +863,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -876,26 +875,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -903,8 +902,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -921,7 +920,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -935,19 +934,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -958,7 +957,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -983,7 +982,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Focused ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -1006,17 +1005,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#B3FFFFFF" />
@@ -1027,24 +1026,24 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1052,8 +1051,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1064,26 +1063,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1091,8 +1090,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1103,26 +1102,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1130,8 +1129,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1148,7 +1147,7 @@
         </Element>
       </Element>
       <Element Type="Microsoft.UI.Xaml.Controls.TimePicker">
-        <Property Name="ActualHeight" Value="53" />
+        <Property Name="ActualHeight" Value="58" />
         <Property Name="ActualWidth" Value="242" />
         <Property Name="Background" Value="#B3FFFFFF" />
         <Property Name="BorderBrush" Value="[Microsoft.UI.Xaml.Media.LinearGradientBrush]" />
@@ -1162,19 +1161,19 @@
         <Property Name="HorizontalAlignment" Value="0" />
         <Property Name="IsTabStop" Value="False" />
         <Property Name="LightDismissOverlayMode" Value="2" />
-        <Property Name="RenderSize" Value="242x53" />
+        <Property Name="RenderSize" Value="242x58" />
         <Property Name="SelectedTime" Value="???" />
         <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
         <Property Name="Time" Value="???" />
         <Property Name="UseSystemFocusVisuals" Value="True" />
         <Property Name="VerticalAlignment" Value="1" />
         <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-          <Property Name="ActualHeight" Value="53" />
+          <Property Name="ActualHeight" Value="58" />
           <Property Name="ActualWidth" Value="242" />
           <Property Name="FlowDirection" Value="0" />
           <Property Name="Margin" Value="0,0,0,0" />
           <Property Name="Name" Value="LayoutRoot" />
-          <Property Name="RenderSize" Value="242x53" />
+          <Property Name="RenderSize" Value="242x58" />
           <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
             <Property Name="ActualHeight" Value="19" />
             <Property Name="ActualWidth" Value="242" />
@@ -1185,7 +1184,7 @@
             <Property Name="Foreground" Value="#E4000000" />
             <Property Name="Grid.Row" Value="0" />
             <Property Name="HorizontalAlignment" Value="3" />
-            <Property Name="Margin" Value="0,0,0,4" />
+            <Property Name="Margin" Value="0,0,0,8" />
             <Property Name="MaxWidth" Value="456" />
             <Property Name="Name" Value="HeaderContentPresenter" />
             <Property Name="RenderSize" Value="242x19" />
@@ -1210,7 +1209,7 @@
             </Element>
           </Element>
           <Element Type="Microsoft.UI.Xaml.Controls.Button">
-            <Property Name="ActualHeight" Value="30" />
+            <Property Name="ActualHeight" Value="31" />
             <Property Name="ActualWidth" Value="242" />
             <Property Name="AutomationProperties.Name" Value="Focused Hover ‎4‎:‎30‎ ‎AM time picker" />
             <Property Name="Background" Value="#B3FFFFFF" />
@@ -1233,17 +1232,17 @@
             <Property Name="MinWidth" Value="242" />
             <Property Name="Name" Value="FlyoutButton" />
             <Property Name="Padding" Value="11,5,11,6" />
-            <Property Name="RenderSize" Value="242x30" />
+            <Property Name="RenderSize" Value="242x31" />
             <Property Name="Style" Value="[Microsoft.UI.Xaml.Style]" />
             <Property Name="Template" Value="[Microsoft.UI.Xaml.Controls.ControlTemplate]" />
             <Property Name="UseSystemFocusVisuals" Value="True" />
             <Property Name="VerticalAlignment" Value="0" />
             <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-              <Property Name="ActualHeight" Value="30" />
+              <Property Name="ActualHeight" Value="31" />
               <Property Name="ActualWidth" Value="242" />
-              <Property Name="RenderSize" Value="242x30" />
+              <Property Name="RenderSize" Value="242x31" />
               <Element Type="Microsoft.UI.Xaml.Controls.ContentPresenter">
-                <Property Name="ActualHeight" Value="30" />
+                <Property Name="ActualHeight" Value="31" />
                 <Property Name="ActualWidth" Value="242" />
                 <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                 <Property Name="Background" Value="#80F9F9F9" />
@@ -1254,24 +1253,24 @@
                 <Property Name="Foreground" Value="#E4000000" />
                 <Property Name="HorizontalContentAlignment" Value="3" />
                 <Property Name="Name" Value="ContentPresenter" />
-                <Property Name="RenderSize" Value="242x30" />
+                <Property Name="RenderSize" Value="242x31" />
                 <Property Name="VerticalContentAlignment" Value="3" />
                 <Element Type="Microsoft.UI.Xaml.Controls.Grid">
-                  <Property Name="ActualHeight" Value="28" />
+                  <Property Name="ActualHeight" Value="29" />
                   <Property Name="ActualWidth" Value="240" />
                   <Property Name="Name" Value="FlyoutButtonContentGrid" />
                   <Property Name="Parent" Value="[Microsoft.UI.Xaml.Controls.Button]" />
-                  <Property Name="RenderSize" Value="240x28" />
+                  <Property Name="RenderSize" Value="240x29" />
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="0" />
                     <Property Name="Name" Value="FirstPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="7.54688" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1279,8 +1278,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="HourTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="4" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1291,26 +1290,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="1" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="FirstColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="80" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="2" />
                     <Property Name="Name" Value="SecondPickerHost" />
-                    <Property Name="RenderSize" Value="80x28" />
+                    <Property Name="RenderSize" Value="80x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="15.0938" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1318,8 +1317,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="MinuteTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="80x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="80x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="30" />
                       <Property Name="TextAlignment" Value="0" />
@@ -1330,26 +1329,26 @@
                     </Element>
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Shapes.Rectangle">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="1" />
                     <Property Name="Fill" Value="#0F000000" />
                     <Property Name="Grid.Column" Value="3" />
                     <Property Name="HorizontalAlignment" Value="1" />
                     <Property Name="Name" Value="SecondColumnDivider" />
-                    <Property Name="RenderSize" Value="1x28" />
+                    <Property Name="RenderSize" Value="1x29" />
                     <Property Name="Visibility" Value="0" />
                     <Property Name="Width" Value="1" />
                   </Element>
                   <Element Type="Microsoft.UI.Xaml.Controls.Border">
-                    <Property Name="ActualHeight" Value="28" />
+                    <Property Name="ActualHeight" Value="29" />
                     <Property Name="ActualWidth" Value="79" />
                     <Property Name="Child" Value="[Microsoft.UI.Xaml.Controls.TextBlock]" />
                     <Property Name="Grid.Column" Value="4" />
                     <Property Name="Name" Value="ThirdPickerHost" />
-                    <Property Name="RenderSize" Value="79x28" />
+                    <Property Name="RenderSize" Value="79x29" />
                     <Property Name="Visibility" Value="0" />
                     <Element Type="Microsoft.UI.Xaml.Controls.TextBlock">
-                      <Property Name="ActualHeight" Value="27.6211" />
+                      <Property Name="ActualHeight" Value="28.6211" />
                       <Property Name="ActualWidth" Value="21.6016" />
                       <Property Name="AutomationProperties.AccessibilityView" Value="0" />
                       <Property Name="FontFamily" Value="Segoe UI" />
@@ -1357,8 +1356,8 @@
                       <Property Name="FontWeight" Value="400" />
                       <Property Name="Inlines" Value="[Microsoft.UI.Xaml.Documents.InlineCollection]" />
                       <Property Name="Name" Value="PeriodTextBlock" />
-                      <Property Name="Padding" Value="0,3,0,6" />
-                      <Property Name="RenderSize" Value="79x28" />
+                      <Property Name="Padding" Value="0,4,0,6" />
+                      <Property Name="RenderSize" Value="79x29" />
                       <Property Name="SelectionHighlightColor" Value="#FF5B2EC5" />
                       <Property Name="Text" Value="AM" />
                       <Property Name="TextAlignment" Value="0" />


### PR DESCRIPTION
## Fixes

Fixes #8950

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

DatePicker and TimePicker header margins, host padding, and picker item spacing do not match the intended control layout.

### New Behavior

Adjusts DatePicker and TimePicker header margins plus host and item padding in the regular and perf2026 resources. Test expectations, integration helpers, verification files, and UI element tree masters are updated to match.

The large line count is expected: most changed lines are generated UI element tree master updates. The change is limited to the intended 35 paths.

## Customer Impact

DatePicker and TimePicker content and headers use corrected spacing and alignment.

## Regression Potential

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

This intentionally changes picker layout metrics and corresponding visual expectations.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

Integration expectations and UI element tree masters are updated for DatePicker, TimePicker, and their flyouts. GitHub CI provides persistent validation.

## Screenshots and recordings

![TimePicker spacing before and after](https://github.com/user-attachments/assets/344c12c4-c849-4e1f-baeb-496ef2fb4f7a)

![DatePicker spacing before and after](https://github.com/user-attachments/assets/d453d61c-875a-4739-90c1-7e9a2baa952d)

## Prior review sign-offs

@codendone, @snigdha011997, @godlytalias, and @hiteshkrmsft previously reviewed and signed off, and are tagged to reconfirm the GitHub version.