### PR TITLE
Restore ContentExternal helper migration

### DIFF
--- a/controls/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.cpp
@@ -177,8 +177,8 @@ CommandBarFlyoutCommandBar::~CommandBarFlyoutCommandBar()
     {
         if (auto systemBackdrop = m_systemBackdrop.get())
         {
-            systemBackdrop.OnTargetDisconnected(m_backdropLink);
-            systemBackdrop.OnTargetDisconnected(m_overflowPopupBackdropLink);
+            systemBackdrop.OnTargetDisconnected(m_backdropLink.SystemBackdropTarget());
+            systemBackdrop.OnTargetDisconnected(m_overflowPopupBackdropLink.SystemBackdropTarget());
         }
     }
 }
@@ -1588,8 +1588,8 @@ void CommandBarFlyoutCommandBar::OnPropertyChanged(const winrt::DependencyProper
 
             if (oldSystemBackdrop)
             {
-                oldSystemBackdrop.OnTargetDisconnected(m_backdropLink);
-                oldSystemBackdrop.OnTargetDisconnected(m_overflowPopupBackdropLink);
+                oldSystemBackdrop.OnTargetDisconnected(m_backdropLink.SystemBackdropTarget());
+                oldSystemBackdrop.OnTargetDisconnected(m_overflowPopupBackdropLink.SystemBackdropTarget());
                 m_registeredWithSystemBackdrop = false;
             }
 
@@ -1601,8 +1601,8 @@ void CommandBarFlyoutCommandBar::OnPropertyChanged(const winrt::DependencyProper
                 {
                     auto visual = winrt::ElementCompositionPreview::GetElementVisual(*this);
                     auto compositor = visual.Compositor();
-                    m_backdropLink = winrt::ContentExternalBackdropLink::Create(compositor);
-                    m_overflowPopupBackdropLink = winrt::ContentExternalBackdropLink::Create(compositor);
+                    m_backdropLink = ContentExternalLinkHelper::BackdropLink::Create(compositor);
+                    m_overflowPopupBackdropLink = ContentExternalLinkHelper::BackdropLink::Create(compositor);
                 }
 
                 TryConnectSystemBackdrop();
@@ -1629,8 +1629,8 @@ void CommandBarFlyoutCommandBar::TryConnectSystemBackdrop()
 
             if (xamlRoot)
             {
-                systemBackdrop.OnTargetConnected(m_backdropLink, XamlRoot());
-                systemBackdrop.OnTargetConnected(m_overflowPopupBackdropLink, XamlRoot());
+                systemBackdrop.OnTargetConnected(m_backdropLink.SystemBackdropTarget(), XamlRoot());
+                systemBackdrop.OnTargetConnected(m_overflowPopupBackdropLink.SystemBackdropTarget(), XamlRoot());
                 m_registeredWithSystemBackdrop = true;
             }
         }

--- a/controls/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyoutCommandBar.h
@@ -6,6 +6,7 @@
 #include "CommandBarFlyoutCommandBar.g.h"
 #include "CommandBarFlyoutCommandBar.properties.h"
 #include "CommandBarFlyoutTrace.h"
+#include <CppWinrtContentExternalBackdropLinkHelper.h>
 
 enum class CommandBarFlyoutOpenCloseAnimationKind
 {
@@ -144,8 +145,8 @@ private:
     // These ContentExternalBackdropLink objects implement the backdrop behind the CommandBarFlyoutCommandBar. We don't
     // use the one built into Popup because we need to animate this backdrop using Storyboards in the CBFCB's template.
     // The one built into Popup is too high up in the Visual tree to be animated by a custom animation.
-    winrt::ContentExternalBackdropLink m_backdropLink{ nullptr };
-    winrt::ContentExternalBackdropLink m_overflowPopupBackdropLink{ nullptr };
+    ContentExternalLinkHelper::BackdropLink m_backdropLink{ nullptr };
+    ContentExternalLinkHelper::BackdropLink m_overflowPopupBackdropLink{ nullptr };
 
     // A copy of the value in the DependencyProperty. We need to unregister with this SystemBackdrop when this
     // CommandBarFlyoutCommandBar is deleted, but the DP value is already cleared by the time we get to Unloaded or the

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -432,10 +432,10 @@ void InkCanvas::AttachToLiftedCompositor()
 
     auto compositor = winrt::CompositionTarget::GetCompositorForCurrentThread();
 
-    m_systemVisualLink = winrt::ContentExternalOutputLink::Create(compositor);
+    m_systemVisualLink = ContentExternalLinkHelper::OutputLink::Create(compositor);
     m_systemVisualLink.IsAboveContent(true);
 
-    winrt::com_ptr<IDCompositionTarget> target = m_systemVisualLink.as<IDCompositionTarget>();
+    winrt::com_ptr<IDCompositionTarget> target = m_systemVisualLink.DCompTarget();
     winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
 
     winrt::check_hresult(m_threadData->m_compositionDevice->Commit());

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -4,7 +4,8 @@
 #pragma once
 
 #include "InkCanvas.g.h"
-#include "dcomp.h"
+#include <dcomp.h>
+#include <CppWinrtContentExternalOutputLinkHelper.h>
 #include <windows.ui.input.inking.h>
 #include <inkpresenterdesktop.h>
 #include <map>
@@ -72,7 +73,7 @@ private:
     muxc::InkPresenter m_inkPresenterProxy{ nullptr };
 
     // ContentExternalOutputLink host for the lifted compositor path; null on the system path.
-    winrt::IContentExternalOutputLink m_systemVisualLink{ nullptr };
+    ContentExternalLinkHelper::OutputLink m_systemVisualLink{ nullptr };
 
     // Writer-side DComp target from the system splice; roots the ink visual under the MUC visual and
     // is released in DetachFromVisualLink. Null on the lifted path.

--- a/controls/dev/SystemBackdropElement/SystemBackdropElement.cpp
+++ b/controls/dev/SystemBackdropElement/SystemBackdropElement.cpp
@@ -48,7 +48,7 @@ void SystemBackdropElement::OnPropertyChanged(const winrt::DependencyPropertyCha
             {
                 if (m_backdropLink)
                 {
-                    oldSystemBackdrop.OnTargetDisconnected(m_backdropLink);
+                    oldSystemBackdrop.OnTargetDisconnected(m_backdropLink.SystemBackdropTarget());
                 }
                 m_registeredWithSystemBackdrop = false;
             }
@@ -193,7 +193,7 @@ void SystemBackdropElement::EnsureCompositionResources()
 
     if (!m_backdropLink)
     {
-        m_backdropLink = winrt::ContentExternalBackdropLink::Create(m_compositor);
+        m_backdropLink = ContentExternalLinkHelper::BackdropLink::Create(m_compositor);
         winrt::Microsoft::UI::Xaml::Hosting::ElementCompositionPreview::SetElementChildVisual(*this, m_backdropLink.PlacementVisual());
     }
 }
@@ -212,7 +212,7 @@ void SystemBackdropElement::TryConnectSystemBackdrop()
 
         if (xamlRoot && m_systemBackdrop)
         {
-            m_systemBackdrop.OnTargetConnected(m_backdropLink, xamlRoot);
+            m_systemBackdrop.OnTargetConnected(m_backdropLink.SystemBackdropTarget(), xamlRoot);
             m_registeredWithSystemBackdrop = true;
         }
     }
@@ -222,7 +222,7 @@ void SystemBackdropElement::ReleaseCompositionResources()
 {
     if (m_systemBackdrop && m_backdropLink)
     {
-        m_systemBackdrop.OnTargetDisconnected(m_backdropLink);
+        m_systemBackdrop.OnTargetDisconnected(m_backdropLink.SystemBackdropTarget());
     }
     m_backdropLink = nullptr;
     m_compositor = nullptr;

--- a/controls/dev/SystemBackdropElement/SystemBackdropElement.h
+++ b/controls/dev/SystemBackdropElement/SystemBackdropElement.h
@@ -5,6 +5,7 @@
 
 #include "SystemBackdropElement.g.h"
 #include "SystemBackdropElement.properties.h"
+#include <CppWinrtContentExternalBackdropLinkHelper.h>
 
 class SystemBackdropElement :
     public ReferenceTracker<SystemBackdropElement, winrt::implementation::SystemBackdropElementT>,
@@ -27,7 +28,7 @@ private:
     void TryConnectSystemBackdrop();
 
     // Member variables
-    winrt::Microsoft::UI::Content::ContentExternalBackdropLink m_backdropLink{ nullptr };
+    ContentExternalLinkHelper::BackdropLink m_backdropLink{ nullptr };
     winrt::Microsoft::UI::Composition::Compositor m_compositor{ nullptr };
     winrt::Microsoft::UI::Xaml::Media::SystemBackdrop m_systemBackdrop{ nullptr };
     winrt::Microsoft::UI::Composition::RectangleClip m_clip{ nullptr };

--- a/controls/dev/WebView2/WebView2.cpp
+++ b/controls/dev/WebView2/WebView2.cpp
@@ -5,7 +5,6 @@
 #include "common.h"
 #include <wil/cppwinrt_helpers.h>  // For wil::resume_foreground (marshals coroutine continuation to the UI DispatcherQueue)
 #include <corewindow.h>
-#include "dcomp.h"
 #include "InvokableCallbackHelper.h"
 #include "winrt\Microsoft.UI.Input.DragDrop.h"
 #include "shobjidl_core.h"
@@ -1875,14 +1874,14 @@ void WebView2::CreateAndSetVisual()
     if (!m_systemVisualBridge)
     {
         winrt::Compositor compositor = winrt::CompositionTarget::GetCompositorForCurrentThread();
-        m_systemVisualBridge = winrt::ContentExternalOutputLink::Create(compositor);
+        m_systemVisualBridge = ContentExternalLinkHelper::OutputLink::Create(compositor);
     }
     UpdateDefaultVisualBackgroundColor();
 
     SetCoreWebViewAndVisualSize(static_cast<float>(ActualWidth()), static_cast<float>(ActualHeight()));
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, m_systemVisualBridge.PlacementVisual());
 
-    winrt::com_ptr<IDCompositionTarget> sharedTarget = m_systemVisualBridge.as<IDCompositionTarget>();
+    winrt::com_ptr<IDCompositionTarget> sharedTarget = m_systemVisualBridge.DCompTarget();
     auto coreWebView2CompositionControllerInterop = m_coreWebViewCompositionController.as<ICoreWebView2CompositionControllerInterop>();
     winrt::check_hresult(coreWebView2CompositionControllerInterop->put_RootVisualTarget(sharedTarget.get()));
 }

