### PR TITLE
[WinUI OSS] Fix GitHub static test package restore

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
@@ -31,26 +31,26 @@ jobs:
       gci env:* | sort-object name
     displayName: Display build machine environment variable
 
-  # Authenticate to NuGet feeds used by this pipeline (WinUI.Dependencies has nuget.org as an upstream source,
-  # so public releases are available through it without direct nuget.org access)
+  # Fork PRs must not authenticate to private package feeds.
   - task: NuGetAuthenticate@1
-    displayName: 'NuGet Authenticate'
+    displayName: 'Authenticate to WinUI.Dependencies'
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
 
   # In this pipeline configuration, 'NuGetCommand' is ambiguous so the specific task guid must be used instead
   # See known NuGet task issue notes.
-  # The latest public release is resolved via the WinUI.Dependencies feed (which has nuget.org as an upstream)
-  # The package is installed into a temp directory to ensure it doesn't get used elsewhere for a build
+  # The pinned public release is installed into a temp directory to ensure it isn't used elsewhere for a build.
   - task: NuGetCommand@2
-    displayName: 'NuGet install Microsoft.WindowsAppSDK'
+    displayName: 'NuGet install Microsoft.WindowsAppSDK 2.4.0'
     inputs:
       command: 'custom'
-      arguments: 'install Microsoft.WindowsAppSDK -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config'
+      arguments: 'install Microsoft.WindowsAppSDK -Version 2.4.0 -DependencyVersion Lowest -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config -NonInteractive'
 
   - task: NuGetCommand@2
-    displayName: 'NuGet install WinMDVersionVerifyLcr'
+    displayName: 'NuGet install WinMDVersionVerifyLcr 1.0.2'
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     inputs:
       command: 'custom'
-      arguments: 'install WinMDVersionVerifyLcr -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config'
+      arguments: 'install WinMDVersionVerifyLcr -Version 1.0.2 -DependencyVersion Ignore -Source "$(WinUILKGDependenciesFeedUri)" -OutputDirectory $(packagesDir) -NonInteractive'
 
   - template: WinUI-DownloadPipelineArtifacts-Steps.yml
     parameters:
@@ -61,8 +61,14 @@ jobs:
 
   - task: powershell@2
     displayName: 'Run WinMD Compat Test'
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     inputs:
       targetType: filePath
       filePath: $(Build.SourcesDirectory)\build\PipelineScripts\VerifyWinMDCompat.ps1
       arguments: -WinMDPath '$(artifactsDir)\packaging\Release\lib\uap10.0' -PackagesDirectory '$(packagesDir)' -isRelease:$${{ parameters.MUXFinalRelease }}
       pwsh: true
+
+  - powershell: |
+      Write-Host "WinMD compatibility validation is not available for fork PRs."
+    displayName: 'Skip WinMD compatibility validation'
+    condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'True'))

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
@@ -4,7 +4,6 @@ parameters:
   runTestJobName: 'RunStaticTests'
   dependsOn: ''
   MUXFinalRelease: false
-  windowsAppSdkVersion: 'latest'
 
 jobs:
 - job: ${{ parameters.runTestJobName }}
@@ -16,14 +15,9 @@ jobs:
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
     packagesDir: $(Agent.TempDirectory)\WinUI-RunStaticTests-Job\packages
-    winMDVersionVerifyLcrVersion: 'latest'
     ob_outputDirectory: '$(Build.SourcesDirectory)\out'
     ob_sdl_codeSignValidation_excludes: '-|packaging\**;-|**\Test\**;-|**\Taef\**;-|**\TestDependencies\**;-|**\Microsoft.Internal.FrameworkUdk.dll'
     ob_sdl_prefast_enabled: false   # this job does no native build
-    ${{ if ne(parameters.windowsAppSdkVersion, 'latest') }}:
-      windowsAppSdkVersionArgument: '-Version ${{ parameters.windowsAppSdkVersion }}'
-    ${{ else }}:
-      windowsAppSdkVersionArgument: ''
 
   steps:
   # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
@@ -44,23 +38,23 @@ jobs:
 
   # In this pipeline configuration, 'NuGetCommand' is ambiguous so the specific task guid must be used instead
   # See known NuGet task issue notes.
-  # Install the latest public release by default, or the version supplied by the caller.
+  # Install the latest public release.
   - task: NuGetCommand@2
     displayName: 'NuGet install Microsoft.WindowsAppSDK'
     inputs:
       command: 'custom'
