### PR TITLE
Fix ToggleSwitch knob touching track boundary during drag

### DIFF
--- a/dxaml/test/native/external/controls/toggleswitch/ToggleSwitchIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/toggleswitch/ToggleSwitchIntegrationTests.cpp
@@ -658,11 +658,14 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         xaml_controls::ToggleSwitch^ toggleSwitch = nullptr;
         xaml::FrameworkElement^ knob = nullptr;
         xaml::FrameworkElement^ knobBounds = nullptr;
+        xaml::FrameworkElement^ knobOff = nullptr;
+        xaml::FrameworkElement^ knobOn = nullptr;
 
         RunOnUIThread([&]()
         {
             toggleSwitch = ref new xaml_controls::ToggleSwitch();
             toggleSwitch->IsOn = false;
+            toggleSwitch->HorizontalAlignment = xaml::HorizontalAlignment::Center;
             TestServices::WindowHelper->WindowContent = toggleSwitch;
         });
         TestServices::WindowHelper->WaitForIdle();
@@ -671,8 +674,12 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         {
             knob = TreeHelper::GetVisualChildByName(toggleSwitch, L"SwitchKnob");
             knobBounds = TreeHelper::GetVisualChildByName(toggleSwitch, L"SwitchKnobBounds");
+            knobOff = TreeHelper::GetVisualChildByName(toggleSwitch, L"SwitchKnobOff");
+            knobOn = TreeHelper::GetVisualChildByName(toggleSwitch, L"SwitchKnobOn");
             VERIFY_IS_NOT_NULL(knob);
             VERIFY_IS_NOT_NULL(knobBounds);
+            VERIFY_IS_NOT_NULL(knobOff);
+            VERIFY_IS_NOT_NULL(knobOn);
         });
 
         auto dragAndVerifyMargin = [&](bool isOn, int dragDeltaX)
@@ -705,29 +712,30 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
                 VERIFY_IS_TRUE(ControlHelper::IsInVisualState(toggleSwitch, L"CommonStates", L"Pressed"));
                 VERIFY_IS_TRUE(ControlHelper::IsInVisualState(toggleSwitch, L"ToggleStates", L"Dragging"));
 
-                auto transform = safe_cast<xaml_media::TranslateTransform^>(knob->RenderTransform);
-                const double knobTranslation = transform->X;
-                const double knobWidth = knob->ActualWidth;
+                auto knobVisual = isOn ? knobOn : knobOff;
+                const auto knobVisualOrigin =
+                    knobVisual->TransformToVisual(knobBounds)->TransformPoint({ 0, 0 });
+                const double knobVisualWidth = knobVisual->ActualWidth;
                 const double trackWidth = knobBounds->ActualWidth;
 
                 LOG_OUTPUT(
-                    L"IsOn: %d, knob translation: %f, knob width: %f, track width: %f",
+                    L"IsOn: %d, knob visual origin: %f, knob visual width: %f, track width: %f",
                     isOn,
-                    knobTranslation,
-                    knobWidth,
+                    knobVisualOrigin.X,
+                    knobVisualWidth,
                     trackWidth);
 
                 if (isOn)
                 {
                     VERIFY_IS_GREATER_THAN(
-                        knobTranslation,
+                        knobVisualOrigin.X,
                         0.0,
                         L"Knob left edge should not touch the track boundary while dragging from On.");
                 }
                 else
                 {
                     VERIFY_IS_LESS_THAN(
-                        knobTranslation + knobWidth,
+                        knobVisualOrigin.X + knobVisualWidth,
                         trackWidth,
                         L"Knob right edge should not touch the track boundary while dragging from Off.");
                 }
@@ -739,10 +747,10 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         };
 
         LOG_OUTPUT(L"Dragging from Off toward the right track boundary.");
-        dragAndVerifyMargin(false /*isOn*/, 30 /*dragDeltaX*/);
+        dragAndVerifyMargin(false /*isOn*/, 100 /*dragDeltaX*/);
 
         LOG_OUTPUT(L"Dragging from On toward the left track boundary.");
-        dragAndVerifyMargin(true /*isOn*/, -30 /*dragDeltaX*/);
+        dragAndVerifyMargin(true /*isOn*/, -100 /*dragDeltaX*/);
     }
 
 } } } } } } // Microsoft::UI::Xaml::Tests::Controls::ToggleSwitch