--- a/controls/dev/WebView2/WebView2.h
+++ b/controls/dev/WebView2/WebView2.h
@@ -10,6 +10,8 @@
 
 #include "DispatcherHelper.h"
 
+#include <dcomp.h>
+#include <CppWinrtContentExternalOutputLinkHelper.h>
 #include <Microsoft.UI.Content.h>
 
 #include "WebView2.g.h"
@@ -223,7 +225,7 @@ private:
     HWND m_inputWindowHwnd{ nullptr };
     winrt::hstring m_stopNavigateOnUriChanged{};
     bool m_canGoPropSetInternally{};
-    winrt::IContentExternalOutputLink m_systemVisualBridge;
+    ContentExternalLinkHelper::OutputLink m_systemVisualBridge;
 
     winrt::UIElement::GettingFocus_revoker m_gettingFocusRevoker;
     winrt::UIElement::GotFocus_revoker m_gotFocusRevoker;

--- a/controls/dev/dll/Microsoft.UI.Xaml.Common.targets
+++ b/controls/dev/dll/Microsoft.UI.Xaml.Common.targets
@@ -34,7 +34,7 @@
       <Enumclass>false</Enumclass>
     </Midl>
     <Link>
-      <AdditionalDependencies>user32.lib;mincore.lib;dxguid.lib;dcomp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>user32.lib;mincore.lib;dxguid.lib;dcomp.lib;$(WinUIDetailsRuntimesPath)\Microsoft.UI.Xaml.Internal2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <!-- Microsoft.winmd will contain the definition of both public, preview and private types. -->
       <WindowsMetadataFile>$(OutDir)$(ProjectWinMDName)</WindowsMetadataFile>
       <GenerateMapFile>true</GenerateMapFile>
