### PR TITLE
CUIElement::TransformToElementCoordinateSpaceThroughViewports: report an invalid viewport for non-invertible transforms

### DIFF
--- a/dxaml/test/native/external/framework/layout/LayoutManagerIntegrationTests.cpp
+++ b/dxaml/test/native/external/framework/layout/LayoutManagerIntegrationTests.cpp
@@ -372,6 +372,93 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         TestServices::WindowHelper->WaitForIdle();
     }
 
+    void LayoutManagerIntegrationTests::ValidateEffectiveViewportChangedWithNonInvertibleTransform()
+    {
+        TestCleanupWrapper cleanup;
+        TestServices::WindowHelper->SetWindowSizeOverride(wf::Size(400, 400));
+
+        ViewportUserControl^ vuc = nullptr;
+        ScaleTransform^ scale = nullptr;
+        Border^ b = nullptr;
+        bool sawInvalidViewport = false;
+        bool sawFiniteViewport = false;
+
+        auto eventReg = CreateSafeEventRegistration(xaml::FrameworkElement, EffectiveViewportChanged);
+
+        LOG_OUTPUT(L"Build a viewport whose content is scaled by a non-zero factor.");
+        RunOnUIThread([&]()
+        {
+            b = ref new Border;
+            b->Height = 50;
+            b->Background = ref new SolidColorBrush(Microsoft::UI::Colors::Red);
+
+            scale = ref new ScaleTransform;
+            scale->ScaleX = 1.0;
+            scale->ScaleY = 1.0;
+
+            auto content = ref new Grid;
+            content->RenderTransform = scale;
+            content->Children->Append(b);
+
+            vuc = ref new ViewportUserControl;
+            vuc->Width = 100;
+            vuc->Height = 100;
+            vuc->Content = content;
+
+            auto g = ref new Grid;
+            g->Children->Append(vuc);
+            TestServices::WindowHelper->WindowContent = g;
+
+            eventReg.Attach(
+                safe_cast<xaml::FrameworkElement^>(b),
+                ref new wf::TypedEventHandler<xaml::FrameworkElement^, xaml::EffectiveViewportChangedEventArgs^>(
+                    [&](Platform::Object^ sender, xaml::EffectiveViewportChangedEventArgs^ e)
+            {
+                if (std::isinf(e->EffectiveViewport.Width))
+                {
+                    sawInvalidViewport = true;
+                }
+                else
+                {
+                    sawFiniteViewport = true;
+                }
+            }));
+        });
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_TRUE(sawFiniteViewport);
+
+        // A ScaleY of 0 is singular, so the global -> local conversion in the viewport walk has no
+        // inverse. Before the guard this failed the whole layout pass instead of reporting a viewport.
+        LOG_OUTPUT(L"Scale the content to 0 and run the viewport walk.");
+        sawInvalidViewport = false;
+        sawFiniteViewport = false;
+        RunOnUIThread([&]()
+        {
+            scale->ScaleY = 0.0;
+            InvalidateViewportHelper::InvalidateViewport(vuc);
+        });
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_TRUE(sawInvalidViewport);
+        VERIFY_IS_FALSE(sawFiniteViewport);
+
+        // The walk must also recover: a failed pass that leaves the viewport dirty flags inconsistent
+        // stops the target from ever being visited again.
+        LOG_OUTPUT(L"Restore the scale and verify the target is still served by the walk.");
+        sawInvalidViewport = false;
+        sawFiniteViewport = false;
+        RunOnUIThread([&]()
+        {
+            scale->ScaleY = 1.0;
+            InvalidateViewportHelper::InvalidateViewport(vuc);
+        });
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_TRUE(sawFiniteViewport);
+        VERIFY_IS_FALSE(sawInvalidViewport);
+    }
+
     void LayoutManagerIntegrationTests::ThrowsExceptionOnInvalidateViewportForNonScrollers()
     {
         TestCleanupWrapper cleanup;

--- a/dxaml/test/native/external/framework/layout/LayoutManagerIntegrationTests.h
+++ b/dxaml/test/native/external/framework/layout/LayoutManagerIntegrationTests.h
@@ -33,6 +33,10 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
                 TEST_METHOD_PROPERTY(L"Description", L"Validates that the EffectiveViewportChanged event can be unregistered correctly.")
             END_TEST_METHOD()
 
+            BEGIN_TEST_METHOD(ValidateEffectiveViewportChangedWithNonInvertibleTransform)
+                TEST_METHOD_PROPERTY(L"Description", L"Validates that a non-invertible transform reports an invalid viewport instead of failing the layout pass.")
+            END_TEST_METHOD()
+
             BEGIN_TEST_METHOD(ThrowsExceptionIfLayoutIsInvalidatedDuringViewportWalk)
                 TEST_METHOD_PROPERTY(L"Description", L"Validates that the IsViewport override cannot be used to invalidate layout.")
             END_TEST_METHOD()

--- a/dxaml/xcp/core/core/elements/uielement.cpp
+++ b/dxaml/xcp/core/core/elements/uielement.cpp
@@ -4731,6 +4731,23 @@ CUIElement::TransformToGlobalCoordinateSpaceThroughViewports(
     return S_OK;
 }
 
+// Empty rect at +/-infinity: the effective viewport walk's "no usable viewport" sentinel.
+static void SetRectToInvalidViewport(_Out_ XRECTF& rect)
+{
+    rect.X = rect.Y = std::numeric_limits<float>::infinity();
+    rect.Width = rect.Height = -std::numeric_limits<float>::infinity();
+}
+
+// False only for a singular 2D transform (e.g. an animated 0 scale); the same determinant gate Invert uses.
+static bool ViewportTransformIsInvertible(_In_ CGeneralTransform* transform)
+{
+    auto* t = do_pointer_cast<CTransform>(transform);
+    if (!t) { return true; }
+    CMILMatrix mat;
+    t->GetTransform(&mat);
+    return mat.GetDeterminant() != 0.0f;
+}
+
 _Check_return_ HRESULT
 CUIElement::TransformToElementCoordinateSpaceThroughViewports(
     _In_ const std::vector<TransformToPreviousViewport>& transformsToViewports,
@@ -4751,12 +4768,23 @@ CUIElement::TransformToElementCoordinateSpaceThroughViewports(
         IFC_RETURN(TransformToVisual(transformsToViewports.back().GetElement(), &transform));
     }
 
+    // A non-invertible transform in the chain has no global -> local conversion; report the sentinel.
     XRECTF transformedRect = {};
     for (const auto& transformToViewport : transformsToViewports)
     {
+        if (!ViewportTransformIsInvertible(transformToViewport.GetTransform()))
+        {
+            SetRectToInvalidViewport(rect);
+            return S_OK;
+        }
         IFC_RETURN(transformToViewport.GetTransform()->TransformRectInverse(rect, &transformedRect));
         rect = transformedRect;
         transformedRect = {};
+    }
+    if (!ViewportTransformIsInvertible(transform))
+    {
+        SetRectToInvalidViewport(rect);
+        return S_OK;
     }
     IFC_RETURN(transform->TransformRectInverse(rect, &transformedRect));
     rect = transformedRect;
@@ -4821,8 +4849,7 @@ CUIElement::ComputeEffectiveViewportChangedEventArgsAndNotifyLayoutManager(
     {
         // If the effective viewport is invalid in at least one direction,
         // it results in an empty rect.
-        ev.X = ev.Y = std::numeric_limits<float>::infinity();
-        ev.Width = ev.Height = -std::numeric_limits<float>::infinity();
+        SetRectToInvalidViewport(ev);
     }
 
     XRECTF mv = { 0.0f, 0.0f, 0.0f, 0.0f };
@@ -4839,8 +4866,7 @@ CUIElement::ComputeEffectiveViewportChangedEventArgsAndNotifyLayoutManager(
     {
         // By design, the max viewport should never be an invalid rect.
         ASSERT(false);
-        mv.X = mv.Y = std::numeric_limits<float>::infinity();
-        mv.Width = mv.Height = -std::numeric_limits<float>::infinity();
+        SetRectToInvalidViewport(mv);
     }
 
     float dx = 0.0f;


### PR DESCRIPTION
Description:  
An element listening to EffectiveViewportChanged under a transform animated through a 0 scale takes down the layout pass. With no explicit UpdateLayout the frame loop has nobody to return the failure to and the process fail-fasts with 0xC000027B.

A ScaleTransform sweeping ScaleX/ScaleY through 0 during a grow/shrink storyboard is enough. ItemsRepeater subscribes internally, so no app-authored handler is needed.

Root cause:  
The viewport walk converts the viewport from global to element-local coordinates by inverting every transform in the chain. CUIElement::TransformToElementCoordinateSpaceThroughViewports calls CGeneralTransform::TransformRectInverse, which reaches CTransform::TransformPoints(fInverse=true) -> CMILMatrix::Invert().

A 0 scale is singular, Invert() returns false and transform.cpp:20 turns that into E_FAIL.

Nothing between there and CLayoutManager::UpdateLayout handles it.

```
FRAME N - ScaleY through 0

  CLayoutManager::UpdateLayout                      layout/LayoutManager.cpp:382
  +- CUIElement::EffectiveViewportWalk              components/elements/UIElementLayout.cpp:397
       +- ComputeEffectiveViewportChangedEventArgsAndNotifyLayoutManager
       |                                            core/elements/uielement.cpp:4712
       |    +- TransformToElementCoordinateSpaceThroughViewports
       |         +- CGeneralTransform::TransformRectInverse
       |              core/elements/transforms.cpp:286
       |              +- CTransform::TransformPoints(fInverse=true)
       |                   core/elements/transform.cpp:16
       |                   if (!mat.Invert()) IFC_RETURN(E_FAIL)   <- singular
       |
       |    before: E_FAIL propagates out of the walk
       |            explicit UpdateLayout -> 0x80004005
       |            frame loop            -> no caller, fail-fast 0xC000027B
       |    after:  SetRectToInvalidViewport(rect), return S_OK
       |
       +- the walk clears its dirty flags at UIElementLayout.cpp:415-417

```

Non-invertible is an expected data condition everywhere else in XAML and every peer path already absorbs it. 

Fix:  
Handle a failed inverse the way TransformGlobalToLocal does, and report the invalid-viewport sentinel.

SetRectToInvalidViewport names the +/-infinity empty rect .
The sentinel is required over {0,0,0,0}, which a virtualizer reads as a valid empty viewport at the origin rather than no intersection.

Behavior:  
Invertible transforms are untouched. The reported viewport is byte-identical to main for rotate, skew, translate, TransformGroup, nested viewports, negative scale and a 1e-7 scale that is tiny but still invertible.

A singular frame reports the invalid viewport instead of failing, and the walk recovers once the transform is invertible again.

Testing:  
Repro'd locally in a WinUI 3 app across 18 cases, main against the fix, one process per case.

On main ScaleX/ScaleY of 0 returns 0x80004005 through UpdateLayout at both call sites, the transformsToViewports loop and the final transform. 

The animated and purely frame-driven cases exit 0xC000027B, and ItemsRepeater realization freezes at 28 containers. All pass with the fix and the repeater grows to 43.

Starvation is measured directly. After one failure, 10 further arranges with a restored ScaleY of 1 produce 0 EffectiveViewportChanged events on main and 10 with the fix.

Added LayoutManagerIntegrationTests::ValidateEffectiveViewportChangedWithNonInvertibleTransform, asserting a finite viewport, then an infinite extent while ScaleY is 0, then a finite viewport again after restoring it. 

The last assertion is what covers the starvation path. It uses the existing ViewportUserControl and InvalidateViewportHelper pattern from ValidateEffectiveViewportChangedUnregistration.