### PR TITLE
RadioMenuFlyoutItem: don't leave stale group registrations behind

### DIFF
--- a/controls/MUXControls.sln
+++ b/controls/MUXControls.sln
@@ -332,6 +332,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RadioMenuFlyoutItem", "Radi
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RadioMenuFlyoutItem", "dev\RadioMenuFlyoutItem\RadioMenuFlyoutItem.vcxitems", "{3353A4A7-87B3-4E43-8F8D-43C7380D1D56}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RadioMenuFlyoutItem_APITests", "dev\RadioMenuFlyoutItem\APITests\RadioMenuFlyoutItem_APITests.shproj", "{9F3C7A21-6D4E-4B58-8C1A-2E5D0B79F384}"
+EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RadioMenuFlyoutItem_InteractionTests", "dev\RadioMenuFlyoutItem\InteractionTests\RadioMenuFlyoutItem_InteractionTests.shproj", "{89EC8D06-CA59-49A9-AEFE-32DCC9DD8020}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RadioMenuFlyoutItem_TestUI", "dev\RadioMenuFlyoutItem\TestUI\RadioMenuFlyoutItem_TestUI.shproj", "{50E838A2-A886-46C9-AB0B-A57F510CE643}"
@@ -1550,6 +1552,7 @@ Global
 		{00832735-360B-46BB-9BFA-B8C281951D55} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
 		{3353A4A7-87B3-4E43-8F8D-43C7380D1D56} = {00832735-360B-46BB-9BFA-B8C281951D55}
 		{89EC8D06-CA59-49A9-AEFE-32DCC9DD8020} = {00832735-360B-46BB-9BFA-B8C281951D55}
+		{9F3C7A21-6D4E-4B58-8C1A-2E5D0B79F384} = {00832735-360B-46BB-9BFA-B8C281951D55}
 		{50E838A2-A886-46C9-AB0B-A57F510CE643} = {00832735-360B-46BB-9BFA-B8C281951D55}
 		{4873DE1A-27B5-47ED-9EDC-69727FD2095C} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
 		{499B8BF7-BCA1-4C23-BAA7-59E2C551BE4B} = {4873DE1A-27B5-47ED-9EDC-69727FD2095C}
@@ -1900,6 +1903,7 @@ Global
 		dev\RadialGradientBrush\TestUI\RadialGradientBrush_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\RadioButtons\APITests\RadioButtons_APITests.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\RadioButtons\TestUI\RadioButtons_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
+		dev\RadioMenuFlyoutItem\APITests\RadioMenuFlyoutItem_APITests.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\RadioMenuFlyoutItem\TestUI\RadioMenuFlyoutItem_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\RatingControl\APITests\RatingControl_APITests.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
 		dev\RatingControl\TestUI\RatingControl_TestUI.projitems*{4e6f8103-9e20-40dd-8fe0-1e73964bb800}*SharedItemsImports = 5
@@ -1968,6 +1972,7 @@ Global
 		dev\DropDownButton\DropDownButton.vcxitems*{8613ed91-ade3-4c5c-a09a-041187841eb3}*SharedItemsImports = 9
 		dev\PullToRefresh\PTRTracing\PTRTracing.vcxitems*{890a5548-0515-4099-b526-0539fe9a0376}*SharedItemsImports = 9
 		dev\RadioMenuFlyoutItem\InteractionTests\RadioMenuFlyoutItem_InteractionTests.projitems*{89ec8d06-ca59-49a9-aefe-32dcc9dd8020}*SharedItemsImports = 13
+		dev\RadioMenuFlyoutItem\APITests\RadioMenuFlyoutItem_APITests.projitems*{9f3c7a21-6d4e-4b58-8c1a-2e5d0b79f384}*SharedItemsImports = 13
 		dev\PersonPicture\TestUI\PersonPicture_TestUI.projitems*{8a1690fb-aa8c-461a-840c-89cdbb44bdba}*SharedItemsImports = 13
 		dev\RadialGradientBrush\RadialGradientBrush.vcxitems*{8b056b8f-c1ab-4a80-bd17-deace9897e6a}*SharedItemsImports = 9
 		dev\MenuBar\MenuBar.vcxitems*{8bc9ceb8-8b4a-11d0-8d11-00a0c91bc942}*SharedItemsImports = 9