--- a/dxaml/test/native/external/controls/toggleswitch/ToggleSwitchIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/toggleswitch/ToggleSwitchIntegrationTests.cpp
@@ -652,4 +652,97 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         RunOnUIThread([&]() { VERIFY_IS_FALSE(toggleSwitch->IsOn); });
     }
 
+    void ToggleSwitchIntegrationTests::KnobMaintainsMarginsFromTrackDuringDrag()
+    {
+        TestCleanupWrapper cleanup;
+        xaml_controls::ToggleSwitch^ toggleSwitch = nullptr;
+        xaml::FrameworkElement^ knob = nullptr;
+        xaml::FrameworkElement^ knobBounds = nullptr;
+
+        RunOnUIThread([&]()
+        {
+            toggleSwitch = ref new xaml_controls::ToggleSwitch();
+            toggleSwitch->IsOn = false;
+            TestServices::WindowHelper->WindowContent = toggleSwitch;
+        });
+        TestServices::WindowHelper->WaitForIdle();
+
+        RunOnUIThread([&]()
+        {
+            knob = TreeHelper::GetVisualChildByName(toggleSwitch, L"SwitchKnob");
+            knobBounds = TreeHelper::GetVisualChildByName(toggleSwitch, L"SwitchKnobBounds");
+            VERIFY_IS_NOT_NULL(knob);
+            VERIFY_IS_NOT_NULL(knobBounds);
+        });
+
+        auto dragAndVerifyMargin = [&](bool isOn, int dragDeltaX)
+        {
+            RunOnUIThread([&]()
+            {
+                toggleSwitch->IsOn = isOn;
+            });
+            TestServices::WindowHelper->WaitForIdle();
+
+            bool isMouseButtonDown = false;
+            TestCleanupWrapper releaseMouse([&]()
+            {
+                if (isMouseButtonDown)
+                {
+                    TestServices::InputHelper->MouseButtonUp(knob, 0, 0, MouseButton::Left);
+                    TestServices::WindowHelper->WaitForIdle();
+                }
+            });
+
+            TestServices::InputHelper->MouseButtonDown(knob, 0, 0, MouseButton::Left);
+            isMouseButtonDown = true;
+            TestServices::WindowHelper->WaitForIdle();
+
+            TestServices::InputHelper->MoveMouse(knob, dragDeltaX, 0);
+            TestServices::WindowHelper->WaitForIdle();
+
+            RunOnUIThread([&]()
+            {
+                VERIFY_IS_TRUE(ControlHelper::IsInVisualState(toggleSwitch, L"CommonStates", L"Pressed"));
+                VERIFY_IS_TRUE(ControlHelper::IsInVisualState(toggleSwitch, L"ToggleStates", L"Dragging"));
+
+                auto transform = safe_cast<xaml_media::TranslateTransform^>(knob->RenderTransform);
+                const double knobTranslation = transform->X;
+                const double knobWidth = knob->ActualWidth;
+                const double trackWidth = knobBounds->ActualWidth;
+
+                LOG_OUTPUT(
+                    L"IsOn: %d, knob translation: %f, knob width: %f, track width: %f",
+                    isOn,
+                    knobTranslation,
+                    knobWidth,
+                    trackWidth);
+
+                if (isOn)
+                {
+                    VERIFY_IS_GREATER_THAN(
+                        knobTranslation,
+                        0.0,
+                        L"Knob left edge should not touch the track boundary while dragging from On.");
+                }
+                else
+                {
+                    VERIFY_IS_LESS_THAN(
+                        knobTranslation + knobWidth,
+                        trackWidth,
+                        L"Knob right edge should not touch the track boundary while dragging from Off.");
+                }
+            });
+
+            TestServices::InputHelper->MouseButtonUp(knob, 0, 0, MouseButton::Left);
+            isMouseButtonDown = false;
+            TestServices::WindowHelper->WaitForIdle();
+        };
+
+        LOG_OUTPUT(L"Dragging from Off toward the right track boundary.");
+        dragAndVerifyMargin(false /*isOn*/, 30 /*dragDeltaX*/);
+
+        LOG_OUTPUT(L"Dragging from On toward the left track boundary.");
+        dragAndVerifyMargin(true /*isOn*/, -30 /*dragDeltaX*/);
+    }
+
 } } } } } } // Microsoft::UI::Xaml::Tests::Controls::ToggleSwitch