@@ -58,6 +58,7 @@
         $(WindowsSDK_IncludePath)\winrt;
         $(MSBuildProjectDirectory)\..\inc;
         $(MSBuildProjectDirectory)\..\Generated;
+        $(WinUIDetailsIncludePath)\Misc;
         $(OutDir);
       </AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>
@@ -84,7 +85,10 @@
       <!-- Disable RTTI to keep binary size down (adds about 50% to release dll size) -->
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <PreprocessorDefinitions>DISABLE_WINRT_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <!-- _ALLOW_COROUTINE_ABI_MISMATCH is necessary since we link Microsoft.UI.Xaml.Internal2.lib which
+          builds with stdcpp17 the same as MUX. We build with stdcpp20. There's no sharing of coroutines so this
+          is safe for now, but may hide issues in the future. -->
+      <PreprocessorDefinitions>DISABLE_WINRT_DEPRECATION;_ALLOW_COROUTINE_ABI_MISMATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <!-- Disable multi-proc building on low powered machines, such as the lab machines -->
       <MultiProcessorCompilation Condition="'$(TF_BUILD)'=='True' AND $(NUMBER_OF_PROCESSORS) &lt;= 4">false</MultiProcessorCompilation>

--- a/dxaml/xcp/core/core/elements/Popup.cpp
+++ b/dxaml/xcp/core/core/elements/Popup.cpp
@@ -1372,14 +1372,11 @@ void CPopup::EnsureContentExternalBackdropLink()
         DCompTreeHost* dcompTreeHostNoRef = GetDCompTreeHost();
         ixp::ICompositor* compositorNoRef = dcompTreeHostNoRef->GetCompositor();
 