--- a/controls/MUXControlsInnerLoop.sln
+++ b/controls/MUXControlsInnerLoop.sln
@@ -319,6 +319,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RadioMenuFlyoutItem", "Radi
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RadioMenuFlyoutItem", "dev\RadioMenuFlyoutItem\RadioMenuFlyoutItem.vcxitems", "{3353A4A7-87B3-4E43-8F8D-43C7380D1D56}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RadioMenuFlyoutItem_APITests", "dev\RadioMenuFlyoutItem\APITests\RadioMenuFlyoutItem_APITests.shproj", "{9F3C7A21-6D4E-4B58-8C1A-2E5D0B79F384}"
+EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RadioMenuFlyoutItem_InteractionTests", "dev\RadioMenuFlyoutItem\InteractionTests\RadioMenuFlyoutItem_InteractionTests.shproj", "{89EC8D06-CA59-49A9-AEFE-32DCC9DD8020}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RadioMenuFlyoutItem_TestUI", "dev\RadioMenuFlyoutItem\TestUI\RadioMenuFlyoutItem_TestUI.shproj", "{50E838A2-A886-46C9-AB0B-A57F510CE643}"
@@ -849,6 +851,7 @@ Global
 		{00832735-360B-46BB-9BFA-B8C281951D55} = {67599AD5-51EC-44CB-85CE-B60CD8CBA270}
 		{3353A4A7-87B3-4E43-8F8D-43C7380D1D56} = {00832735-360B-46BB-9BFA-B8C281951D55}
 		{89EC8D06-CA59-49A9-AEFE-32DCC9DD8020} = {00832735-360B-46BB-9BFA-B8C281951D55}
+		{9F3C7A21-6D4E-4B58-8C1A-2E5D0B79F384} = {00832735-360B-46BB-9BFA-B8C281951D55}
 		{50E838A2-A886-46C9-AB0B-A57F510CE643} = {00832735-360B-46BB-9BFA-B8C281951D55}
 		{6AA772A6-CBF7-4FF3-8864-BC9366015DC2} = {666B53C4-A747-4538-AA51-8FF9DEE1BF60}
 		{D59C7B8E-5C09-4856-8AF3-25585A888707} = {85F9040A-109D-42FF-9BE3-4CF4181DDEF1}
@@ -1055,6 +1058,7 @@ Global
 		dev\DropDownButton\DropDownButton.vcxitems*{8613ed91-ade3-4c5c-a09a-041187841eb3}*SharedItemsImports = 9
 		dev\PullToRefresh\PTRTracing\PTRTracing.vcxitems*{890a5548-0515-4099-b526-0539fe9a0376}*SharedItemsImports = 9
 		dev\RadioMenuFlyoutItem\InteractionTests\RadioMenuFlyoutItem_InteractionTests.projitems*{89ec8d06-ca59-49a9-aefe-32dcc9dd8020}*SharedItemsImports = 13
+		dev\RadioMenuFlyoutItem\APITests\RadioMenuFlyoutItem_APITests.projitems*{9f3c7a21-6d4e-4b58-8c1a-2e5d0b79f384}*SharedItemsImports = 13
 		dev\PersonPicture\TestUI\PersonPicture_TestUI.projitems*{8a1690fb-aa8c-461a-840c-89cdbb44bdba}*SharedItemsImports = 13
 		dev\RadialGradientBrush\RadialGradientBrush.vcxitems*{8b056b8f-c1ab-4a80-bd17-deace9897e6a}*SharedItemsImports = 9
 		dev\MenuBar\MenuBar.vcxitems*{8bc9ceb8-8b4a-11d0-8d11-00a0c91bc942}*SharedItemsImports = 9

