### PR TITLE
Guard island input site lookup during shutdown

### DIFF
--- a/dxaml/xcp/core/core/elements/depends.cpp
+++ b/dxaml/xcp/core/core/elements/depends.cpp
@@ -316,7 +316,7 @@ wrl::ComPtr<InputSiteHelper::IIslandInputSite> CDependencyObject::GetElementIsla
             return spPopup->GetIslandInputSite();
         }
 
-        if (coreServices->HasXamlIslandRoots())
+        if (coreServices && coreServices->HasXamlIslandRoots())
         {
             // If this element is in a XamlIslandRoot tree, return the IslandInputSite for that island.
             auto root = coreServices->GetRootForElement(this);
@@ -329,7 +329,18 @@ wrl::ComPtr<InputSiteHelper::IIslandInputSite> CDependencyObject::GetElementIsla
     }
 
     // By default, return the primary IslandInputSite that was registered with InputServices on startup.
-    return coreServices->GetInputServices()->GetPrimaryRegisteredIslandInputSite();
+    // During shutdown the core services or the input services may already be torn down, in which case
+    // there is no island input site to return. Callers already treat a null result as "no input site" -
+    // see the _In_opt_ contract on CInputServices::GetUnderlyingInputHwndFromIslandInputSite.
+    if (coreServices)
+    {
+        if (auto inputServices = coreServices->GetInputServices())
+        {
+            return inputServices->GetPrimaryRegisteredIslandInputSite();
+        }
+    }
+
+    return nullptr;
 }
 
 HWND CDependencyObject::GetElementPositioningWindow()


### PR DESCRIPTION
## Fixes

Fixes #11653

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Carries forward @jonwis's fix from #11063, rebased onto the current `dxaml/` layout (that PR still patches the old `src/dxaml/...` path, so it no longer applies). Credit for the diagnosis and the fix is his — I hit the same crash independently and he [suggested](https://github.com/microsoft/microsoft-ui-xaml/pull/11063#issuecomment-5345985100) opening a fresh issue and PR to move it to completion.

`CDependencyObject::GetElementIslandInputSite()` dereferenced the result of `CCoreServices::GetInputServices()` without a null check:

```cpp
return coreServices->GetInputServices()->GetPrimaryRegisteredIslandInputSite();
```

During framework shutdown the input services are already gone, so this runs `GetPrimaryRegisteredIslandInputSite()` on a null `this` and faults while reading `m_islandInputSiteRegistrations`. Tearing down a focused `TextBox` reaches it via `CTextBoxBase::Destroy` → the RichEdit gripper code → `TextServicesHost::TxGetWindow`.

This PR null-checks core services and input services and returns `nullptr` instead. It also adds the matching `coreServices &&` guard on the `HasXamlIslandRoots()` call above, as in the original PR.

Returning null is safe because it is already the contract: every caller of `GetElementIslandInputSite()` funnels the result into `CInputServices::GetUnderlyingInputHwndFromIslandInputSite()`, which is declared `_In_opt_` and null-checks its argument before use. `GetPrimaryRegisteredIslandInputSite()` itself already returns `nullptr` when no island input sites are registered, so callers must handle null regardless.

### Current Behavior

Closing a window while a `TextBox` has focus crashes the process with `0xC0000005` inside `Microsoft.UI.Xaml.dll` during shutdown. Reproduces 3/3 on 1.7.260224002, 1.8.260317003, 1.8.260804001 and 2.4.0 (details and a minimal repro in the linked issue).

### New Behavior

The lookup returns `nullptr` when there is no input site left to return, callers treat that as "no input hwnd" as they already do, and the app exits cleanly with exit code 0.

## Customer Impact

User-facing. Any app that leaves a text input focused when the window closes currently dies with an access violation instead of exiting cleanly. It is invisible to the user mid-session but logs an Application Error / WER crash on every exit, drowning real crashes in telemetry and breaking any work that depends on a clean shutdown.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The change only alters behaviour on paths that dereference a null pointer today, i.e. paths that currently crash. When core services and input services are alive the behaviour is byte-for-byte identical.

One caveat carried over from #11063: @jonwis noted that all callsites handle a null return **except** DirectManipulation. The DManip path goes through `CInputServices::GetIslandInputSiteRegistrationForUIElement()`, which `FAIL_FAST_IF`s on a missing registration but does not call `GetElementIslandInputSite()`, so it is not reached by this change. Worth a second pair of eyes from someone who owns that area.

## Testing

I tried to validate this with a local build and could not get there. `init.cmd amd64chk` completes fine, but `build.cmd mux /i amd64chk` fails in `XamlCompilerPrerequisites.sln` with `MSB8040` — Spectre-mitigated libraries are required — for `manifest.vcxproj`, `gencompheadersandidl.vcxproj` and `genmrtheadersandidl.vcxproj`. Neither toolset on this machine ships them (VS 2022 14.44 or VS 2026 14.51), and setting `SpectreMitigation=false` in the environment does not override it for those three projects even though `eng/common.props` guards the property. Two notes in passing, in case they are useful: the build selected the VS 2026 MSBuild while `OneTimeSetup.cmd` is documented as assuming VS 2022, and `GettingStarted.md` says CI builds are not supported yet, so I do not know whether this PR gets an automated build.

So to be clear about what is and is not verified: the change is a null check applied to the current source and checked by reading every caller, not by compiling. Happy to install the `.vsconfig` components and retry if you would like a local build result before this merges.

Verified against shipped binaries that the bug is still live and that the behaviour is exactly what the guard addresses:

| Scenario (Windows App SDK 2.4.0) | Result |
|---|---|
| Repro app, `TextBox` focused at close | 3/3 crash, `0xC0000005` |
| Repro app, `TextBox` never focused | 3/3 clean exit (0) |
| Repro app, focus moved off the input in `AppWindow.Closing` | 3/3 clean exit (0) |
