### PR TITLE
[Do Not Review] Validate Evergreen WebView2 on RS5

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-InstallDependencies-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-InstallDependencies-Steps.yml
@@ -109,15 +109,6 @@ steps:
       arguments: 'restore build\packages.TestInProduction.config -Source $(WinUIInternalFeedUri) -PackagesDirectory $(Build.SourcesDirectory)\packages'
       includeNuGetOrg: false
 
-  # Note: Restore the WebView2 Runtime package from the authenticated WinUI.Dependencies feed.
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: 'NuGet restore WebView2 Runtime installer'
-    condition: succeeded()
-    inputs:
-      command: 'custom'
-      arguments: 'restore build\packages.webview2.config -Source $(WinUIInternalFeedUri) -PackagesDirectory $(Build.SourcesDirectory)\packages'
-      includeNuGetOrg: false
-
   - task: VSBuild@1
     displayName: 'Restore Maestro dependencies'
     condition: and(succeeded(), ne(variables['Build.Repository.Provider'], 'GitHub'), ne(variables['Build.Repository.Provider'], 'GitHubEnterprise'))

--- a/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
@@ -72,6 +72,34 @@ jobs:
       script: |
         Get-Item -Path 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion'
 
+  # Validation-only provisioning until Evergreen is included in the Win10-2019-LTSC image.
+  - ${{ if eq( parameters.testOS, 'Win10-RS5' ) }}:
+    - task: PowerShell@2
+      displayName: 'Install Evergreen WebView2 Runtime on RS5'
+      inputs:
+        targetType: 'inline'
+        script: |
+          $ErrorActionPreference = 'Stop'
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+          $installerPath = Join-Path $env:Agent_TempDirectory 'MicrosoftEdgeWebview2Setup.exe'
+          try {
+            Invoke-WebRequest -UseBasicParsing -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $installerPath
+
+            $signature = Get-AuthenticodeSignature -FilePath $installerPath
+            if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
+              throw "Evergreen WebView2 bootstrapper signature validation failed. Status: $($signature.Status); signer: $($signature.SignerCertificate.Subject)"
+            }
+
+            $installer = Start-Process -FilePath $installerPath -ArgumentList '/silent', '/install' -Wait -PassThru
+            if ($installer.ExitCode -ne 0) {
+              throw "Evergreen WebView2 bootstrapper exited with code $($installer.ExitCode)."
+            }
+          }
+          finally {
+            Remove-Item -Path $installerPath -Force -ErrorAction SilentlyContinue
+          }
+
   - template: WinUI-DownloadPipelineArtifacts-Steps.yml
     parameters:
       itemPattern: '**/@(helixworkitems|TestPayload)/**'

--- a/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
@@ -75,25 +75,31 @@ jobs:
   # Validation-only provisioning until Evergreen is included in the Win10-2019-LTSC image.
   - ${{ if eq( parameters.testOS, 'Win10-RS5' ) }}:
     - task: PowerShell@2
-      displayName: 'Install Evergreen WebView2 Runtime on RS5'
+      displayName: 'Install x64 Evergreen WebView2 Standalone Runtime on RS5'
       inputs:
         targetType: 'inline'
         script: |
           $ErrorActionPreference = 'Stop'
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-          $installerPath = Join-Path $env:Agent_TempDirectory 'MicrosoftEdgeWebview2Setup.exe'
+          $installerPath = Join-Path $env:Agent_TempDirectory 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
           try {
-            Invoke-WebRequest -UseBasicParsing -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $installerPath
+            $downloadTimer = [System.Diagnostics.Stopwatch]::StartNew()
+            Invoke-WebRequest -UseBasicParsing -Uri 'https://go.microsoft.com/fwlink/?linkid=2124701' -OutFile $installerPath
+            $downloadTimer.Stop()
+            Write-Host "Evergreen WebView2 Standalone Installer download duration: $($downloadTimer.Elapsed)"
 
             $signature = Get-AuthenticodeSignature -FilePath $installerPath
             if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notmatch 'O=Microsoft Corporation') {
-              throw "Evergreen WebView2 bootstrapper signature validation failed. Status: $($signature.Status); signer: $($signature.SignerCertificate.Subject)"
+              throw "Evergreen WebView2 Standalone Installer signature validation failed. Status: $($signature.Status); signer: $($signature.SignerCertificate.Subject)"
             }
 