--- a/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItemTests.cs
+++ b/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItemTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using MUXControlsTestApp.Utilities;
+
+using Microsoft.UI.Xaml.Controls;
+using Common;
+
+using WEX.TestExecution;
+using WEX.TestExecution.Markup;
+using WEX.Logging.Interop;
+
+namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
+{
+    [TestClass]
+    public class RadioMenuFlyoutItemTests : ApiTestBase
+    {
+        [TestMethod]
+        public void VerifyItemsInTheSameGroupUncheckEachOther()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var first = new RadioMenuFlyoutItem() { GroupName = "VerifySameGroup" };
+                var second = new RadioMenuFlyoutItem() { GroupName = "VerifySameGroup" };
+
+                first.IsChecked = true;
+                second.IsChecked = true;
+
+                Verify.IsFalse(first.IsChecked, "Checking the second item should uncheck the first one in the same group.");
+                Verify.IsTrue(second.IsChecked, "The second item should be checked.");
+            });
+        }
+
+        [TestMethod]
+        [TestProperty("RegressionBug", "11098")]
+        public void VerifyGroupNameSetAfterIsCheckedDoesNotLeakRegistration()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                // Mimics the XAML attribute order IsChecked="True" GroupName="...", where IsChecked is
+                // applied while GroupName is still the default empty string.
+                var itemInNamedGroup = new RadioMenuFlyoutItem();
+                itemInNamedGroup.IsChecked = true;
+                itemInNamedGroup.GroupName = "VerifyGroupNameSetAfterIsChecked";
+
+                // This item belongs to the default group, which is the group the item above was
+                // momentarily registered under.
+                var itemInDefaultGroup = new RadioMenuFlyoutItem();
+                itemInDefaultGroup.IsChecked = true;
+
+                Verify.IsTrue(itemInNamedGroup.IsChecked,
+                    "An item that moved to another group should not be unchecked by an item in the default group.");
+                Verify.IsTrue(itemInDefaultGroup.IsChecked, "The item in the default group should be checked.");
+            });
+        }
+
+        [TestMethod]
+        [TestProperty("RegressionBug", "11098")]
+        public void VerifyChangingGroupNameWhileCheckedMovesRegistration()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var movedItem = new RadioMenuFlyoutItem() { GroupName = "VerifyMoveGroupOne" };
+                movedItem.IsChecked = true;
+
+                movedItem.GroupName = "VerifyMoveGroupTwo";
+
+                // The first group must no longer refer to the moved item.
+                var itemInFirstGroup = new RadioMenuFlyoutItem() { GroupName = "VerifyMoveGroupOne" };
+                itemInFirstGroup.IsChecked = true;
+
+                Verify.IsTrue(movedItem.IsChecked,
+                    "The moved item should not be unchecked by an item joining the group it left.");
+                Verify.IsTrue(itemInFirstGroup.IsChecked, "The item in the first group should be checked.");
+
+                // ...and the second group must now refer to it.
+                var itemInSecondGroup = new RadioMenuFlyoutItem() { GroupName = "VerifyMoveGroupTwo" };
+                itemInSecondGroup.IsChecked = true;
+
+                Verify.IsFalse(movedItem.IsChecked,
+                    "The moved item should be unchecked by an item joining the group it moved to.");
+                Verify.IsTrue(itemInSecondGroup.IsChecked, "The item in the second group should be checked.");
+            });
+        }
+
+        [TestMethod]
+        [TestProperty("RegressionBug", "11098")]
+        public void VerifyUnloadingAMovedItemKeepsAnotherItemsRegistration()
+        {
+            StackPanel panel = null;
+            RadioMenuFlyoutItem movedItem = null;
+            RadioMenuFlyoutItem groupOwner = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                movedItem = new RadioMenuFlyoutItem() { GroupName = "VerifyUnloadGroupOne" };
+                movedItem.IsChecked = true;
+
+                panel = new StackPanel();
+                panel.Children.Add(movedItem);
+
+                Content = panel;
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                movedItem.GroupName = "VerifyUnloadGroupTwo";
+
+                groupOwner = new RadioMenuFlyoutItem() { GroupName = "VerifyUnloadGroupTwo" };
+                groupOwner.IsChecked = true;
+
+                Verify.IsFalse(movedItem.IsChecked, "The moved item should have been unchecked by the new group owner.");
+
+                // Unloading the moved item must not drop the registration that now belongs to groupOwner.
+                panel.Children.Remove(movedItem);
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                var newItem = new RadioMenuFlyoutItem() { GroupName = "VerifyUnloadGroupTwo" };
+                newItem.IsChecked = true;
+
+                Verify.IsFalse(groupOwner.IsChecked,
+                    "The group owner should still have been registered for its group, and so be unchecked by the new item.");
+                Verify.IsTrue(newItem.IsChecked, "The new item should be checked.");
+            });
+        }
+    }
+}

