### PR TITLE
TabViewItem: don't enter the drag visual state when dragging is disallowed

### DIFF
--- a/controls/dev/TabView/InteractionTests/TabViewTests.cs
+++ b/controls/dev/TabView/InteractionTests/TabViewTests.cs
@@ -782,6 +782,56 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("Description", "Verifies that dragging a tab shows the drag visual when the TabView allows dragging.")]
+        public void VerifyTabEntersDragVisualStateWhenDraggingIsEnabled()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                FindElement.ByName<Button>("ResetFirstTabDragDropVisualStateLogButton").InvokeAndWait();
+
+                InputHelper.MouseDragDistance(FindElement.ByName("FirstTab"), 200, Direction.East, 4000);
+
+                FindElement.ByName<Button>("GetFirstTabDragDropVisualStateButton").InvokeAndWait();
+
+                var visitedStates = FindElement.ByName<TextBlock>("FirstTabDragDropVisualStateLogTextBlock").DocumentText;
+                Verify.IsTrue(visitedStates.Contains("DragDropVisualVisible"),
+                    $"The dragged tab should enter the DragDropVisualVisible state. Visited states: '{visitedStates}'.");
+            }
+        }
+
+        [TestMethod]
+        [TestProperty("Description", "Verifies that a tab neither enters nor gets stuck in the drag visual state when the TabView disallows dragging.")]
+        [TestProperty("RegressionBug", "10749")]
+        public void VerifyTabDoesNotEnterDragVisualStateWhenDraggingIsDisabled()
+        {
+            using (var setup = new TestSetupHelper("TabView Tests"))
+            {
+                Log.Comment("Disallow both reordering and dragging of tabs.");
+                FindElement.ByName<CheckBox>("CanDragTabsCheckBox").Uncheck();
+                FindElement.ByName<CheckBox>("CanReorderTabsCheckBox").Uncheck();
+
+                FindElement.ByName<Button>("ResetFirstTabDragDropVisualStateLogButton").InvokeAndWait();
+
+                Log.Comment("Drag the first tab away from the tab strip and release the pointer outside of it.");
+                var firstTab = FindElement.ByName("FirstTab");
+                InputHelper.LeftMouseButtonDown(firstTab);
+                InputHelper.MoveMouse(firstTab, 40, 0);
+                InputHelper.MoveMouse(firstTab, 300, 200);
+                InputHelper.LeftMouseButtonUp();
+
+                FindElement.ByName<Button>("GetFirstTabDragDropVisualStateButton").InvokeAndWait();
+
+                var visitedStates = FindElement.ByName<TextBlock>("FirstTabDragDropVisualStateLogTextBlock").DocumentText;
+                Verify.IsFalse(visitedStates.Contains("DragDropVisualVisible"),
+                    $"The tab should never enter the DragDropVisualVisible state while the TabView disallows dragging. Visited states: '{visitedStates}'.");
+
+                var currentState = FindElement.ByName<TextBlock>("FirstTabDragDropVisualStateTextBlock").DocumentText;
+                Verify.AreNotEqual("DragDropVisualVisible", currentState,
+                    "The tab should not be left in the drag visual state.");
+            }
+        }
+
+        [TestMethod]
         public void ScrollButtonToolTipTest()
         {
             using (var setup = new TestSetupHelper("TabView Tests"))

--- a/controls/dev/TabView/TabViewItem.cpp
+++ b/controls/dev/TabView/TabViewItem.cpp
@@ -485,8 +485,26 @@ bool TabViewItem::ShouldStartDrag(winrt::PointerRoutedEventArgs const& args)
         m_dragPointerId == args.Pointer().PointerId();
 }
 
+// Mirrors the conditions under which ListViewBaseItem captures the pointer to detect a drag gesture.
+// Without that capture this item stops receiving pointer events once the pointer leaves its bounds, so it
+// would never see the PointerReleased that takes it back out of the drag visual state.
+bool TabViewItem::IsDraggingAllowed()
+{
+    if (const auto tabView = GetParentTabView())
+    {
+        return tabView.CanDragTabs() || tabView.CanReorderTabs() || CanDrag();
+    }
+
+    return true;
+}
+
 void TabViewItem::BeginCheckingForDrag(uint32_t const& pointerId)
 {
+    if (!IsDraggingAllowed())
+    {
+        return;
+    }
+
     m_dragPointerId = pointerId;
     m_isCheckingforDrag = true;
 }

--- a/controls/dev/TabView/TabViewItem.h
+++ b/controls/dev/TabView/TabViewItem.h
@@ -82,6 +82,7 @@ private:
     
     void UpdateSelectedBackgroundPathTranslateTransform();
 
+    bool IsDraggingAllowed();
     void BeginCheckingForDrag(const uint32_t& pointerId);
     void StopCheckingForDrag(const uint32_t& pointerId);
 