-      arguments: 'install Microsoft.WindowsAppSDK $(windowsAppSdkVersionArgument) -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config -NonInteractive'
+      arguments: 'install Microsoft.WindowsAppSDK -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config -NonInteractive'
 
   - task: DownloadPackage@1
-    displayName: 'Download WinMDVersionVerifyLcr $(winMDVersionVerifyLcrVersion)'
+    displayName: 'Download latest WinMDVersionVerifyLcr'
     condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     inputs:
       packageType: 'nuget'
       feed: 'WinUI.Dependencies'
       definition: 'WinMDVersionVerifyLcr'
-      version: '$(winMDVersionVerifyLcrVersion)'
+      version: 'latest'
       extract: true
-      downloadPath: '$(packagesDir)\WinMDVersionVerifyLcr\$(winMDVersionVerifyLcrVersion)'
+      downloadPath: '$(packagesDir)\WinMDVersionVerifyLcr'
 
   - template: WinUI-DownloadPipelineArtifacts-Steps.yml
     parameters:
@@ -75,7 +69,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: $(Build.SourcesDirectory)\build\PipelineScripts\VerifyWinMDCompat.ps1
-      arguments: -WinMDPath '$(artifactsDir)\packaging\Release\lib\uap10.0' -PackagesDirectory '$(packagesDir)' -WinMDVersionVerifyLcrVersion '$(winMDVersionVerifyLcrVersion)' -isRelease:$${{ parameters.MUXFinalRelease }}
+      arguments: -WinMDPath '$(artifactsDir)\packaging\Release\lib\uap10.0' -PackagesDirectory '$(packagesDir)' -isRelease:$${{ parameters.MUXFinalRelease }}
       pwsh: true
 
   - powershell: |

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
@@ -16,6 +16,7 @@ jobs:
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
     packagesDir: $(Agent.TempDirectory)\WinUI-RunStaticTests-Job\packages
+    winMDVersionVerifyLcrVersion: '1.0.2'
     ob_outputDirectory: '$(Build.SourcesDirectory)\out'
     ob_sdl_codeSignValidation_excludes: '-|packaging\**;-|**\Test\**;-|**\Taef\**;-|**\TestDependencies\**;-|**\Microsoft.Internal.FrameworkUdk.dll'
     ob_sdl_prefast_enabled: false   # this job does no native build
@@ -50,12 +51,16 @@ jobs:
       command: 'custom'
       arguments: 'install Microsoft.WindowsAppSDK $(windowsAppSdkVersionArgument) -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config -NonInteractive'
 
-  - task: NuGetCommand@2
-    displayName: 'NuGet install WinMDVersionVerifyLcr 1.0.2'
+  - task: DownloadPackage@1
+    displayName: 'Download WinMDVersionVerifyLcr $(winMDVersionVerifyLcrVersion)'
     condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     inputs:
-      command: 'custom'
-      arguments: 'install WinMDVersionVerifyLcr -Version 1.0.2 -DependencyVersion Ignore -Source "$(WinUILKGDependenciesFeedUri)" -OutputDirectory $(packagesDir) -NonInteractive'
+      packageType: 'nuget'
+      feed: 'WinUI.Dependencies'
+      definition: 'WinMDVersionVerifyLcr'
+      version: '$(winMDVersionVerifyLcrVersion)'
+      extract: true
+      downloadPath: '$(packagesDir)\WinMDVersionVerifyLcr\$(winMDVersionVerifyLcrVersion)'
 
   - template: WinUI-DownloadPipelineArtifacts-Steps.yml
     parameters:
@@ -70,7 +75,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: $(Build.SourcesDirectory)\build\PipelineScripts\VerifyWinMDCompat.ps1
-      arguments: -WinMDPath '$(artifactsDir)\packaging\Release\lib\uap10.0' -PackagesDirectory '$(packagesDir)' -isRelease:$${{ parameters.MUXFinalRelease }}
+      arguments: -WinMDPath '$(artifactsDir)\packaging\Release\lib\uap10.0' -PackagesDirectory '$(packagesDir)' -WinMDVersionVerifyLcrVersion '$(winMDVersionVerifyLcrVersion)' -isRelease:$${{ parameters.MUXFinalRelease }}
       pwsh: true
 
   - powershell: |

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
@@ -16,7 +16,7 @@ jobs:
   variables:
     artifactsDir: $(Build.SourcesDirectory)\Artifacts
     packagesDir: $(Agent.TempDirectory)\WinUI-RunStaticTests-Job\packages