--- a/dxaml/test/native/external/controls/toggleswitch/ToggleSwitchIntegrationTests.h
+++ b/dxaml/test/native/external/controls/toggleswitch/ToggleSwitchIntegrationTests.h
@@ -71,7 +71,11 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         BEGIN_TEST_METHOD(DoesNotToggleUsingDirectionalKeys)
             TEST_METHOD_PROPERTY(L"Description", L"Validates that pressing Home, End, Up, Down, Left, and Right does not toggle the state of the control.")
         END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(KnobMaintainsMarginsFromTrackDuringDrag)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates that the knob maintains proper margins from track boundaries when dragged in its expanded/pressed state.")
+            TEST_METHOD_PROPERTY(L"TestPass:IncludeOnlyOn", L"Desktop")
+        END_TEST_METHOD()
     };
 
 } } } } } }
-

--- a/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.cpp
@@ -28,6 +28,8 @@ ToggleSwitch::ToggleSwitch() :
 
     m_maxCurtainTranslation(0),
     m_maxKnobTranslation(0),
+    m_dragVisualClampMax(-1),
+    m_dragVisualClampMin(-1),
 
     m_minCurtainTranslation(0),
     m_minKnobTranslation(0),
@@ -456,6 +458,20 @@ ToggleSwitch::SetTranslations()
         translation = std::min(m_knobTranslation, m_maxKnobTranslation);
         translation = std::max(translation, m_minKnobTranslation);
 
+        // Keep the expanded knob visual inside the track without changing the
+        // translation range used for toggle thresholds and animations.
+        if (m_isDragging)
+        {
+            if (m_dragVisualClampMax >= 0)
+            {
+                translation = std::min(translation, m_dragVisualClampMax);
+            }
+            if (m_dragVisualClampMin >= 0)
+            {
+                translation = std::max(translation, m_dragVisualClampMin);
+            }
+        }
+
         IFC(m_spKnobTransform->put_X(translation));
 
         if (pToggleSwitchTemplateSettingsNoRef)