--- a/controls/dev/TabView/TestUI/TabViewPage.xaml
+++ b/controls/dev/TabView/TestUI/TabViewPage.xaml
@@ -25,6 +25,8 @@
                     <CheckBox x:Name="HandleTabItemCloseRequestedCheckBox" AutomationProperties.Name="HandleTabItemCloseRequestedCheckBox" Content="Handle TabViewItem close"/>
                     <CheckBox x:Name="IsAddButtonVisibleCheckBox" AutomationProperties.Name="IsAddButtonVisibleCheckBox" Content="Add button visible" IsChecked="{x:Bind Tabs.IsAddTabButtonVisible, Mode=TwoWay}"/>
                     <CheckBox x:Name="IsDisabledTabVisibleCheckBox" AutomationProperties.Name="IsDisabledTabVisibleCheckBox" Checked="IsDisabledTabVisibleCheckBox_CheckChanged" Unchecked="IsDisabledTabVisibleCheckBox_CheckChanged" Content="Disabled tab visible" IsChecked="True"/>
+                    <CheckBox x:Name="CanDragTabsCheckBox" AutomationProperties.Name="CanDragTabsCheckBox" Content="CanDragTabs" IsChecked="{x:Bind Tabs.CanDragTabs, Mode=TwoWay}"/>
+                    <CheckBox x:Name="CanReorderTabsCheckBox" AutomationProperties.Name="CanReorderTabsCheckBox" Content="CanReorderTabs" IsChecked="{x:Bind Tabs.CanReorderTabs, Mode=TwoWay}"/>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                         <TextBlock VerticalAlignment="Center">Tab Width:</TextBlock>
                         <ComboBox x:Name="TabWidthComboBox" AutomationProperties.Name="TabWidthComboBox" Margin="4,0,0,0" SelectedIndex="0" SelectionChanged="TabWidthComboBox_SelectionChanged">
@@ -123,6 +125,15 @@
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                         <TextBlock x:Name="TabsItemChangedEventArgsTextBlock" AutomationProperties.Name="TabsItemChangedEventArgsTextBlock" Margin="4,0,0,0" Text="" />
                         <TextBlock x:Name="TabsItemChangedEventArgsIndexTextBlock" AutomationProperties.Name="TabsItemChangedEventArgsIndexTextBlock" Margin="4,0,0,0" Text="" />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <Button x:Name="ResetFirstTabDragDropVisualStateLogButton" AutomationProperties.Name="ResetFirstTabDragDropVisualStateLogButton" Content="Reset FirstTab drag state" Click="ResetFirstTabDragDropVisualStateLogButton_Click"/>
+                        <Button x:Name="GetFirstTabDragDropVisualStateButton" AutomationProperties.Name="GetFirstTabDragDropVisualStateButton" Content="Get FirstTab drag state" Margin="4,0,0,0" Click="GetFirstTabDragDropVisualStateButton_Click"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <TextBlock x:Name="FirstTabDragDropVisualStateTextBlock" AutomationProperties.Name="FirstTabDragDropVisualStateTextBlock" Margin="4,0,0,0" Text=""/>
+                        <TextBlock x:Name="FirstTabDragDropVisualStateLogTextBlock" AutomationProperties.Name="FirstTabDragDropVisualStateLogTextBlock" Margin="4,0,0,0" Text=""/>
                     </StackPanel>
 
                     <TextBlock x:Name="TabDraggedResultsTextBlock" AutomationProperties.Name="TabDraggedResultsTextBlock" />

--- a/controls/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/controls/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Input;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Shapes;
 using System.Reflection;
+using System.Collections.Generic;
 
 using System.Collections.ObjectModel;
 using Windows.Devices.PointOfService;