-    winMDVersionVerifyLcrVersion: '1.0.2'
+    winMDVersionVerifyLcrVersion: 'latest'
     ob_outputDirectory: '$(Build.SourcesDirectory)\out'
     ob_sdl_codeSignValidation_excludes: '-|packaging\**;-|**\Test\**;-|**\Taef\**;-|**\TestDependencies\**;-|**\Microsoft.Internal.FrameworkUdk.dll'
     ob_sdl_prefast_enabled: false   # this job does no native build

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Job.yml
@@ -4,6 +4,7 @@ parameters:
   runTestJobName: 'RunStaticTests'
   dependsOn: ''
   MUXFinalRelease: false
+  windowsAppSdkVersion: 'latest'
 
 jobs:
 - job: ${{ parameters.runTestJobName }}
@@ -18,6 +19,10 @@ jobs:
     ob_outputDirectory: '$(Build.SourcesDirectory)\out'
     ob_sdl_codeSignValidation_excludes: '-|packaging\**;-|**\Test\**;-|**\Taef\**;-|**\TestDependencies\**;-|**\Microsoft.Internal.FrameworkUdk.dll'
     ob_sdl_prefast_enabled: false   # this job does no native build
+    ${{ if ne(parameters.windowsAppSdkVersion, 'latest') }}:
+      windowsAppSdkVersionArgument: '-Version ${{ parameters.windowsAppSdkVersion }}'
+    ${{ else }}:
+      windowsAppSdkVersionArgument: ''
 
   steps:
   # This is a temporarily workaround to avoid getting non-fatal "folder C:\__t\NativeCompilerPrefast not found"
@@ -38,12 +43,12 @@ jobs:
 
   # In this pipeline configuration, 'NuGetCommand' is ambiguous so the specific task guid must be used instead
   # See known NuGet task issue notes.
-  # The pinned public release is installed into a temp directory to ensure it isn't used elsewhere for a build.
+  # Install the latest public release by default, or the version supplied by the caller.
   - task: NuGetCommand@2
-    displayName: 'NuGet install Microsoft.WindowsAppSDK 2.4.0'
+    displayName: 'NuGet install Microsoft.WindowsAppSDK'
     inputs:
       command: 'custom'
-      arguments: 'install Microsoft.WindowsAppSDK -Version 2.4.0 -DependencyVersion Lowest -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config -NonInteractive'
+      arguments: 'install Microsoft.WindowsAppSDK $(windowsAppSdkVersionArgument) -OutputDirectory $(packagesDir) -ConfigFile $(Build.SourcesDirectory)\nuget.config -NonInteractive'
 
   - task: NuGetCommand@2
     displayName: 'NuGet install WinMDVersionVerifyLcr 1.0.2'

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
@@ -9,8 +9,6 @@ stages:
   displayName: Run Static Tests Stage
   dependsOn: Build
   condition: not(failed())
-  variables:
-  - group: WinUI-InternalFeed
   jobs:
   - template: WinUI-RunStaticTests-Job.yml
     parameters:

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 parameters:
   MUXFinalRelease: false
+  windowsAppSdkVersion: 'latest'
 
 stages:
 - stage: RunStaticTests
@@ -13,3 +14,4 @@ stages:
     parameters:
       runTestJobName: RunStaticTests
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+      windowsAppSdkVersion: ${{ parameters.windowsAppSdkVersion }}

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
@@ -9,6 +9,8 @@ stages:
   displayName: Run Static Tests Stage
   dependsOn: Build
   condition: not(failed())
+  variables:
+  - group: WinUI-InternalFeed
   jobs:
   - template: WinUI-RunStaticTests-Job.yml
     parameters:

--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 parameters:
   MUXFinalRelease: false
-  windowsAppSdkVersion: 'latest'
 
 stages:
 - stage: RunStaticTests
@@ -14,4 +13,3 @@ stages:
     parameters:
       runTestJobName: RunStaticTests
       MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
-      windowsAppSdkVersion: ${{ parameters.windowsAppSdkVersion }}

--- a/build/PipelineScripts/VerifyWinMDCompat.ps1
+++ b/build/PipelineScripts/VerifyWinMDCompat.ps1
@@ -10,6 +10,8 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WinAppSDKWinUIVersion = "",
     [Parameter(Mandatory = $false)]