-        wrl::ComPtr<ixp::IContentExternalBackdropLinkStatics> backdropLinkStatics;
-        IFCFAILFAST(wf::GetActivationFactory(wrl_wrappers::HStringReference(
-            RuntimeClass_Microsoft_UI_Content_ContentExternalBackdropLink).Get(), &backdropLinkStatics));
-        IFCFAILFAST(backdropLinkStatics->Create(compositorNoRef, m_backdropLink.ReleaseAndGetAddressOf()));
+        IFCFAILFAST(ContentExternalBackdropLinkHelper::Create(compositorNoRef, m_backdropLink));
 
-        IFCFAILFAST(m_backdropLink->put_ExternalBackdropBorderMode(ixp::CompositionBorderMode::CompositionBorderMode_Soft));
+        IFCFAILFAST(m_backdropLink->SetExternalBackdropBorderMode(ixp::CompositionBorderMode::CompositionBorderMode_Soft));
 
-        IFCFAILFAST(m_backdropLink->get_PlacementVisual(m_systemBackdropPlacementVisual.ReleaseAndGetAddressOf()));
+        IFCFAILFAST(m_backdropLink->GetPlacementVisual(m_systemBackdropPlacementVisual.ReleaseAndGetAddressOf()));
         DCompTreeHost::SetTagIfEnabled(m_systemBackdropPlacementVisual.Get(), VisualDebugTags::WindowedPopup_SystemBackdropPlacementVisual);
 
         // If there's already an animation root visual, then the windowed popup is already open. Add the system backdrop
@@ -1414,7 +1411,7 @@ void CPopup::DiscardContentExternalBackdropLink()
 
         m_systemBackdropPlacementVisual.Reset();
 
-        m_backdropLink.Reset();
+        m_backdropLink.reset();
     }
 }
 
