### PR TITLE
[Do Not Merge] Update OSS WinUIDetails dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
     <FrameworkUdkPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">3.0.0-experimental-27300.1893.260705-0915.0</FrameworkUdkPackageVersion>
     <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IxpTransportPackageVersion>
     <BasePackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.3-experimental1</BasePackageVersion>
-    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260822.0</WinUIDetailsNugetVersion>
+    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260824.2</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
     <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>


### PR DESCRIPTION
## Summary

Updates the OSS WinUIDetails dependency to the corrected public package. This restores the complete helper payload required by the current `winui3/main` sources, including the CompositionVisualSurface and ContentExternal helpers.

## Validation

- Confirmed the package is available from the public WinUI dependencies feed.
- Confirmed the public package is Microsoft-signed and byte-identical to the official build artifact.
- Confirmed all required headers and architecture libraries are present.