--- a/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItemTests.cs
+++ b/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItemTests.cs
@@ -130,5 +130,119 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
                 Verify.IsTrue(newItem.IsChecked, "The new item should be checked.");
             });
         }
+
+        [TestMethod]
+        [TestProperty("RegressionBug", "11098")]
+        public void VerifyMovingToANewGroupKeepsAnotherItemsRegistration()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var movedItem = new RadioMenuFlyoutItem() { GroupName = "VerifyStaleEraseGroupOne" };
+                movedItem.IsChecked = true;
+
+                // Takes the group over. This leaves movedItem unchecked while it still remembers being
+                // registered under the group, which is the state that used to erase the wrong entry.
+                var groupOwner = new RadioMenuFlyoutItem() { GroupName = "VerifyStaleEraseGroupOne" };
+                groupOwner.IsChecked = true;
+
+                Verify.IsFalse(movedItem.IsChecked, "The first item should have been unchecked by the new group owner.");
+
+                movedItem.GroupName = "VerifyStaleEraseGroupTwo";
+                movedItem.IsChecked = true;
+
+                var newItem = new RadioMenuFlyoutItem() { GroupName = "VerifyStaleEraseGroupOne" };
+                newItem.IsChecked = true;
+
+                Verify.IsFalse(groupOwner.IsChecked,
+                    "The group owner should still have been registered for its group, and so be unchecked by the new item.");
+                Verify.IsTrue(newItem.IsChecked, "The new item should be checked.");
+                Verify.IsTrue(movedItem.IsChecked, "The item that moved to another group should still be checked.");
+            });
+        }
+
+        [TestMethod]
+        [TestProperty("RegressionBug", "11098")]
+        public void VerifyGroupNameChangeOnAnUnloadedItemDoesNotClaimTheGroup()
+        {
+            StackPanel panel = null;
+            RadioMenuFlyoutItem unloadedItem = null;
+            RadioMenuFlyoutItem groupOwner = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                unloadedItem = new RadioMenuFlyoutItem() { GroupName = "VerifyDetachedGroupOne" };
+                unloadedItem.IsChecked = true;
+
+                panel = new StackPanel();
+                panel.Children.Add(unloadedItem);
+
+                Content = panel;
+                Content.UpdateLayout();
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                // Unloading drops the registration, but IsChecked stays true.
+                panel.Children.Remove(unloadedItem);
+            });
+
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                groupOwner = new RadioMenuFlyoutItem() { GroupName = "VerifyDetachedGroupTwo" };
+                groupOwner.IsChecked = true;
+
+                // An item that is no longer in the tree must not take the group over from one that is.
+                unloadedItem.GroupName = "VerifyDetachedGroupTwo";
+
+                Verify.IsTrue(groupOwner.IsChecked, "An unloaded item joining the group should not uncheck its owner.");
+
+                var newItem = new RadioMenuFlyoutItem() { GroupName = "VerifyDetachedGroupTwo" };
+                newItem.IsChecked = true;
+
+                Verify.IsFalse(groupOwner.IsChecked,
+                    "The group owner should still have been registered for its group, and so be unchecked by the new item.");
+                Verify.IsTrue(newItem.IsChecked, "The new item should be checked.");
+            });
+        }
+
+        [TestMethod]
+        [TestProperty("RegressionBug", "11098")]
+        public void VerifyGroupNameChangedWhileUncheckingDoesNotLeaveTwoRegistrations()
+        {
+            RunOnUIThread.Execute(() =>
+            {
+                var previousOwner = new RadioMenuFlyoutItem() { GroupName = "VerifyReentrantGroupOne" };
+                previousOwner.IsChecked = true;
+
+                var newOwner = new RadioMenuFlyoutItem() { GroupName = "VerifyReentrantGroupOne" };
+
+                // Re-enters the registration update from the middle of it: unchecking previousOwner runs
+                // this callback, which moves newOwner to another group before the registration is written.
+                previousOwner.RegisterPropertyChangedCallback(RadioMenuFlyoutItem.IsCheckedProperty, (sender, dp) =>
+                {
+                    if (!previousOwner.IsChecked)
+                    {
+                        newOwner.GroupName = "VerifyReentrantGroupTwo";
+                    }
+                });
+
+                newOwner.IsChecked = true;
+
+                Verify.IsFalse(previousOwner.IsChecked, "The previous owner should have been unchecked.");
+                Verify.AreEqual("VerifyReentrantGroupTwo", newOwner.GroupName, "The item should have moved to the second group.");
+
+                // The item only belongs to the second group now, so the first one must not reach it.
+                var itemInFirstGroup = new RadioMenuFlyoutItem() { GroupName = "VerifyReentrantGroupOne" };
+                itemInFirstGroup.IsChecked = true;
+
+                Verify.IsTrue(newOwner.IsChecked,
+                    "An item that moved to another group while unchecking should not be unchecked by the group it left.");
+                Verify.IsTrue(itemInFirstGroup.IsChecked, "The item in the first group should be checked.");
+            });
+        }
     }
 }