+            $installTimer = [System.Diagnostics.Stopwatch]::StartNew()
             $installer = Start-Process -FilePath $installerPath -ArgumentList '/silent', '/install' -Wait -PassThru
+            $installTimer.Stop()
+            Write-Host "Evergreen WebView2 Standalone Installer installation duration: $($installTimer.Elapsed)"
             if ($installer.ExitCode -ne 0) {
-              throw "Evergreen WebView2 bootstrapper exited with code $($installer.ExitCode)."
+              throw "Evergreen WebView2 Standalone Installer exited with code $($installer.ExitCode)."
             }
           }
           finally {

--- a/controls/dev/WebView2/InteractionTests/WebView2Tests.cs
+++ b/controls/dev/WebView2/InteractionTests/WebView2Tests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
             EnsureBrowser();
         }
 
-        // Ensure a suitable version of Edge browser or WebView2 runtime is present. If not, use mini_installer to install the runtime.
+        // Ensure the test image provides a WebView2 Runtime compatible with the SDK.
         public static void EnsureBrowser()
         {
             // If a previous run of CoreWebView2Initialized_FailedTest failed to clean up the
@@ -60,24 +60,21 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
             // 3. Check if a runtime is already installed, and if it's compatible.
             bool hasCompatibleRuntimeInstalled = GetHasCompatibleRuntimeInstalled(browserBuildVersion, sdkBuildVersion);
 
-            // 4a. If we have a compatible runtime installed, continue on to the tests!
+            // 4. If we have a compatible runtime installed, continue on to the tests.
             if (hasCompatibleRuntimeInstalled)
             {
                 return;
             }
 
-            // 4b. If we don't have a compatible runtime, try to install one.
-
-            // 5. Before installing, check if Edge is already installing/updating. We can't run the standalone installer if it is.
+            // An Evergreen update may already be in progress. Wait for it before failing the test.
             bool didWait = WaitForEdgeIfAlreadyInstalling();
 
             if (didWait && IsEdgeAlreadyInstalling())
             {
-                Log.Error("WebView2Tests Init: Edge took more than 3 minutes to install, give up.");
+                Verify.Fail("WebView2Tests Init: Evergreen WebView2 Runtime update did not finish within 3 minutes.");
             }
             else if (didWait)
             {
-                // If we waited for Edge to finish installing/updating and it finished, check the versions again
                 browserBuildVersion = GetInstalledBrowserVersion();
                 hasCompatibleRuntimeInstalled = GetHasCompatibleRuntimeInstalled(browserBuildVersion, sdkBuildVersion);
                 if (hasCompatibleRuntimeInstalled)
@@ -86,21 +83,11 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
                 }
             }
 
-            // 6. If Edge wasn't already installing/updating, or it was but installed something old (unlikely),
-            // run the standalone installer to install it.
-            // This installation can sometimes fail, so we'll try a number of times before failing out.
-            int attemptsLeft = 5;
-            bool successfullyInstalled = false;
-            while (attemptsLeft > 0)
-            {
-                attemptsLeft--;
-                successfullyInstalled = TryInstallingBrowser(attemptsLeft);
-                if (successfullyInstalled) break;
-            }
-            if (attemptsLeft == 0 && !successfullyInstalled)
-            {
-                Log.Error("WebView2Tests Init: Browser installation failed, out of retries.");
-            }
+            Verify.Fail(string.Format(
+                "WebView2Tests Init: The test image must provide a compatible Evergreen WebView2 Runtime. " +
+                "Installed Runtime build: {0}; required SDK build: {1}.",
+                browserBuildVersion,
+                sdkBuildVersion));
         }
 
         private static void RemoveFakeBrowserExecutableFolderKey()
@@ -180,7 +167,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
             // Browser/Runtime version ex: 80.0.361.48
             // WebView2 SDK version ex: 0.8.355
             // Webview2Loader compares the build versions (361 and 355 in above example), we do so here as well