+    [string]$WinMDVersionVerifyLcrVersion = "",
+    [Parameter(Mandatory = $false)]
     [bool]$isRelease = $false
 )
 
@@ -108,7 +110,16 @@ if (-not $env:BUILD_BUILDID)
     $nugetResultCode = $?
 }
 
-$WinMDVersionVerifyLcrVersionToUse = Get-LatestVersion "WinMDVersionVerifyLcr"
+if ($WinMDVersionVerifyLcrVersion)
+{
+    $WinMDVersionVerifyLcrVersionToUse = $WinMDVersionVerifyLcrVersion
+    Write-Host "Specific WinMDVersionVerifyLcr version specified: $WinMDVersionVerifyLcrVersionToUse"
+}
+else
+{
+    $WinMDVersionVerifyLcrVersionToUse = Get-LatestVersion "WinMDVersionVerifyLcr"
+}
+
 $winMDVersionVerifyLcrPath = [System.IO.Path]::Combine($PackagesDirectory, "WinMDVersionVerifyLcr", $WinMDVersionVerifyLcrVersionToUse, "WinMDVersionVerifyLcr.exe")
 if (-not (Test-Path $winMDVersionVerifyLcrPath))
 {

--- a/build/PipelineScripts/VerifyWinMDCompat.ps1
+++ b/build/PipelineScripts/VerifyWinMDCompat.ps1
@@ -10,8 +10,6 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$WinAppSDKWinUIVersion = "",
     [Parameter(Mandatory = $false)]
-    [string]$WinMDVersionVerifyLcrVersion = "",
-    [Parameter(Mandatory = $false)]
     [bool]$isRelease = $false
 )
 
@@ -110,19 +108,10 @@ if (-not $env:BUILD_BUILDID)
     $nugetResultCode = $?
 }
 
-if ($WinMDVersionVerifyLcrVersion)
-{
-    $WinMDVersionVerifyLcrVersionToUse = $WinMDVersionVerifyLcrVersion
-    Write-Host "Specific WinMDVersionVerifyLcr version specified: $WinMDVersionVerifyLcrVersionToUse"
-}
-else
-{
-    $WinMDVersionVerifyLcrVersionToUse = Get-LatestVersion "WinMDVersionVerifyLcr"
-}
-
-$winMDVersionVerifyLcrPath = [System.IO.Path]::Combine($PackagesDirectory, "WinMDVersionVerifyLcr", $WinMDVersionVerifyLcrVersionToUse, "WinMDVersionVerifyLcr.exe")
+$winMDVersionVerifyLcrPath = [System.IO.Path]::Combine($PackagesDirectory, "WinMDVersionVerifyLcr", "WinMDVersionVerifyLcr.exe")
 if (-not (Test-Path $winMDVersionVerifyLcrPath))
 {
+    $WinMDVersionVerifyLcrVersionToUse = Get-LatestVersion "WinMDVersionVerifyLcr"
     $winMDVersionVerifyLcrPath = [System.IO.Path]::Combine($PackagesDirectory, "WinMDVersionVerifyLcr.$WinMDVersionVerifyLcrVersionToUse", "WinMDVersionVerifyLcr.exe")
 }
 

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -176,7 +176,7 @@ extends:
           failOnTestFailure: false
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml
         parameters:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
 


### PR DESCRIPTION
## Summary

Fix GitHub static-test package restoration and enable the WinMD compatibility verifier to run in OSS PR validation.

## Changes

- Restore the latest available `Microsoft.WindowsAppSDK` package and its required dependencies.
- Download the latest `WinMDVersionVerifyLcr` package for non-fork PR validation.
- Use a deterministic package directory so `VerifyWinMDCompat.ps1` can locate the verifier reliably.
- Preserve local script execution with the existing NuGet-installed package layout.
- Skip private-package authentication and WinMD compatibility validation for fork PRs.
- Load the GitHub static-test template from the PR branch.

## Validation

- Confirmed that `Microsoft.WindowsAppSDK` and its required dependency closure restore successfully.
- Confirmed that the latest `WinMDVersionVerifyLcr` package downloads successfully.
- Confirmed that `WinMDVersionVerifyLcr.exe` is found in the configured package directory and executes successfully.
- Confirmed that the modified pipeline YAML files parse successfully.
- The verifier currently reports a separately tracked Tabular API-versioning issue introduced through #11641; this is unrelated to package restoration or verifier execution.