--- a/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItem_APITests.projitems
+++ b/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItem_APITests.projitems
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>9f3c7a21-6d4e-4b58-8c1a-2e5d0b79f384</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>RadioMenuFlyoutItem_APITests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)RadioMenuFlyoutItemTests.cs" />
+  </ItemGroup>
+</Project>

--- a/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItem_APITests.shproj
+++ b/controls/dev/RadioMenuFlyoutItem/APITests/RadioMenuFlyoutItem_APITests.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9f3c7a21-6d4e-4b58-8c1a-2e5d0b79f384</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="RadioMenuFlyoutItem_APITests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/controls/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
+++ b/controls/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
@@ -35,9 +35,9 @@ void RadioMenuFlyoutItem::OnLoaded(winrt::IInspectable const&, winrt::RoutedEven
 void RadioMenuFlyoutItem::OnUnloaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
 {
     // If this is the checked item, remove it from the lookup.
-    if (m_isChecked && s_selectionMap)
+    if (m_isChecked)
     {
-        SharedHelpers::EraseIfExists(*s_selectionMap, m_groupName);
+        UnregisterFromGroup();
     }
 }
 
@@ -58,7 +58,10 @@ void RadioMenuFlyoutItem::OnPropertyChanged(const winrt::DependencyPropertyChang
     }
     else if (property == s_GroupNameProperty)
     {
-        m_groupName = GroupName();
+        // Move the registration over to the new group. IsChecked is frequently applied before GroupName
+        // (that is the order the properties appear in for typical XAML markup), which would otherwise
+        // leave this item registered under the group it no longer belongs to.
+        UpdateCheckedItemInGroup();
     }
 }
 
@@ -90,6 +93,11 @@ void RadioMenuFlyoutItem::UpdateCheckedItemInGroup()
     {
         const auto groupName = GroupName();
 
+        if (m_isRegistered && m_registeredGroupName != groupName)
+        {
+            UnregisterFromGroup();
+        }
+
         if (const auto previousCheckedItemWeak = (*s_selectionMap)[groupName])
         {
             if (auto previousCheckedItem = previousCheckedItemWeak.get())
@@ -107,7 +115,30 @@ void RadioMenuFlyoutItem::UpdateCheckedItemInGroup()
         // an extra Release() in this process.
         auto weakThis {winrt::make_weak(static_cast<winrt::RadioMenuFlyoutItem>(*this))};
         (*s_selectionMap)[groupName] = weakThis;
+        m_registeredGroupName = groupName;
+        m_isRegistered = true;
     }
+}
+
+void RadioMenuFlyoutItem::UnregisterFromGroup()
+{
+    if (!m_isRegistered || !s_selectionMap)
+    {
+        return;
+    }
+
+    if (const auto it = s_selectionMap->find(m_registeredGroupName); it != s_selectionMap->end())
+    {
+        // Only drop the entry while it still refers to this item. Another item may have taken the group
+        // over in the meantime, and erasing by group name alone would discard that item's registration.
+        const auto registeredItem = it->second.get();
+        if (!registeredItem || registeredItem == static_cast<winrt::RadioMenuFlyoutItem>(*this))
+        {
+            s_selectionMap->erase(it);
+        }
+    }
+
+    m_isRegistered = false;
 }
 
 void RadioMenuFlyoutItem::OnAreCheckStatesEnabledPropertyChanged(const winrt::DependencyObject& sender, const winrt::DependencyPropertyChangedEventArgs& args)

