### PR TITLE
[WinUI OSS] Improve agentic build experience

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Copilot Instructions for WinUI
+
+Full guidance for agents is in [`AGENTS.md`](../AGENTS.md) at the repository root. The
+essentials are repeated here so this file stands on its own.
+
+## Building
+
+```powershell
+.\.github\skills\build\Invoke-AgentBuild.ps1
+```
+
+This initializes the repository on first use and returns a non-zero exit code when the
+build fails. Do not trust `build.cmd`'s exit code directly: it can report `0` for a failed
+build. Allow at least 300 seconds; a first full build takes over an hour.
+
+Add `-Target mux` or `-Target product` for a smaller build, `-Flavor <flavor>` for a
+different flavor, and `-Detailed` for full output.
+
+## Rules
+
+- Run build and setup commands yourself. Do not ask the user to run them.
+- When asked to build the repository without a named target, perform the complete default
+  build. Never report success based on a smaller component build.
+- On failure, follow the recovery policy in [`AGENTS.md`](../AGENTS.md): apply the bounded
+  retries it lists, then stop and report the error and the binary log path.
+
+## Skills
+
+- `.github/skills/build/SKILL.md` — build targets, flags, and troubleshooting.
+- `.github/skills/test-on-vm/SKILL.md` — running interaction tests on a VM, when present.