@@ -4112,7 +4109,7 @@ _Check_return_ HRESULT CPopup::GetSystemBackdrop(_Outptr_result_maybenull_ RealW
     if (m_backdropLink)
     {
         wrl::ComPtr<ixp::ICompositionSupportsSystemBackdrop> icssb;
-        IFC_RETURN(m_backdropLink.As(&icssb));
+        IFC_RETURN(m_backdropLink->AsSystemBackdropTarget(&icssb));
         IFC_RETURN(icssb->get_SystemBackdrop(systemBackdropBrush));
     }
     else
@@ -4130,7 +4127,7 @@ _Check_return_ HRESULT CPopup::SetSystemBackdrop(_In_opt_ RealWUComp::ICompositi
         EnsureContentExternalBackdropLink();
 
         wrl::ComPtr<ixp::ICompositionSupportsSystemBackdrop> icssb;
-        IFC_RETURN(m_backdropLink.As(&icssb));
+        IFC_RETURN(m_backdropLink->AsSystemBackdropTarget(&icssb));
         IFC_RETURN(icssb->put_SystemBackdrop(systemBackdropBrush));
     }
     else

--- a/dxaml/xcp/core/inc/Popup.h
+++ b/dxaml/xcp/core/inc/Popup.h
@@ -10,6 +10,7 @@
 #include <XYFocus.h>
 #include <fwd/windows.ui.composition.h>
 #include <Microsoft.UI.Content.h>
+#include <ContentExternalLinkHelper.h>
 
 class HitTestPolygon;
 class CKeyEventArgs;
@@ -610,7 +611,7 @@ private:
     wrl::ComPtr<ixp::IVisual> m_contentIslandRootVisual;
     wrl::ComPtr<ixp::IVisual> m_windowedPopupDebugVisual;
     wrl::ComPtr<ixp::IVisual> m_animationRootVisual;
-    wrl::ComPtr<ixp::IContentExternalBackdropLink> m_backdropLink;
+    std::unique_ptr<ContentExternalBackdropLinkHelper> m_backdropLink;
     wrl::ComPtr<ixp::IVisual> m_systemBackdropPlacementVisual;
     wgr::RectInt32 m_windowedPopupMoveAndResizeRect = {};
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
     <FrameworkUdkPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">3.0.0-experimental-27300.1893.260705-0915.0</FrameworkUdkPackageVersion>
     <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IxpTransportPackageVersion>
     <BasePackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.3-experimental1</BasePackageVersion>
-    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260825.1</WinUIDetailsNugetVersion>
+    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260826.0</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
     <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
     <FrameworkUdkPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">3.0.0-experimental-27300.1893.260705-0915.0</FrameworkUdkPackageVersion>
     <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IxpTransportPackageVersion>
     <BasePackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.3-experimental1</BasePackageVersion>
-    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260625.0</WinUIDetailsNugetVersion>
+    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260824.2</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
     <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,7 +57,7 @@
     <FrameworkUdkPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">3.0.0-experimental-27300.1893.260705-0915.0</FrameworkUdkPackageVersion>
     <IxpTransportPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.1.4-experimental</IxpTransportPackageVersion>
     <BasePackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.3-experimental1</BasePackageVersion>
-    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260824.2</WinUIDetailsNugetVersion>
+    <WinUIDetailsNugetVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.10.0-experimental.20260825.1</WinUIDetailsNugetVersion>
     <!-- Package Versions for use in sample and test apps. Once Transport packages are removed revert to using old version variables -->
     <FoundationPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.19-experimental</FoundationPackageVersion>
     <IXPPackageVersion Condition="'$(IsInternalWinUIBuild)' != 'true'">2.0.11-experimental</IXPPackageVersion>

--- a/eng/folderpaths.props
+++ b/eng/folderpaths.props
@@ -205,7 +205,7 @@
     <LiftedIXPInternalPackagePath>$(NugetPackageDirectory)\$(LiftedIXPInternalPackageName)\$(IxpInternalPackageVersion)</LiftedIXPInternalPackagePath>
     <LiftedIXPInternalPGIRuntimePath>$(LiftedIXPInternalPackagePath)\runtimes\win10-$(NugetArch)\native\pgi</LiftedIXPInternalPGIRuntimePath>
 
-    <LiftedIXPIncludePaths>$(LiftedIXPIncludePath);$(WinUIDetailsIncludePath)\LiftedIXP;$(FrameworkUdkPackagePath)\include\;$(LiftedIXPGeneratedIncludePath)</LiftedIXPIncludePaths>
+    <LiftedIXPIncludePaths>$(LiftedIXPIncludePath);$(WinUIDetailsIncludePath)\LiftedIXP;$(WinUIDetailsIncludePath)\Misc;$(FrameworkUdkPackagePath)\include\;$(LiftedIXPGeneratedIncludePath)</LiftedIXPIncludePaths>
   </PropertyGroup>
 
   <!-- Lifted MRT paths -->


### PR DESCRIPTION
## Summary

Restores the deferred ContentExternal helper migration on GitHub `main` now that the complete public WinUIDetails package is available.

This change also updates the OSS WinUIDetails pin and include path required by that migration. The package includes the ContentExternal helpers and the CompositionVisualSurface helper needed by the current source tree.

## Validation

- Confirmed Andy's source patch is identical to the original deferred change.
- Confirmed the corrected package is available from the public WinUI dependencies feed.
- Confirmed the public package is Microsoft-signed and contains the required headers and architecture libraries.