--- a/controls/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
+++ b/controls/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cpp
@@ -58,10 +58,13 @@ void RadioMenuFlyoutItem::OnPropertyChanged(const winrt::DependencyPropertyChang
     }
     else if (property == s_GroupNameProperty)
     {
-        // Move the registration over to the new group. IsChecked is frequently applied before GroupName
-        // (that is the order the properties appear in for typical XAML markup), which would otherwise
-        // leave this item registered under the group it no longer belongs to.
-        UpdateCheckedItemInGroup();
+        // Move an existing registration over to the new group. IsChecked is frequently applied before
+        // GroupName. Only do this while actually registered: an unloaded item keeps IsChecked,
+        // and it could take over the new group over from an item that is actually still in the tree.
+        if (m_isRegistered)
+        {
+            UpdateCheckedItemInGroup();
+        }
     }
 }
 
@@ -107,9 +110,18 @@ void RadioMenuFlyoutItem::UpdateCheckedItemInGroup()
                     // Uncheck the previously checked item.
                     RadioMenuFlyoutItem* rawPreviousCheckedItem = winrt::get_self<RadioMenuFlyoutItem>(previousCheckedItem);
                     rawPreviousCheckedItem->IsChecked(false);
+
+                    // Unchecking runs app code, which can re-enter this method and move us to another
+                    // group or uncheck us. We need to validate that we are still checked and in the same
+                    // group before registering ourselves.
+                    if (!IsChecked() || GroupName() != groupName)
+                    {
+                        return;
+                    }
                 }
             }
         }
+
         // Previously we used get_weak() here, but we found the potential to hit a 
         // refcounting problem where in some scenarios the outer object gets
         // an extra Release() in this process.

--- a/controls/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.h
+++ b/controls/dev/RadioMenuFlyoutItem/RadioMenuFlyoutItem.h
@@ -60,10 +60,16 @@ private:
     void OnInternalIsCheckedChanged(const winrt::DependencyObject& sender, const winrt::DependencyProperty& args);
 
     void UpdateCheckedItemInGroup();
+    void UnregisterFromGroup();
 
-    // Copies of IsChecked & GroupName to avoid using those dependency properties in the ~RadioMenuFlyoutItem() destructor which would lead to crashes.
+    // Copy of IsChecked to avoid using that dependency property in the ~RadioMenuFlyoutItem() destructor which would lead to crashes.
     bool m_isChecked{ false };
-    winrt::hstring m_groupName{ L"" };
+
+    // The group this item is currently registered under in s_selectionMap. GroupName() can change after
+    // the registration was made (it is commonly set after IsChecked, e.g. by XAML attribute order), so
+    // cleaning up must go through the name actually used at registration time rather than the current value.
+    winrt::hstring m_registeredGroupName{ L"" };
+    bool m_isRegistered{ false };
 
     bool m_isSafeUncheck{ false };
 

--- a/controls/test/MUXControlsTestApp/MUXControlsTestApp.csproj
+++ b/controls/test/MUXControlsTestApp/MUXControlsTestApp.csproj
@@ -266,6 +266,7 @@
   <Import Project="$(MUXCProjectRoot)dev\PullToRefresh\ScrollViewerIRefreshInfoProviderAdapter\APITests\APITests.projitems" Label="Shared" Condition="$(FeaturePullToRefreshEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\RadioButtons\APITests\RadioButtons_APITests.projitems" Label="Shared" Condition="$(FeatureRadioButtonsEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\RadioButtons\TestUI\RadioButtons_TestUI.projitems" Label="Shared" Condition="$(FeatureRadioButtonsEnabled) == 'true'" />