@@ -33,6 +34,8 @@ namespace MUXControlsTestApp
     {
         int _newTabNumber = 1;
         SymbolIconSource _iconSource;
+        VisualStateGroup firstTabDragDropVisualStateGroup;
+        readonly List<string> firstTabDragDropVisualStateLog = new List<string>();
 
         public TabViewPage()
         {
@@ -173,6 +176,54 @@ namespace MUXControlsTestApp
         public void GetTab1ToolTipButton_Click(object sender, RoutedEventArgs e)
         {
             GetToolTipStringForUIElement(SecondTab, Tab1ToolTipTextBlock);
+        }
+
+        public void ResetFirstTabDragDropVisualStateLogButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (firstTabDragDropVisualStateGroup == null)
+            {
+                firstTabDragDropVisualStateGroup = FindDragDropVisualStateGroup(FirstTab);
+
+                if (firstTabDragDropVisualStateGroup != null)
+                {
+                    firstTabDragDropVisualStateGroup.CurrentStateChanged +=
+                        (s, args) => firstTabDragDropVisualStateLog.Add(args.NewState?.Name ?? "none");
+                }
+            }
+
+            firstTabDragDropVisualStateLog.Clear();
+            FirstTabDragDropVisualStateTextBlock.Text = string.Empty;
+            FirstTabDragDropVisualStateLogTextBlock.Text = string.Empty;
+        }
+
+        public void GetFirstTabDragDropVisualStateButton_Click(object sender, RoutedEventArgs e)
+        {
+            FirstTabDragDropVisualStateTextBlock.Text = firstTabDragDropVisualStateGroup?.CurrentState?.Name ?? "none";
+            FirstTabDragDropVisualStateLogTextBlock.Text = string.Join(",", firstTabDragDropVisualStateLog);
+        }
+
+        // The drag/drop visual state group in the TabViewItem template is unnamed, so find it by the states it holds.
+        private static VisualStateGroup FindDragDropVisualStateGroup(TabViewItem tabViewItem)
+        {
+            if (VisualTreeHelper.GetChildrenCount(tabViewItem) == 0)
+            {
+                return null;
+            }
+
+            var templateRoot = VisualTreeHelper.GetChild(tabViewItem, 0) as FrameworkElement;
+
+            foreach (var group in VisualStateManager.GetVisualStateGroups(templateRoot))
+            {
+                foreach (var state in group.States)
+                {
+                    if (state.Name == "DragDropVisualVisible")
+                    {
+                        return group;
+                    }
+                }
+            }
+
+            return null;
         }
 
         public void GetToolTipStringForUIElement(UIElement item, TextBlock textBlock)

--- a/controls/dev/TabView/TestUI/TabViewPage.xaml.cs
+++ b/controls/dev/TabView/TestUI/TabViewPage.xaml.cs
@@ -210,7 +210,10 @@ namespace MUXControlsTestApp
                 return null;
             }
 
-            var templateRoot = VisualTreeHelper.GetChild(tabViewItem, 0) as FrameworkElement;
+            if (VisualTreeHelper.GetChild(tabViewItem, 0) is not FrameworkElement templateRoot)
+            {
+                return null;
+            }
 
             foreach (var group in VisualStateManager.GetVisualStateGroups(templateRoot))
             {


### PR DESCRIPTION
## Fixes

Fixes #10749
Fixes #9015

## PR Type

- [x] Bugfix

## Description

A `TabViewItem` would enter (and get stuck in) the `DragDropVisualVisible` visual state even when the parent `TabView` disallowed dragging and reordering.

`TabViewItem::BeginCheckingForDrag` unconditionally armed drag tracking on `PointerPressed`. `ListViewBaseItem` only captures the pointer for drag detection when the item is actually draggable, so when dragging is disallowed the item stops receiving pointer events as soon as the pointer leaves its bounds — the `PointerReleased`/`PointerCaptureLost` that would take it back out of the drag visual state never arrives, and the state sticks until the item is unfocused and refocused.

The fix adds `TabViewItem::IsDraggingAllowed()`, which mirrors the conditions under which `ListViewBaseItem` captures the pointer (`TabView.CanDragTabs`, `TabView.CanReorderTabs`, or the item's own `UIElement.CanDrag`). `BeginCheckingForDrag` now bails out early when dragging isn't allowed, so the drag visual state is never entered in the first place. When the item has no parent `TabView`, the previous behavior is preserved.

### Current Behavior

With `<TabView CanReorderTabs="False">`, dragging a tab still shows the drag visual (`DragDropVisualVisible`) and the tab remains in that state after the pointer is released.

### New Behavior

With dragging and reordering disallowed, the tab never enters `DragDropVisualVisible`. Behavior is unchanged when dragging or reordering is allowed, or when the item sets `CanDrag="True"` itself.

## Customer Impact

User-facing. Fixes an invalid, persistent visual state on `TabViewItem` for apps that turn off tab dragging/reordering.

## Regression Potential

- [x] Low risk — isolated change, limited scope

The change is scoped to `TabViewItem`'s pointer-pressed drag tracking and only skips work in the case where the drag could not have been carried out anyway. All existing paths where dragging is allowed are untouched.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

Two new interaction tests in `TabViewTests.cs`:

- `VerifyTabEntersDragVisualStateWhenDraggingIsEnabled` — guards against regressing the normal case, asserting the drag visual still appears when dragging is allowed.
- `VerifyTabDoesNotEnterDragVisualStateWhenDraggingIsDisabled` — the regression test for this issue: unchecks `CanDragTabs`/`CanReorderTabs`, drags the tab off the tab strip, and asserts the tab neither visits nor is left in `DragDropVisualVisible`.

The test page (`TabViewPage`) gained `CanDragTabs`/`CanReorderTabs` checkboxes and a small readout of the first tab's drag/drop visual state group (current state plus the log of states visited), which is what the tests assert against.