-            if (browserBuildVersion >= sdkBuildVersion)
+            if (browserBuildVersion > 0 && sdkBuildVersion > 0 && browserBuildVersion >= sdkBuildVersion)
             {
                 Log.Comment("WebView2Tests Init: Installed Edge build will be used for testing... ");
                 hasCompatibleRuntime = true;
@@ -220,43 +207,6 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
                 }
             }
             return edgeUpdateIsRunning;
-        }
-
-        private static bool TryInstallingBrowser(int attemptsLeft)
-        {
-            bool successfullyInstalled = false;
-            string installer = "mini_installer.exe";
-            // Note: Starting with SDK 0.9.488 / Edge version 83, evergreen WebView2 no longer targets the Stable
-            //       browser channel. Instead, it targets another set of binaries, branded Evergreen WebView2 Runtime.
-            //       (See https://docs.microsoft.com/en-us/microsoft-edge/webview2/releasenotes).
-            //
-            //       Accordingly, Update mini_installer args to install WV2Runtime instead of full browser.
-            string installerArgs_WV2Runtime = "--msedgewebview --system-level";
-            Log.Comment(@"WebView2Tests Init: Installing WebView2 runtime: '{0} {1}'", installer, installerArgs_WV2Runtime);
-            ProcessStartInfo installerStartInfo = new ProcessStartInfo(installer, installerArgs_WV2Runtime);
-
-            Process installerProcess = Process.Start(installerStartInfo);
-            installerProcess.WaitForExit();
-
-            if (installerProcess.ExitCode == 0)
-            {
-                Log.Comment("WebView2Tests Init: {0} exited successfully", installer);
-                successfullyInstalled = true;
-            }
-            else
-            {
-                Log.Warning("WebView2Tests Init: {0} failed with exit code {1}! Attempts left: {2}", installer, installerProcess.ExitCode, attemptsLeft);
-                // Print information about some of the error codes we sometimes hit
-                if (installerProcess.ExitCode == 4)
-                {
-                    Log.Comment("Exit code 4 = HIGHER_VERSION_EXISTS, Higher version already exists");
-                }
-                else if (installerProcess.ExitCode == 60)
-                {
-                    Log.Comment("Exit code 60 = SETUP_SINGLETON_ACQUISITION_FAILED, The setup process could not acquire the exclusive right to modify the installation.");
-                }
-            }
-            return successfullyInstalled;
         }
 
         [TestCleanup]

--- a/dxaml/test/infra/taefhostappmanaged/TaefHostAppManaged.csproj
+++ b/dxaml/test/infra/taefhostappmanaged/TaefHostAppManaged.csproj
@@ -262,12 +262,6 @@
         <Destination>$(TestDependenciesResourcesDestinationPath)</Destination>
       </BinplaceItem>
     </ItemGroup>
-    <!-- Copy mini_installer.exe if the Microsoft.UI.DCPP.Dependencies.Edge package has been restored (which only happens in the pipelines) -->
-    <ItemGroup Condition="('$(arch)'=='x86' or '$(arch)'=='amd64') and Exists('$(NugetPackageDirectory)\Microsoft.UI.DCPP.Dependencies.Edge.144.0.3719.82')">
-      <BinplaceItem Include="$(NugetPackageDirectory)\Microsoft.UI.DCPP.Dependencies.Edge.144.0.3719.82\edge\mini_installer\$(DependencyPlatform)\mini_installer.exe">
-        <Destination>$(TestDependenciesResourcesDestinationPath)</Destination>
-      </BinplaceItem>
-    </ItemGroup>
   </Target>
   <Target Name="AppxExternalBinaries" BeforeTargets="GetPackagingOutputs" DependsOnTargets="ChooseExternalBinaries">
     <ItemGroup>


### PR DESCRIPTION
This validation change tests Evergreen WebView2 Runtime support on RS5. It installs the official Microsoft-signed Evergreen Runtime before RS5 tests, removes the DCPP installer restore and payload copy, and makes WebView2 tests fail clearly when a compatible Runtime is unavailable. This helps verify that RS5 can run without the internal DCPP fallback.