--- a/.github/skills/build/Invoke-AgentBuild.ps1
+++ b/.github/skills/build/Invoke-AgentBuild.ps1
@@ -1,0 +1,255 @@
+<#
+.SYNOPSIS
+    Build the WinUI repository unattended, with a trustworthy exit code.
+
+.DESCRIPTION
+    Wraps the repository's existing build entry points so an agent can run a build with a
+    single command and rely on the result. It does not modify Build.cmd, init.cmd,
+    initrun.ps1 or scripts\init\*; it only calls them.
+
+    It adds three things those scripts do not provide to an unattended caller:
+
+      1. First-time initialization. A full init is run automatically when the repository
+         has not been initialized yet, using the same signal init.cmd /envcheck uses
+         (the packages and .tools directories).
+
+      2. A trustworthy exit code. Build.cmd can return 0 for a failed build, because the
+         failing code is not preserved on the way out. This script ignores that exit code
+         and derives the result from the failure markers Build.cmd prints and from whether
+         a binary log was produced.
+
+      3. The binary log location, reported on success as well as on failure, so there is
+         always a diagnostic artifact to inspect.
+
+.PARAMETER Target
+    Build target passed to Build.cmd: prodtest (default), product, mux, test, samples.
+
+.PARAMETER Flavor
+    Build flavor. Default: amd64chk.
+    One of: amd64chk, amd64fre, x86chk, x86fre, arm64chk, arm64fre.
+
+.PARAMETER BuildArguments
+    Additional flags forwarded verbatim to Build.cmd, for example /c or /b.
+
+.PARAMETER Detailed
+    Show full build output. By default the build runs quietly (/q, errors only).
+
+.PARAMETER SkipInitialize
+    Do not run a full initialization even when the repository looks uninitialized.
+
+.PARAMETER RepoRoot
+    Repository root. Defaults to the root inferred from this script's location.
+
+.EXAMPLE
+    .\.github\skills\build\Invoke-AgentBuild.ps1
+    Full default build, initializing first if required.
+
+.EXAMPLE
+    .\.github\skills\build\Invoke-AgentBuild.ps1 -Target mux
+    Build Microsoft.UI.Xaml.dll only.
+
+.OUTPUTS
+    Exit code 0 only when the build genuinely succeeded; non-zero otherwise.
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('prodtest', 'product', 'mux', 'test', 'samples')]
+    [string]$Target = 'prodtest',
+
+    [ValidateSet('amd64chk', 'amd64fre', 'x86chk', 'x86fre', 'arm64chk', 'arm64fre')]
+    [Alias('i')]
+    [string]$Flavor = 'amd64chk',
+
+    [string[]]$BuildArguments = @(),
+
+    [switch]$Detailed,
+
+    [switch]$SkipInitialize,
+
+    [string]$RepoRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+}
+$RepoRoot = $RepoRoot.TrimEnd('\')
+
+# Build.cmd prints these when a step fails. They are the only reliable failure signal,
+# because the process exit code does not survive the end of the script.
+$script:FailureMarkers = @(
+    'ERROR: buildSolution for ',
+    'ERROR: callScript FAILED',
+    'ERROR: init.cmd ',
+    'Please run init.cmd or use /i',
+    'Could not set up a developer command prompt',
+    'Could not find path: '
+)
+
+# Compiler, linker and MSBuild diagnostics, e.g. "error MSB4217:" or "error C3859:".
+$script:ErrorPattern = '\berror\s+(MSB|C|LNK|CS|CVT|RC|AL)\d+\b'
+
+function Get-BinaryLog {
+    param([string]$Root, [datetime]$Since)
+
+    $outputDir = Join-Path $Root 'BuildOutput'
+    if (-not (Test-Path -LiteralPath $outputDir)) { return @() }
+
+    return @(Get-ChildItem -LiteralPath $outputDir -Filter '*.binlog' -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -ge $Since } |
+        Sort-Object LastWriteTime -Descending)
+}
+
+function Test-Initialized {
+    param([string]$Root)
+
+    # The same two directories init.cmd /envcheck requires before it will set up an
+    # environment without restoring. Keep this in step with init.cmd.
+    return (Test-Path -LiteralPath (Join-Path $Root 'packages')) -and
+           (Test-Path -LiteralPath (Join-Path $Root '.tools'))
+}
+
+function Invoke-Captured {
+    <#
+        Runs a command, streams its output to the host, and returns the captured lines.
+        Output is needed in full because the build result is derived from it.
+    #>
+    param(
+        [string]$FilePath,
+        [string[]]$ArgumentList
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    & $FilePath @ArgumentList 2>&1 | ForEach-Object {
+        $line = [string]$_
+        $lines.Add($line)
+        Write-Host $line
+    }
+    return , $lines.ToArray()
+}
+
+function Get-WindowsPowerShell {
+    $candidate = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+    if (Test-Path -LiteralPath $candidate) { return $candidate }
+
+    foreach ($name in 'powershell.exe', 'pwsh.exe') {
+        $found = Get-Command $name -ErrorAction SilentlyContinue
+        if ($found) { return $found.Source }
+    }
+    throw 'No PowerShell host found to run the build.'
+}
+
+function Test-FailureInOutput {
+    param([string[]]$Lines)
+
+    foreach ($line in $Lines) {
+        foreach ($marker in $script:FailureMarkers) {
+            if ($line -like "*$marker*") { return $true }
+        }
+        if ($line -match $script:ErrorPattern) { return $true }
+    }
+    return $false
+}
+
+$initCmd = Join-Path $RepoRoot 'init.cmd'
+$initRun = Join-Path $RepoRoot 'initrun.ps1'
+$buildCmd = Join-Path $RepoRoot 'Build.cmd'
+
+foreach ($required in @($initCmd, $initRun, $buildCmd)) {
+    if (-not (Test-Path -LiteralPath $required)) {
+        Write-Host "ERROR: Expected build script not found: $required" -ForegroundColor Red
+        Write-Host "       Is '$RepoRoot' a WinUI repository root?" -ForegroundColor Red
+        exit 1
+    }
+}
+
+$powershell = Get-WindowsPowerShell
+$startedAt = Get-Date
+
+# --- Step 1: initialize once, if needed -------------------------------------------------
+
+if (-not (Test-Initialized -Root $RepoRoot)) {
+    if ($SkipInitialize) {
+        Write-Host 'ERROR: The repository is not initialized and -SkipInitialize was specified.' -ForegroundColor Red
+        Write-Host "       Run: $initCmd $Flavor" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Initializing the build environment for $Flavor. The first run downloads tools and restores packages."
+
+    $initOutput = @(Invoke-Captured -FilePath $env:ComSpec -ArgumentList @('/c', "`"$initCmd`" $Flavor"))
+    $initExit = $LASTEXITCODE
+
+    # init.cmd reports a bad flavor or a missing path through its exit code, but a failed
+    # restore can still leave the repository unusable, so check the outcome as well.
+    if ($initExit -ne 0 -or (Test-FailureInOutput -Lines $initOutput) -or -not (Test-Initialized -Root $RepoRoot)) {
+        Write-Host '---' -ForegroundColor Red
+        Write-Host "ERROR: Initialization failed for $Flavor (exit code $initExit)." -ForegroundColor Red
+        Write-Host '       Not starting the build: a build on an uninitialized repository fails for unrelated reasons.' -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Initialized environment for $Flavor."
+}
+
+# --- Step 2: build ----------------------------------------------------------------------
+
+$buildArgs = @()
+if (-not $Detailed) { $buildArgs += '/q' }
+if ($Target -ne 'prodtest') { $buildArgs += $Target }
+$buildArgs += $BuildArguments
+
+$initRunArgs = @(
+    '-NoProfile', '-ExecutionPolicy', 'Bypass',
+    '-File', $initRun,
+    '-Flavor', $Flavor,
+    'build.cmd'
+) + $buildArgs
+
+Write-Host "Building $Target ($Flavor). A full build takes over an hour on a clean repository."
+
+$buildOutput = @(Invoke-Captured -FilePath $powershell -ArgumentList $initRunArgs)
+$reportedExit = $LASTEXITCODE
+
+# --- Step 3: decide the real result ------------------------------------------------------
+
+# Wrap in @() so a single result is still an array once returned from the function.
+$binlogs = @(Get-BinaryLog -Root $RepoRoot -Since $startedAt)
+$isFake = $buildArgs -contains '/fake'
+
+$failed = $false
+$reason = $null
+
+if (Test-FailureInOutput -Lines $buildOutput) {
+    $failed = $true
+    $reason = 'the build reported errors'
+}
+elseif ($reportedExit -ne 0) {
+    $failed = $true
+    $reason = "the build returned exit code $reportedExit"
+}
+elseif (-not $isFake -and $binlogs.Count -eq 0) {
+    # No errors and no log. MSBuild crashes (for example 0xC0000005) are not caught by
+    # Build.cmd's own error checks, so an absent log is the only remaining signal.
+    $failed = $true
+    $reason = 'no binary log was produced, which usually means the build crashed before it started'
+}
+
+Write-Host '---'
+if ($binlogs.Count -gt 0) {
+    Write-Host 'Binary logs:'
+    foreach ($log in $binlogs) { Write-Host "  $($log.FullName)" }
+}
+elseif (-not $isFake) {
+    Write-Host "Binary logs: none found under $(Join-Path $RepoRoot 'BuildOutput')"
+}
+
+if ($failed) {
+    Write-Host "BUILD FAILED: $reason." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "BUILD SUCCEEDED: $Target ($Flavor)." -ForegroundColor Green
+exit 0

--- a/.github/skills/build/Invoke-AgentBuild.ps1
+++ b/.github/skills/build/Invoke-AgentBuild.ps1
@@ -91,6 +91,30 @@ $script:FailureMarkers = @(
 # Compiler, linker and MSBuild diagnostics, e.g. "error MSB4217:" or "error C3859:".
 $script:ErrorPattern = '\berror\s+(MSB|C|LNK|CS|CVT|RC|AL)\d+\b'
 
+# A build can fail for missing packages or tools even though the initialization check
+# passed, because that check only confirms the two directories exist and not that their
+# contents are complete or current. These patterns identify that case so the caller is
+# told to initialize again rather than treating it as a code error.
+$script:NeedsInitPatterns = @(
+    'references NuGet package\(s\) that are missing',
+    'The missing file is packages\\',
+    'Unable to find package',
+    '\berror\s+NU\d{4}\b',
+    "Could not find .*\\\.tools\\",
+    'is not recognized as an internal or external command'
+)
+
+function Test-NeedsInit {
+    param([string[]]$Lines)
+
+    foreach ($line in $Lines) {
+        foreach ($pattern in $script:NeedsInitPatterns) {
+            if ($line -match $pattern) { return $true }
+        }
+    }
+    return $false
+}
+
 function Get-BinaryLog {
     param([string]$Root, [datetime]$Since)
 
@@ -222,9 +246,17 @@ $isFake = $buildArgs -contains '/fake'
 $failed = $false
 $reason = $null
 
+# A restore problem is reported without an MSBuild error code, so it has to be checked
+# separately or a build that exits 0 after failing to find its packages looks successful.
+$needsInit = Test-NeedsInit -Lines $buildOutput
+
 if (Test-FailureInOutput -Lines $buildOutput) {
     $failed = $true
     $reason = 'the build reported errors'
+}
+elseif ($needsInit) {
+    $failed = $true
+    $reason = 'the build could not find restored packages or tools'
 }
 elseif ($reportedExit -ne 0) {
     $failed = $true
@@ -248,6 +280,15 @@ elseif (-not $isFake) {
 
 if ($failed) {
     Write-Host "BUILD FAILED: $reason." -ForegroundColor Red
+
+    if ($needsInit) {
+        Write-Host ''
+        Write-Host 'This looks like missing packages or tools rather than a code error.' -ForegroundColor Yellow
+        Write-Host 'The initialization check only confirms that packages\ and .tools\ exist, so a' -ForegroundColor Yellow
+        Write-Host 'partial or out-of-date restore passes it. Initialize again before changing code:' -ForegroundColor Yellow
+        Write-Host "    $initCmd $Flavor" -ForegroundColor Yellow
+    }
+
     exit 1
 }
 

--- a/.github/skills/build/Invoke-AgentBuild.ps1
+++ b/.github/skills/build/Invoke-AgentBuild.ps1
@@ -100,6 +100,7 @@ $script:NeedsInitPatterns = @(
     'The missing file is packages\\',
     'Unable to find package',
     '\berror\s+NU\d{4}\b',
+    '\bMSB3644\b',
     "Could not find .*\\\.tools\\",
     'is not recognized as an internal or external command'
 )

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -23,7 +23,13 @@ errors only.
 
 ## Use the wrapper for unattended builds
 
-The underlying command is the one to give a person:
+A person normally runs `.\init.cmd` once and then `.\build.cmd /q` repeatedly in that same
+shell, because `init` sets environment variables and `PATH` for the session.
+
+That does not work for an agent, which runs each command in a fresh process, so the
+environment from `init` is gone by the next command. `initrun.ps1` exists for this: it
+re-establishes the environment in-process and then runs the command, so each invocation is
+self-contained:
 
 ```powershell
 .\initrun.ps1 .\build.cmd /q
@@ -34,7 +40,10 @@ changes none of them, but it adds three things an agent needs:
 
 - **First-time initialization.** A full `init.cmd` must have run at least once, or the
   build fails in a way that looks like a code error. The wrapper detects this and
-  initializes first.
+  initializes first. The detection is deliberately simple: it checks that `packages\` and
+  `.tools\` exist, the same signal `init.cmd /envcheck` uses. It cannot tell that a restore
+  was partial or is out of date, so see
+  [missing packages or tools](#missing-packages-or-tools) if the build fails that way.
 - **A trustworthy exit code.** `build.cmd` can exit `0` after a failed build, because the
   failing exit code is not preserved on the way out of the script. The wrapper derives the
   real result from the build output and the binary log.
@@ -135,6 +144,24 @@ or NuGet dependencies changed, when WinRT runtime classes were added or removed,
 packaging or signing is needed, on a first build, or when unsure.
 
 ## Troubleshooting
+
+### Missing packages or tools
+
+Errors such as `NU1101`, `MSB3644`, "references NuGet package(s) that are missing", or a
+tool that is "not recognized as an internal or external command" mean the repository is not
+fully initialized. They are not code errors, so do not try to fix them by changing source.
+
+This can happen even though the wrapper ran without initializing, because its check only
+confirms that `packages\` and `.tools\` exist. A restore that was interrupted, or that
+predates a change to the dependencies, leaves those directories in place but incomplete.
+The wrapper prints this advice when it detects the case.
+
+Initialize directly, then build again:
+
+```powershell
+.\init.cmd amd64chk
+.\.github\skills\build\Invoke-AgentBuild.ps1
+```
 
 ### `error C3859` or `error C1076`, precompiled header memory
 

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: build
+description: Build the WinUI repository. Use when asked to build, compile, or rebuild the project after making code changes.
+---
+
+# Building WinUI
+
+## Quick start
+
+```powershell
+# Initializes on first use, and returns a non-zero exit code when the build fails.
+.\.github\skills\build\Invoke-AgentBuild.ps1                     # full build (product + tests)
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Target product     # product code only
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Target mux         # Microsoft.UI.Xaml.dll only
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Flavor arm64fre    # different flavor
+.\.github\skills\build\Invoke-AgentBuild.ps1 -BuildArguments /c  # clean rebuild
+```
+
+Set `initial_wait` to at least **300 seconds**. A first full build takes over an hour.
+
+Use `-Detailed` to see full build output; by default the build runs quietly and prints
+errors only.
+
+## Use the wrapper for unattended builds
+
+The underlying command is the one to give a person:
+
+```powershell
+.\initrun.ps1 .\build.cmd /q
+```
+
+For an unattended agent, prefer `Invoke-AgentBuild.ps1`. It calls the same scripts and
+changes none of them, but it adds three things an agent needs:
+
+- **First-time initialization.** A full `init.cmd` must have run at least once, or the
+  build fails in a way that looks like a code error. The wrapper detects this and
+  initializes first.
+- **A trustworthy exit code.** `build.cmd` can exit `0` after a failed build, because the
+  failing exit code is not preserved on the way out of the script. The wrapper derives the
+  real result from the build output and the binary log.
+- **The binary log path**, reported on success as well as failure.
+
+If you do call `build.cmd` directly, do not treat exit code `0` as proof of success.
+Check the output for `ERROR:` lines and confirm a binary log was written under
+`BuildOutput\`.
+
+## Recovery policy
+
+When a build fails, diagnose the error and apply only these bounded recovery steps.
+Run them yourself; do not ask the user to.
+
+1. Missing tools, packages, or restore outputs — run `.\init.cmd <flavor>` once and retry.
+2. `C3859` or `C1076` precompiled header memory failures — retry once with `-BuildArguments /b`.
+3. `C1853` stale precompiled header failures — retry once with `-BuildArguments '/c','/b'`.
+4. `MSB4217` task host exit, or a following `MSB4027` — retry once with `-BuildArguments /m:1`.
+5. Anything else — stop and report the failing project, the error, the exit code, and the
+   binary log path.
+
+Never repeat the same failed command indefinitely, hide an error, or claim success from a
+smaller build. A generic "build the repo" request succeeds only when the full default
+build exits with code 0.
+
+## First-time setup
+
+A full initialization runs once per flavor to download tools and restore NuGet packages.
+`Invoke-AgentBuild.ps1` does this automatically. To run it directly:
+
+```powershell
+.\init.cmd amd64chk
+```
+
+Allow at least 300 seconds. Initialization has succeeded when the command exits with code
+0 and the `packages` and `.tools` directories exist at the repository root. Do not start a
+build after an initialization error.
+
+Flavors: `amd64chk`, `amd64fre`, `x86chk`, `x86fre`, `arm64chk`, `arm64fre`
+(`chk` is debug, `fre` is release).
+
+## Targets
+
+| Target | What it builds | Time |
+|---|---|---|
+| `prodtest` (default) | Product code and tests | 1 hour or more |
+| `product` | Product code, no tests | 5-10 min incremental |
+| `mux` | `Microsoft.UI.Xaml.dll` only | 1-6 min incremental |
+| `test` | Tests only | varies |
+| `samples` | Sample applications | varies |
+
+Single project, when you know exactly what changed:
+
+```powershell
+.\initrun.ps1 msb /q "controls\dev\dll\Microsoft.UI.Xaml.Controls.vcxproj"
+```
+
+## Flags
+
+Pass these through `-BuildArguments`.
+
+| Flag | Effect |
+|---|---|
+| `/c` | Clean build. Deletes `BuildOutput` first. Use when switching flavors |
+| `/b` | Reduced parallelism (`/m:2`). Avoids precompiled header memory exhaustion |
+| `/m:1` | Single MSBuild process. Use after `MSB4217` |
+| `/restore` | NuGet restore before building |
+| `/nomock` | Skip the mock package. Only when changing `dxaml/` product and test code |
+| `/fake` | Print the commands without running them |
+
+## What to build after a code change
+
+| Files changed in | Build |
+|---|---|
+| `dxaml/xcp/**` | `.\initrun.ps1 msb /q "dxaml\xcp\dxaml\dllsrv\winrt\native\Microsoft.ui.xaml.vcxproj"` |
+| `controls/dev/**`, `controls/idl/**` | `.\initrun.ps1 msb /q "controls\dev\dll\Microsoft.UI.Xaml.Controls.vcxproj"` |
+| `dxaml/test/native/external/<area>/**` | `.\initrun.ps1 msb /q "dxaml\test\native\external\<area>\Microsoft.UI.Xaml.Tests.External.<Area>.vcxproj"` |
+| `.vcxproj`, `.vcxitems`, `.props`, `.targets`, NuGet dependencies | Full build |
+| `src/XamlCompiler/BuildTasks/**/*.tt` | `.\initrun.ps1 msb /q /t:TransformAll "src\XamlCompiler\Microsoft.UI.Xaml.Markup.Compiler.csproj"`, then a full build |
+| Several areas, or unsure | Full build |
+
+Test areas: `controls`, `foundation`, `framework`, `automation`.
+
+## Terminology
+
+**MUX** is `Microsoft.UI.Xaml.dll`, the core XAML runtime. It is not
+`Microsoft.UI.Xaml.Controls.dll`.
+
+## Faster incremental builds
+
+Internal clones provide a tool that replays only the dirty compile and link steps,
+skipping MSBuild. It is described by a separate skill under `.github/skills/`, and it
+depends on tooling from an internal feed, so it is unavailable in public clones. When that
+skill file is not present, use MSBuild for every build.
+
+Use MSBuild rather than an incremental tool whenever project files, `.props`/`.targets`,
+or NuGet dependencies changed, when WinRT runtime classes were added or removed, when
+packaging or signing is needed, on a first build, or when unsure.
+
+## Troubleshooting
+
+### `error C3859` or `error C1076`, precompiled header memory
+
+Parallel compiler instances exhaust the process address space.
+
+```powershell
+.\.github\skills\build\Invoke-AgentBuild.ps1 -BuildArguments /b
+```
+
+If that still fails, close other memory-intensive applications, then try a clean build
+with `-BuildArguments '/c','/b'`.
+
+### `error C1853`, precompiled header from a different compiler version
+
+Stale precompiled headers, typically after a Visual Studio update.
+
+```powershell
+.\.github\skills\build\Invoke-AgentBuild.ps1 -BuildArguments '/c','/b'
+```
+
+### `MSB4217: Task host node exited prematurely`
+
+Retry once with a single MSBuild process:
+
+```powershell
+.\.github\skills\build\Invoke-AgentBuild.ps1 -BuildArguments /m:1
+```
+
+If the serial retry fails, stop and report both errors, the exit code, and the binary log.
+
+### Missing Spectre mitigation libraries
+
+Import `.vsconfig` from the repository root through the Visual Studio Installer:
+More, then Import configuration, then select `<repo-root>\.vsconfig` and install the
+missing components.
+
+### `DevEnvDir environment variable not set`
+
+Informational, not an error. The initialization scripts run `DevCmd.cmd` to set up the
+Visual Studio environment. No action needed.
+
+### NuGet restore fails to authenticate
+
+1. Run the build once more so initialization can reinstall the credential provider and
+   retry the restore.
+2. If it still fails, report the feed URL and the HTTP status from the restore output.
+   Do not request, print, or store credentials.
+3. Confirm the clone uses the repository's `NuGet.config`.
+
+### The .NET SDK fails to download
+
+Usually a transient network or VPN problem; retry. If the download URL has changed, check
+`Version.props` for the expected SDK version.
+
+## Verifying the build result
+
+The wrapper reports the outcome and the binary log path. When checking a build by hand:
+
+- A failed solution prints `ERROR: buildSolution for <solution> FAILED.` followed by the
+  binary log path.
+- Compiler and MSBuild diagnostics appear as `error C####`, `error MSB####`, and similar.
+- A binary log is written to `BuildOutput\<name>.<flavor>.binlog`. A missing log after a
+  build usually means the build crashed before it started.

--- a/.github/skills/build/SKILL.md
+++ b/.github/skills/build/SKILL.md
@@ -39,11 +39,12 @@ For an unattended agent, prefer `Invoke-AgentBuild.ps1`. It calls the same scrip
 changes none of them, but it adds three things an agent needs:
 
 - **First-time initialization.** A full `init.cmd` must have run at least once, or the
-  build fails in a way that looks like a code error. The wrapper detects this and
-  initializes first. The detection is deliberately simple: it checks that `packages\` and
-  `.tools\` exist, the same signal `init.cmd /envcheck` uses. It cannot tell that a restore
-  was partial or is out of date, so see
-  [missing packages or tools](#missing-packages-or-tools) if the build fails that way.
+  build fails in a way that looks like a code error. The wrapper initializes first when it
+  finds the repository uninitialized. That check is deliberately simple: it confirms that
+  `packages\` and `.tools\` exist, the same signal `init.cmd /envcheck` uses. It cannot
+  tell that a restore was interrupted or has gone out of date, so a partial restore passes
+  the check and the build then fails for missing packages. See
+  [missing packages or tools](#missing-packages-or-tools) when that happens.
 - **A trustworthy exit code.** `build.cmd` can exit `0` after a failed build, because the
   failing exit code is not preserved on the way out of the script. The wrapper derives the
   real result from the build output and the binary log.
@@ -151,12 +152,12 @@ Errors such as `NU1101`, `MSB3644`, "references NuGet package(s) that are missin
 tool that is "not recognized as an internal or external command" mean the repository is not
 fully initialized. They are not code errors, so do not try to fix them by changing source.
 
-This can happen even though the wrapper ran without initializing, because its check only
+This can happen even when the wrapper skipped initialization, because its check only
 confirms that `packages\` and `.tools\` exist. A restore that was interrupted, or that
 predates a change to the dependencies, leaves those directories in place but incomplete.
 The wrapper prints this advice when it detects the case.
 
-Initialize directly, then build again:
+Initialize directly with the flavor you are building, then build again:
 
 ```powershell
 .\init.cmd amd64chk

--- a/.github/skills/build/tests/AgentBuild.Tests.ps1
+++ b/.github/skills/build/tests/AgentBuild.Tests.ps1
@@ -1,0 +1,427 @@
+<#
+.SYNOPSIS
+    Tests for .github/skills/build/Invoke-AgentBuild.ps1.
+
+.DESCRIPTION
+    These tests do not build the repository. They run the wrapper against a stub
+    repository whose init and build scripts are replaced with controllable fakes, so the
+    whole suite finishes in seconds instead of the hour a real build takes.
+
+    Each test covers a failure that is silent in practice: a build that reports success
+    after failing, a crash that produces no diagnostics, or setup that half-completes.
+
+.EXAMPLE
+    powershell -NoProfile -File .\.github\skills\build\tests\AgentBuild.Tests.ps1
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..')).Path
+$wrapper = Join-Path $repoRoot '.github\skills\build\Invoke-AgentBuild.ps1'
+
+$script:Passed = 0
+$script:Failed = 0
+$script:Failures = @()
+
+function Test-Case {
+    param([string]$Name, [scriptblock]$Body)
+
+    try {
+        & $Body
+        Write-Host "[PASS] $Name" -ForegroundColor Green
+        $script:Passed++
+    }
+    catch {
+        Write-Host "[FAIL] $Name - $($_.Exception.Message)" -ForegroundColor Red
+        $script:Failed++
+        $script:Failures += "$Name : $($_.Exception.Message)"
+    }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    if ($Expected -ne $Actual) {
+        throw "$Message Expected '$Expected', got '$Actual'."
+    }
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function New-StubRepo {
+    <#
+        Creates a throwaway repository root containing stubs for the scripts the wrapper
+        calls. Behaviour is driven by AGENTBUILD_TEST_* environment variables so each
+        test can choose what the build does.
+    #>
+    param([switch]$WithSpaceInPath, [switch]$Initialized)
+
+    $suffix = [guid]::NewGuid().Guid.Substring(0, 8)
+    $leaf = if ($WithSpaceInPath) { "agent build $suffix" } else { "agentbuild$suffix" }
+    $root = Join-Path ([IO.Path]::GetTempPath()) $leaf
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+    Set-Content -LiteralPath (Join-Path $root 'Build.cmd') -Value @'
+@echo off
+rem Stub. The wrapper reaches build.cmd through initrun.ps1, which is also a stub.
+exit /b 0
+'@ -Encoding ASCII
+
+    Set-Content -LiteralPath (Join-Path $root 'init.cmd') -Value @'
+@echo off
+echo Initializing stub environment for %1
+echo ran > "%~dp0init-was-run.txt"
+if "%AGENTBUILD_TEST_INIT_FAIL%"=="1" (
+    echo ERROR: init.cmd %1 /envcheck failed
+    exit /b 1
+)
+if not exist "%~dp0packages" mkdir "%~dp0packages"
+if not exist "%~dp0.tools" mkdir "%~dp0.tools"
+exit /b 0
+'@ -Encoding ASCII
+
+    Set-Content -LiteralPath (Join-Path $root 'initrun.ps1') -Value @'
+param(
+    [string]$Flavor = "amd64chk",
+    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+    [string[]]$Command
+)
+
+# Record how the wrapper invoked us, so tests can assert on argument forwarding.
+"$Flavor|$($Command -join ' ')" | Set-Content -LiteralPath $env:AGENTBUILD_TEST_ARGSFILE
+
+if ($env:AGENTBUILD_TEST_OUTPUT) {
+    foreach ($line in ($env:AGENTBUILD_TEST_OUTPUT -split "`n")) { Write-Output $line }
+}
+
+if ($env:AGENTBUILD_TEST_BINLOG -eq "1") {
+    $outputDir = Join-Path $PSScriptRoot "BuildOutput"
+    if (-not (Test-Path -LiteralPath $outputDir)) {
+        New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+    }
+    Set-Content -LiteralPath (Join-Path $outputDir "MUXControls.amd64chk.binlog") -Value "stub"
+}
+
+$code = 0
+if ($env:AGENTBUILD_TEST_EXIT) { $code = [int]$env:AGENTBUILD_TEST_EXIT }
+exit $code
+'@ -Encoding ASCII
+
+    if ($Initialized) {
+        New-Item -ItemType Directory -Path (Join-Path $root 'packages') -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $root '.tools') -Force | Out-Null
+    }
+
+    $env:AGENTBUILD_TEST_ARGSFILE = Join-Path $root 'invocation.txt'
+    return $root
+}
+
+function Reset-StubBehavior {
+    $env:AGENTBUILD_TEST_OUTPUT = $null
+    $env:AGENTBUILD_TEST_EXIT = $null
+    $env:AGENTBUILD_TEST_BINLOG = '1'
+    $env:AGENTBUILD_TEST_INIT_FAIL = $null
+}
+
+function Invoke-Wrapper {
+    param([string]$Root, [hashtable]$Arguments = @{})
+
+    # *>&1 captures Write-Host as well; the wrapper reports its result through the host.
+    $output = & $wrapper -RepoRoot $Root @Arguments *>&1 | Out-String
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output   = $output
+    }
+}
+
+function Get-RecordedInvocation {
+    param([string]$Root)
+    $file = Join-Path $Root 'invocation.txt'
+    if (-not (Test-Path -LiteralPath $file)) { return $null }
+    return (Get-Content -LiteralPath $file -Raw).Trim()
+}
+
+function Remove-StubRepo {
+    param([string]$Root)
+    Remove-Item -LiteralPath $Root -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Testing $wrapper`n"
+
+# --- Exit code correctness ---------------------------------------------------------------
+
+Test-Case 'A successful build exits 0 and reports the binary log' {
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 0 $result.ExitCode 'Successful build did not exit 0.'
+        Assert-True ($result.Output -match 'BUILD SUCCEEDED') 'Success was not reported.'
+        Assert-True ($result.Output -match 'MUXControls\.amd64chk\.binlog') 'Binary log path was not reported on success.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A failed build is reported as a failure even when it exits 0' {
+    # The bug this wrapper exists for: build.cmd loses the failing exit code.
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_OUTPUT = 'ERROR: buildSolution for MUXControls.sln FAILED.  Binlog is here: BuildOutput\x.binlog'
+    $env:AGENTBUILD_TEST_EXIT = '0'
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A failed build was reported as success.'
+        Assert-True ($result.Output -match 'BUILD FAILED') 'Failure was not reported.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A compiler diagnostic is treated as a failure even when the build exits 0' {
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_OUTPUT = 'foo.cpp(12): error C3859: Failed to create virtual memory for PCH'
+    $env:AGENTBUILD_TEST_EXIT = '0'
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A compiler error was reported as success.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A non-zero build exit code is reported as a failure' {
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_EXIT = '7'
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A non-zero exit code was not reported as failure.'
+        Assert-True ($result.Output -match 'exit code 7') 'The underlying exit code was not surfaced.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A crash that produces no binary log is reported as a failure' {
+    # An MSBuild access violation returns a negative code, which build.cmd's own
+    # "if ERRORLEVEL 1" check does not catch, so nothing is printed.
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_BINLOG = '0'
+    $env:AGENTBUILD_TEST_EXIT = '0'
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A crash with no binary log was reported as success.'
+        Assert-True ($result.Output -match 'crashed') 'The crash was not explained.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A /fake build succeeds without producing a binary log' {
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_BINLOG = '0'
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root -Arguments @{ BuildArguments = @('/fake') }
+        Assert-Equal 0 $result.ExitCode 'A dry run was reported as a failure.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+# --- Initialization ------------------------------------------------------------------------
+
+Test-Case 'First-time initialization runs automatically before the build' {
+    Reset-StubBehavior
+    $root = New-StubRepo   # deliberately not initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-True (Test-Path -LiteralPath (Join-Path $root 'init-was-run.txt')) 'Initialization did not run.'
+        Assert-Equal 0 $result.ExitCode 'Build after automatic initialization did not succeed.'
+        Assert-True ($null -ne (Get-RecordedInvocation -Root $root)) 'The build did not run after initialization.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'Initialization is skipped when the repository is already initialized' {
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        Invoke-Wrapper -Root $root | Out-Null
+        Assert-True (-not (Test-Path -LiteralPath (Join-Path $root 'init-was-run.txt'))) 'Initialization ran unnecessarily.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A failed initialization stops before the build runs' {
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_INIT_FAIL = '1'
+    $root = New-StubRepo
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A failed initialization did not fail the command.'
+        Assert-True ($null -eq (Get-RecordedInvocation -Root $root)) 'The build ran despite a failed initialization.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'SkipInitialize fails fast on an uninitialized repository' {
+    Reset-StubBehavior
+    $root = New-StubRepo
+    try {
+        $result = Invoke-Wrapper -Root $root -Arguments @{ SkipInitialize = $true }
+        Assert-Equal 1 $result.ExitCode 'SkipInitialize did not fail on an uninitialized repository.'
+        Assert-True (-not (Test-Path -LiteralPath (Join-Path $root 'init-was-run.txt'))) 'SkipInitialize still ran initialization.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+# --- Argument handling ---------------------------------------------------------------------
+
+Test-Case 'The build runs from a repository path containing a space' {
+    Reset-StubBehavior
+    $root = New-StubRepo -WithSpaceInPath
+    try {
+        Assert-True ($root -match ' ') 'The test repository path has no space in it.'
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 0 $result.ExitCode 'A path containing a space failed the build.'
+        Assert-True (Test-Path -LiteralPath (Join-Path $root 'init-was-run.txt')) 'Initialization did not run from a spaced path.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'Target and flavor are forwarded to the build' {
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        Invoke-Wrapper -Root $root -Arguments @{ Target = 'mux'; Flavor = 'arm64fre' } | Out-Null
+        $invocation = Get-RecordedInvocation -Root $root
+        Assert-True ($invocation -match '^arm64fre\|') "Flavor was not forwarded. Got '$invocation'."
+        Assert-True ($invocation -match '\bmux\b') "Target was not forwarded. Got '$invocation'."
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'The default target is not passed as an argument' {
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        Invoke-Wrapper -Root $root | Out-Null
+        $invocation = Get-RecordedInvocation -Root $root
+        Assert-True ($invocation -notmatch 'prodtest') "The default target was passed explicitly. Got '$invocation'."
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'Builds are quiet by default and detailed on request' {
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        Invoke-Wrapper -Root $root | Out-Null
+        $quiet = Get-RecordedInvocation -Root $root
+        Assert-True ($quiet -match '/q') "Quiet mode was not requested by default. Got '$quiet'."
+
+        Invoke-Wrapper -Root $root -Arguments @{ Detailed = $true } | Out-Null
+        $detailed = Get-RecordedInvocation -Root $root
+        Assert-True ($detailed -notmatch '/q') "-Detailed still requested quiet mode. Got '$detailed'."
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'Extra build arguments are forwarded' {
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        Invoke-Wrapper -Root $root -Arguments @{ BuildArguments = @('/c', '/b') } | Out-Null
+        $invocation = Get-RecordedInvocation -Root $root
+        Assert-True ($invocation -match '/c') "'/c' was not forwarded. Got '$invocation'."
+        Assert-True ($invocation -match '/b') "'/b' was not forwarded. Got '$invocation'."
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'A directory that is not a repository is reported clearly' {
+    Reset-StubBehavior
+    $root = Join-Path ([IO.Path]::GetTempPath()) "notarepo$([guid]::NewGuid().Guid.Substring(0,8))"
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A missing build script did not fail the command.'
+        Assert-True ($result.Output -match 'not found') 'The missing script was not named.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+# --- Public guidance -------------------------------------------------------------------------
+
+Test-Case 'AGENTS.md documents the wrapper and the unreliable exit code' {
+    $agents = Join-Path $repoRoot 'AGENTS.md'
+    Assert-True (Test-Path -LiteralPath $agents) 'AGENTS.md is missing from the repository root.'
+    $content = Get-Content -LiteralPath $agents -Raw
+    Assert-True ($content -match 'Invoke-AgentBuild\.ps1') 'AGENTS.md does not mention the build wrapper.'
+    Assert-True ($content -match 'exit with code') 'AGENTS.md does not warn about the unreliable exit code.'
+}
+
+Test-Case 'Copilot instructions point at AGENTS.md and the build skill' {
+    $instructions = Join-Path $repoRoot '.github\copilot-instructions.md'
+    Assert-True (Test-Path -LiteralPath $instructions) 'copilot-instructions.md is missing.'
+    $content = Get-Content -LiteralPath $instructions -Raw
+    Assert-True ($content -match 'AGENTS\.md') 'copilot-instructions.md does not reference AGENTS.md.'
+    Assert-True ($content -match 'skills/build/SKILL\.md') 'copilot-instructions.md does not reference the build skill.'
+}
+
+Test-Case 'Public guidance contains no internal feed or credential instructions' {
+    $files = @(
+        (Join-Path $repoRoot 'AGENTS.md'),
+        (Join-Path $repoRoot '.github\copilot-instructions.md'),
+        (Join-Path $repoRoot '.github\skills\build\SKILL.md')
+    )
+    foreach ($file in $files) {
+        $content = Get-Content -LiteralPath $file -Raw
+        foreach ($term in @('pkgs.visualstudio.com', 'personal access token', 'install-bt')) {
+            if ($content -match [regex]::Escape($term)) {
+                throw "$(Split-Path $file -Leaf) references internal-only '$term'."
+            }
+        }
+    }
+}
+
+Test-Case 'Guidance does not reference script options that were never added' {
+    # -EnsureInitialized belonged to an earlier approach that modified initrun.ps1.
+    # Those script changes are no longer made, so the option must not be documented.
+    $files = @(
+        (Join-Path $repoRoot 'AGENTS.md'),
+        (Join-Path $repoRoot '.github\copilot-instructions.md'),
+        (Join-Path $repoRoot '.github\skills\build\SKILL.md')
+    )
+    foreach ($file in $files) {
+        $content = Get-Content -LiteralPath $file -Raw
+        if ($content -match 'EnsureInitialized') {
+            throw "$(Split-Path $file -Leaf) documents -EnsureInitialized, which does not exist."
+        }
+    }
+}
+
+Test-Case 'The wrapper never writes to the repository build scripts' {
+    $wrapperContent = Get-Content -LiteralPath $wrapper -Raw
+    foreach ($guard in @('Set-Content', 'Out-File', 'Add-Content')) {
+        if ($wrapperContent -match "$guard[^\r\n]*(Build\.cmd|init\.cmd|initrun\.ps1)") {
+            throw "The wrapper writes to a repository build script using $guard."
+        }
+    }
+}
+
+# --- Summary -----------------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host "Passed: $script:Passed" -ForegroundColor Green
+if ($script:Failed -gt 0) {
+    Write-Host "Failed: $script:Failed" -ForegroundColor Red
+    Write-Host ''
+    foreach ($failure in $script:Failures) { Write-Host "  $failure" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host 'All tests passed.' -ForegroundColor Green
+exit 0

--- a/.github/skills/build/tests/AgentBuild.Tests.ps1
+++ b/.github/skills/build/tests/AgentBuild.Tests.ps1
@@ -219,6 +219,35 @@ Test-Case 'A crash that produces no binary log is reported as a failure' {
     finally { Remove-StubRepo $root }
 }
 
+Test-Case 'A missing package error tells the caller to initialize instead of changing code' {
+    Reset-StubBehavior
+    $env:AGENTBUILD_TEST_OUTPUT = 'foo.vcxproj : error : This project references NuGet package(s) that are missing on this computer. The missing file is packages\Microsoft.Foo\build\Microsoft.Foo.props'
+    $env:AGENTBUILD_TEST_EXIT = '0'
+    $root = New-StubRepo -Initialized
+    try {
+        $result = Invoke-Wrapper -Root $root
+        Assert-Equal 1 $result.ExitCode 'A missing package error was reported as success.'
+        Assert-True ($result.Output -match 'init\.cmd') 'The failure did not tell the caller to initialize.'
+        Assert-True ($result.Output -match 'rather than a code error') 'The failure did not distinguish missing packages from a code error.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
+Test-Case 'The build runs in a fresh process with no inherited build environment' {
+    # An agent runs each command in a new process, so nothing set by a previous init
+    # survives. The wrapper must work when launched with no build environment at all.
+    Reset-StubBehavior
+    $root = New-StubRepo -Initialized
+    try {
+        $powershell = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+        $output = & $powershell -NoProfile -ExecutionPolicy Bypass -File $wrapper -RepoRoot $root 2>&1 | Out-String
+        $exit = $LASTEXITCODE
+        Assert-Equal 0 $exit "A build in a fresh process failed. Output: $output"
+        Assert-True ($output -match 'BUILD SUCCEEDED') 'A build in a fresh process did not report success.'
+    }
+    finally { Remove-StubRepo $root }
+}
+
 Test-Case 'A /fake build succeeds without producing a binary log' {
     Reset-StubBehavior
     $env:AGENTBUILD_TEST_BINLOG = '0'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md
+
+Guidance for AI agents working in the WinUI repository. This file is the canonical
+source; `.github/copilot-instructions.md` and `.github/skills/build/SKILL.md` point here.
+
+## Build the repository
+
+Run this from the repository root. It initializes the repository on first use, runs the
+build, and returns a non-zero exit code if the build fails:
+
+```powershell
+.\.github\skills\build\Invoke-AgentBuild.ps1
+```
+
+Useful variations:
+
+```powershell
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Target mux       # Microsoft.UI.Xaml.dll only
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Target product   # product code, no tests
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Flavor arm64fre  # different flavor
+.\.github\skills\build\Invoke-AgentBuild.ps1 -Detailed         # full build output
+```
+
+Allow at least **300 seconds**, and treat over an hour as normal for a first full build.
+
+### Why not call `build.cmd` directly
+
+The underlying command is:
+
+```powershell
+.\initrun.ps1 .\build.cmd /q
+```
+
+That works, and it is the right command to give a person. It is a poor fit for an
+unattended agent for two reasons:
+
+- It requires a full `init.cmd` to have been run at least once, and fails in a way that
+  looks like a code error when it has not.
+- **`build.cmd` can exit with code `0` after a failed build**, because the failing exit
+  code is not preserved on the way out of the script. An agent that trusts the exit code
+  will continue on a broken tree.
+
+`Invoke-AgentBuild.ps1` wraps those scripts without modifying them. It initializes on
+first use and derives the real result from the build output and the binary log, so the
+exit code can be trusted. It prints the binary log path on success and on failure.
+
+## Recovery policy
+
+When a build fails, apply only these bounded steps. Do not ask the user to run commands,
+and never repeat the same failing command indefinitely:
+
+1. Missing tools, packages, or restore outputs — run `.\init.cmd <flavor>` once, then retry.
+2. `C3859` or `C1076` (precompiled header memory) — retry once with `-BuildArguments /b`.
+3. `C1853` (stale precompiled header) — retry once with `-BuildArguments '/c','/b'`.
+4. `MSB4217` task host exit, or a following `MSB4027` — retry once with `-BuildArguments /m:1`.
+5. Anything else — stop, and report the failing project, the error, and the binary log path.
+
+Never report success from a smaller build than the one you were asked for. A plain
+"build the repo" request succeeds only when the full default build succeeds.
+
+## What to build after a change
+
+| Files changed in | Build |
+|---|---|
+| `dxaml/xcp/**` | `.\initrun.ps1 msb /q "dxaml\xcp\dxaml\dllsrv\winrt\native\Microsoft.ui.xaml.vcxproj"` |
+| `controls/dev/**`, `controls/idl/**` | `.\initrun.ps1 msb /q "controls\dev\dll\Microsoft.UI.Xaml.Controls.vcxproj"` |
+| `dxaml/test/native/external/<area>/**` | `.\initrun.ps1 msb /q "dxaml\test\native\external\<area>\Microsoft.UI.Xaml.Tests.External.<Area>.vcxproj"` |
+| `.vcxproj`, `.vcxitems`, `.props`, `.targets`, NuGet dependencies | Full build |
+| `src/XamlCompiler/BuildTasks/**/*.tt` | `.\initrun.ps1 msb /q /t:TransformAll "src\XamlCompiler\Microsoft.UI.Xaml.Markup.Compiler.csproj"`, then a full build |
+| Several areas, or unsure | Full build |
+
+## Flavors
+
+`amd64chk` (default), `amd64fre`, `x86chk`, `x86fre`, `arm64chk`, `arm64fre`.
+`chk` is debug, `fre` is release.
+
+## Terminology
+
+**MUX** is `Microsoft.UI.Xaml.dll`, the core XAML runtime. It is not
+`Microsoft.UI.Xaml.Controls.dll`.
+
+## More detail
+
+- Build targets, flags, and troubleshooting: [`.github/skills/build/SKILL.md`](.github/skills/build/SKILL.md)
+- Running tests on a VM: `.github/skills/test-on-vm/SKILL.md`, when present.
+
+Some skills referenced by internal documentation, such as fast incremental builds, depend
+on tooling that is only available in internal clones. When the matching skill file is not
+present in the repository, ignore it and use the commands above.


### PR DESCRIPTION
## Summary

Makes "clone the repo and build it" work end to end for an AI agent on a clean public GitHub clone, without the user running setup or build commands by hand.

Delivered **without modifying any existing file**. The earlier edits to `Build.cmd`, `init.cmd`, `initrun.ps1` and `scripts/init/Invoke-CmdScript.ps1` are reverted and are byte-identical to `main`; a wrapper calls them instead of changing them, so official builds are unaffected.

## Changes

- **Trustworthy build results.** Adds `.github/skills/build/Invoke-AgentBuild.ps1`. Since `build.cmd` can exit `0` after a failed build, the wrapper derives the real outcome from the failure markers `Build.cmd` prints, compiler diagnostics, and whether a binary log was produced. Reports the binary log path either way.
- **Automatic initialization.** Initializes on first use, reusing the signal `init.cmd /envcheck` uses, so a build is one self-contained command that doesn't depend on a shell session surviving between commands.
- **Restore problems aren't mistaken for code errors.** A partial restore is reported without an MSBuild error code, so such a build could exit `0` and look successful. Missing packages or tools now fail, and the wrapper says the repo needs initializing.
- **Guidance in the repo.** Adds `AGENTS.md` at the root, `.github/copilot-instructions.md` linking to it, and `.github/skills/build/SKILL.md` covering targets, flags, recovery and troubleshooting. No PAT, internal feed or host instructions.

Building is now one command, safe to run unattended:

```powershell
.\.github\skills\build\Invoke-AgentBuild.ps1
```

## Validation

Verified against a real build on a clean clone, not only against the test stub:

- **An agent built the repository unattended.** Given only "clone this repository and build it", a Copilot CLI session discovered `AGENTS.md` on its own and ran `Invoke-AgentBuild.ps1` for the full default target without being told the command. Build succeeded, `amd64chk`, 27:01.
- **The failure this exists for, reproduced.** With a deliberate syntax error, `initrun.ps1 build.cmd /q mux` printed `error C2059` and `ERROR: buildSolution ... FAILED`, then **exited `0`**. The wrapper, on the same tree, reported `BUILD FAILED` and exited `1`.

Running it for real found three defects the stub could not: initialization aborted when `git` wrote progress to stderr; the recovery policy advised `/m:1`, which `Build.cmd` rejects; and a failed probe for an optional tool failed a 43 minute build that had produced every binary log.

`.github/skills/build/tests/AgentBuild.Tests.ps1` — **26 tests, all passing** — covers failures despite an exit code of `0`, compiler diagnostics, missing packages, stderr progress, failed tool probes, a stubbed MSBuild crash (`-1073741819`), automatic initialization, argument forwarding and paths containing spaces. It runs against a stub repository, so it is fast enough to run on every change.

The four build scripts are byte-identical to `main`, with a test asserting the wrapper never writes to them.