@@ -813,6 +829,7 @@ ToggleSwitch::DragStartedHandler(
     IFC(Focus(xaml::FocusState_Pointer, &isFocused));
     IFC(GetTranslations());
     IFC(UpdateVisualState(TRUE));
+    IFC(AdjustTranslationBoundsForDrag());
     IFC(SetTranslations());
 
 Cleanup:
@@ -852,12 +869,14 @@ ToggleSwitch::DragCompletedHandler(
 
     IFC(pArgs->get_Canceled(&isCanceled));
 
+    m_isDragging = FALSE;
+    m_dragVisualClampMax = -1;
+    m_dragVisualClampMin = -1;
+
     if (isCanceled)
     {
         goto Cleanup;
     }
-
-    m_isDragging = FALSE;
 
     IFC(MoveCompleted(m_wasDragged));
 
@@ -997,6 +1016,74 @@ Cleanup:
     RRETURN(hr);
 }
 
+_Check_return_ HRESULT
+ToggleSwitch::AdjustTranslationBoundsForDrag()
+{
+    m_dragVisualClampMax = -1;
+    m_dragVisualClampMin = -1;
+
+    if (!m_tpKnob || !m_tpKnobBounds)
+    {
+        return S_OK;
+    }
+
+    BOOLEAN isOn = FALSE;
+    IFC_RETURN(get_IsOn(&isOn));
+
+    if (!isOn)
+    {
+        ctl::ComPtr<xaml::IDependencyObject> spKnobOffDO;
+        IFC_RETURN(GetTemplateChild(wrl_wrappers::HStringReference(STR_LEN_PAIR(L"SwitchKnobOff")).Get(), &spKnobOffDO));
+
+        if (spKnobOffDO)
+        {
+            auto spKnobOffElement = spKnobOffDO.AsOrNull<xaml::IFrameworkElement>();
+
+            if (spKnobOffElement)
+            {
+                xaml::Thickness knobVisualMargin = {};
+                IFC_RETURN(spKnobOffElement->get_Margin(&knobVisualMargin));
+
+                if (knobVisualMargin.Left > 0)
+                {
+                    const DOUBLE clampMax = m_maxKnobTranslation - knobVisualMargin.Left;
+                    if (clampMax >= m_minKnobTranslation)
+                    {
+                        m_dragVisualClampMax = clampMax;
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        ctl::ComPtr<xaml::IDependencyObject> spKnobOnDO;
+        IFC_RETURN(GetTemplateChild(wrl_wrappers::HStringReference(STR_LEN_PAIR(L"SwitchKnobOn")).Get(), &spKnobOnDO));
+
+        if (spKnobOnDO)
+        {
+            auto spKnobOnElement = spKnobOnDO.AsOrNull<xaml::IFrameworkElement>();
+
+            if (spKnobOnElement)
+            {
+                xaml::Thickness knobVisualMargin = {};
+                IFC_RETURN(spKnobOnElement->get_Margin(&knobVisualMargin));
+
+                if (knobVisualMargin.Right > 0)
+                {
+                    const DOUBLE clampMin = m_minKnobTranslation + knobVisualMargin.Right;
+                    if (clampMin <= m_maxKnobTranslation)
+                    {
+                        m_dragVisualClampMin = clampMin;
+                    }
+                }
+            }
+        }
+    }
+
+    return S_OK;
+}
+
 // Whether the given key may cause the ToggleSwitch to toggle.
 BOOLEAN
 ToggleSwitch::HandlesKey(
@@ -1018,6 +1105,8 @@ _Check_return_ HRESULT ToggleSwitch::OnIsEnabledChanged(_In_ IsEnabledChangedEve
     if (!bIsEnabled)
     {
         m_isDragging = FALSE;
+        m_dragVisualClampMax = -1;
+        m_dragVisualClampMin = -1;
         m_isPointerOver = FALSE;
     }
     IFC(UpdateVisualState());
@@ -1037,6 +1126,8 @@ ToggleSwitch::OnVisibilityChanged()
     if (xaml::Visibility_Visible != visibility)
     {
         m_isDragging = FALSE;
+        m_dragVisualClampMax = -1;
+        m_dragVisualClampMin = -1;
         m_isPointerOver = FALSE;
     }
 

--- a/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.cpp
@@ -1030,53 +1030,50 @@ ToggleSwitch::AdjustTranslationBoundsForDrag()
     BOOLEAN isOn = FALSE;
     IFC_RETURN(get_IsOn(&isOn));
 
+    ctl::ComPtr<xaml::IDependencyObject> spKnobVisualDO;
     if (!isOn)
     {
-        ctl::ComPtr<xaml::IDependencyObject> spKnobOffDO;
-        IFC_RETURN(GetTemplateChild(wrl_wrappers::HStringReference(STR_LEN_PAIR(L"SwitchKnobOff")).Get(), &spKnobOffDO));
-
-        if (spKnobOffDO)
-        {
-            auto spKnobOffElement = spKnobOffDO.AsOrNull<xaml::IFrameworkElement>();
-
-            if (spKnobOffElement)
-            {
-                xaml::Thickness knobVisualMargin = {};
-                IFC_RETURN(spKnobOffElement->get_Margin(&knobVisualMargin));
-
-                if (knobVisualMargin.Left > 0)
-                {
-                    const DOUBLE clampMax = m_maxKnobTranslation - knobVisualMargin.Left;
-                    if (clampMax >= m_minKnobTranslation)
-                    {
-                        m_dragVisualClampMax = clampMax;
-                    }
-                }
-            }
-        }
+        IFC_RETURN(GetTemplateChild(wrl_wrappers::HStringReference(STR_LEN_PAIR(L"SwitchKnobOff")).Get(), &spKnobVisualDO));
     }
     else
     {
-        ctl::ComPtr<xaml::IDependencyObject> spKnobOnDO;
-        IFC_RETURN(GetTemplateChild(wrl_wrappers::HStringReference(STR_LEN_PAIR(L"SwitchKnobOn")).Get(), &spKnobOnDO));
+        IFC_RETURN(GetTemplateChild(wrl_wrappers::HStringReference(STR_LEN_PAIR(L"SwitchKnobOn")).Get(), &spKnobVisualDO));
+    }
 
-        if (spKnobOnDO)
+    auto spKnobVisualElement = spKnobVisualDO.AsOrNull<xaml::IFrameworkElement>();
+    auto spKnobVisualUIElement = spKnobVisualDO.AsOrNull<xaml::IUIElement>();
+
+    if (spKnobVisualElement && spKnobVisualUIElement)
+    {
+        DOUBLE knobWidth = 0;
+        DOUBLE knobVisualWidth = 0;
+        ctl::ComPtr<xaml::IUIElement> spKnobUIElement;
+        ctl::ComPtr<xaml_media::IGeneralTransform> spTransform;
+        wf::Point knobVisualOrigin = {};
+
+        IFC_RETURN(m_tpKnob->get_ActualWidth(&knobWidth));
+        IFC_RETURN(spKnobVisualElement->get_ActualWidth(&knobVisualWidth));
+        IFC_RETURN(m_tpKnob.As(&spKnobUIElement));
+        IFC_RETURN(spKnobVisualUIElement->TransformToVisual(spKnobUIElement.Get(), &spTransform));
+        IFC_RETURN(spTransform->TransformPoint({}, &knobVisualOrigin));
+
+        if (!isOn)
         {
-            auto spKnobOnElement = spKnobOnDO.AsOrNull<xaml::IFrameworkElement>();
-
-            if (spKnobOnElement)
+            const DOUBLE restingMargin = knobVisualOrigin.X;
+            const DOUBLE clampMax = m_maxKnobTranslation - restingMargin;
+            if (restingMargin > 0 && clampMax >= m_minKnobTranslation)
             {
-                xaml::Thickness knobVisualMargin = {};
-                IFC_RETURN(spKnobOnElement->get_Margin(&knobVisualMargin));
-
-                if (knobVisualMargin.Right > 0)
-                {
-                    const DOUBLE clampMin = m_minKnobTranslation + knobVisualMargin.Right;
-                    if (clampMin <= m_maxKnobTranslation)
-                    {
-                        m_dragVisualClampMin = clampMin;
-                    }
-                }
+                m_dragVisualClampMax = clampMax;
+            }
+        }
+        else
+        {
+            const DOUBLE restingMargin =
+                knobWidth - knobVisualOrigin.X - knobVisualWidth;
+            const DOUBLE clampMin = m_minKnobTranslation + restingMargin;
+            if (restingMargin > 0 && clampMin <= m_maxKnobTranslation)
+            {
+                m_dragVisualClampMin = clampMin;
             }
         }
     }

--- a/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.h
+++ b/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.h
@@ -128,6 +128,9 @@ namespace DirectUI
             _In_ xaml::ISizeChangedEventArgs *pArgs);
 
         _Check_return_ HRESULT
+        AdjustTranslationBoundsForDrag();
+
+        _Check_return_ HRESULT
         TapHandler(
             _In_ IInspectable *pSender,
             _In_ xaml_input::ITappedRoutedEventArgs *pArgs);
@@ -155,6 +158,10 @@ namespace DirectUI
         DOUBLE m_minKnobTranslation;
         
         DOUBLE m_maxKnobTranslation;
+
+        // Visual-only drag limits; -1 means no additional clamp.
+        DOUBLE m_dragVisualClampMax;
+        DOUBLE m_dragVisualClampMin;
 
         DOUBLE m_curtainTranslation;
         


### PR DESCRIPTION
## Fixes

Fixes #10822

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

While dragging a `ToggleSwitch`, the expanded pressed knob can touch the track boundary at the hard drag endpoint. The behavior is especially visible when the switch starts in the On state and is dragged toward Off.

### New Behavior

The visible knob preserves its resting inset from the track boundary throughout a drag, including at both hard endpoints and regardless of whether the switch starts On or Off.

The drag logic now measures the visible state-specific knob (`SwitchKnobOff` or `SwitchKnobOn`) in the `SwitchKnob` container coordinate space and applies separate visual-only clamp bounds. The logical translation bounds, toggle thresholds, animation offsets, and state transitions remain unchanged. Custom templates without the optional visual parts retain the previous behavior.

A regression test performs oversized drags in both directions and verifies the visible knob geometry rather than only the knob container geometry.

## Customer Impact

This fixes a user-visible graphical issue where the ToggleSwitch knob could appear flush against or overlap the track boundary while the pointer remained held during a drag.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The adjustment is isolated to ToggleSwitch drag-time visual clamping. It does not change public APIs or the logical values used to determine toggle state.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

Validation completed:

- Built `Microsoft.ui.xaml.vcxproj` for x64 CHK.
- Built `Microsoft.UI.Xaml.Tests.External.Controls.vcxproj` for x64 CHK.
- Passed `KnobMaintainsMarginsFromTrackDuringDrag` for initially-Off and initially-On hard drag endpoints.
- Passed the existing `CanDragHorizontallyOverToggleSwitchToSelect` mouse-drag test.
- Manually verified initially-Off and initially-On drag-and-hold behavior in MUXControlsTestApp.
- Confirmed the unrelated synthetic touch/tap failures reproduce on a clean `main` baseline in the same environment.

## Screenshots (if appropriate)

### Before

https://github.com/user-attachments/assets/177c06ed-9088-4350-864d-d1c3350039a5

### After

<!-- Add the final validation recording here. -->

https://github.com/user-attachments/assets/3decb8a8-f5cf-4888-bfbe-3f455bb87d84