+  <Import Project="$(MUXCProjectRoot)dev\RadioMenuFlyoutItem\APITests\RadioMenuFlyoutItem_APITests.projitems" Label="Shared" Condition="$(FeatureRadioMenuFlyoutItemEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\RatingControl\APITests\RatingControl_APITests.projitems" Label="Shared" Condition="$(FeatureRatingControlEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\Repeater\APITests\Repeater_APITests.projitems" Label="Shared" Condition="$(FeatureRepeaterEnabled) == 'true'" />
   <Import Project="$(MUXCProjectRoot)dev\ScrollPresenter\APITests\ScrollPresenter_APITests.projitems" Label="Shared" Condition="$(FeatureScrollPresenterEnabled) == 'true'" />


### PR DESCRIPTION
## Fixes

Closes #11098

## PR Type

- [x] Bugfix

## Description

`RadioMenuFlyoutItem` keys its thread-static `s_selectionMap` (group name → checked item) by `GroupName`, but nothing tied a registration to the key it was actually made under. That produced two related defects:

1. **A registration made under a previous group name was never removed.** `UpdateCheckedItemInGroup` only ever inserted under the *current* `GroupName`. Applying `IsChecked` before `GroupName` — which is what plain XAML attribute order does for `IsChecked="True" GroupName="MyGroup"` — registered the item under the default empty group and left that entry behind. An unrelated item in the default group would then uncheck it.

2. **`OnUnloaded` could erase a different item's registration.** It called `SharedHelpers::EraseIfExists(*s_selectionMap, m_groupName)`, keyed by the *current* `GroupName`. `EraseIfExists` erases by key unconditionally, so once `GroupName` had changed, unloading discarded whichever item now owned that group.

The fix records the group name used at registration time (`m_registeredGroupName`) separately from the current property value:

- `UpdateCheckedItemInGroup` drops the previous registration before making a new one under a different name.
- `OnPropertyChanged` for `GroupName` now re-runs `UpdateCheckedItemInGroup`, so a checked item *moves* its registration rather than leaving a ghost.
- A new `UnregisterFromGroup` erases the entry only while it still refers to this item, so cleanup can never discard another item's registration.

The now-redundant `m_groupName` copy is removed; `m_registeredGroupName` serves the same purpose of keeping the destructor away from dependency properties.

### Current Behavior

With `IsChecked="True" GroupName="MyGroup"` (in that attribute order), the item is registered under both `""` and `"MyGroup"`. Checking an unrelated `RadioMenuFlyoutItem` that has no `GroupName` silently unchecks it. Equivalently, changing `GroupName` in code while an item is checked leaves a stale entry under the old name.

### New Behavior

An item is registered under exactly one group at a time, and that registration follows `GroupName` when it changes. Items in different groups no longer affect one another.

## Customer Impact

User-facing. Apps that bind `IsChecked`/`GroupName` to view-model state, or that simply write the attributes in `IsChecked`-then-`GroupName` order, no longer get radio items silently unchecking each other across unrelated menus. The old behavior was effectively dependent on XAML attribute order, which makes it hard to diagnose from app code.

## Regression Potential

- [x] Low risk — isolated change, limited scope

The change is confined to how `RadioMenuFlyoutItem` maintains its own entry in `s_selectionMap`. The check/uncheck logic itself is untouched, and the added cleanup is guarded so it only ever removes this item's own registration.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

This control had no API test project, so this PR adds one alongside the existing `InteractionTests` and `TestUI` projects. Four tests in `RadioMenuFlyoutItemTests.cs`:

| Test | Covers |
| --- | --- |
| `VerifyItemsInTheSameGroupUncheckEachOther` | ordinary same-group behavior, as a guard against over-correcting |
| `VerifyGroupNameSetAfterIsCheckedDoesNotLeakRegistration` | `GroupName` applied after `IsChecked` (the XAML attribute-order repro) |
| `VerifyChangingGroupNameWhileCheckedMovesRegistration` | `GroupName` changed in code while the item is checked |
| `VerifyUnloadingAMovedItemKeepsAnotherItemsRegistration` | unloading an item that has moved group, covering the `EraseIfExists` case |

Verified as a red/green pair against a locally built `Microsoft.UI.Xaml.Controls.dll`:

- **Without the fix:** `Total=4, Passed=1, Failed=3` — the three regression tests fail, the same-group guard passes.
- **With the fix:** `Total=4, Passed=4, Failed=0`.
